### PR TITLE
Add design system foundation (Colors, Typography, Spacing, Shape, Motion)

### DIFF
--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/theme/Motion.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/theme/Motion.kt
@@ -1,0 +1,48 @@
+package com.riox432.civitdeck.ui.theme
+
+import androidx.compose.animation.core.FastOutLinearInEasing
+import androidx.compose.animation.core.FastOutSlowInEasing
+import androidx.compose.animation.core.LinearOutSlowInEasing
+import androidx.compose.animation.core.spring
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.core.Spring as SpringSpec
+
+// Duration tokens (ms)
+object Duration {
+    const val fast = 150
+    const val normal = 300
+    const val slow = 500
+}
+
+// Easing tokens
+object Easing {
+    val standard = FastOutSlowInEasing // Material standard
+    val decelerate = LinearOutSlowInEasing // entering elements
+    val accelerate = FastOutLinearInEasing // exiting elements
+}
+
+// Spring tokens
+object Spring {
+    val default = spring<Float>(
+        dampingRatio = SpringSpec.DampingRatioNoBouncy,
+        stiffness = SpringSpec.StiffnessMedium,
+    )
+    val bouncy = spring<Float>(
+        dampingRatio = SpringSpec.DampingRatioMediumBouncy,
+        stiffness = SpringSpec.StiffnessMedium,
+    )
+    val stiff = spring<Float>(
+        dampingRatio = SpringSpec.DampingRatioNoBouncy,
+        stiffness = SpringSpec.StiffnessHigh,
+    )
+}
+
+// Tween helper
+object Tween {
+    fun fast(easing: androidx.compose.animation.core.Easing = Easing.standard) =
+        tween<Float>(Duration.fast, easing = easing)
+    fun normal(easing: androidx.compose.animation.core.Easing = Easing.standard) =
+        tween<Float>(Duration.normal, easing = easing)
+    fun slow(easing: androidx.compose.animation.core.Easing = Easing.standard) =
+        tween<Float>(Duration.slow, easing = easing)
+}

--- a/iosApp/iosApp.xcodeproj/project.pbxproj
+++ b/iosApp/iosApp.xcodeproj/project.pbxproj
@@ -24,6 +24,7 @@
 		CD0006032D000006000CD001 /* CivitDeckFonts.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD0006022D000006000CD001 /* CivitDeckFonts.swift */; };
 		CD0006052D000006000CD001 /* CivitDeckSpacing.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD0006042D000006000CD001 /* CivitDeckSpacing.swift */; };
 		CD0006072D000006000CD001 /* CivitDeckShapes.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD0006062D000006000CD001 /* CivitDeckShapes.swift */; };
+		CD00060B2D000006000CD001 /* CivitDeckMotion.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD00060A2D000006000CD001 /* CivitDeckMotion.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -47,6 +48,7 @@
 		CD0006022D000006000CD001 /* CivitDeckFonts.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CivitDeckFonts.swift; sourceTree = "<group>"; };
 		CD0006042D000006000CD001 /* CivitDeckSpacing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CivitDeckSpacing.swift; sourceTree = "<group>"; };
 		CD0006062D000006000CD001 /* CivitDeckShapes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CivitDeckShapes.swift; sourceTree = "<group>"; };
+		CD00060A2D000006000CD001 /* CivitDeckMotion.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CivitDeckMotion.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -122,6 +124,7 @@
 				CD0006022D000006000CD001 /* CivitDeckFonts.swift */,
 				CD0006042D000006000CD001 /* CivitDeckSpacing.swift */,
 				CD0006062D000006000CD001 /* CivitDeckShapes.swift */,
+				CD00060A2D000006000CD001 /* CivitDeckMotion.swift */,
 			);
 			path = DesignSystem;
 			sourceTree = "<group>";
@@ -274,6 +277,7 @@
 				CD0006032D000006000CD001 /* CivitDeckFonts.swift in Sources */,
 				CD0006052D000006000CD001 /* CivitDeckSpacing.swift in Sources */,
 				CD0006072D000006000CD001 /* CivitDeckShapes.swift in Sources */,
+				CD00060B2D000006000CD001 /* CivitDeckMotion.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/iosApp/iosApp/DesignSystem/CivitDeckMotion.swift
+++ b/iosApp/iosApp/DesignSystem/CivitDeckMotion.swift
@@ -1,0 +1,28 @@
+import SwiftUI
+
+// MARK: - Duration
+enum MotionDuration {
+    static let fast: Double = 0.15
+    static let normal: Double = 0.3
+    static let slow: Double = 0.5
+}
+
+// MARK: - Animation presets
+enum MotionAnimation {
+    static let standard = Animation.easeInOut(duration: MotionDuration.normal)
+    static let fast = Animation.easeInOut(duration: MotionDuration.fast)
+    static let slow = Animation.easeInOut(duration: MotionDuration.slow)
+
+    // Enter (decelerate)
+    static let enter = Animation.easeOut(duration: MotionDuration.normal)
+    static let enterFast = Animation.easeOut(duration: MotionDuration.fast)
+
+    // Exit (accelerate)
+    static let exit = Animation.easeIn(duration: MotionDuration.normal)
+    static let exitFast = Animation.easeIn(duration: MotionDuration.fast)
+
+    // Spring
+    static let spring = Animation.spring(response: 0.3, dampingFraction: 0.7)
+    static let springBouncy = Animation.spring(response: 0.3, dampingFraction: 0.5)
+    static let springStiff = Animation.spring(response: 0.2, dampingFraction: 1.0)
+}


### PR DESCRIPTION
## Description

Add a complete design system foundation for both Android (Jetpack Compose) and iOS (SwiftUI) platforms. This establishes shared design tokens for colors, typography, spacing, shapes, and motion — ensuring visual consistency across platforms.

**Android** (`ui/theme/`): Color, Type, Shape (with Spacing, CornerRadius, IconSize), Motion (Duration, Easing, Spring, Tween), and CivitDeckTheme integrating Material 3.

**iOS** (`DesignSystem/`): CivitDeckColors, CivitDeckFonts, CivitDeckSpacing, CivitDeckShapes, CivitDeckMotion (MotionDuration, MotionAnimation).

Design tokens are applied to all existing screens on both platforms.

## Related Issues

Closes #35

## Screenshots / Video

<!-- If applicable, add screenshots or screen recordings -->

## Test Plan

- [x] Android `assembleDebug` builds successfully
- [x] Android `detekt` passes
- [x] iOS `xcodebuild build` succeeds
- [x] No changes to existing runtime behavior (token application only)

## Review Checklist

- [x] Code follows project architecture (Clean Architecture + MVVM)
- [x] Shared logic is in `commonMain`, platform-specific code only when necessary
- [x] No unnecessary dependencies added
- [x] Tests added/updated as needed

## Breaking Changes

None