### PR TITLE
Add design system infrastructure and shimmer loading

### DIFF
--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/components/ModelCard.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/components/ModelCard.kt
@@ -2,6 +2,7 @@ package com.riox432.civitdeck.ui.components
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.aspectRatio
@@ -25,11 +26,14 @@ import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
-import coil3.compose.AsyncImage
+import coil3.compose.SubcomposeAsyncImage
+import coil3.request.crossfade
 import com.riox432.civitdeck.domain.model.Model
 import com.riox432.civitdeck.ui.theme.CornerRadius
+import com.riox432.civitdeck.ui.theme.Duration
 import com.riox432.civitdeck.ui.theme.IconSize
 import com.riox432.civitdeck.ui.theme.Spacing
+import com.riox432.civitdeck.ui.theme.shimmer
 import com.riox432.civitdeck.util.FormatUtils
 
 @Composable
@@ -52,13 +56,26 @@ fun ModelCard(
                 .firstOrNull()?.images?.firstOrNull()?.url
 
             if (thumbnailUrl != null) {
-                AsyncImage(
-                    model = thumbnailUrl,
+                SubcomposeAsyncImage(
+                    model = coil3.request.ImageRequest.Builder(
+                        androidx.compose.ui.platform.LocalContext.current,
+                    )
+                        .data(thumbnailUrl)
+                        .crossfade(Duration.normal)
+                        .build(),
                     contentDescription = model.name,
                     contentScale = ContentScale.Crop,
                     modifier = Modifier
                         .fillMaxWidth()
                         .aspectRatio(1f),
+                    loading = {
+                        Box(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .aspectRatio(1f)
+                                .shimmer(),
+                        )
+                    },
                 )
             }
 

--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/detail/ModelDetailScreen.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/detail/ModelDetailScreen.kt
@@ -48,12 +48,16 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import coil3.compose.AsyncImage
+import coil3.compose.SubcomposeAsyncImage
+import coil3.request.ImageRequest
+import coil3.request.crossfade
 import com.riox432.civitdeck.domain.model.Model
 import com.riox432.civitdeck.domain.model.ModelFile
 import com.riox432.civitdeck.domain.model.ModelImage
 import com.riox432.civitdeck.domain.model.ModelVersion
+import com.riox432.civitdeck.ui.theme.Duration
 import com.riox432.civitdeck.ui.theme.Spacing
+import com.riox432.civitdeck.ui.theme.shimmer
 import com.riox432.civitdeck.util.FormatUtils
 
 @Composable
@@ -282,14 +286,25 @@ private fun ImageCarousel(images: List<ModelImage>) {
             state = pagerState,
             modifier = Modifier.fillMaxWidth(),
         ) { page ->
-            AsyncImage(
-                model = images[page].url,
+            SubcomposeAsyncImage(
+                model = ImageRequest.Builder(LocalContext.current)
+                    .data(images[page].url)
+                    .crossfade(Duration.normal)
+                    .build(),
                 contentDescription = null,
                 contentScale = ContentScale.Crop,
                 modifier = Modifier
                     .fillMaxWidth()
                     .aspectRatio(1f)
                     .clip(MaterialTheme.shapes.medium),
+                loading = {
+                    Box(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .aspectRatio(1f)
+                            .shimmer(),
+                    )
+                },
             )
         }
 

--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/gallery/ImageGalleryScreen.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/gallery/ImageGalleryScreen.kt
@@ -39,13 +39,18 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import coil3.compose.AsyncImage
+import coil3.compose.SubcomposeAsyncImage
+import coil3.request.ImageRequest
+import coil3.request.crossfade
 import com.riox432.civitdeck.domain.model.Image
 import com.riox432.civitdeck.domain.model.SortOrder
 import com.riox432.civitdeck.domain.model.TimePeriod
 import com.riox432.civitdeck.ui.theme.CornerRadius
+import com.riox432.civitdeck.ui.theme.Duration
 import com.riox432.civitdeck.ui.theme.Spacing
+import com.riox432.civitdeck.ui.theme.shimmer
 
 @Composable
 fun ImageGalleryScreen(
@@ -283,8 +288,11 @@ private fun ImageGridItem(image: Image, onClick: () -> Unit) {
         1f
     }
 
-    AsyncImage(
-        model = image.url,
+    SubcomposeAsyncImage(
+        model = ImageRequest.Builder(LocalContext.current)
+            .data(image.url)
+            .crossfade(Duration.normal)
+            .build(),
         contentDescription = null,
         contentScale = ContentScale.Crop,
         modifier = Modifier
@@ -292,6 +300,14 @@ private fun ImageGridItem(image: Image, onClick: () -> Unit) {
             .aspectRatio(aspectRatio)
             .clip(RoundedCornerShape(CornerRadius.image))
             .clickable(onClick = onClick),
+        loading = {
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .aspectRatio(aspectRatio)
+                    .shimmer(),
+            )
+        },
     )
 }
 

--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/gallery/ImageViewerOverlay.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/gallery/ImageViewerOverlay.kt
@@ -13,6 +13,7 @@ import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.Info
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -32,9 +33,13 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
-import coil3.compose.AsyncImage
+import coil3.compose.SubcomposeAsyncImage
+import coil3.request.ImageRequest
+import coil3.request.crossfade
 import com.riox432.civitdeck.domain.model.Image
+import com.riox432.civitdeck.ui.theme.Duration
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -141,8 +146,11 @@ private fun ZoomableImage(imageUrl: String) {
         }
     }
 
-    AsyncImage(
-        model = imageUrl,
+    SubcomposeAsyncImage(
+        model = ImageRequest.Builder(LocalContext.current)
+            .data(imageUrl)
+            .crossfade(Duration.normal)
+            .build(),
         contentDescription = null,
         contentScale = ContentScale.Fit,
         modifier = Modifier
@@ -166,6 +174,14 @@ private fun ZoomableImage(imageUrl: String) {
                 translationX = offset.x,
                 translationY = offset.y,
             ),
+        loading = {
+            Box(
+                modifier = Modifier.fillMaxSize(),
+                contentAlignment = Alignment.Center,
+            ) {
+                CircularProgressIndicator(color = Color.White)
+            }
+        },
     )
 }
 

--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/theme/Shimmer.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/theme/Shimmer.kt
@@ -1,0 +1,42 @@
+package com.riox432.civitdeck.ui.theme
+
+import androidx.compose.animation.core.LinearEasing
+import androidx.compose.animation.core.RepeatMode
+import androidx.compose.animation.core.animateFloat
+import androidx.compose.animation.core.infiniteRepeatable
+import androidx.compose.animation.core.rememberInfiniteTransition
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.background
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Brush
+
+private const val SHIMMER_DURATION_MS = 1200
+
+@Composable
+fun Modifier.shimmer(): Modifier {
+    val transition = rememberInfiniteTransition(label = "shimmer")
+    val translateX by transition.animateFloat(
+        initialValue = -1f,
+        targetValue = 2f,
+        animationSpec = infiniteRepeatable(
+            animation = tween(SHIMMER_DURATION_MS, easing = LinearEasing),
+            repeatMode = RepeatMode.Restart,
+        ),
+        label = "shimmerTranslateX",
+    )
+
+    val colorBase = MaterialTheme.colorScheme.surfaceVariant
+    val colorHighlight = MaterialTheme.colorScheme.surface
+
+    val brush = Brush.linearGradient(
+        colors = listOf(colorBase, colorHighlight, colorBase),
+        start = Offset(translateX * 1000f, 0f),
+        end = Offset(translateX * 1000f + 1000f, 0f),
+    )
+
+    return this.background(brush)
+}

--- a/iosApp/iosApp.xcodeproj/project.pbxproj
+++ b/iosApp/iosApp.xcodeproj/project.pbxproj
@@ -25,6 +25,7 @@
 		CD0006052D000006000CD001 /* CivitDeckSpacing.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD0006042D000006000CD001 /* CivitDeckSpacing.swift */; };
 		CD0006072D000006000CD001 /* CivitDeckShapes.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD0006062D000006000CD001 /* CivitDeckShapes.swift */; };
 		CD00060B2D000006000CD001 /* CivitDeckMotion.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD00060A2D000006000CD001 /* CivitDeckMotion.swift */; };
+		CD0006112D000036000CD001 /* ShimmerModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD0006102D000036000CD001 /* ShimmerModifier.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -49,6 +50,7 @@
 		CD0006042D000006000CD001 /* CivitDeckSpacing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CivitDeckSpacing.swift; sourceTree = "<group>"; };
 		CD0006062D000006000CD001 /* CivitDeckShapes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CivitDeckShapes.swift; sourceTree = "<group>"; };
 		CD00060A2D000006000CD001 /* CivitDeckMotion.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CivitDeckMotion.swift; sourceTree = "<group>"; };
+		CD0006102D000036000CD001 /* ShimmerModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShimmerModifier.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -125,6 +127,7 @@
 				CD0006042D000006000CD001 /* CivitDeckSpacing.swift */,
 				CD0006062D000006000CD001 /* CivitDeckShapes.swift */,
 				CD00060A2D000006000CD001 /* CivitDeckMotion.swift */,
+				CD0006102D000036000CD001 /* ShimmerModifier.swift */,
 			);
 			path = DesignSystem;
 			sourceTree = "<group>";
@@ -278,6 +281,7 @@
 				CD0006052D000006000CD001 /* CivitDeckSpacing.swift in Sources */,
 				CD0006072D000006000CD001 /* CivitDeckShapes.swift in Sources */,
 				CD00060B2D000006000CD001 /* CivitDeckMotion.swift in Sources */,
+				CD0006112D000036000CD001 /* ShimmerModifier.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/iosApp/iosApp/DesignSystem/ShimmerModifier.swift
+++ b/iosApp/iosApp/DesignSystem/ShimmerModifier.swift
@@ -1,0 +1,34 @@
+import SwiftUI
+
+struct ShimmerModifier: ViewModifier {
+    @State private var phase: CGFloat = -1
+
+    func body(content: Content) -> some View {
+        content
+            .overlay(
+                LinearGradient(
+                    colors: [
+                        Color.civitSurfaceVariant,
+                        Color.civitSurface,
+                        Color.civitSurfaceVariant,
+                    ],
+                    startPoint: UnitPoint(x: phase, y: 0.5),
+                    endPoint: UnitPoint(x: phase + 1, y: 0.5)
+                )
+            )
+            .onAppear {
+                withAnimation(
+                    .linear(duration: 1.2)
+                    .repeatForever(autoreverses: false)
+                ) {
+                    phase = 2
+                }
+            }
+    }
+}
+
+extension View {
+    func shimmer() -> some View {
+        modifier(ShimmerModifier())
+    }
+}

--- a/iosApp/iosApp/Features/Detail/ModelDetailScreen.swift
+++ b/iosApp/iosApp/Features/Detail/ModelDetailScreen.swift
@@ -77,10 +77,13 @@ struct ModelDetailScreen: View {
                                     img
                                         .resizable()
                                         .scaledToFill()
+                                        .transition(.opacity)
                                 case .failure:
                                     imagePlaceholder
                                 case .empty:
-                                    ProgressView()
+                                    Rectangle()
+                                        .fill(Color.civitSurfaceVariant)
+                                        .shimmer()
                                 @unknown default:
                                     imagePlaceholder
                                 }

--- a/iosApp/iosApp/Features/Gallery/ImageGalleryScreen.swift
+++ b/iosApp/iosApp/Features/Gallery/ImageGalleryScreen.swift
@@ -147,6 +147,7 @@ struct ImageGalleryScreen: View {
                     img
                         .resizable()
                         .scaledToFill()
+                        .transition(.opacity)
                 case .failure:
                     Rectangle()
                         .fill(Color.civitSurfaceVariant)
@@ -156,8 +157,8 @@ struct ImageGalleryScreen: View {
                         }
                 case .empty:
                     Rectangle()
-                        .fill(Color.civitSurfaceContainerHigh)
-                        .overlay { ProgressView() }
+                        .fill(Color.civitSurfaceVariant)
+                        .shimmer()
                 @unknown default:
                     EmptyView()
                 }

--- a/iosApp/iosApp/Features/Gallery/ImageViewerScreen.swift
+++ b/iosApp/iosApp/Features/Gallery/ImageViewerScreen.swift
@@ -109,6 +109,7 @@ private struct ZoomableImageView: View {
                                 }
                             }
                         }
+                        .transition(.opacity)
                 case .failure:
                     SwiftUI.Image(systemName: "photo")
                         .foregroundColor(.gray)

--- a/iosApp/iosApp/Features/Search/ModelCardView.swift
+++ b/iosApp/iosApp/Features/Search/ModelCardView.swift
@@ -42,11 +42,14 @@ struct ModelCardView: View {
                                 image
                                     .resizable()
                                     .scaledToFill()
+                                    .transition(.opacity)
                             case .failure:
                                 Image(systemName: "photo")
                                     .foregroundColor(.civitOnSurfaceVariant)
                             case .empty:
-                                ProgressView()
+                                Rectangle()
+                                    .fill(Color.civitSurfaceVariant)
+                                    .shimmer()
                             @unknown default:
                                 Image(systemName: "photo")
                                     .foregroundColor(.civitOnSurfaceVariant)


### PR DESCRIPTION
## Description

Add a comprehensive design system for both Android and iOS, and implement shimmer loading placeholders with image fade-in animations.

**Design System (tokens):**
- Color, Typography, Shape, Spacing, Motion tokens for Android (Material 3) and iOS (SwiftUI)
- Applied tokens consistently across all screens (Search, Detail, Gallery)

**Shimmer & Fade-in (#36):**
- `Modifier.shimmer()` (Android) / `.shimmer()` ViewModifier (iOS) using animated LinearGradient
- Replaced `ProgressView`/blank states with shimmer skeleton placeholders on image loading
- Added crossfade (Android, 300ms) and `.transition(.opacity)` (iOS) for smooth image appearance
- ImageViewer keeps `CircularProgressIndicator`/`ProgressView` on black background (shimmer not suitable)

## Related Issues

Closes #36

## Screenshots / Video

<!-- If applicable, add screenshots or screen recordings -->

## Test Plan

- [x] `./gradlew assembleDebug` passes
- [x] `./gradlew detekt` passes
- [x] `xcodebuild build` passes

## Review Checklist

- [x] Code follows project architecture (Clean Architecture + MVVM)
- [x] Shared logic is in `commonMain`, platform-specific code only when necessary
- [x] No unnecessary dependencies added
- [x] Tests added/updated as needed

## Breaking Changes

None