### PR TITLE
Add Android model detail screen with Navigation 3

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,6 +31,7 @@ open iosApp/iosApp.xcodeproj          # Open in Xcode
 - Room KMP — local database (favorites, cache)
 - Koin — dependency injection
 - Jetpack Compose (Android) / SwiftUI (iOS) — UI
+- Navigation 3 (`androidx.navigation3`) — Android screen navigation
 - Clean Architecture + MVVM pattern with UDF (Unidirectional Data Flow)
 
 ### Module Structure
@@ -55,9 +56,12 @@ CivitDeck/
 ├── androidApp/                # Android application (Jetpack Compose)
 │   └── src/main/
 │       └── kotlin/
-│           ├── ui/            # Compose screens & components
-│           ├── viewmodel/     # Android ViewModels
-│           └── di/            # Android DI module
+│           └── ui/
+│               ├── navigation/    # Nav3 NavDisplay & route definitions
+│               ├── search/        # Search screen + ViewModel
+│               ├── detail/        # Detail screen + ViewModel
+│               ├── components/    # Reusable Compose components
+│               └── util/          # Format utilities
 └── iosApp/                    # iOS application (SwiftUI)
     └── CivitDeck/
         ├── Views/             # SwiftUI views

--- a/README.md
+++ b/README.md
@@ -33,10 +33,10 @@ CivitDeck fills that gap. Browse models, explore images, read prompts, and save 
 
 | Layer | Technology |
 |-------|-----------|
-| **Shared (KMP)** | Ktor Client, Kotlinx Serialization, SQLDelight, Koin |
-| **Android** | Jetpack Compose, Material Design 3, Coil |
+| **Shared (KMP)** | Ktor Client, Kotlinx Serialization, Room KMP, Koin |
+| **Android** | Jetpack Compose, Material Design 3, Navigation 3, Coil |
 | **iOS** | SwiftUI |
-| **Architecture** | Clean Architecture + MVI |
+| **Architecture** | Clean Architecture + MVVM (UDF) |
 | **CI/CD** | GitHub Actions |
 
 ## Architecture
@@ -46,7 +46,7 @@ CivitDeck fills that gap. Browse models, explore images, read prompts, and save 
 │              Shared (KMP)                │
 │                                          │
 │  ┌──────────┐ ┌──────────┐ ┌─────────┐  │
-│  │   Ktor   │ │Repository│ │SQLDelight│  │
+│  │   Ktor   │ │Repository│ │ Room KMP │  │
 │  │  Client  │ │          │ │ (Cache)  │  │
 │  └────┬─────┘ └────┬─────┘ └────┬────┘  │
 │       └──────┬─────┘            │        │
@@ -79,20 +79,18 @@ cd CivitDeck
 ./gradlew :androidApp:installDebug
 
 # iOS
-cd iosApp
-pod install
-open CivitDeck.xcworkspace
+open iosApp/iosApp.xcodeproj
 ```
 
 ## Roadmap
 
 ### Phase 1 — MVP
 - [x] Project setup (KMP + Android + iOS)
-- [ ] CivitAI API client (Ktor)
-- [ ] Model search & browse (Android)
-- [ ] Model detail screen (Android)
+- [x] CivitAI API client (Ktor)
+- [x] Model search & browse (Android)
+- [x] Model detail screen (Android)
+- [x] Local favorites & offline cache (Room KMP)
 - [ ] Image gallery & metadata viewer (Android)
-- [ ] Local favorites & offline cache
 - [ ] Documentation (README, ARCHITECTURE, CONTRIBUTING)
 
 ### Phase 2 — iOS & Polish

--- a/androidApp/build.gradle.kts
+++ b/androidApp/build.gradle.kts
@@ -9,7 +9,7 @@ plugins {
 
 android {
     namespace = "com.omooooori.civitdeck"
-    compileSdk = 35
+    compileSdk = 36
 
     defaultConfig {
         applicationId = "com.omooooori.civitdeck"
@@ -55,8 +55,12 @@ dependencies {
     implementation(libs.androidx.activity.compose)
     implementation(libs.koin.android)
     implementation(libs.koin.compose)
+    implementation(libs.koin.compose.viewmodel)
     implementation(libs.androidx.lifecycle.viewmodel.compose)
     implementation(libs.androidx.lifecycle.runtime.compose)
     implementation(libs.coil.compose)
     implementation(libs.coil.network.ktor3)
+    implementation(libs.androidx.navigation3.runtime)
+    implementation(libs.androidx.navigation3.ui)
+    implementation(libs.androidx.lifecycle.viewmodel.navigation3)
 }

--- a/androidApp/src/main/kotlin/com/omooooori/civitdeck/CivitDeckApplication.kt
+++ b/androidApp/src/main/kotlin/com/omooooori/civitdeck/CivitDeckApplication.kt
@@ -2,6 +2,7 @@ package com.omooooori.civitdeck
 
 import android.app.Application
 import com.omooooori.civitdeck.di.initKoin
+import com.omooooori.civitdeck.ui.detail.ModelDetailViewModel
 import com.omooooori.civitdeck.ui.search.ModelSearchViewModel
 import org.koin.android.ext.koin.androidContext
 import org.koin.core.module.dsl.viewModel
@@ -19,4 +20,5 @@ class CivitDeckApplication : Application() {
 
 val androidModule = module {
     viewModel { ModelSearchViewModel(get()) }
+    viewModel { params -> ModelDetailViewModel(params.get(), get(), get(), get()) }
 }

--- a/androidApp/src/main/kotlin/com/omooooori/civitdeck/MainActivity.kt
+++ b/androidApp/src/main/kotlin/com/omooooori/civitdeck/MainActivity.kt
@@ -5,22 +5,16 @@ import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import androidx.compose.material3.MaterialTheme
-import com.omooooori.civitdeck.ui.search.ModelSearchScreen
-import com.omooooori.civitdeck.ui.search.ModelSearchViewModel
-import org.koin.androidx.viewmodel.ext.android.viewModel
+import com.omooooori.civitdeck.ui.navigation.CivitDeckNavGraph
 
 class MainActivity : ComponentActivity() {
-    private val modelSearchViewModel: ModelSearchViewModel by viewModel()
-
     override fun onCreate(savedInstanceState: Bundle?) {
         enableEdgeToEdge()
         window.isNavigationBarContrastEnforced = false
         super.onCreate(savedInstanceState)
         setContent {
             MaterialTheme {
-                ModelSearchScreen(
-                    viewModel = modelSearchViewModel,
-                )
+                CivitDeckNavGraph()
             }
         }
     }

--- a/androidApp/src/main/kotlin/com/omooooori/civitdeck/ui/components/ModelCard.kt
+++ b/androidApp/src/main/kotlin/com/omooooori/civitdeck/ui/components/ModelCard.kt
@@ -19,7 +19,7 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import coil3.compose.AsyncImage
 import com.omooooori.civitdeck.domain.model.Model
-import java.util.Locale
+import com.omooooori.civitdeck.ui.util.FormatUtils
 
 @Composable
 fun ModelCard(
@@ -73,15 +73,15 @@ fun ModelCard(
                     verticalAlignment = Alignment.CenterVertically,
                 ) {
                     StatItem(
-                        label = formatCount(model.stats.downloadCount),
+                        label = FormatUtils.formatCount(model.stats.downloadCount),
                         icon = "downloads",
                     )
                     StatItem(
-                        label = formatCount(model.stats.favoriteCount),
+                        label = FormatUtils.formatCount(model.stats.favoriteCount),
                         icon = "favorites",
                     )
                     StatItem(
-                        label = String.format(Locale.US, "%.1f", model.stats.rating),
+                        label = FormatUtils.formatRating(model.stats.rating),
                         icon = "rating",
                     )
                 }
@@ -116,10 +116,4 @@ private fun StatItem(
             color = MaterialTheme.colorScheme.onSurfaceVariant,
         )
     }
-}
-
-private fun formatCount(count: Int): String = when {
-    count >= 1_000_000 -> String.format(Locale.US, "%.1fM", count / 1_000_000.0)
-    count >= 1_000 -> String.format(Locale.US, "%.1fK", count / 1_000.0)
-    else -> count.toString()
 }

--- a/androidApp/src/main/kotlin/com/omooooori/civitdeck/ui/detail/ModelDetailScreen.kt
+++ b/androidApp/src/main/kotlin/com/omooooori/civitdeck/ui/detail/ModelDetailScreen.kt
@@ -1,0 +1,514 @@
+package com.omooooori.civitdeck.ui.detail
+
+import android.content.Intent
+import android.text.Html
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.foundation.pager.HorizontalPager
+import androidx.compose.foundation.pager.rememberPagerState
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Favorite
+import androidx.compose.material.icons.filled.FavoriteBorder
+import androidx.compose.material.icons.filled.Share
+import androidx.compose.material3.Button
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FilterChip
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SuggestionChip
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import coil3.compose.AsyncImage
+import com.omooooori.civitdeck.domain.model.Model
+import com.omooooori.civitdeck.domain.model.ModelFile
+import com.omooooori.civitdeck.domain.model.ModelImage
+import com.omooooori.civitdeck.domain.model.ModelVersion
+import com.omooooori.civitdeck.ui.util.FormatUtils
+
+@Composable
+fun ModelDetailScreen(
+    viewModel: ModelDetailViewModel,
+    onBack: () -> Unit,
+) {
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+
+    Scaffold(
+        topBar = {
+            ModelDetailTopBar(
+                uiState = uiState,
+                onBack = onBack,
+                onFavoriteToggle = viewModel::onFavoriteToggle,
+            )
+        },
+    ) { padding ->
+        ModelDetailBody(
+            uiState = uiState,
+            onRetry = viewModel::retry,
+            onVersionSelected = viewModel::onVersionSelected,
+            contentPadding = padding,
+        )
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun ModelDetailTopBar(
+    uiState: ModelDetailUiState,
+    onBack: () -> Unit,
+    onFavoriteToggle: () -> Unit,
+) {
+    val context = LocalContext.current
+    TopAppBar(
+        title = {
+            Text(
+                text = uiState.model?.name ?: "",
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+            )
+        },
+        navigationIcon = {
+            IconButton(onClick = onBack) {
+                Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+            }
+        },
+        actions = {
+            IconButton(
+                onClick = {
+                    val model = uiState.model ?: return@IconButton
+                    val shareIntent = Intent(Intent.ACTION_SEND).apply {
+                        type = "text/plain"
+                        putExtra(Intent.EXTRA_TEXT, "https://civitai.com/models/${model.id}")
+                    }
+                    context.startActivity(Intent.createChooser(shareIntent, "Share model"))
+                },
+            ) {
+                Icon(Icons.Default.Share, contentDescription = "Share")
+            }
+            IconButton(onClick = onFavoriteToggle) {
+                Icon(
+                    imageVector = if (uiState.isFavorite) {
+                        Icons.Default.Favorite
+                    } else {
+                        Icons.Default.FavoriteBorder
+                    },
+                    contentDescription = "Favorite",
+                    tint = if (uiState.isFavorite) {
+                        MaterialTheme.colorScheme.error
+                    } else {
+                        MaterialTheme.colorScheme.onSurface
+                    },
+                )
+            }
+        },
+    )
+}
+
+@Composable
+private fun ModelDetailBody(
+    uiState: ModelDetailUiState,
+    onRetry: () -> Unit,
+    onVersionSelected: (Int) -> Unit,
+    contentPadding: PaddingValues,
+) {
+    when {
+        uiState.isLoading -> {
+            Box(
+                modifier = Modifier.fillMaxSize().padding(contentPadding),
+                contentAlignment = Alignment.Center,
+            ) {
+                CircularProgressIndicator()
+            }
+        }
+        uiState.error != null -> {
+            Box(
+                modifier = Modifier.fillMaxSize().padding(contentPadding),
+                contentAlignment = Alignment.Center,
+            ) {
+                Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                    Text(
+                        text = uiState.error ?: "Unknown error",
+                        color = MaterialTheme.colorScheme.error,
+                    )
+                    Spacer(modifier = Modifier.height(16.dp))
+                    Button(onClick = onRetry) {
+                        Text("Retry")
+                    }
+                }
+            }
+        }
+        uiState.model != null -> {
+            ModelDetailContent(
+                model = uiState.model!!,
+                selectedVersionIndex = uiState.selectedVersionIndex,
+                onVersionSelected = onVersionSelected,
+                contentPadding = contentPadding,
+            )
+        }
+    }
+}
+
+@Composable
+private fun ModelDetailContent(
+    model: Model,
+    selectedVersionIndex: Int,
+    onVersionSelected: (Int) -> Unit,
+    contentPadding: PaddingValues,
+) {
+    val selectedVersion = model.modelVersions.getOrNull(selectedVersionIndex)
+
+    LazyColumn(
+        modifier = Modifier.fillMaxSize(),
+        contentPadding = PaddingValues(
+            top = contentPadding.calculateTopPadding(),
+            bottom = contentPadding.calculateBottomPadding() + 16.dp,
+        ),
+    ) {
+        // Image carousel
+        item {
+            ImageCarousel(images = selectedVersion?.images ?: emptyList())
+        }
+
+        // Model header
+        item {
+            ModelHeader(model = model)
+        }
+
+        // Stats row
+        item {
+            StatsRow(model = model)
+        }
+
+        // Tags
+        if (model.tags.isNotEmpty()) {
+            item {
+                TagsSection(tags = model.tags)
+            }
+        }
+
+        // Description
+        if (!model.description.isNullOrBlank()) {
+            item {
+                DescriptionSection(description = model.description!!)
+            }
+        }
+
+        // Version selector
+        if (model.modelVersions.size > 1) {
+            item {
+                VersionSelector(
+                    versions = model.modelVersions,
+                    selectedIndex = selectedVersionIndex,
+                    onVersionSelected = onVersionSelected,
+                )
+            }
+        }
+
+        // Version detail
+        if (selectedVersion != null) {
+            item {
+                VersionDetail(version = selectedVersion)
+            }
+        }
+    }
+}
+
+@Composable
+private fun ImageCarousel(images: List<ModelImage>) {
+    if (images.isEmpty()) return
+
+    val pagerState = rememberPagerState { images.size }
+
+    Column {
+        HorizontalPager(
+            state = pagerState,
+            modifier = Modifier.fillMaxWidth(),
+        ) { page ->
+            AsyncImage(
+                model = images[page].url,
+                contentDescription = null,
+                contentScale = ContentScale.Crop,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .aspectRatio(1f)
+                    .clip(MaterialTheme.shapes.medium),
+            )
+        }
+
+        if (images.size > 1) {
+            Text(
+                text = "${pagerState.currentPage + 1} / ${images.size}",
+                style = MaterialTheme.typography.labelSmall,
+                modifier = Modifier
+                    .align(Alignment.CenterHorizontally)
+                    .padding(top = 8.dp),
+            )
+        }
+    }
+}
+
+@Composable
+private fun ModelHeader(model: Model) {
+    Column(modifier = Modifier.padding(horizontal = 16.dp, vertical = 12.dp)) {
+        Text(
+            text = model.name,
+            style = MaterialTheme.typography.headlineSmall,
+        )
+        Spacer(modifier = Modifier.height(4.dp))
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+            SuggestionChip(
+                onClick = {},
+                label = {
+                    Text(
+                        text = model.type.name,
+                        style = MaterialTheme.typography.labelSmall,
+                    )
+                },
+            )
+            if (model.creator != null) {
+                Text(
+                    text = "by ${model.creator!!.username}",
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun StatsRow(model: Model) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp, vertical = 8.dp),
+        horizontalArrangement = Arrangement.SpaceEvenly,
+    ) {
+        StatColumn(
+            value = FormatUtils.formatCount(model.stats.downloadCount),
+            label = "Downloads",
+        )
+        StatColumn(
+            value = FormatUtils.formatCount(model.stats.favoriteCount),
+            label = "Favorites",
+        )
+        StatColumn(
+            value = FormatUtils.formatRating(model.stats.rating),
+            label = "Rating",
+        )
+        StatColumn(
+            value = FormatUtils.formatCount(model.stats.commentCount),
+            label = "Comments",
+        )
+    }
+}
+
+@Composable
+private fun StatColumn(value: String, label: String) {
+    Column(horizontalAlignment = Alignment.CenterHorizontally) {
+        Text(
+            text = value,
+            style = MaterialTheme.typography.titleMedium,
+        )
+        Text(
+            text = label,
+            style = MaterialTheme.typography.labelSmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+    }
+}
+
+@OptIn(ExperimentalLayoutApi::class)
+@Composable
+private fun TagsSection(tags: List<String>) {
+    Column(modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp)) {
+        Text(
+            text = "Tags",
+            style = MaterialTheme.typography.titleSmall,
+        )
+        Spacer(modifier = Modifier.height(8.dp))
+        FlowRow(
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+            verticalArrangement = Arrangement.spacedBy(4.dp),
+        ) {
+            tags.forEach { tag ->
+                SuggestionChip(
+                    onClick = {},
+                    label = { Text(tag, style = MaterialTheme.typography.labelSmall) },
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun DescriptionSection(description: String) {
+    Column(modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp)) {
+        HorizontalDivider(modifier = Modifier.padding(bottom = 8.dp))
+        Text(
+            text = "Description",
+            style = MaterialTheme.typography.titleSmall,
+        )
+        Spacer(modifier = Modifier.height(8.dp))
+        val plainText = Html.fromHtml(description, Html.FROM_HTML_MODE_COMPACT).toString()
+        Text(
+            text = AnnotatedString(plainText),
+            style = MaterialTheme.typography.bodyMedium,
+        )
+    }
+}
+
+@Composable
+private fun VersionSelector(
+    versions: List<ModelVersion>,
+    selectedIndex: Int,
+    onVersionSelected: (Int) -> Unit,
+) {
+    Column(modifier = Modifier.padding(vertical = 8.dp)) {
+        HorizontalDivider(modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp))
+        Text(
+            text = "Versions",
+            style = MaterialTheme.typography.titleSmall,
+            modifier = Modifier.padding(horizontal = 16.dp),
+        )
+        Spacer(modifier = Modifier.height(8.dp))
+        LazyRow(
+            contentPadding = PaddingValues(horizontal = 16.dp),
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+            itemsIndexed(versions) { index, version ->
+                FilterChip(
+                    selected = index == selectedIndex,
+                    onClick = { onVersionSelected(index) },
+                    label = { Text(version.name) },
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun VersionDetail(version: ModelVersion) {
+    Column(modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp)) {
+        if (version.baseModel != null) {
+            DetailRow(label = "Base Model", value = version.baseModel!!)
+        }
+
+        if (version.trainedWords.isNotEmpty()) {
+            Spacer(modifier = Modifier.height(8.dp))
+            Text(
+                text = "Trained Words",
+                style = MaterialTheme.typography.titleSmall,
+            )
+            Spacer(modifier = Modifier.height(4.dp))
+            Text(
+                text = version.trainedWords.joinToString(", "),
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+
+        if (version.files.isNotEmpty()) {
+            Spacer(modifier = Modifier.height(12.dp))
+            Text(
+                text = "Files",
+                style = MaterialTheme.typography.titleSmall,
+            )
+            Spacer(modifier = Modifier.height(4.dp))
+            version.files.forEach { file ->
+                FileInfoRow(file = file)
+                Spacer(modifier = Modifier.height(4.dp))
+            }
+        }
+    }
+}
+
+@Composable
+private fun DetailRow(label: String, value: String) {
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.SpaceBetween,
+    ) {
+        Text(
+            text = label,
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        Text(
+            text = value,
+            style = MaterialTheme.typography.bodyMedium,
+        )
+    }
+}
+
+@Composable
+private fun FileInfoRow(file: ModelFile) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(vertical = 4.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Column(modifier = Modifier.weight(1f)) {
+            Text(
+                text = file.name,
+                style = MaterialTheme.typography.bodySmall,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+            )
+            Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                Text(
+                    text = FormatUtils.formatFileSize(file.sizeKB),
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+                file.format?.let { format ->
+                    Text(
+                        text = format,
+                        style = MaterialTheme.typography.labelSmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+                file.fp?.let { fp ->
+                    Text(
+                        text = fp,
+                        style = MaterialTheme.typography.labelSmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+            }
+        }
+    }
+}

--- a/androidApp/src/main/kotlin/com/omooooori/civitdeck/ui/detail/ModelDetailViewModel.kt
+++ b/androidApp/src/main/kotlin/com/omooooori/civitdeck/ui/detail/ModelDetailViewModel.kt
@@ -1,0 +1,85 @@
+package com.omooooori.civitdeck.ui.detail
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.omooooori.civitdeck.domain.model.Model
+import com.omooooori.civitdeck.domain.usecase.GetModelDetailUseCase
+import com.omooooori.civitdeck.domain.usecase.ObserveIsFavoriteUseCase
+import com.omooooori.civitdeck.domain.usecase.ToggleFavoriteUseCase
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+
+data class ModelDetailUiState(
+    val model: Model? = null,
+    val isFavorite: Boolean = false,
+    val isLoading: Boolean = true,
+    val error: String? = null,
+    val selectedVersionIndex: Int = 0,
+)
+
+class ModelDetailViewModel(
+    private val modelId: Long,
+    private val getModelDetailUseCase: GetModelDetailUseCase,
+    private val observeIsFavoriteUseCase: ObserveIsFavoriteUseCase,
+    private val toggleFavoriteUseCase: ToggleFavoriteUseCase,
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow(ModelDetailUiState())
+    val uiState: StateFlow<ModelDetailUiState> = _uiState.asStateFlow()
+
+    init {
+        loadModel()
+        observeFavorite()
+    }
+
+    fun onVersionSelected(index: Int) {
+        _uiState.update { it.copy(selectedVersionIndex = index) }
+    }
+
+    fun onFavoriteToggle() {
+        val model = _uiState.value.model ?: return
+        viewModelScope.launch {
+            try {
+                toggleFavoriteUseCase(model)
+            } catch (e: CancellationException) {
+                throw e
+            } catch (_: Exception) {
+                // Favorite toggle failure is non-critical
+            }
+        }
+    }
+
+    fun retry() {
+        loadModel()
+    }
+
+    private fun loadModel() {
+        viewModelScope.launch {
+            _uiState.update { it.copy(isLoading = true, error = null) }
+            try {
+                val model = getModelDetailUseCase(modelId)
+                _uiState.update {
+                    it.copy(model = model, isLoading = false)
+                }
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                _uiState.update {
+                    it.copy(isLoading = false, error = e.message ?: "Unknown error")
+                }
+            }
+        }
+    }
+
+    private fun observeFavorite() {
+        viewModelScope.launch {
+            observeIsFavoriteUseCase(modelId).collect { isFavorite ->
+                _uiState.update { it.copy(isFavorite = isFavorite) }
+            }
+        }
+    }
+}

--- a/androidApp/src/main/kotlin/com/omooooori/civitdeck/ui/navigation/CivitDeckNavGraph.kt
+++ b/androidApp/src/main/kotlin/com/omooooori/civitdeck/ui/navigation/CivitDeckNavGraph.kt
@@ -1,0 +1,51 @@
+package com.omooooori.civitdeck.ui.navigation
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.mutableStateListOf
+import androidx.compose.runtime.remember
+import androidx.lifecycle.viewmodel.navigation3.rememberViewModelStoreNavEntryDecorator
+import androidx.navigation3.runtime.entryProvider
+import androidx.navigation3.runtime.rememberSaveableStateHolderNavEntryDecorator
+import androidx.navigation3.ui.NavDisplay
+import com.omooooori.civitdeck.ui.detail.ModelDetailScreen
+import com.omooooori.civitdeck.ui.detail.ModelDetailViewModel
+import com.omooooori.civitdeck.ui.search.ModelSearchScreen
+import com.omooooori.civitdeck.ui.search.ModelSearchViewModel
+import org.koin.compose.viewmodel.koinViewModel
+import org.koin.core.parameter.parametersOf
+
+data object SearchRoute
+
+data class DetailRoute(val modelId: Long)
+
+@Composable
+fun CivitDeckNavGraph() {
+    val backStack = remember { mutableStateListOf<Any>(SearchRoute) }
+
+    NavDisplay(
+        backStack = backStack,
+        onBack = { backStack.removeLastOrNull() },
+        entryDecorators = listOf(
+            rememberSaveableStateHolderNavEntryDecorator(),
+            rememberViewModelStoreNavEntryDecorator(),
+        ),
+        entryProvider = entryProvider {
+            entry<SearchRoute> {
+                val viewModel: ModelSearchViewModel = koinViewModel()
+                ModelSearchScreen(
+                    viewModel = viewModel,
+                    onModelClick = { modelId -> backStack.add(DetailRoute(modelId)) },
+                )
+            }
+            entry<DetailRoute> { key ->
+                val viewModel: ModelDetailViewModel = koinViewModel(
+                    key = key.modelId.toString(),
+                ) { parametersOf(key.modelId) }
+                ModelDetailScreen(
+                    viewModel = viewModel,
+                    onBack = { backStack.removeLastOrNull() },
+                )
+            }
+        },
+    )
+}

--- a/androidApp/src/main/kotlin/com/omooooori/civitdeck/ui/util/FormatUtils.kt
+++ b/androidApp/src/main/kotlin/com/omooooori/civitdeck/ui/util/FormatUtils.kt
@@ -1,0 +1,20 @@
+package com.omooooori.civitdeck.ui.util
+
+import java.util.Locale
+
+object FormatUtils {
+    fun formatCount(count: Int): String = when {
+        count >= 1_000_000 -> String.format(Locale.US, "%.1fM", count / 1_000_000.0)
+        count >= 1_000 -> String.format(Locale.US, "%.1fK", count / 1_000.0)
+        else -> count.toString()
+    }
+
+    fun formatRating(rating: Double): String =
+        String.format(Locale.US, "%.1f", rating)
+
+    fun formatFileSize(sizeKB: Double): String = when {
+        sizeKB >= 1_000_000 -> String.format(Locale.US, "%.1f GB", sizeKB / 1_000_000.0)
+        sizeKB >= 1_000 -> String.format(Locale.US, "%.1f MB", sizeKB / 1_000.0)
+        else -> String.format(Locale.US, "%.0f KB", sizeKB)
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -11,6 +11,8 @@ sqlite = "2.6.2"
 ksp = "2.2.0-2.0.2"
 androidx-activity-compose = "1.10.1"
 androidx-lifecycle = "2.9.0"
+androidx-navigation3 = "1.0.0"
+androidx-lifecycle-viewmodel-navigation3 = "1.0.0"
 detekt = "1.23.8"
 
 [libraries]
@@ -34,6 +36,7 @@ sqlite-bundled = { module = "androidx.sqlite:sqlite-bundled", version.ref = "sql
 koin-core = { module = "io.insert-koin:koin-core", version.ref = "koin" }
 koin-android = { module = "io.insert-koin:koin-android", version.ref = "koin" }
 koin-compose = { module = "io.insert-koin:koin-compose", version.ref = "koin" }
+koin-compose-viewmodel = { module = "io.insert-koin:koin-compose-viewmodel", version.ref = "koin" }
 
 # Coil
 coil-compose = { module = "io.coil-kt.coil3:coil-compose", version.ref = "coil" }
@@ -43,6 +46,9 @@ coil-network-ktor3 = { module = "io.coil-kt.coil3:coil-network-ktor3", version.r
 androidx-activity-compose = { module = "androidx.activity:activity-compose", version.ref = "androidx-activity-compose" }
 androidx-lifecycle-viewmodel-compose = { module = "androidx.lifecycle:lifecycle-viewmodel-compose", version.ref = "androidx-lifecycle" }
 androidx-lifecycle-runtime-compose = { module = "androidx.lifecycle:lifecycle-runtime-compose", version.ref = "androidx-lifecycle" }
+androidx-navigation3-runtime = { module = "androidx.navigation3:navigation3-runtime", version.ref = "androidx-navigation3" }
+androidx-navigation3-ui = { module = "androidx.navigation3:navigation3-ui", version.ref = "androidx-navigation3" }
+androidx-lifecycle-viewmodel-navigation3 = { module = "androidx.lifecycle:lifecycle-viewmodel-navigation3", version.ref = "androidx-lifecycle-viewmodel-navigation3" }
 
 # Detekt
 detekt-formatting = { module = "io.gitlab.arturbosch.detekt:detekt-formatting", version.ref = "detekt" }

--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -55,7 +55,7 @@ kotlin {
 
 android {
     namespace = "com.omooooori.civitdeck.shared"
-    compileSdk = 35
+    compileSdk = 36
 
     defaultConfig {
         minSdk = 24

--- a/shared/src/commonMain/kotlin/com/omooooori/civitdeck/di/DomainModule.kt
+++ b/shared/src/commonMain/kotlin/com/omooooori/civitdeck/di/DomainModule.kt
@@ -1,5 +1,6 @@
 package com.omooooori.civitdeck.di
 
+import com.omooooori.civitdeck.domain.usecase.GetModelDetailUseCase
 import com.omooooori.civitdeck.domain.usecase.GetModelsUseCase
 import com.omooooori.civitdeck.domain.usecase.ObserveFavoritesUseCase
 import com.omooooori.civitdeck.domain.usecase.ObserveIsFavoriteUseCase
@@ -8,6 +9,7 @@ import org.koin.dsl.module
 
 val domainModule = module {
     factory { GetModelsUseCase(get()) }
+    factory { GetModelDetailUseCase(get()) }
     factory { ToggleFavoriteUseCase(get()) }
     factory { ObserveFavoritesUseCase(get()) }
     factory { ObserveIsFavoriteUseCase(get()) }

--- a/shared/src/commonMain/kotlin/com/omooooori/civitdeck/domain/usecase/GetModelDetailUseCase.kt
+++ b/shared/src/commonMain/kotlin/com/omooooori/civitdeck/domain/usecase/GetModelDetailUseCase.kt
@@ -1,0 +1,8 @@
+package com.omooooori.civitdeck.domain.usecase
+
+import com.omooooori.civitdeck.domain.model.Model
+import com.omooooori.civitdeck.domain.repository.ModelRepository
+
+class GetModelDetailUseCase(private val repository: ModelRepository) {
+    suspend operator fun invoke(modelId: Long): Model = repository.getModel(modelId)
+}


### PR DESCRIPTION
## Description

Add a model detail screen for Android, accessible by tapping a model card on the search screen. Introduces Navigation 3 (`androidx.navigation3`) for screen-to-screen navigation.

**What's included:**
- Navigation 3 setup with `NavDisplay`, `entryProvider` DSL, and ViewModel-scoped decorators
- `ModelDetailScreen` — image carousel (HorizontalPager), model header, stats, tags (FlowRow), HTML description, version selector (FilterChip), and file info
- `ModelDetailViewModel` — loads model detail, observes favorite state, toggles favorite, version selection
- `GetModelDetailUseCase` in shared module
- `FormatUtils` extracted from `ModelCard` for shared formatting logic
- `compileSdk` bumped 35→36 (required by Navigation 3)
- AGENTS.md and README.md updated (SQLDelight→Room KMP, added Nav3, fixed roadmap)

## Related Issues

Closes #5

## Screenshots / Video

<!-- If applicable, add screenshots or screen recordings -->

## Test Plan

- [x] Build: `./gradlew :androidApp:assembleDebug` passes
- [x] Detekt: `./gradlew detekt` passes
- [x] Search screen renders as before
- [x] Tap a model card → navigates to detail screen
- [x] Detail screen shows image carousel, model info, stats, tags, description, versions
- [x] Version selector switches displayed version content
- [x] Favorite toggle works
- [x] Share button opens share sheet with CivitAI URL
- [x] Back button returns to search screen

## Review Checklist

- [x] Code follows project architecture (Clean Architecture + MVVM)
- [x] Shared logic is in `commonMain`, platform-specific code only when necessary
- [x] No unnecessary dependencies added
- [x] Tests added/updated as needed

## Breaking Changes

- `compileSdk` bumped from 35 to 36 (required by `androidx.navigation3:1.0.0`)