### PR TITLE
Add shared element transition between search and detail screens

### DIFF
--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/components/ModelCard.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/components/ModelCard.kt
@@ -1,5 +1,6 @@
 package com.riox432.civitdeck.ui.components
 
+import androidx.compose.animation.ExperimentalSharedTransitionApi
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -26,9 +27,12 @@ import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
+import androidx.navigation3.ui.LocalNavAnimatedContentScope
 import coil3.compose.SubcomposeAsyncImage
 import coil3.request.crossfade
 import com.riox432.civitdeck.domain.model.Model
+import com.riox432.civitdeck.ui.navigation.LocalSharedTransitionScope
+import com.riox432.civitdeck.ui.navigation.SharedElementKeys
 import com.riox432.civitdeck.ui.theme.CornerRadius
 import com.riox432.civitdeck.ui.theme.Duration
 import com.riox432.civitdeck.ui.theme.IconSize
@@ -36,6 +40,7 @@ import com.riox432.civitdeck.ui.theme.Spacing
 import com.riox432.civitdeck.ui.theme.shimmer
 import com.riox432.civitdeck.util.FormatUtils
 
+@OptIn(ExperimentalSharedTransitionApi::class)
 @Composable
 fun ModelCard(
     model: Model,
@@ -56,6 +61,27 @@ fun ModelCard(
                 .firstOrNull()?.images?.firstOrNull()?.url
 
             if (thumbnailUrl != null) {
+                val sharedTransitionScope = LocalSharedTransitionScope.current
+                val animatedContentScope = LocalNavAnimatedContentScope.current
+
+                val imageModifier = if (sharedTransitionScope != null) {
+                    with(sharedTransitionScope) {
+                        Modifier
+                            .fillMaxWidth()
+                            .aspectRatio(1f)
+                            .sharedElement(
+                                rememberSharedContentState(
+                                    key = SharedElementKeys.modelThumbnail(model.id),
+                                ),
+                                animatedVisibilityScope = animatedContentScope,
+                            )
+                    }
+                } else {
+                    Modifier
+                        .fillMaxWidth()
+                        .aspectRatio(1f)
+                }
+
                 SubcomposeAsyncImage(
                     model = coil3.request.ImageRequest.Builder(
                         androidx.compose.ui.platform.LocalContext.current,
@@ -65,9 +91,7 @@ fun ModelCard(
                         .build(),
                     contentDescription = model.name,
                     contentScale = ContentScale.Crop,
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .aspectRatio(1f),
+                    modifier = imageModifier,
                     loading = {
                         Box(
                             modifier = Modifier

--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/navigation/CivitDeckNavGraph.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/navigation/CivitDeckNavGraph.kt
@@ -1,11 +1,9 @@
 package com.riox432.civitdeck.ui.navigation
 
-import androidx.compose.animation.fadeIn
-import androidx.compose.animation.fadeOut
-import androidx.compose.animation.slideInHorizontally
-import androidx.compose.animation.slideOutHorizontally
-import androidx.compose.animation.togetherWith
+import androidx.compose.animation.ExperimentalSharedTransitionApi
+import androidx.compose.animation.SharedTransitionLayout
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.remember
 import androidx.lifecycle.viewmodel.navigation3.rememberViewModelStoreNavEntryDecorator
@@ -18,45 +16,32 @@ import com.riox432.civitdeck.ui.gallery.ImageGalleryScreen
 import com.riox432.civitdeck.ui.gallery.ImageGalleryViewModel
 import com.riox432.civitdeck.ui.search.ModelSearchScreen
 import com.riox432.civitdeck.ui.search.ModelSearchViewModel
-import com.riox432.civitdeck.ui.theme.Duration
-import com.riox432.civitdeck.ui.theme.Easing
 import org.koin.compose.viewmodel.koinViewModel
 import org.koin.core.parameter.parametersOf
 
 data object SearchRoute
 
-data class DetailRoute(val modelId: Long)
+data class DetailRoute(val modelId: Long, val thumbnailUrl: String? = null)
 
 data class ImageGalleryRoute(val modelVersionId: Long)
 
-private val navTween = androidx.compose.animation.core.tween<androidx.compose.ui.unit.IntOffset>(
-    durationMillis = Duration.normal,
-    easing = Easing.standard,
-)
-private val navFadeTween = androidx.compose.animation.core.tween<Float>(
-    durationMillis = Duration.normal,
-    easing = Easing.standard,
-)
-
+@OptIn(ExperimentalSharedTransitionApi::class)
 @Composable
 fun CivitDeckNavGraph() {
     val backStack = remember { mutableStateListOf<Any>(SearchRoute) }
 
+    SharedTransitionLayout {
+        CompositionLocalProvider(LocalSharedTransitionScope provides this) {
+            CivitDeckNavDisplay(backStack)
+        }
+    }
+}
+
+@Composable
+private fun CivitDeckNavDisplay(backStack: MutableList<Any>) {
     NavDisplay(
         backStack = backStack,
         onBack = { backStack.removeLastOrNull() },
-        transitionSpec = {
-            (fadeIn(navFadeTween) + slideInHorizontally(navTween) { it / 4 }) togetherWith
-                (fadeOut(navFadeTween) + slideOutHorizontally(navTween) { -it / 4 })
-        },
-        popTransitionSpec = {
-            (fadeIn(navFadeTween) + slideInHorizontally(navTween) { -it / 4 }) togetherWith
-                (fadeOut(navFadeTween) + slideOutHorizontally(navTween) { it / 4 })
-        },
-        predictivePopTransitionSpec = {
-            (fadeIn(navFadeTween) + slideInHorizontally(navTween) { -it / 4 }) togetherWith
-                (fadeOut(navFadeTween) + slideOutHorizontally(navTween) { it / 4 })
-        },
         entryDecorators = listOf(
             rememberSaveableStateHolderNavEntryDecorator(),
             rememberViewModelStoreNavEntryDecorator(),
@@ -66,7 +51,9 @@ fun CivitDeckNavGraph() {
                 val viewModel: ModelSearchViewModel = koinViewModel()
                 ModelSearchScreen(
                     viewModel = viewModel,
-                    onModelClick = { modelId -> backStack.add(DetailRoute(modelId)) },
+                    onModelClick = { modelId, thumbnailUrl ->
+                        backStack.add(DetailRoute(modelId, thumbnailUrl))
+                    },
                 )
             }
             entry<DetailRoute> { key ->
@@ -75,8 +62,12 @@ fun CivitDeckNavGraph() {
                 ) { parametersOf(key.modelId) }
                 ModelDetailScreen(
                     viewModel = viewModel,
+                    modelId = key.modelId,
+                    initialThumbnailUrl = key.thumbnailUrl,
                     onBack = { backStack.removeLastOrNull() },
-                    onViewImages = { modelVersionId -> backStack.add(ImageGalleryRoute(modelVersionId)) },
+                    onViewImages = { modelVersionId ->
+                        backStack.add(ImageGalleryRoute(modelVersionId))
+                    },
                 )
             }
             entry<ImageGalleryRoute> { key ->

--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/navigation/SharedElementKeys.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/navigation/SharedElementKeys.kt
@@ -1,0 +1,12 @@
+package com.riox432.civitdeck.ui.navigation
+
+import androidx.compose.animation.ExperimentalSharedTransitionApi
+import androidx.compose.animation.SharedTransitionScope
+import androidx.compose.runtime.staticCompositionLocalOf
+
+object SharedElementKeys {
+    fun modelThumbnail(modelId: Long): String = "model_thumbnail_$modelId"
+}
+
+@OptIn(ExperimentalSharedTransitionApi::class)
+val LocalSharedTransitionScope = staticCompositionLocalOf<SharedTransitionScope?> { null }

--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/search/ModelSearchScreen.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/search/ModelSearchScreen.kt
@@ -64,7 +64,7 @@ import com.riox432.civitdeck.ui.theme.Spacing
 @Composable
 fun ModelSearchScreen(
     viewModel: ModelSearchViewModel,
-    onModelClick: (Long) -> Unit = {},
+    onModelClick: (Long, String?) -> Unit = { _, _ -> },
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     val gridState = rememberLazyGridState()
@@ -233,7 +233,7 @@ private fun ModelSearchContent(
     uiState: ModelSearchUiState,
     gridState: LazyGridState,
     onRefresh: () -> Unit,
-    onModelClick: (Long) -> Unit,
+    onModelClick: (Long, String?) -> Unit,
     bottomPadding: androidx.compose.ui.unit.Dp = 0.dp,
 ) {
     val stateKey = when {
@@ -288,7 +288,7 @@ private fun ModelGrid(
     models: List<Model>,
     gridState: LazyGridState,
     isLoadingMore: Boolean,
-    onModelClick: (Long) -> Unit,
+    onModelClick: (Long, String?) -> Unit,
     bottomPadding: androidx.compose.ui.unit.Dp = 0.dp,
 ) {
     LazyVerticalGrid(
@@ -304,9 +304,11 @@ private fun ModelGrid(
         verticalArrangement = Arrangement.spacedBy(Spacing.sm),
     ) {
         items(items = models, key = { it.id }) { model ->
+            val thumbnailUrl = model.modelVersions
+                .firstOrNull()?.images?.firstOrNull()?.url
             ModelCard(
                 model = model,
-                onClick = { onModelClick(model.id) },
+                onClick = { onModelClick(model.id, thumbnailUrl) },
                 modifier = Modifier.animateItem(),
             )
         }


### PR DESCRIPTION
## Description

Add shared element transition for model thumbnail images between the Search screen (ModelCard) and Detail screen (ImageCarousel). When tapping a model card, the thumbnail smoothly animates into the detail screen's image carousel, and animates back when navigating back.

Key implementation details:
- `SharedTransitionLayout` wraps `NavDisplay` with `CompositionLocal` for scope access
- Thumbnail URL passed via `DetailRoute` for placeholder display during API loading
- Shared element applies to whichever carousel page is currently visible, enabling seamless back transitions from any page
- Fixed 1:1 aspect ratio carousel with `ContentScale.Fit` and letterbox background

## Related Issues

<!-- Link related GitHub issues: Closes #123, Fixes #456 -->

## Screenshots / Video

<!-- If applicable, add screenshots or screen recordings -->

## Test Plan

- [ ] Search → tap ModelCard → thumbnail animates smoothly into Detail carousel
- [ ] Detail → back → carousel image animates back to list thumbnail
- [ ] Swipe to non-first image in Detail → back → still transitions smoothly
- [ ] Fast tap Search → Detail → Back repeatedly without crash
- [ ] `./gradlew detekt` passes

## Review Checklist

- [x] Code follows project architecture (Clean Architecture + MVVM)
- [x] Shared logic is in `commonMain`, platform-specific code only when necessary
- [x] No unnecessary dependencies added
- [ ] Tests added/updated as needed

## Breaking Changes

None