### PR TITLE
Add iOS model search & detail screens

### DIFF
--- a/iosApp/iosApp.xcodeproj/project.pbxproj
+++ b/iosApp/iosApp.xcodeproj/project.pbxproj
@@ -14,6 +14,8 @@
 		CD0002012D000002000CD001 /* ModelSearchViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD0002002D000002000CD001 /* ModelSearchViewModel.swift */; };
 		CD0002032D000002000CD001 /* ModelSearchScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD0002022D000002000CD001 /* ModelSearchScreen.swift */; };
 		CD0002052D000002000CD001 /* ModelCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD0002042D000002000CD001 /* ModelCardView.swift */; };
+		CD0004012D000004000CD001 /* ModelDetailViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD0004002D000004000CD001 /* ModelDetailViewModel.swift */; };
+		CD0004032D000004000CD001 /* ModelDetailScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD0004022D000004000CD001 /* ModelDetailScreen.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -27,6 +29,8 @@
 		CD0002002D000002000CD001 /* ModelSearchViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModelSearchViewModel.swift; sourceTree = "<group>"; };
 		CD0002022D000002000CD001 /* ModelSearchScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModelSearchScreen.swift; sourceTree = "<group>"; };
 		CD0002042D000002000CD001 /* ModelCardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModelCardView.swift; sourceTree = "<group>"; };
+		CD0004002D000004000CD001 /* ModelDetailViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModelDetailViewModel.swift; sourceTree = "<group>"; };
+		CD0004022D000004000CD001 /* ModelDetailScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModelDetailScreen.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -98,8 +102,18 @@
 			isa = PBXGroup;
 			children = (
 				CD0003012D000003000CD001 /* Search */,
+				CD0004042D000004000CD001 /* Detail */,
 			);
 			path = Features;
+			sourceTree = "<group>";
+		};
+		CD0004042D000004000CD001 /* Detail */ = {
+			isa = PBXGroup;
+			children = (
+				CD0004002D000004000CD001 /* ModelDetailViewModel.swift */,
+				CD0004022D000004000CD001 /* ModelDetailScreen.swift */,
+			);
+			path = Detail;
 			sourceTree = "<group>";
 		};
 		CD0003012D000003000CD001 /* Search */ = {
@@ -210,6 +224,8 @@
 				CD0002012D000002000CD001 /* ModelSearchViewModel.swift in Sources */,
 				CD0002032D000002000CD001 /* ModelSearchScreen.swift in Sources */,
 				CD0002052D000002000CD001 /* ModelCardView.swift in Sources */,
+				CD0004012D000004000CD001 /* ModelDetailViewModel.swift in Sources */,
+				CD0004032D000004000CD001 /* ModelDetailScreen.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/iosApp/iosApp/Features/Detail/ModelDetailScreen.swift
+++ b/iosApp/iosApp/Features/Detail/ModelDetailScreen.swift
@@ -1,0 +1,388 @@
+import SwiftUI
+import Shared
+
+struct ModelDetailScreen: View {
+    @StateObject private var viewModel: ModelDetailViewModel
+
+    init(modelId: Int64) {
+        _viewModel = StateObject(wrappedValue: ModelDetailViewModel(modelId: modelId))
+    }
+
+    var body: some View {
+        Group {
+            if viewModel.isLoading && viewModel.model == nil {
+                ProgressView()
+            } else if let error = viewModel.error, viewModel.model == nil {
+                errorView(message: error)
+            } else if let model = viewModel.model {
+                modelContent(model: model)
+            }
+        }
+        .navigationTitle(viewModel.model?.name ?? "")
+        .navigationBarTitleDisplayMode(.inline)
+        .task {
+            await viewModel.observeFavorite()
+        }
+        .toolbar {
+            ToolbarItem(placement: .navigationBarTrailing) {
+                if let model = viewModel.model,
+                   let url = URL(string: "https://civitai.com/models/\(model.id)") {
+                    ShareLink(item: url) {
+                        Image(systemName: "square.and.arrow.up")
+                    }
+                }
+            }
+            ToolbarItem(placement: .navigationBarTrailing) {
+                Button {
+                    viewModel.onFavoriteToggle()
+                } label: {
+                    Image(systemName: viewModel.isFavorite ? "heart.fill" : "heart")
+                        .foregroundColor(viewModel.isFavorite ? .red : .primary)
+                }
+            }
+        }
+    }
+
+    // MARK: - Content
+
+    private func modelContent(model: Model) -> some View {
+        ScrollView {
+            VStack(spacing: 16) {
+                imageCarousel(model: model)
+                modelHeader(model: model)
+                statsRow(model: model)
+                viewImagesButton
+                tagsSection(tags: model.tags)
+                descriptionSection(description: model.description_)
+                versionSelector(model: model)
+                versionDetail
+            }
+        }
+    }
+
+    // MARK: - Image Carousel
+
+    private func imageCarousel(model: Model) -> some View {
+        let images = viewModel.selectedVersion?.images ?? []
+        return Group {
+            if !images.isEmpty {
+                TabView {
+                    ForEach(Array(images.enumerated()), id: \.offset) { _, image in
+                        if let url = URL(string: image.url) {
+                            AsyncImage(url: url) { phase in
+                                switch phase {
+                                case .success(let img):
+                                    img
+                                        .resizable()
+                                        .scaledToFill()
+                                case .failure:
+                                    imagePlaceholder
+                                case .empty:
+                                    ProgressView()
+                                @unknown default:
+                                    imagePlaceholder
+                                }
+                            }
+                            .frame(maxWidth: .infinity)
+                            .aspectRatio(1, contentMode: .fit)
+                            .clipped()
+                        }
+                    }
+                }
+                .tabViewStyle(.page(indexDisplayMode: .automatic))
+                .frame(height: UIScreen.main.bounds.width)
+            }
+        }
+    }
+
+    private var imagePlaceholder: some View {
+        Rectangle()
+            .fill(Color(.systemGray5))
+            .overlay {
+                Image(systemName: "photo")
+                    .foregroundColor(.secondary)
+            }
+    }
+
+    // MARK: - Model Header
+
+    private func modelHeader(model: Model) -> some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text(model.name)
+                .font(.title2)
+                .fontWeight(.bold)
+
+            HStack(spacing: 8) {
+                Text(model.type.name)
+                    .font(.caption)
+                    .padding(.horizontal, 8)
+                    .padding(.vertical, 4)
+                    .background(Color(.systemGray5))
+                    .clipShape(Capsule())
+
+                if let creator = model.creator {
+                    Text("by \(creator.username)")
+                        .font(.subheadline)
+                        .foregroundColor(.secondary)
+                }
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(.horizontal, 16)
+    }
+
+    // MARK: - Stats Row
+
+    private func statsRow(model: Model) -> some View {
+        HStack {
+            statColumn(
+                value: FormatUtils.shared.formatCount(count: model.stats.downloadCount),
+                label: "Downloads"
+            )
+            Spacer()
+            statColumn(
+                value: FormatUtils.shared.formatCount(count: model.stats.favoriteCount),
+                label: "Favorites"
+            )
+            Spacer()
+            statColumn(
+                value: FormatUtils.shared.formatRating(rating: model.stats.rating),
+                label: "Rating"
+            )
+            Spacer()
+            statColumn(
+                value: FormatUtils.shared.formatCount(count: model.stats.commentCount),
+                label: "Comments"
+            )
+        }
+        .padding(.horizontal, 16)
+    }
+
+    private func statColumn(value: String, label: String) -> some View {
+        VStack(spacing: 2) {
+            Text(value)
+                .font(.headline)
+            Text(label)
+                .font(.caption)
+                .foregroundColor(.secondary)
+        }
+    }
+
+    // MARK: - View Images Button
+
+    private var viewImagesButton: some View {
+        Button {
+            // Will navigate to image gallery in future issue
+        } label: {
+            Text("View Community Images")
+                .frame(maxWidth: .infinity)
+        }
+        .buttonStyle(.bordered)
+        .padding(.horizontal, 16)
+    }
+
+    // MARK: - Tags Section
+
+    @ViewBuilder
+    private func tagsSection(tags: [String]) -> some View {
+        if !tags.isEmpty {
+            VStack(alignment: .leading, spacing: 8) {
+                Text("Tags")
+                    .font(.subheadline)
+                    .fontWeight(.semibold)
+
+                WrappingHStack(tags: tags)
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(.horizontal, 16)
+        }
+    }
+
+    // MARK: - Description Section
+
+    @ViewBuilder
+    private func descriptionSection(description: String?) -> some View {
+        if let description, !description.isEmpty {
+            VStack(alignment: .leading, spacing: 8) {
+                Divider()
+                Text("Description")
+                    .font(.subheadline)
+                    .fontWeight(.semibold)
+                Text(htmlToPlainText(description))
+                    .font(.body)
+                    .foregroundColor(.secondary)
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(.horizontal, 16)
+        }
+    }
+
+    // MARK: - Version Selector
+
+    @ViewBuilder
+    private func versionSelector(model: Model) -> some View {
+        let versions = model.modelVersions
+        if versions.count > 1 {
+            VStack(alignment: .leading, spacing: 8) {
+                Divider()
+                    .padding(.horizontal, 16)
+
+                Text("Versions")
+                    .font(.subheadline)
+                    .fontWeight(.semibold)
+                    .padding(.horizontal, 16)
+
+                ScrollView(.horizontal, showsIndicators: false) {
+                    HStack(spacing: 8) {
+                        ForEach(Array(versions.enumerated()), id: \.offset) { index, version in
+                            Button {
+                                viewModel.onVersionSelected(index)
+                            } label: {
+                                Text(version.name)
+                                    .font(.caption)
+                                    .fontWeight(index == viewModel.selectedVersionIndex ? .semibold : .regular)
+                                    .padding(.horizontal, 12)
+                                    .padding(.vertical, 6)
+                                    .background(
+                                        index == viewModel.selectedVersionIndex
+                                            ? Color.accentColor.opacity(0.2)
+                                            : Color(.systemGray5)
+                                    )
+                                    .foregroundColor(
+                                        index == viewModel.selectedVersionIndex
+                                            ? .accentColor : .primary
+                                    )
+                                    .clipShape(Capsule())
+                            }
+                        }
+                    }
+                    .padding(.horizontal, 16)
+                }
+            }
+        }
+    }
+
+    // MARK: - Version Detail
+
+    @ViewBuilder
+    private var versionDetail: some View {
+        if let version = viewModel.selectedVersion {
+            VStack(alignment: .leading, spacing: 8) {
+                if let baseModel = version.baseModel {
+                    HStack {
+                        Text("Base Model")
+                            .foregroundColor(.secondary)
+                        Spacer()
+                        Text(baseModel)
+                    }
+                    .font(.subheadline)
+                }
+
+                let trainedWords = version.trainedWords
+                if !trainedWords.isEmpty {
+                    Text("Trained Words")
+                        .font(.subheadline)
+                        .fontWeight(.semibold)
+                    Text(trainedWords.joined(separator: ", "))
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                }
+
+                let files = version.files
+                if !files.isEmpty {
+                    Text("Files")
+                        .font(.subheadline)
+                        .fontWeight(.semibold)
+                        .padding(.top, 4)
+
+                    ForEach(Array(files.enumerated()), id: \.offset) { _, file in
+                        fileInfoRow(file: file)
+                    }
+                }
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(.horizontal, 16)
+            .padding(.bottom, 16)
+        }
+    }
+
+    private func fileInfoRow(file: ModelFile) -> some View {
+        VStack(alignment: .leading, spacing: 2) {
+            Text(file.name)
+                .font(.caption)
+                .lineLimit(1)
+
+            HStack(spacing: 8) {
+                Text(FormatUtils.shared.formatFileSize(sizeKB: file.sizeKB))
+                    .font(.caption2)
+                    .foregroundColor(.secondary)
+                if let format = file.format {
+                    Text(format)
+                        .font(.caption2)
+                        .foregroundColor(.secondary)
+                }
+                if let fp = file.fp {
+                    Text(fp)
+                        .font(.caption2)
+                        .foregroundColor(.secondary)
+                }
+            }
+        }
+        .padding(.vertical, 2)
+    }
+
+    // MARK: - Error View
+
+    private func errorView(message: String) -> some View {
+        VStack(spacing: 16) {
+            Text(message)
+                .foregroundColor(.red)
+                .multilineTextAlignment(.center)
+            Button("Retry") {
+                viewModel.retry()
+            }
+            .buttonStyle(.bordered)
+        }
+        .padding()
+    }
+
+    // MARK: - Helpers
+
+    private func htmlToPlainText(_ html: String) -> String {
+        guard let data = html.data(using: .utf8),
+              let attributedString = try? NSAttributedString(
+                data: data,
+                options: [
+                    .documentType: NSAttributedString.DocumentType.html,
+                    .characterEncoding: String.Encoding.utf8.rawValue,
+                ],
+                documentAttributes: nil
+              ) else {
+            return html
+        }
+        return attributedString.string
+    }
+}
+
+// MARK: - Wrapping HStack for Tags
+
+private struct WrappingHStack: View {
+    let tags: [String]
+
+    var body: some View {
+        LazyVGrid(
+            columns: [GridItem(.adaptive(minimum: 80), spacing: 8)],
+            alignment: .leading,
+            spacing: 8
+        ) {
+            ForEach(tags, id: \.self) { tag in
+                Text(tag)
+                    .font(.caption)
+                    .padding(.horizontal, 10)
+                    .padding(.vertical, 4)
+                    .background(Color(.systemGray5))
+                    .clipShape(Capsule())
+            }
+        }
+    }
+}

--- a/iosApp/iosApp/Features/Detail/ModelDetailViewModel.swift
+++ b/iosApp/iosApp/Features/Detail/ModelDetailViewModel.swift
@@ -1,0 +1,71 @@
+import Foundation
+import Shared
+
+@MainActor
+final class ModelDetailViewModel: ObservableObject {
+    @Published var model: Model?
+    @Published var isFavorite: Bool = false
+    @Published var isLoading: Bool = true
+    @Published var error: String?
+    @Published var selectedVersionIndex: Int = 0
+
+    private let modelId: Int64
+    private let getModelDetailUseCase: GetModelDetailUseCase
+    private let observeIsFavoriteUseCase: ObserveIsFavoriteUseCase
+    private let toggleFavoriteUseCase: ToggleFavoriteUseCase
+
+    var selectedVersion: ModelVersion? {
+        guard let model else { return nil }
+        let versions = model.modelVersions
+        guard selectedVersionIndex < versions.count else { return nil }
+        return versions[selectedVersionIndex]
+    }
+
+    init(modelId: Int64) {
+        self.modelId = modelId
+        self.getModelDetailUseCase = KoinHelper.shared.getModelDetailUseCase()
+        self.observeIsFavoriteUseCase = KoinHelper.shared.getObserveIsFavoriteUseCase()
+        self.toggleFavoriteUseCase = KoinHelper.shared.getToggleFavoriteUseCase()
+        loadModel()
+    }
+
+    /// Called from SwiftUI .task modifier — observes favorite state reactively via SKIE Flow.
+    func observeFavorite() async {
+        let flow = SkieSwiftFlow<KotlinBoolean>(observeIsFavoriteUseCase.invoke(modelId: modelId))
+        for await value in flow {
+            isFavorite = value.boolValue
+        }
+    }
+
+    func onFavoriteToggle() {
+        guard let model else { return }
+        Task {
+            try? await toggleFavoriteUseCase.invoke(model: model)
+        }
+    }
+
+    func onVersionSelected(_ index: Int) {
+        selectedVersionIndex = index
+    }
+
+    func retry() {
+        loadModel()
+    }
+
+    private func loadModel() {
+        Task {
+            isLoading = true
+            error = nil
+            do {
+                let result = try await getModelDetailUseCase.invoke(modelId: modelId)
+                model = result
+                isLoading = false
+            } catch is CancellationError {
+                return
+            } catch {
+                self.error = error.localizedDescription
+                isLoading = false
+            }
+        }
+    }
+}

--- a/iosApp/iosApp/Features/Search/ModelSearchScreen.swift
+++ b/iosApp/iosApp/Features/Search/ModelSearchScreen.swift
@@ -31,6 +31,9 @@ struct ModelSearchScreen: View {
             .navigationTitle("CivitDeck")
             .navigationBarTitleDisplayMode(.inline)
             .toolbarBackground(.visible, for: .navigationBar)
+            .navigationDestination(for: Int64.self) { modelId in
+                ModelDetailScreen(modelId: modelId)
+            }
         }
     }
 
@@ -65,12 +68,15 @@ struct ModelSearchScreen: View {
         ScrollView {
             LazyVGrid(columns: columns, spacing: 12) {
                 ForEach(Array(viewModel.models.enumerated()), id: \.element.id) { index, model in
-                    ModelCardView(model: model)
-                        .onAppear {
-                            if index == viewModel.models.count - 3 {
-                                viewModel.loadMore()
-                            }
+                    NavigationLink(value: model.id) {
+                        ModelCardView(model: model)
+                    }
+                    .buttonStyle(.plain)
+                    .onAppear {
+                        if index == viewModel.models.count - 3 {
+                            viewModel.loadMore()
                         }
+                    }
                 }
             }
             .padding(.horizontal, 12)


### PR DESCRIPTION
## Description

Implement model search and detail screens for iOS (SwiftUI), providing feature parity with the Android version.

**Search screen:**
- 2-column grid display of models
- Text search and model type filter chips
- Infinite scroll pagination and pull-to-refresh

**Detail screen:**
- Image carousel (TabView + page style)
- Model header (name, type badge, creator)
- Stats row (downloads, favorites, rating, comments)
- Tags display, HTML description converted to plain text
- Version selector and version detail (base model, trained words, file info)
- Share button, favorite button (known toggle bug → tracked in #28)

**Shared:**
- Consume Kotlin Flows as Swift AsyncSequence via SKIE
- Move FormatUtils to shared commonMain for reuse across iOS/Android
- NavigationStack + navigationDestination for screen navigation

## Related Issues

Closes #9
- Known bug: #28

## Screenshots / Video

<!-- If applicable, add screenshots or screen recordings -->

## Test Plan

- [x] Model list displays on search screen
- [x] Text search and type filter work correctly
- [x] Infinite scroll and pull-to-refresh work
- [x] Tapping a card navigates to the detail screen
- [x] Image carousel is swipeable
- [x] Version selector switches displayed content
- [x] Share button presents the share sheet
- [x] Back button returns to search screen

## Review Checklist

- [x] Code follows project architecture (Clean Architecture + MVVM)
- [x] Shared logic is in `commonMain`, platform-specific code only when necessary
- [x] No unnecessary dependencies added
- [x] Tests added/updated as needed

## Breaking Changes

None