### PR TITLE
Add Android image gallery & metadata viewer

### DIFF
--- a/androidApp/src/main/kotlin/com/omooooori/civitdeck/CivitDeckApplication.kt
+++ b/androidApp/src/main/kotlin/com/omooooori/civitdeck/CivitDeckApplication.kt
@@ -3,6 +3,7 @@ package com.omooooori.civitdeck
 import android.app.Application
 import com.omooooori.civitdeck.di.initKoin
 import com.omooooori.civitdeck.ui.detail.ModelDetailViewModel
+import com.omooooori.civitdeck.ui.gallery.ImageGalleryViewModel
 import com.omooooori.civitdeck.ui.search.ModelSearchViewModel
 import org.koin.android.ext.koin.androidContext
 import org.koin.core.module.dsl.viewModel
@@ -21,4 +22,5 @@ class CivitDeckApplication : Application() {
 val androidModule = module {
     viewModel { ModelSearchViewModel(get()) }
     viewModel { params -> ModelDetailViewModel(params.get(), get(), get(), get()) }
+    viewModel { params -> ImageGalleryViewModel(params.get(), get()) }
 }

--- a/androidApp/src/main/kotlin/com/omooooori/civitdeck/ui/detail/ModelDetailScreen.kt
+++ b/androidApp/src/main/kotlin/com/omooooori/civitdeck/ui/detail/ModelDetailScreen.kt
@@ -26,6 +26,7 @@ import androidx.compose.material.icons.filled.Favorite
 import androidx.compose.material.icons.filled.FavoriteBorder
 import androidx.compose.material.icons.filled.Share
 import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FilterChip
@@ -59,6 +60,7 @@ import com.omooooori.civitdeck.ui.util.FormatUtils
 fun ModelDetailScreen(
     viewModel: ModelDetailViewModel,
     onBack: () -> Unit,
+    onViewImages: () -> Unit = {},
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
 
@@ -75,6 +77,7 @@ fun ModelDetailScreen(
             uiState = uiState,
             onRetry = viewModel::retry,
             onVersionSelected = viewModel::onVersionSelected,
+            onViewImages = onViewImages,
             contentPadding = padding,
         )
     }
@@ -138,6 +141,7 @@ private fun ModelDetailBody(
     uiState: ModelDetailUiState,
     onRetry: () -> Unit,
     onVersionSelected: (Int) -> Unit,
+    onViewImages: () -> Unit,
     contentPadding: PaddingValues,
 ) {
     when {
@@ -171,6 +175,7 @@ private fun ModelDetailBody(
                 model = uiState.model!!,
                 selectedVersionIndex = uiState.selectedVersionIndex,
                 onVersionSelected = onVersionSelected,
+                onViewImages = onViewImages,
                 contentPadding = contentPadding,
             )
         }
@@ -182,6 +187,7 @@ private fun ModelDetailContent(
     model: Model,
     selectedVersionIndex: Int,
     onVersionSelected: (Int) -> Unit,
+    onViewImages: () -> Unit,
     contentPadding: PaddingValues,
 ) {
     val selectedVersion = model.modelVersions.getOrNull(selectedVersionIndex)
@@ -206,6 +212,11 @@ private fun ModelDetailContent(
         // Stats row
         item {
             StatsRow(model = model)
+        }
+
+        // View Images button
+        item {
+            ViewImagesButton(onClick = onViewImages)
         }
 
         // Tags
@@ -239,6 +250,22 @@ private fun ModelDetailContent(
                 VersionDetail(version = selectedVersion)
             }
         }
+    }
+}
+
+@Composable
+private fun ViewImagesButton(onClick: () -> Unit) {
+    Button(
+        onClick = onClick,
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp, vertical = 8.dp),
+        colors = ButtonDefaults.buttonColors(
+            containerColor = MaterialTheme.colorScheme.secondaryContainer,
+            contentColor = MaterialTheme.colorScheme.onSecondaryContainer,
+        ),
+    ) {
+        Text("View Community Images")
     }
 }
 

--- a/androidApp/src/main/kotlin/com/omooooori/civitdeck/ui/gallery/ImageGalleryScreen.kt
+++ b/androidApp/src/main/kotlin/com/omooooori/civitdeck/ui/gallery/ImageGalleryScreen.kt
@@ -1,0 +1,296 @@
+package com.omooooori.civitdeck.ui.gallery
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.staggeredgrid.LazyVerticalStaggeredGrid
+import androidx.compose.foundation.lazy.staggeredgrid.StaggeredGridCells
+import androidx.compose.foundation.lazy.staggeredgrid.itemsIndexed
+import androidx.compose.foundation.lazy.staggeredgrid.rememberLazyStaggeredGridState
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.Button
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FilterChip
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Switch
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.derivedStateOf
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import coil3.compose.AsyncImage
+import com.omooooori.civitdeck.domain.model.Image
+import com.omooooori.civitdeck.domain.model.SortOrder
+import com.omooooori.civitdeck.domain.model.TimePeriod
+
+@Composable
+fun ImageGalleryScreen(
+    viewModel: ImageGalleryViewModel,
+    onBack: () -> Unit,
+) {
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+
+    Scaffold(
+        topBar = {
+            ImageGalleryTopBar(onBack = onBack)
+        },
+    ) { padding ->
+        ImageGalleryBody(
+            uiState = uiState,
+            onSortSelected = viewModel::onSortSelected,
+            onPeriodSelected = viewModel::onPeriodSelected,
+            onNsfwToggle = viewModel::onNsfwToggle,
+            onImageClick = viewModel::onImageSelected,
+            onLoadMore = viewModel::loadMore,
+            onRetry = viewModel::retry,
+            contentPadding = padding,
+        )
+    }
+
+    if (uiState.selectedImageIndex != null) {
+        ImageViewerOverlay(
+            images = uiState.images,
+            initialIndex = uiState.selectedImageIndex!!,
+            onDismiss = viewModel::onDismissViewer,
+        )
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun ImageGalleryTopBar(onBack: () -> Unit) {
+    TopAppBar(
+        title = { Text("Images") },
+        navigationIcon = {
+            IconButton(onClick = onBack) {
+                Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+            }
+        },
+    )
+}
+
+@Composable
+private fun ImageGalleryBody(
+    uiState: ImageGalleryUiState,
+    onSortSelected: (SortOrder) -> Unit,
+    onPeriodSelected: (TimePeriod) -> Unit,
+    onNsfwToggle: () -> Unit,
+    onImageClick: (Int) -> Unit,
+    onLoadMore: () -> Unit,
+    onRetry: () -> Unit,
+    contentPadding: PaddingValues,
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(contentPadding),
+    ) {
+        FilterBar(
+            uiState = uiState,
+            onSortSelected = onSortSelected,
+            onPeriodSelected = onPeriodSelected,
+            onNsfwToggle = onNsfwToggle,
+        )
+
+        when {
+            uiState.isLoading -> LoadingState()
+            uiState.error != null && uiState.images.isEmpty() -> {
+                ErrorState(error = uiState.error!!, onRetry = onRetry)
+            }
+            else -> {
+                ImageGrid(
+                    images = uiState.images,
+                    isLoadingMore = uiState.isLoadingMore,
+                    onImageClick = onImageClick,
+                    onLoadMore = onLoadMore,
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun FilterBar(
+    uiState: ImageGalleryUiState,
+    onSortSelected: (SortOrder) -> Unit,
+    onPeriodSelected: (TimePeriod) -> Unit,
+    onNsfwToggle: () -> Unit,
+) {
+    Column(modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp)) {
+        SortFilterRow(
+            selectedSort = uiState.selectedSort,
+            onSortSelected = onSortSelected,
+        )
+        Spacer(modifier = Modifier.height(4.dp))
+        PeriodAndNsfwRow(
+            selectedPeriod = uiState.selectedPeriod,
+            showNsfw = uiState.showNsfw,
+            onPeriodSelected = onPeriodSelected,
+            onNsfwToggle = onNsfwToggle,
+        )
+    }
+}
+
+@Composable
+private fun SortFilterRow(
+    selectedSort: SortOrder,
+    onSortSelected: (SortOrder) -> Unit,
+) {
+    Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+        SortOrder.entries.forEach { sort ->
+            FilterChip(
+                selected = sort == selectedSort,
+                onClick = { onSortSelected(sort) },
+                label = { Text(sort.name, style = MaterialTheme.typography.labelSmall) },
+            )
+        }
+    }
+}
+
+@Composable
+private fun PeriodAndNsfwRow(
+    selectedPeriod: TimePeriod,
+    showNsfw: Boolean,
+    onPeriodSelected: (TimePeriod) -> Unit,
+    onNsfwToggle: () -> Unit,
+) {
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+            TimePeriod.entries.forEach { period ->
+                FilterChip(
+                    selected = period == selectedPeriod,
+                    onClick = { onPeriodSelected(period) },
+                    label = {
+                        Text(period.name, style = MaterialTheme.typography.labelSmall)
+                    },
+                )
+            }
+        }
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(4.dp),
+        ) {
+            Text("NSFW", style = MaterialTheme.typography.labelSmall)
+            Switch(checked = showNsfw, onCheckedChange = { onNsfwToggle() })
+        }
+    }
+}
+
+@Composable
+private fun LoadingState() {
+    Box(
+        modifier = Modifier.fillMaxSize(),
+        contentAlignment = Alignment.Center,
+    ) {
+        CircularProgressIndicator()
+    }
+}
+
+@Composable
+private fun ErrorState(error: String, onRetry: () -> Unit) {
+    Box(
+        modifier = Modifier.fillMaxSize(),
+        contentAlignment = Alignment.Center,
+    ) {
+        Column(horizontalAlignment = Alignment.CenterHorizontally) {
+            Text(text = error, color = MaterialTheme.colorScheme.error)
+            Spacer(modifier = Modifier.height(16.dp))
+            Button(onClick = onRetry) { Text("Retry") }
+        }
+    }
+}
+
+@Composable
+private fun ImageGrid(
+    images: List<Image>,
+    isLoadingMore: Boolean,
+    onImageClick: (Int) -> Unit,
+    onLoadMore: () -> Unit,
+) {
+    val gridState = rememberLazyStaggeredGridState()
+
+    val shouldLoadMore by remember {
+        derivedStateOf {
+            val lastVisibleItem = gridState.layoutInfo.visibleItemsInfo.lastOrNull()
+            lastVisibleItem != null && lastVisibleItem.index >= images.size - LOAD_MORE_THRESHOLD
+        }
+    }
+
+    LaunchedEffect(shouldLoadMore) {
+        if (shouldLoadMore) onLoadMore()
+    }
+
+    LazyVerticalStaggeredGrid(
+        columns = StaggeredGridCells.Fixed(2),
+        state = gridState,
+        contentPadding = PaddingValues(8.dp),
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+        verticalItemSpacing = 8.dp,
+        modifier = Modifier.fillMaxSize(),
+    ) {
+        itemsIndexed(images, key = { _, image -> image.id }) { index, image ->
+            ImageGridItem(
+                image = image,
+                onClick = { onImageClick(index) },
+            )
+        }
+        if (isLoadingMore) {
+            item {
+                Box(
+                    modifier = Modifier.fillMaxWidth().padding(16.dp),
+                    contentAlignment = Alignment.Center,
+                ) {
+                    CircularProgressIndicator()
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun ImageGridItem(image: Image, onClick: () -> Unit) {
+    val aspectRatio = if (image.width > 0 && image.height > 0) {
+        image.width.toFloat() / image.height.toFloat()
+    } else {
+        1f
+    }
+
+    AsyncImage(
+        model = image.url,
+        contentDescription = null,
+        contentScale = ContentScale.Crop,
+        modifier = Modifier
+            .fillMaxWidth()
+            .aspectRatio(aspectRatio)
+            .clip(MaterialTheme.shapes.medium)
+            .clickable(onClick = onClick),
+    )
+}
+
+private const val LOAD_MORE_THRESHOLD = 6

--- a/androidApp/src/main/kotlin/com/omooooori/civitdeck/ui/gallery/ImageGalleryViewModel.kt
+++ b/androidApp/src/main/kotlin/com/omooooori/civitdeck/ui/gallery/ImageGalleryViewModel.kt
@@ -1,0 +1,149 @@
+package com.omooooori.civitdeck.ui.gallery
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.omooooori.civitdeck.domain.model.Image
+import com.omooooori.civitdeck.domain.model.NsfwLevel
+import com.omooooori.civitdeck.domain.model.SortOrder
+import com.omooooori.civitdeck.domain.model.TimePeriod
+import com.omooooori.civitdeck.domain.usecase.GetImagesUseCase
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+
+data class ImageGalleryUiState(
+    val images: List<Image> = emptyList(),
+    val selectedSort: SortOrder = SortOrder.HighestRated,
+    val selectedPeriod: TimePeriod = TimePeriod.AllTime,
+    val showNsfw: Boolean = false,
+    val isLoading: Boolean = false,
+    val isLoadingMore: Boolean = false,
+    val error: String? = null,
+    val nextCursor: String? = null,
+    val hasMore: Boolean = true,
+    val selectedImageIndex: Int? = null,
+)
+
+class ImageGalleryViewModel(
+    private val modelId: Long,
+    private val getImagesUseCase: GetImagesUseCase,
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow(ImageGalleryUiState())
+    val uiState: StateFlow<ImageGalleryUiState> = _uiState.asStateFlow()
+
+    private var loadJob: Job? = null
+
+    init {
+        loadImages()
+    }
+
+    fun onSortSelected(sort: SortOrder) {
+        loadJob?.cancel()
+        _uiState.update {
+            it.copy(
+                selectedSort = sort,
+                nextCursor = null,
+                images = emptyList(),
+                hasMore = true,
+            )
+        }
+        loadImages()
+    }
+
+    fun onPeriodSelected(period: TimePeriod) {
+        loadJob?.cancel()
+        _uiState.update {
+            it.copy(
+                selectedPeriod = period,
+                nextCursor = null,
+                images = emptyList(),
+                hasMore = true,
+            )
+        }
+        loadImages()
+    }
+
+    fun onNsfwToggle() {
+        loadJob?.cancel()
+        _uiState.update {
+            it.copy(
+                showNsfw = !it.showNsfw,
+                nextCursor = null,
+                images = emptyList(),
+                hasMore = true,
+            )
+        }
+        loadImages()
+    }
+
+    fun loadMore() {
+        val state = _uiState.value
+        if (state.isLoading || state.isLoadingMore || !state.hasMore) return
+        loadImages(isLoadMore = true)
+    }
+
+    fun onImageSelected(index: Int) {
+        _uiState.update { it.copy(selectedImageIndex = index) }
+    }
+
+    fun onDismissViewer() {
+        _uiState.update { it.copy(selectedImageIndex = null) }
+    }
+
+    fun retry() {
+        loadImages()
+    }
+
+    private fun loadImages(isLoadMore: Boolean = false) {
+        loadJob = viewModelScope.launch {
+            _uiState.update {
+                if (isLoadMore) {
+                    it.copy(isLoadingMore = true)
+                } else {
+                    it.copy(isLoading = true)
+                }
+            }
+            try {
+                val state = _uiState.value
+                val nsfwLevel = if (state.showNsfw) NsfwLevel.Soft else NsfwLevel.None
+                val result = getImagesUseCase(
+                    modelId = modelId,
+                    sort = state.selectedSort,
+                    period = state.selectedPeriod,
+                    nsfwLevel = nsfwLevel,
+                    cursor = if (isLoadMore) state.nextCursor else null,
+                    limit = PAGE_SIZE,
+                )
+                _uiState.update {
+                    it.copy(
+                        images = if (isLoadMore) it.images + result.items else result.items,
+                        isLoading = false,
+                        isLoadingMore = false,
+                        error = null,
+                        nextCursor = result.metadata.nextCursor,
+                        hasMore = result.metadata.nextCursor != null,
+                    )
+                }
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                _uiState.update {
+                    it.copy(
+                        isLoading = false,
+                        isLoadingMore = false,
+                        error = e.message ?: "Unknown error",
+                    )
+                }
+            }
+        }
+    }
+
+    companion object {
+        private const val PAGE_SIZE = 20
+    }
+}

--- a/androidApp/src/main/kotlin/com/omooooori/civitdeck/ui/gallery/ImageViewerOverlay.kt
+++ b/androidApp/src/main/kotlin/com/omooooori/civitdeck/ui/gallery/ImageViewerOverlay.kt
@@ -1,0 +1,174 @@
+package com.omooooori.civitdeck.ui.gallery
+
+import androidx.activity.compose.BackHandler
+import androidx.compose.foundation.background
+import androidx.compose.foundation.gestures.detectTapGestures
+import androidx.compose.foundation.gestures.rememberTransformableState
+import androidx.compose.foundation.gestures.transformable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.pager.HorizontalPager
+import androidx.compose.foundation.pager.rememberPagerState
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.Info
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.IconButtonDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.unit.dp
+import coil3.compose.AsyncImage
+import com.omooooori.civitdeck.domain.model.Image
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun ImageViewerOverlay(
+    images: List<Image>,
+    initialIndex: Int,
+    onDismiss: () -> Unit,
+) {
+    BackHandler(onBack = onDismiss)
+
+    val pagerState = rememberPagerState(initialPage = initialIndex) { images.size }
+    var showMetadata by remember { mutableStateOf(false) }
+    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(Color.Black),
+    ) {
+        ImagePager(
+            images = images,
+            pagerState = pagerState,
+        )
+
+        ViewerControls(
+            onDismiss = onDismiss,
+            onInfoClick = { showMetadata = true },
+            hasMetadata = images.getOrNull(pagerState.currentPage)?.meta != null,
+        )
+    }
+
+    if (showMetadata) {
+        val currentImage = images.getOrNull(pagerState.currentPage)
+        currentImage?.meta?.let { meta ->
+            MetadataBottomSheet(
+                meta = meta,
+                sheetState = sheetState,
+                onDismiss = { showMetadata = false },
+            )
+        }
+    }
+}
+
+@Composable
+private fun ImagePager(
+    images: List<Image>,
+    pagerState: androidx.compose.foundation.pager.PagerState,
+) {
+    HorizontalPager(
+        state = pagerState,
+        modifier = Modifier.fillMaxSize(),
+    ) { page ->
+        ZoomableImage(imageUrl = images[page].url)
+    }
+}
+
+@Composable
+private fun ViewerControls(
+    onDismiss: () -> Unit,
+    onInfoClick: () -> Unit,
+    hasMetadata: Boolean,
+) {
+    Box(modifier = Modifier.fillMaxSize()) {
+        IconButton(
+            onClick = onDismiss,
+            modifier = Modifier
+                .align(Alignment.TopStart)
+                .padding(16.dp),
+            colors = IconButtonDefaults.iconButtonColors(
+                contentColor = Color.White,
+            ),
+        ) {
+            Icon(Icons.Default.Close, contentDescription = "Close")
+        }
+
+        if (hasMetadata) {
+            IconButton(
+                onClick = onInfoClick,
+                modifier = Modifier
+                    .align(Alignment.BottomEnd)
+                    .padding(16.dp),
+                colors = IconButtonDefaults.iconButtonColors(
+                    containerColor = MaterialTheme.colorScheme.surface.copy(alpha = 0.7f),
+                    contentColor = MaterialTheme.colorScheme.onSurface,
+                ),
+            ) {
+                Icon(Icons.Default.Info, contentDescription = "Metadata")
+            }
+        }
+    }
+}
+
+@Composable
+private fun ZoomableImage(imageUrl: String) {
+    var scale by remember { mutableFloatStateOf(1f) }
+    var offset by remember { mutableStateOf(Offset.Zero) }
+
+    val transformableState = rememberTransformableState { zoomChange, panChange, _ ->
+        scale = (scale * zoomChange).coerceIn(MIN_ZOOM, MAX_ZOOM)
+        offset = if (scale > 1f) {
+            offset + panChange
+        } else {
+            Offset.Zero
+        }
+    }
+
+    AsyncImage(
+        model = imageUrl,
+        contentDescription = null,
+        contentScale = ContentScale.Fit,
+        modifier = Modifier
+            .fillMaxSize()
+            .pointerInput(Unit) {
+                detectTapGestures(
+                    onDoubleTap = {
+                        if (scale > 1f) {
+                            scale = 1f
+                            offset = Offset.Zero
+                        } else {
+                            scale = DOUBLE_TAP_ZOOM
+                        }
+                    },
+                )
+            }
+            .transformable(state = transformableState)
+            .graphicsLayer(
+                scaleX = scale,
+                scaleY = scale,
+                translationX = offset.x,
+                translationY = offset.y,
+            ),
+    )
+}
+
+private const val MIN_ZOOM = 0.5f
+private const val MAX_ZOOM = 5f
+private const val DOUBLE_TAP_ZOOM = 2.5f

--- a/androidApp/src/main/kotlin/com/omooooori/civitdeck/ui/gallery/MetadataBottomSheet.kt
+++ b/androidApp/src/main/kotlin/com/omooooori/civitdeck/ui/gallery/MetadataBottomSheet.kt
@@ -1,0 +1,144 @@
+package com.omooooori.civitdeck.ui.gallery
+
+import android.content.ClipData
+import android.content.ClipboardManager
+import android.content.Context
+import android.widget.Toast
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.SheetState
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import com.omooooori.civitdeck.domain.model.ImageGenerationMeta
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun MetadataBottomSheet(
+    meta: ImageGenerationMeta,
+    sheetState: SheetState,
+    onDismiss: () -> Unit,
+) {
+    val context = LocalContext.current
+
+    ModalBottomSheet(
+        onDismissRequest = onDismiss,
+        sheetState = sheetState,
+    ) {
+        MetadataContent(meta = meta, context = context)
+    }
+}
+
+@Composable
+private fun MetadataContent(
+    meta: ImageGenerationMeta,
+    context: Context,
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp, vertical = 8.dp)
+            .padding(bottom = 32.dp),
+    ) {
+        Text(
+            text = "Generation Info",
+            style = MaterialTheme.typography.titleMedium,
+            fontWeight = FontWeight.Bold,
+        )
+        Spacer(modifier = Modifier.height(12.dp))
+
+        PromptSection(meta = meta, context = context)
+        MetadataParams(meta = meta)
+    }
+}
+
+@Composable
+private fun PromptSection(
+    meta: ImageGenerationMeta,
+    context: Context,
+) {
+    meta.prompt?.let { prompt ->
+        MetadataLabel("Prompt")
+        Text(
+            text = prompt,
+            style = MaterialTheme.typography.bodySmall,
+        )
+        Spacer(modifier = Modifier.height(8.dp))
+        OutlinedButton(
+            onClick = { copyToClipboard(context, "Prompt", prompt) },
+        ) {
+            Text("Copy Prompt")
+        }
+        Spacer(modifier = Modifier.height(8.dp))
+    }
+    meta.negativePrompt?.let { negPrompt ->
+        MetadataLabel("Negative Prompt")
+        Text(
+            text = negPrompt,
+            style = MaterialTheme.typography.bodySmall,
+        )
+        Spacer(modifier = Modifier.height(8.dp))
+    }
+    if (meta.prompt != null || meta.negativePrompt != null) {
+        HorizontalDivider(modifier = Modifier.padding(vertical = 8.dp))
+    }
+}
+
+@Composable
+private fun MetadataParams(meta: ImageGenerationMeta) {
+    meta.model?.let { MetadataRow("Model", it) }
+    meta.sampler?.let { MetadataRow("Sampler", it) }
+    meta.steps?.let { MetadataRow("Steps", it.toString()) }
+    meta.cfgScale?.let { MetadataRow("CFG Scale", it.toString()) }
+    meta.seed?.let { MetadataRow("Seed", it.toString()) }
+    meta.size?.let { MetadataRow("Size", it) }
+}
+
+@Composable
+private fun MetadataLabel(label: String) {
+    Text(
+        text = label,
+        style = MaterialTheme.typography.labelMedium,
+        color = MaterialTheme.colorScheme.primary,
+    )
+    Spacer(modifier = Modifier.height(4.dp))
+}
+
+@Composable
+private fun MetadataRow(label: String, value: String) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(vertical = 4.dp),
+        horizontalArrangement = Arrangement.SpaceBetween,
+    ) {
+        Text(
+            text = label,
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        Text(
+            text = value,
+            style = MaterialTheme.typography.bodyMedium,
+        )
+    }
+}
+
+private fun copyToClipboard(context: Context, label: String, text: String) {
+    val clipboard = context.getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
+    clipboard.setPrimaryClip(ClipData.newPlainText(label, text))
+    Toast.makeText(context, "Copied to clipboard", Toast.LENGTH_SHORT).show()
+}

--- a/androidApp/src/main/kotlin/com/omooooori/civitdeck/ui/navigation/CivitDeckNavGraph.kt
+++ b/androidApp/src/main/kotlin/com/omooooori/civitdeck/ui/navigation/CivitDeckNavGraph.kt
@@ -9,6 +9,8 @@ import androidx.navigation3.runtime.rememberSaveableStateHolderNavEntryDecorator
 import androidx.navigation3.ui.NavDisplay
 import com.omooooori.civitdeck.ui.detail.ModelDetailScreen
 import com.omooooori.civitdeck.ui.detail.ModelDetailViewModel
+import com.omooooori.civitdeck.ui.gallery.ImageGalleryScreen
+import com.omooooori.civitdeck.ui.gallery.ImageGalleryViewModel
 import com.omooooori.civitdeck.ui.search.ModelSearchScreen
 import com.omooooori.civitdeck.ui.search.ModelSearchViewModel
 import org.koin.compose.viewmodel.koinViewModel
@@ -17,6 +19,8 @@ import org.koin.core.parameter.parametersOf
 data object SearchRoute
 
 data class DetailRoute(val modelId: Long)
+
+data class ImageGalleryRoute(val modelId: Long)
 
 @Composable
 fun CivitDeckNavGraph() {
@@ -42,6 +46,16 @@ fun CivitDeckNavGraph() {
                     key = key.modelId.toString(),
                 ) { parametersOf(key.modelId) }
                 ModelDetailScreen(
+                    viewModel = viewModel,
+                    onBack = { backStack.removeLastOrNull() },
+                    onViewImages = { backStack.add(ImageGalleryRoute(key.modelId)) },
+                )
+            }
+            entry<ImageGalleryRoute> { key ->
+                val viewModel: ImageGalleryViewModel = koinViewModel(
+                    key = "gallery_${key.modelId}",
+                ) { parametersOf(key.modelId) }
+                ImageGalleryScreen(
                     viewModel = viewModel,
                     onBack = { backStack.removeLastOrNull() },
                 )

--- a/shared/src/commonMain/kotlin/com/omooooori/civitdeck/di/DomainModule.kt
+++ b/shared/src/commonMain/kotlin/com/omooooori/civitdeck/di/DomainModule.kt
@@ -1,5 +1,6 @@
 package com.omooooori.civitdeck.di
 
+import com.omooooori.civitdeck.domain.usecase.GetImagesUseCase
 import com.omooooori.civitdeck.domain.usecase.GetModelDetailUseCase
 import com.omooooori.civitdeck.domain.usecase.GetModelsUseCase
 import com.omooooori.civitdeck.domain.usecase.ObserveFavoritesUseCase
@@ -10,6 +11,7 @@ import org.koin.dsl.module
 val domainModule = module {
     factory { GetModelsUseCase(get()) }
     factory { GetModelDetailUseCase(get()) }
+    factory { GetImagesUseCase(get()) }
     factory { ToggleFavoriteUseCase(get()) }
     factory { ObserveFavoritesUseCase(get()) }
     factory { ObserveIsFavoriteUseCase(get()) }

--- a/shared/src/commonMain/kotlin/com/omooooori/civitdeck/domain/usecase/GetImagesUseCase.kt
+++ b/shared/src/commonMain/kotlin/com/omooooori/civitdeck/domain/usecase/GetImagesUseCase.kt
@@ -1,0 +1,30 @@
+package com.omooooori.civitdeck.domain.usecase
+
+import com.omooooori.civitdeck.domain.model.Image
+import com.omooooori.civitdeck.domain.model.NsfwLevel
+import com.omooooori.civitdeck.domain.model.PaginatedResult
+import com.omooooori.civitdeck.domain.model.SortOrder
+import com.omooooori.civitdeck.domain.model.TimePeriod
+import com.omooooori.civitdeck.domain.repository.ImageRepository
+
+class GetImagesUseCase(private val repository: ImageRepository) {
+    suspend operator fun invoke(
+        modelId: Long? = null,
+        modelVersionId: Long? = null,
+        username: String? = null,
+        sort: SortOrder? = null,
+        period: TimePeriod? = null,
+        nsfwLevel: NsfwLevel? = null,
+        limit: Int? = null,
+        cursor: String? = null,
+    ): PaginatedResult<Image> = repository.getImages(
+        modelId = modelId,
+        modelVersionId = modelVersionId,
+        username = username,
+        sort = sort,
+        period = period,
+        nsfwLevel = nsfwLevel,
+        limit = limit,
+        cursor = cursor,
+    )
+}


### PR DESCRIPTION
## Description

Add image gallery screen accessible from model detail screen. Features:
- Staggered grid layout (`LazyVerticalStaggeredGrid`) showing community images
- Full-screen image viewer with pinch-to-zoom and double-tap zoom
- HorizontalPager for swiping between images in viewer
- Metadata bottom sheet showing generation parameters (prompt, negative prompt, model, sampler, steps, CFG scale, seed, size)
- Copy prompt to clipboard
- Filter controls: sort order, time period, NSFW toggle
- Cursor-based infinite scroll pagination

## Related Issues

Closes #6

## Screenshots / Video

<!-- If applicable, add screenshots or screen recordings -->

## Test Plan

- [ ] Model detail screen → "View Community Images" → gallery screen
- [ ] Staggered grid displays images with correct aspect ratios
- [ ] Sort/Period/NSFW filter controls work
- [ ] Infinite scroll loads more images
- [ ] Tap image → full-screen viewer
- [ ] Pinch-to-zoom and double-tap zoom
- [ ] Swipe between images
- [ ] Info button → metadata bottom sheet
- [ ] Copy Prompt copies to clipboard
- [ ] Back navigation works correctly

## Review Checklist

- [x] Code follows project architecture (Clean Architecture + MVVM)
- [x] Shared logic is in `commonMain`, platform-specific code only when necessary
- [x] No unnecessary dependencies added
- [ ] Tests added/updated as needed

## Breaking Changes

None