### PR TITLE
Add favorites list screen with bottom navigation (#50)

### DIFF
--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/CivitDeckApplication.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/CivitDeckApplication.kt
@@ -3,6 +3,7 @@ package com.riox432.civitdeck
 import android.app.Application
 import com.riox432.civitdeck.di.initKoin
 import com.riox432.civitdeck.ui.detail.ModelDetailViewModel
+import com.riox432.civitdeck.ui.favorites.FavoritesViewModel
 import com.riox432.civitdeck.ui.gallery.ImageGalleryViewModel
 import com.riox432.civitdeck.ui.search.ModelSearchViewModel
 import org.koin.android.ext.koin.androidContext
@@ -21,6 +22,7 @@ class CivitDeckApplication : Application() {
 
 val androidModule = module {
     viewModel { ModelSearchViewModel(get(), get(), get()) }
+    viewModel { FavoritesViewModel(get()) }
     viewModel { params -> ModelDetailViewModel(params.get(), get(), get(), get()) }
     viewModel { params -> ImageGalleryViewModel(params.get(), get()) }
 }

--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/favorites/FavoritesScreen.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/favorites/FavoritesScreen.kt
@@ -1,0 +1,229 @@
+package com.riox432.civitdeck.ui.favorites
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.grid.GridCells
+import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
+import androidx.compose.foundation.lazy.grid.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.Download
+import androidx.compose.material.icons.outlined.FavoriteBorder
+import androidx.compose.material.icons.outlined.Star
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import coil3.compose.SubcomposeAsyncImage
+import coil3.request.crossfade
+import com.riox432.civitdeck.domain.model.FavoriteModelSummary
+import com.riox432.civitdeck.ui.theme.CornerRadius
+import com.riox432.civitdeck.ui.theme.Duration
+import com.riox432.civitdeck.ui.theme.IconSize
+import com.riox432.civitdeck.ui.theme.Spacing
+import com.riox432.civitdeck.ui.theme.shimmer
+import com.riox432.civitdeck.util.FormatUtils
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun FavoritesScreen(
+    favorites: List<FavoriteModelSummary>,
+    onModelClick: (Long) -> Unit,
+) {
+    Scaffold(
+        topBar = { TopAppBar(title = { Text("Favorites") }) },
+    ) { padding ->
+        if (favorites.isEmpty()) {
+            EmptyFavorites()
+        } else {
+            FavoritesGrid(
+                favorites = favorites,
+                onModelClick = onModelClick,
+                topPadding = padding.calculateTopPadding(),
+            )
+        }
+    }
+}
+
+@Composable
+private fun EmptyFavorites() {
+    Box(
+        modifier = Modifier.fillMaxSize(),
+        contentAlignment = Alignment.Center,
+    ) {
+        Column(horizontalAlignment = Alignment.CenterHorizontally) {
+            Text(
+                text = "No favorites yet",
+                style = MaterialTheme.typography.titleMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            Text(
+                text = "Models you favorite will appear here",
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+    }
+}
+
+@Composable
+private fun FavoritesGrid(
+    favorites: List<FavoriteModelSummary>,
+    onModelClick: (Long) -> Unit,
+    topPadding: Dp = 0.dp,
+) {
+    LazyVerticalGrid(
+        columns = GridCells.Fixed(2),
+        contentPadding = PaddingValues(
+            start = Spacing.md,
+            end = Spacing.md,
+            top = Spacing.sm + topPadding,
+            bottom = Spacing.lg,
+        ),
+        horizontalArrangement = Arrangement.spacedBy(Spacing.sm),
+        verticalArrangement = Arrangement.spacedBy(Spacing.sm),
+    ) {
+        items(items = favorites, key = { it.id }) { model ->
+            FavoriteCard(
+                model = model,
+                onClick = { onModelClick(model.id) },
+                modifier = Modifier.animateItem(),
+            )
+        }
+    }
+}
+
+@Composable
+private fun FavoriteCard(
+    model: FavoriteModelSummary,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Card(
+        onClick = onClick,
+        modifier = modifier.fillMaxWidth(),
+        shape = RoundedCornerShape(CornerRadius.card),
+        elevation = CardDefaults.cardElevation(defaultElevation = 2.dp),
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.surface,
+        ),
+    ) {
+        Column {
+            if (model.thumbnailUrl != null) {
+                SubcomposeAsyncImage(
+                    model = coil3.request.ImageRequest.Builder(
+                        androidx.compose.ui.platform.LocalContext.current,
+                    )
+                        .data(model.thumbnailUrl)
+                        .crossfade(Duration.normal)
+                        .build(),
+                    contentDescription = model.name,
+                    contentScale = ContentScale.Crop,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .aspectRatio(1f),
+                    loading = {
+                        Box(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .aspectRatio(1f)
+                                .shimmer(),
+                        )
+                    },
+                )
+            }
+
+            FavoriteCardInfo(model = model)
+        }
+    }
+}
+
+@Composable
+private fun FavoriteCardInfo(model: FavoriteModelSummary) {
+    Column(
+        modifier = Modifier.padding(Spacing.sm),
+        verticalArrangement = Arrangement.spacedBy(Spacing.xs),
+    ) {
+        Text(
+            text = model.name,
+            style = MaterialTheme.typography.titleSmall,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
+        )
+
+        Text(
+            text = model.type.name,
+            style = MaterialTheme.typography.labelSmall,
+            modifier = Modifier
+                .background(
+                    color = MaterialTheme.colorScheme.surfaceVariant,
+                    shape = RoundedCornerShape(50),
+                )
+                .padding(horizontal = 6.dp, vertical = 2.dp),
+        )
+
+        Row(
+            horizontalArrangement = Arrangement.spacedBy(Spacing.sm),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            FavoriteStatItem(
+                label = FormatUtils.formatCount(model.downloadCount),
+                icon = Icons.Outlined.Download,
+            )
+            FavoriteStatItem(
+                label = FormatUtils.formatCount(model.favoriteCount),
+                icon = Icons.Outlined.FavoriteBorder,
+            )
+            FavoriteStatItem(
+                label = FormatUtils.formatRating(model.rating),
+                icon = Icons.Outlined.Star,
+            )
+        }
+    }
+}
+
+@Composable
+private fun FavoriteStatItem(
+    label: String,
+    icon: ImageVector,
+    modifier: Modifier = Modifier,
+) {
+    Row(
+        modifier = modifier,
+        horizontalArrangement = Arrangement.spacedBy(2.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Icon(
+            imageVector = icon,
+            contentDescription = null,
+            modifier = Modifier.size(IconSize.statIcon),
+            tint = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        Text(
+            text = label,
+            style = MaterialTheme.typography.labelSmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+    }
+}

--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/favorites/FavoritesViewModel.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/favorites/FavoritesViewModel.kt
@@ -1,0 +1,18 @@
+package com.riox432.civitdeck.ui.favorites
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.riox432.civitdeck.domain.model.FavoriteModelSummary
+import com.riox432.civitdeck.domain.usecase.ObserveFavoritesUseCase
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.stateIn
+
+class FavoritesViewModel(
+    observeFavoritesUseCase: ObserveFavoritesUseCase,
+) : ViewModel() {
+
+    val favorites: StateFlow<List<FavoriteModelSummary>> =
+        observeFavoritesUseCase()
+            .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), emptyList())
+}

--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/navigation/CivitDeckNavGraph.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/navigation/CivitDeckNavGraph.kt
@@ -2,16 +2,36 @@ package com.riox432.civitdeck.ui.navigation
 
 import androidx.compose.animation.ExperimentalSharedTransitionApi
 import androidx.compose.animation.SharedTransitionLayout
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Favorite
+import androidx.compose.material.icons.filled.Search
+import androidx.compose.material.icons.outlined.FavoriteBorder
+import androidx.compose.material.icons.outlined.Search
+import androidx.compose.material3.Icon
+import androidx.compose.material3.NavigationBar
+import androidx.compose.material3.NavigationBarItem
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateListOf
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.mapSaver
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.navigation3.rememberViewModelStoreNavEntryDecorator
 import androidx.navigation3.runtime.entryProvider
 import androidx.navigation3.runtime.rememberSaveableStateHolderNavEntryDecorator
 import androidx.navigation3.ui.NavDisplay
 import com.riox432.civitdeck.ui.detail.ModelDetailScreen
 import com.riox432.civitdeck.ui.detail.ModelDetailViewModel
+import com.riox432.civitdeck.ui.favorites.FavoritesScreen
+import com.riox432.civitdeck.ui.favorites.FavoritesViewModel
 import com.riox432.civitdeck.ui.gallery.ImageGalleryScreen
 import com.riox432.civitdeck.ui.gallery.ImageGalleryViewModel
 import com.riox432.civitdeck.ui.search.ModelSearchScreen
@@ -21,19 +41,91 @@ import org.koin.core.parameter.parametersOf
 
 data object SearchRoute
 
+data object FavoritesRoute
+
 data class DetailRoute(val modelId: Long, val thumbnailUrl: String? = null)
 
 data class ImageGalleryRoute(val modelVersionId: Long)
 
+private enum class Tab { Search, Favorites }
+
 @OptIn(ExperimentalSharedTransitionApi::class)
 @Composable
 fun CivitDeckNavGraph() {
-    val backStack = remember { mutableStateListOf<Any>(SearchRoute) }
+    var selectedTab by rememberSaveable(
+        stateSaver = mapSaver(
+            save = { mapOf("tab" to it.name) },
+            restore = { Tab.valueOf(it["tab"] as String) },
+        ),
+    ) { mutableStateOf(Tab.Search) }
+    val searchBackStack = remember { mutableStateListOf<Any>(SearchRoute) }
+    val favoritesBackStack = remember { mutableStateListOf<Any>(FavoritesRoute) }
 
-    SharedTransitionLayout {
-        CompositionLocalProvider(LocalSharedTransitionScope provides this) {
-            CivitDeckNavDisplay(backStack)
+    val activeBackStack = when (selectedTab) {
+        Tab.Search -> searchBackStack
+        Tab.Favorites -> favoritesBackStack
+    }
+
+    Scaffold(
+        bottomBar = {
+            BottomNavBar(
+                selectedTab = selectedTab,
+                onTabSelected = { tab ->
+                    if (tab == selectedTab) {
+                        // Pop to root on re-select
+                        val stack = if (tab == Tab.Search) searchBackStack else favoritesBackStack
+                        while (stack.size > 1) stack.removeLast()
+                    } else {
+                        selectedTab = tab
+                    }
+                },
+            )
+        },
+    ) { padding ->
+        SharedTransitionLayout(modifier = Modifier.padding(bottom = padding.calculateBottomPadding())) {
+            CompositionLocalProvider(LocalSharedTransitionScope provides this) {
+                CivitDeckNavDisplay(activeBackStack)
+            }
         }
+    }
+}
+
+@Composable
+private fun BottomNavBar(
+    selectedTab: Tab,
+    onTabSelected: (Tab) -> Unit,
+) {
+    NavigationBar {
+        NavigationBarItem(
+            selected = selectedTab == Tab.Search,
+            onClick = { onTabSelected(Tab.Search) },
+            icon = {
+                Icon(
+                    imageVector = if (selectedTab == Tab.Search) {
+                        Icons.Filled.Search
+                    } else {
+                        Icons.Outlined.Search
+                    },
+                    contentDescription = "Search",
+                )
+            },
+            label = { Text("Search") },
+        )
+        NavigationBarItem(
+            selected = selectedTab == Tab.Favorites,
+            onClick = { onTabSelected(Tab.Favorites) },
+            icon = {
+                Icon(
+                    imageVector = if (selectedTab == Tab.Favorites) {
+                        Icons.Filled.Favorite
+                    } else {
+                        Icons.Outlined.FavoriteBorder
+                    },
+                    contentDescription = "Favorites",
+                )
+            },
+            label = { Text("Favorites") },
+        )
     }
 }
 
@@ -53,6 +145,16 @@ private fun CivitDeckNavDisplay(backStack: MutableList<Any>) {
                     viewModel = viewModel,
                     onModelClick = { modelId, thumbnailUrl ->
                         backStack.add(DetailRoute(modelId, thumbnailUrl))
+                    },
+                )
+            }
+            entry<FavoritesRoute> {
+                val viewModel: FavoritesViewModel = koinViewModel()
+                val favorites by viewModel.favorites.collectAsStateWithLifecycle()
+                FavoritesScreen(
+                    favorites = favorites,
+                    onModelClick = { modelId ->
+                        backStack.add(DetailRoute(modelId))
                     },
                 )
             }

--- a/iosApp/iosApp.xcodeproj/project.pbxproj
+++ b/iosApp/iosApp.xcodeproj/project.pbxproj
@@ -26,6 +26,8 @@
 		CD0006072D000006000CD001 /* CivitDeckShapes.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD0006062D000006000CD001 /* CivitDeckShapes.swift */; };
 		CD00060B2D000006000CD001 /* CivitDeckMotion.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD00060A2D000006000CD001 /* CivitDeckMotion.swift */; };
 		CD0006112D000036000CD001 /* ShimmerModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD0006102D000036000CD001 /* ShimmerModifier.swift */; };
+		CD0007012D000007000CD001 /* FavoritesViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD0007002D000007000CD001 /* FavoritesViewModel.swift */; };
+		CD0007032D000007000CD001 /* FavoritesScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD0007022D000007000CD001 /* FavoritesScreen.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -51,6 +53,8 @@
 		CD0006062D000006000CD001 /* CivitDeckShapes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CivitDeckShapes.swift; sourceTree = "<group>"; };
 		CD00060A2D000006000CD001 /* CivitDeckMotion.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CivitDeckMotion.swift; sourceTree = "<group>"; };
 		CD0006102D000036000CD001 /* ShimmerModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShimmerModifier.swift; sourceTree = "<group>"; };
+		CD0007002D000007000CD001 /* FavoritesViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FavoritesViewModel.swift; sourceTree = "<group>"; };
+		CD0007022D000007000CD001 /* FavoritesScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FavoritesScreen.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -136,10 +140,20 @@
 			isa = PBXGroup;
 			children = (
 				CD0003012D000003000CD001 /* Search */,
+				CD0007042D000007000CD001 /* Favorites */,
 				CD0004042D000004000CD001 /* Detail */,
 				CD0005082D000005000CD001 /* Gallery */,
 			);
 			path = Features;
+			sourceTree = "<group>";
+		};
+		CD0007042D000007000CD001 /* Favorites */ = {
+			isa = PBXGroup;
+			children = (
+				CD0007002D000007000CD001 /* FavoritesViewModel.swift */,
+				CD0007022D000007000CD001 /* FavoritesScreen.swift */,
+			);
+			path = Favorites;
 			sourceTree = "<group>";
 		};
 		CD0005082D000005000CD001 /* Gallery */ = {
@@ -282,6 +296,8 @@
 				CD0006072D000006000CD001 /* CivitDeckShapes.swift in Sources */,
 				CD00060B2D000006000CD001 /* CivitDeckMotion.swift in Sources */,
 				CD0006112D000036000CD001 /* ShimmerModifier.swift in Sources */,
+				CD0007012D000007000CD001 /* FavoritesViewModel.swift in Sources */,
+				CD0007032D000007000CD001 /* FavoritesScreen.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/iosApp/iosApp/ContentView.swift
+++ b/iosApp/iosApp/ContentView.swift
@@ -2,6 +2,16 @@ import SwiftUI
 
 struct ContentView: View {
     var body: some View {
-        ModelSearchScreen()
+        TabView {
+            ModelSearchScreen()
+                .tabItem {
+                    Label("Search", systemImage: "magnifyingglass")
+                }
+
+            FavoritesScreen()
+                .tabItem {
+                    Label("Favorites", systemImage: "heart")
+                }
+        }
     }
 }

--- a/iosApp/iosApp/Features/Favorites/FavoritesScreen.swift
+++ b/iosApp/iosApp/Features/Favorites/FavoritesScreen.swift
@@ -1,0 +1,155 @@
+import SwiftUI
+import Shared
+
+struct FavoritesScreen: View {
+    @StateObject private var viewModel = FavoritesViewModel()
+
+    private let columns = [
+        GridItem(.flexible(), spacing: Spacing.sm),
+        GridItem(.flexible(), spacing: Spacing.sm),
+    ]
+
+    var body: some View {
+        NavigationStack {
+            Group {
+                if viewModel.favorites.isEmpty {
+                    emptyView
+                } else {
+                    favoritesGrid
+                }
+            }
+            .navigationTitle("Favorites")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbarBackground(.visible, for: .navigationBar)
+            .navigationDestination(for: Int64.self) { modelId in
+                ModelDetailScreen(modelId: modelId)
+            }
+        }
+        .task {
+            await viewModel.observe()
+        }
+    }
+
+    private var favoritesGrid: some View {
+        ScrollView {
+            LazyVGrid(columns: columns, spacing: Spacing.sm) {
+                ForEach(viewModel.favorites, id: \.id) { model in
+                    NavigationLink(value: model.id) {
+                        FavoriteCardView(model: model)
+                    }
+                    .buttonStyle(.plain)
+                }
+            }
+            .padding(.horizontal, Spacing.md)
+        }
+    }
+
+    private var emptyView: some View {
+        VStack(spacing: Spacing.sm) {
+            Image(systemName: "heart.slash")
+                .font(.largeTitle)
+                .foregroundColor(.civitOnSurfaceVariant)
+            Text("No favorites yet")
+                .font(.civitTitleMedium)
+                .foregroundColor(.civitOnSurfaceVariant)
+            Text("Models you favorite will appear here")
+                .font(.civitBodyMedium)
+                .foregroundColor(.civitOnSurfaceVariant)
+        }
+    }
+}
+
+private struct FavoriteCardView: View {
+    let model: FavoriteModelSummary
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            thumbnailImage
+
+            VStack(alignment: .leading, spacing: Spacing.xs) {
+                Text(model.name)
+                    .font(.civitTitleSmall)
+                    .lineLimit(1)
+
+                Text(model.type.name)
+                    .font(.civitLabelSmall)
+                    .padding(.horizontal, 6)
+                    .padding(.vertical, 2)
+                    .background(Color.civitSurfaceVariant)
+                    .clipShape(Capsule())
+
+                statsRow
+            }
+            .padding(Spacing.sm)
+        }
+        .background(Color.civitSurface)
+        .clipShape(RoundedRectangle(cornerRadius: CornerRadius.card))
+        .shadow(color: .black.opacity(0.1), radius: 4, x: 0, y: 2)
+    }
+
+    private var thumbnailImage: some View {
+        Group {
+            if let urlString = model.thumbnailUrl, let imageUrl = URL(string: urlString) {
+                Color.civitSurfaceVariant
+                    .aspectRatio(1, contentMode: .fit)
+                    .overlay {
+                        AsyncImage(url: imageUrl) { phase in
+                            switch phase {
+                            case .success(let image):
+                                image
+                                    .resizable()
+                                    .scaledToFill()
+                                    .transition(.opacity)
+                            case .failure:
+                                Image(systemName: "photo")
+                                    .foregroundColor(.civitOnSurfaceVariant)
+                            case .empty:
+                                Rectangle()
+                                    .fill(Color.civitSurfaceVariant)
+                                    .shimmer()
+                            @unknown default:
+                                Image(systemName: "photo")
+                                    .foregroundColor(.civitOnSurfaceVariant)
+                            }
+                        }
+                    }
+                    .clipped()
+            } else {
+                Rectangle()
+                    .fill(Color.civitSurfaceVariant)
+                    .aspectRatio(1, contentMode: .fit)
+                    .overlay {
+                        Image(systemName: "photo")
+                            .foregroundColor(.civitOnSurfaceVariant)
+                    }
+            }
+        }
+    }
+
+    private var statsRow: some View {
+        HStack(spacing: Spacing.sm) {
+            statItem(
+                icon: "arrow.down.circle",
+                value: FormatUtils.shared.formatCount(count: model.downloadCount)
+            )
+            statItem(
+                icon: "heart",
+                value: FormatUtils.shared.formatCount(count: model.favoriteCount)
+            )
+            statItem(
+                icon: "star",
+                value: FormatUtils.shared.formatRating(rating: model.rating)
+            )
+        }
+    }
+
+    private func statItem(icon: String, value: String) -> some View {
+        HStack(spacing: 2) {
+            Image(systemName: icon)
+                .font(.system(size: IconSize.statIcon))
+            Text(value)
+                .font(.civitLabelSmall)
+        }
+        .foregroundColor(.civitOnSurfaceVariant)
+    }
+}

--- a/iosApp/iosApp/Features/Favorites/FavoritesViewModel.swift
+++ b/iosApp/iosApp/Features/Favorites/FavoritesViewModel.swift
@@ -1,0 +1,20 @@
+import Foundation
+import Shared
+
+@MainActor
+final class FavoritesViewModel: ObservableObject {
+    @Published var favorites: [FavoriteModelSummary] = []
+
+    private let observeFavoritesUseCase: ObserveFavoritesUseCase
+
+    init() {
+        self.observeFavoritesUseCase = KoinHelper.shared.getObserveFavoritesUseCase()
+    }
+
+    func observe() async {
+        for await list in observeFavoritesUseCase.invoke() {
+            let items = list.compactMap { $0 as? FavoriteModelSummary }
+            self.favorites = items
+        }
+    }
+}

--- a/shared/schemas/com.riox432.civitdeck.data.local.CivitDeckDatabase/2.json
+++ b/shared/schemas/com.riox432.civitdeck.data.local.CivitDeckDatabase/2.json
@@ -1,0 +1,137 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 2,
+    "identityHash": "1147c981e907cade9a72d505b511c685",
+    "entities": [
+      {
+        "tableName": "favorite_models",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `name` TEXT NOT NULL, `type` TEXT NOT NULL, `nsfw` INTEGER NOT NULL, `thumbnailUrl` TEXT, `creatorName` TEXT, `downloadCount` INTEGER NOT NULL, `favoriteCount` INTEGER NOT NULL, `rating` REAL NOT NULL, `favoritedAt` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "nsfw",
+            "columnName": "nsfw",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "thumbnailUrl",
+            "columnName": "thumbnailUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "creatorName",
+            "columnName": "creatorName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "downloadCount",
+            "columnName": "downloadCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "favoriteCount",
+            "columnName": "favoriteCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "rating",
+            "columnName": "rating",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "favoritedAt",
+            "columnName": "favoritedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "cached_api_responses",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`cacheKey` TEXT NOT NULL, `responseJson` TEXT NOT NULL, `cachedAt` INTEGER NOT NULL, PRIMARY KEY(`cacheKey`))",
+        "fields": [
+          {
+            "fieldPath": "cacheKey",
+            "columnName": "cacheKey",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "responseJson",
+            "columnName": "responseJson",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cachedAt",
+            "columnName": "cachedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "cacheKey"
+          ]
+        }
+      },
+      {
+        "tableName": "user_preferences",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `nsfwFilterLevel` TEXT NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "nsfwFilterLevel",
+            "columnName": "nsfwFilterLevel",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '1147c981e907cade9a72d505b511c685')"
+    ]
+  }
+}


### PR DESCRIPTION
## Description

Add a dedicated Favorites tab accessible via bottom navigation on both platforms. Users can view their favorited models in a grid layout and navigate to model details.

**Android:**
- New `FavoritesViewModel` using `ObserveFavoritesUseCase` with Flow
- New `FavoritesScreen` with grid layout matching search screen style
- Bottom `NavigationBar` with Search and Favorites tabs
- Each tab maintains its own back stack (pop-to-root on re-select)
- `FavoritesRoute` added to Navigation3 entry provider

**iOS:**
- New `FavoritesViewModel` observing favorites via SKIE async sequence
- New `FavoritesScreen` with grid layout and `FavoriteCardView`
- `ContentView` updated from single screen to `TabView` with Search and Favorites tabs
- Each tab has its own `NavigationStack`

## Related Issues

Closes #50

## Screenshots / Video

<!-- If applicable, add screenshots or screen recordings -->

## Test Plan

- [ ] Android: Bottom nav appears with Search and Favorites tabs
- [ ] Android: Tapping Favorites shows empty state when no favorites exist
- [ ] Android: After favoriting a model, it appears in Favorites tab
- [ ] Android: Tapping a favorite card navigates to model detail
- [ ] Android: Re-selecting current tab pops to root
- [ ] iOS: TabView shows Search and Favorites tabs
- [ ] iOS: Favorites list updates reactively when models are favorited/unfavorited

## Review Checklist

- [x] Code follows project architecture (Clean Architecture + MVVM)
- [x] Shared logic is in `commonMain`, platform-specific code only when necessary
- [x] No unnecessary dependencies added
- [ ] Tests added/updated as needed

## Breaking Changes

None