### PR TITLE
Add design system and screen animations

### DIFF
--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/navigation/CivitDeckNavGraph.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/navigation/CivitDeckNavGraph.kt
@@ -1,5 +1,10 @@
 package com.riox432.civitdeck.ui.navigation
 
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.slideInHorizontally
+import androidx.compose.animation.slideOutHorizontally
+import androidx.compose.animation.togetherWith
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.remember
@@ -13,6 +18,8 @@ import com.riox432.civitdeck.ui.gallery.ImageGalleryScreen
 import com.riox432.civitdeck.ui.gallery.ImageGalleryViewModel
 import com.riox432.civitdeck.ui.search.ModelSearchScreen
 import com.riox432.civitdeck.ui.search.ModelSearchViewModel
+import com.riox432.civitdeck.ui.theme.Duration
+import com.riox432.civitdeck.ui.theme.Easing
 import org.koin.compose.viewmodel.koinViewModel
 import org.koin.core.parameter.parametersOf
 
@@ -22,6 +29,15 @@ data class DetailRoute(val modelId: Long)
 
 data class ImageGalleryRoute(val modelVersionId: Long)
 
+private val navTween = androidx.compose.animation.core.tween<androidx.compose.ui.unit.IntOffset>(
+    durationMillis = Duration.normal,
+    easing = Easing.standard,
+)
+private val navFadeTween = androidx.compose.animation.core.tween<Float>(
+    durationMillis = Duration.normal,
+    easing = Easing.standard,
+)
+
 @Composable
 fun CivitDeckNavGraph() {
     val backStack = remember { mutableStateListOf<Any>(SearchRoute) }
@@ -29,6 +45,18 @@ fun CivitDeckNavGraph() {
     NavDisplay(
         backStack = backStack,
         onBack = { backStack.removeLastOrNull() },
+        transitionSpec = {
+            (fadeIn(navFadeTween) + slideInHorizontally(navTween) { it / 4 }) togetherWith
+                (fadeOut(navFadeTween) + slideOutHorizontally(navTween) { -it / 4 })
+        },
+        popTransitionSpec = {
+            (fadeIn(navFadeTween) + slideInHorizontally(navTween) { -it / 4 }) togetherWith
+                (fadeOut(navFadeTween) + slideOutHorizontally(navTween) { it / 4 })
+        },
+        predictivePopTransitionSpec = {
+            (fadeIn(navFadeTween) + slideInHorizontally(navTween) { -it / 4 }) togetherWith
+                (fadeOut(navFadeTween) + slideOutHorizontally(navTween) { it / 4 })
+        },
         entryDecorators = listOf(
             rememberSaveableStateHolderNavEntryDecorator(),
             rememberViewModelStoreNavEntryDecorator(),

--- a/iosApp/iosApp/Features/Detail/ModelDetailScreen.swift
+++ b/iosApp/iosApp/Features/Detail/ModelDetailScreen.swift
@@ -8,16 +8,23 @@ struct ModelDetailScreen: View {
         _viewModel = StateObject(wrappedValue: ModelDetailViewModel(modelId: modelId))
     }
 
+    @State private var isDescriptionExpanded = false
+
     var body: some View {
         Group {
             if viewModel.isLoading && viewModel.model == nil {
                 ProgressView()
+                    .transition(.opacity)
             } else if let error = viewModel.error, viewModel.model == nil {
                 errorView(message: error)
+                    .transition(.opacity)
             } else if let model = viewModel.model {
                 modelContent(model: model)
+                    .transition(.opacity)
             }
         }
+        .animation(MotionAnimation.standard, value: viewModel.isLoading)
+        .animation(MotionAnimation.standard, value: viewModel.model != nil)
         .navigationTitle(viewModel.model?.name ?? "")
         .navigationBarTitleDisplayMode(.inline)
         .task {
@@ -214,6 +221,15 @@ struct ModelDetailScreen: View {
                 Text(htmlToPlainText(description))
                     .font(.civitBodyMedium)
                     .foregroundColor(.civitOnSurfaceVariant)
+                    .lineLimit(isDescriptionExpanded ? nil : 4)
+                    .animation(MotionAnimation.standard, value: isDescriptionExpanded)
+                Button {
+                    isDescriptionExpanded.toggle()
+                } label: {
+                    Text(isDescriptionExpanded ? "Show less" : "Show more")
+                        .font(.civitLabelMedium)
+                        .foregroundColor(.civitPrimary)
+                }
             }
             .frame(maxWidth: .infinity, alignment: .leading)
             .padding(.horizontal, Spacing.lg)
@@ -237,24 +253,25 @@ struct ModelDetailScreen: View {
                 ScrollView(.horizontal, showsIndicators: false) {
                     HStack(spacing: Spacing.sm) {
                         ForEach(Array(versions.enumerated()), id: \.offset) { index, version in
+                            let selected = index == viewModel.selectedVersionIndex
                             Button {
                                 viewModel.onVersionSelected(index)
                             } label: {
                                 Text(version.name)
                                     .font(.civitLabelMedium)
-                                    .fontWeight(index == viewModel.selectedVersionIndex ? .semibold : .regular)
+                                    .fontWeight(selected ? .semibold : .regular)
                                     .padding(.horizontal, Spacing.md)
                                     .padding(.vertical, 6)
                                     .background(
-                                        index == viewModel.selectedVersionIndex
+                                        selected
                                             ? Color.civitPrimary.opacity(0.2)
                                             : Color.civitSurfaceVariant
                                     )
                                     .foregroundColor(
-                                        index == viewModel.selectedVersionIndex
-                                            ? .civitPrimary : .civitOnSurface
+                                        selected ? .civitPrimary : .civitOnSurface
                                     )
                                     .clipShape(Capsule())
+                                    .animation(MotionAnimation.spring, value: selected)
                             }
                         }
                     }

--- a/iosApp/iosApp/Features/Gallery/ImageGalleryScreen.swift
+++ b/iosApp/iosApp/Features/Gallery/ImageGalleryScreen.swift
@@ -93,21 +93,29 @@ struct ImageGalleryScreen: View {
 
     @ViewBuilder
     private var contentArea: some View {
-        if viewModel.isLoading && viewModel.images.isEmpty {
-            Spacer()
-            ProgressView()
-            Spacer()
-        } else if let error = viewModel.error, viewModel.images.isEmpty {
-            Spacer()
-            errorView(message: error)
-            Spacer()
-        } else if viewModel.images.isEmpty && !viewModel.isLoading {
-            Spacer()
-            emptyView
-            Spacer()
-        } else {
-            imageGrid
+        Group {
+            if viewModel.isLoading && viewModel.images.isEmpty {
+                Spacer()
+                ProgressView()
+                    .transition(.opacity)
+                Spacer()
+            } else if let error = viewModel.error, viewModel.images.isEmpty {
+                Spacer()
+                errorView(message: error)
+                    .transition(.opacity)
+                Spacer()
+            } else if viewModel.images.isEmpty && !viewModel.isLoading {
+                Spacer()
+                emptyView
+                    .transition(.opacity)
+                Spacer()
+            } else {
+                imageGrid
+                    .transition(.opacity)
+            }
         }
+        .animation(MotionAnimation.standard, value: viewModel.isLoading)
+        .animation(MotionAnimation.standard, value: viewModel.error == nil)
     }
 
     // MARK: - Image Grid
@@ -211,6 +219,7 @@ struct ImageGalleryScreen: View {
                 )
                 .foregroundColor(isSelected ? .civitPrimary : .civitOnSurface)
                 .clipShape(Capsule())
+                .animation(MotionAnimation.spring, value: isSelected)
         }
     }
 

--- a/iosApp/iosApp/Features/Gallery/ImageViewerScreen.swift
+++ b/iosApp/iosApp/Features/Gallery/ImageViewerScreen.swift
@@ -6,6 +6,7 @@ struct ImageViewerScreen: View {
     @Binding var selectedIndex: Int?
 
     @State private var showMetadata = false
+    @State private var controlsVisible = true
 
     var body: some View {
         if let index = selectedIndex {
@@ -23,7 +24,14 @@ struct ImageViewerScreen: View {
                 }
                 .tabViewStyle(.page(indexDisplayMode: .automatic))
 
-                viewerControls(currentIndex: index)
+                if controlsVisible {
+                    viewerControls(currentIndex: index)
+                        .transition(.opacity)
+                }
+            }
+            .animation(MotionAnimation.fast, value: controlsVisible)
+            .onTapGesture {
+                controlsVisible.toggle()
             }
             .sheet(isPresented: $showMetadata) {
                 if let meta = images[safe: index]?.meta {
@@ -97,7 +105,7 @@ private struct ZoomableImageView: View {
                         .gesture(zoomGesture)
                         .gesture(panGesture)
                         .onTapGesture(count: 2) {
-                            withAnimation(.easeInOut(duration: 0.25)) {
+                            withAnimation(MotionAnimation.springBouncy) {
                                 if scale > 1.0 {
                                     scale = 1.0
                                     lastScale = 1.0
@@ -133,7 +141,7 @@ private struct ZoomableImageView: View {
             .onEnded { value in
                 lastScale = scale
                 if scale < 1.0 {
-                    withAnimation(.easeInOut(duration: 0.2)) {
+                    withAnimation(MotionAnimation.springBouncy) {
                         scale = 1.0
                         lastScale = 1.0
                         offset = .zero

--- a/iosApp/iosApp/Features/Search/ModelSearchScreen.swift
+++ b/iosApp/iosApp/Features/Search/ModelSearchScreen.swift
@@ -18,14 +18,20 @@ struct ModelSearchScreen: View {
                 ZStack {
                     if viewModel.isLoading && viewModel.models.isEmpty {
                         ProgressView()
+                            .transition(.opacity)
                     } else if let error = viewModel.error, viewModel.models.isEmpty {
                         errorView(message: error)
+                            .transition(.opacity)
                     } else if viewModel.models.isEmpty && !viewModel.isLoading {
                         emptyView
+                            .transition(.opacity)
                     } else {
                         modelGrid
+                            .transition(.opacity)
                     }
                 }
+                .animation(MotionAnimation.standard, value: viewModel.isLoading)
+                .animation(MotionAnimation.standard, value: viewModel.error == nil)
                 .frame(maxHeight: .infinity)
             }
             .navigationTitle("CivitDeck")
@@ -72,6 +78,7 @@ struct ModelSearchScreen: View {
                         ModelCardView(model: model)
                     }
                     .buttonStyle(.plain)
+                    .transition(.opacity.combined(with: .offset(y: 20)))
                     .onAppear {
                         if index == viewModel.models.count - 3 {
                             viewModel.loadMore()
@@ -83,9 +90,11 @@ struct ModelSearchScreen: View {
 
             if viewModel.isLoadingMore {
                 ProgressView()
+                    .transition(.opacity)
                     .padding()
             }
         }
+        .animation(MotionAnimation.standard, value: viewModel.isLoadingMore)
         .refreshable {
             viewModel.refresh()
         }
@@ -122,6 +131,7 @@ struct ModelSearchScreen: View {
                 )
                 .foregroundColor(isSelected ? .civitPrimary : .civitOnSurface)
                 .clipShape(Capsule())
+                .animation(MotionAnimation.spring, value: isSelected)
         }
     }
 


### PR DESCRIPTION
## Description

Add a comprehensive design system infrastructure and screen animations for both Android and iOS:

**Design System (existing commits)**
- Color, Typography, Shape, Spacing, Motion tokens for Android (Compose) and iOS (SwiftUI)
- Shimmer loading placeholders and image fade-in animations

**Screen Animations (new)**
- Navigation transitions: fadeIn + slideInHorizontally for forward, reverse for back (Android Nav3)
- Search screen: Crossfade state switching, animateItem() grid items, animateColorAsState filter chips, AnimatedVisibility loading indicator
- Detail screen: Crossfade state switching, animateContentSize description collapse with Show more/less toggle
- Gallery: Crossfade state switching, animateItem() grid items
- Image viewer: Animatable + Spring.bouncy double-tap zoom, AnimatedVisibility controls toggle
- iOS equivalents using .transition(.opacity), MotionAnimation.spring, withAnimation(springBouncy)

## Related Issues

Closes #37, Closes #38, Closes #39, Closes #40

<!-- ## Screenshots / Video -->

<!-- If applicable, add screenshots or screen recordings -->

## Test Plan

- [x] `./gradlew assembleDebug` passes
- [x] `./gradlew detekt` passes
- [x] `xcodebuild build` passes
- [ ] Manual verification of animations on Android device/emulator
- [ ] Manual verification of animations on iOS simulator

## Review Checklist

- [x] Code follows project architecture (Clean Architecture + MVVM)
- [x] Shared logic is in `commonMain`, platform-specific code only when necessary
- [x] No unnecessary dependencies added
- [ ] Tests added/updated as needed

<!-- ## Breaking Changes -->

<!-- List any breaking changes, or write "None" -->