### PR TITLE
Add prompt collection feature

### DIFF
--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/CivitDeckApplication.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/CivitDeckApplication.kt
@@ -6,6 +6,7 @@ import com.riox432.civitdeck.ui.creator.CreatorProfileViewModel
 import com.riox432.civitdeck.ui.detail.ModelDetailViewModel
 import com.riox432.civitdeck.ui.favorites.FavoritesViewModel
 import com.riox432.civitdeck.ui.gallery.ImageGalleryViewModel
+import com.riox432.civitdeck.ui.prompts.SavedPromptsViewModel
 import com.riox432.civitdeck.ui.search.ModelSearchViewModel
 import org.koin.android.ext.koin.androidContext
 import org.koin.core.module.dsl.viewModel
@@ -26,5 +27,6 @@ val androidModule = module {
     viewModel { FavoritesViewModel(get()) }
     viewModel { params -> ModelDetailViewModel(params.get(), get(), get(), get()) }
     viewModel { params -> CreatorProfileViewModel(params.get(), get()) }
-    viewModel { params -> ImageGalleryViewModel(params.get(), get()) }
+    viewModel { params -> ImageGalleryViewModel(params.get(), get(), get()) }
+    viewModel { SavedPromptsViewModel(get(), get()) }
 }

--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/gallery/ImageGalleryScreen.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/gallery/ImageGalleryScreen.kt
@@ -84,6 +84,7 @@ fun ImageGalleryScreen(
             images = uiState.images,
             initialIndex = uiState.selectedImageIndex!!,
             onDismiss = viewModel::onDismissViewer,
+            onSavePrompt = viewModel::savePrompt,
         )
     }
 }

--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/gallery/ImageGalleryViewModel.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/gallery/ImageGalleryViewModel.kt
@@ -3,10 +3,12 @@ package com.riox432.civitdeck.ui.gallery
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.riox432.civitdeck.domain.model.Image
+import com.riox432.civitdeck.domain.model.ImageGenerationMeta
 import com.riox432.civitdeck.domain.model.NsfwLevel
 import com.riox432.civitdeck.domain.model.SortOrder
 import com.riox432.civitdeck.domain.model.TimePeriod
 import com.riox432.civitdeck.domain.usecase.GetImagesUseCase
+import com.riox432.civitdeck.domain.usecase.SavePromptUseCase
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -31,6 +33,7 @@ data class ImageGalleryUiState(
 class ImageGalleryViewModel(
     private val modelVersionId: Long,
     private val getImagesUseCase: GetImagesUseCase,
+    private val savePromptUseCase: SavePromptUseCase,
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow(ImageGalleryUiState())
@@ -97,6 +100,12 @@ class ImageGalleryViewModel(
 
     fun retry() {
         loadImages()
+    }
+
+    fun savePrompt(meta: ImageGenerationMeta, sourceImageUrl: String?) {
+        viewModelScope.launch {
+            savePromptUseCase(meta, sourceImageUrl)
+        }
     }
 
     private fun loadImages(isLoadMore: Boolean = false) {

--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/gallery/ImageViewerOverlay.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/gallery/ImageViewerOverlay.kt
@@ -42,6 +42,7 @@ import coil3.compose.SubcomposeAsyncImage
 import coil3.request.ImageRequest
 import coil3.request.crossfade
 import com.riox432.civitdeck.domain.model.Image
+import com.riox432.civitdeck.domain.model.ImageGenerationMeta
 import com.riox432.civitdeck.ui.theme.Duration
 import com.riox432.civitdeck.ui.theme.Spring
 import kotlinx.coroutines.launch
@@ -52,6 +53,7 @@ fun ImageViewerOverlay(
     images: List<Image>,
     initialIndex: Int,
     onDismiss: () -> Unit,
+    onSavePrompt: (ImageGenerationMeta, String?) -> Unit = { _, _ -> },
 ) {
     BackHandler(onBack = onDismiss)
 
@@ -95,6 +97,7 @@ fun ImageViewerOverlay(
                 meta = meta,
                 sheetState = sheetState,
                 onDismiss = { showMetadata = false },
+                onSavePrompt = { onSavePrompt(meta, currentImage.url) },
             )
         }
     }

--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/gallery/MetadataBottomSheet.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/gallery/MetadataBottomSheet.kt
@@ -31,6 +31,7 @@ fun MetadataBottomSheet(
     meta: ImageGenerationMeta,
     sheetState: SheetState,
     onDismiss: () -> Unit,
+    onSavePrompt: () -> Unit = {},
 ) {
     val context = LocalContext.current
 
@@ -38,7 +39,7 @@ fun MetadataBottomSheet(
         onDismissRequest = onDismiss,
         sheetState = sheetState,
     ) {
-        MetadataContent(meta = meta, context = context)
+        MetadataContent(meta = meta, context = context, onSavePrompt = onSavePrompt)
     }
 }
 
@@ -46,6 +47,7 @@ fun MetadataBottomSheet(
 private fun MetadataContent(
     meta: ImageGenerationMeta,
     context: Context,
+    onSavePrompt: () -> Unit,
 ) {
     Column(
         modifier = Modifier
@@ -60,7 +62,7 @@ private fun MetadataContent(
         )
         Spacer(modifier = Modifier.height(12.dp))
 
-        PromptSection(meta = meta, context = context)
+        PromptSection(meta = meta, context = context, onSavePrompt = onSavePrompt)
         MetadataParams(meta = meta)
     }
 }
@@ -69,6 +71,7 @@ private fun MetadataContent(
 private fun PromptSection(
     meta: ImageGenerationMeta,
     context: Context,
+    onSavePrompt: () -> Unit,
 ) {
     meta.prompt?.let { prompt ->
         MetadataLabel("Prompt")
@@ -77,10 +80,15 @@ private fun PromptSection(
             style = MaterialTheme.typography.bodySmall,
         )
         Spacer(modifier = Modifier.height(8.dp))
-        OutlinedButton(
-            onClick = { copyToClipboard(context, "Prompt", prompt) },
-        ) {
-            Text("Copy Prompt")
+        Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+            OutlinedButton(
+                onClick = { copyToClipboard(context, "Prompt", prompt) },
+            ) {
+                Text("Copy Prompt")
+            }
+            OutlinedButton(onClick = onSavePrompt) {
+                Text("Save Prompt")
+            }
         }
         Spacer(modifier = Modifier.height(8.dp))
     }

--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/navigation/CivitDeckNavGraph.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/navigation/CivitDeckNavGraph.kt
@@ -37,6 +37,8 @@ import com.riox432.civitdeck.ui.favorites.FavoritesScreen
 import com.riox432.civitdeck.ui.favorites.FavoritesViewModel
 import com.riox432.civitdeck.ui.gallery.ImageGalleryScreen
 import com.riox432.civitdeck.ui.gallery.ImageGalleryViewModel
+import com.riox432.civitdeck.ui.prompts.SavedPromptsScreen
+import com.riox432.civitdeck.ui.prompts.SavedPromptsViewModel
 import com.riox432.civitdeck.ui.search.ModelSearchScreen
 import com.riox432.civitdeck.ui.search.ModelSearchViewModel
 import org.koin.compose.viewmodel.koinViewModel
@@ -51,6 +53,8 @@ data class DetailRoute(val modelId: Long, val thumbnailUrl: String? = null)
 data class ImageGalleryRoute(val modelVersionId: Long)
 
 data class CreatorRoute(val username: String)
+
+data object SavedPromptsRoute
 
 private enum class Tab { Search, Favorites }
 
@@ -151,6 +155,7 @@ private fun CivitDeckNavDisplay(backStack: MutableList<Any>) {
                     onModelClick = { modelId, thumbnailUrl ->
                         backStack.add(DetailRoute(modelId, thumbnailUrl))
                     },
+                    onSavedPromptsClick = { backStack.add(SavedPromptsRoute) },
                 )
             }
             entry<FavoritesRoute> {
@@ -166,6 +171,13 @@ private fun CivitDeckNavDisplay(backStack: MutableList<Any>) {
             detailEntry(backStack)
             creatorEntry(backStack)
             galleryEntry(backStack)
+            entry<SavedPromptsRoute> {
+                val viewModel: SavedPromptsViewModel = koinViewModel()
+                SavedPromptsScreen(
+                    viewModel = viewModel,
+                    onBack = { backStack.removeLastOrNull() },
+                )
+            }
         },
     )
 }

--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/prompts/SavedPromptsScreen.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/prompts/SavedPromptsScreen.kt
@@ -1,0 +1,191 @@
+package com.riox432.civitdeck.ui.prompts
+
+import android.content.ClipData
+import android.content.ClipboardManager
+import android.content.Context
+import android.widget.Toast
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material3.Card
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.riox432.civitdeck.domain.model.SavedPrompt
+import com.riox432.civitdeck.ui.theme.CornerRadius
+import com.riox432.civitdeck.ui.theme.Spacing
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun SavedPromptsScreen(
+    viewModel: SavedPromptsViewModel,
+    onBack: () -> Unit,
+) {
+    val prompts by viewModel.prompts.collectAsStateWithLifecycle()
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("Saved Prompts") },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                    }
+                },
+            )
+        },
+    ) { padding ->
+        if (prompts.isEmpty()) {
+            EmptyState(modifier = Modifier.padding(padding))
+        } else {
+            PromptList(
+                prompts = prompts,
+                onDelete = viewModel::delete,
+                modifier = Modifier.padding(padding),
+            )
+        }
+    }
+}
+
+@Composable
+private fun EmptyState(modifier: Modifier = Modifier) {
+    Box(
+        modifier = modifier.fillMaxSize(),
+        contentAlignment = Alignment.Center,
+    ) {
+        Text(
+            text = "No saved prompts yet",
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+    }
+}
+
+@Composable
+private fun PromptList(
+    prompts: List<SavedPrompt>,
+    onDelete: (Long) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val context = LocalContext.current
+    LazyColumn(
+        modifier = modifier.fillMaxSize(),
+        contentPadding = androidx.compose.foundation.layout.PaddingValues(Spacing.lg),
+        verticalArrangement = Arrangement.spacedBy(Spacing.sm),
+    ) {
+        items(prompts, key = { it.id }) { prompt ->
+            PromptCard(
+                prompt = prompt,
+                onCopy = { copyToClipboard(context, prompt.prompt) },
+                onDelete = { onDelete(prompt.id) },
+                modifier = Modifier.animateItem(),
+            )
+        }
+    }
+}
+
+@Composable
+private fun PromptCard(
+    prompt: SavedPrompt,
+    onCopy: () -> Unit,
+    onDelete: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Card(
+        modifier = modifier.fillMaxWidth(),
+        shape = RoundedCornerShape(CornerRadius.card),
+    ) {
+        Column(modifier = Modifier.padding(Spacing.lg)) {
+            prompt.modelName?.let {
+                Text(
+                    text = it,
+                    style = MaterialTheme.typography.labelMedium,
+                    color = MaterialTheme.colorScheme.primary,
+                )
+                Spacer(modifier = Modifier.height(Spacing.xs))
+            }
+            Text(
+                text = prompt.prompt,
+                style = MaterialTheme.typography.bodySmall,
+                maxLines = 4,
+                overflow = TextOverflow.Ellipsis,
+            )
+            prompt.negativePrompt?.let {
+                Spacer(modifier = Modifier.height(Spacing.xs))
+                Text(
+                    text = "Negative: $it",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    maxLines = 2,
+                    overflow = TextOverflow.Ellipsis,
+                )
+            }
+            Spacer(modifier = Modifier.height(Spacing.sm))
+            PromptParams(prompt)
+            Spacer(modifier = Modifier.height(Spacing.sm))
+            Row(
+                horizontalArrangement = Arrangement.spacedBy(Spacing.sm),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                OutlinedButton(onClick = onCopy) {
+                    Text("Copy")
+                }
+                Spacer(modifier = Modifier.weight(1f))
+                IconButton(onClick = onDelete) {
+                    Icon(
+                        Icons.Default.Delete,
+                        contentDescription = "Delete",
+                        tint = MaterialTheme.colorScheme.error,
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun PromptParams(prompt: SavedPrompt) {
+    val params = buildList {
+        prompt.sampler?.let { add("Sampler: $it") }
+        prompt.steps?.let { add("Steps: $it") }
+        prompt.cfgScale?.let { add("CFG: $it") }
+        prompt.seed?.let { add("Seed: $it") }
+        prompt.size?.let { add("Size: $it") }
+    }
+    if (params.isNotEmpty()) {
+        Text(
+            text = params.joinToString(" · "),
+            style = MaterialTheme.typography.labelSmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+    }
+}
+
+private fun copyToClipboard(context: Context, text: String) {
+    val clipboard = context.getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
+    clipboard.setPrimaryClip(ClipData.newPlainText("Prompt", text))
+    Toast.makeText(context, "Copied to clipboard", Toast.LENGTH_SHORT).show()
+}

--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/prompts/SavedPromptsViewModel.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/prompts/SavedPromptsViewModel.kt
@@ -1,0 +1,27 @@
+package com.riox432.civitdeck.ui.prompts
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.riox432.civitdeck.domain.model.SavedPrompt
+import com.riox432.civitdeck.domain.usecase.DeleteSavedPromptUseCase
+import com.riox432.civitdeck.domain.usecase.ObserveSavedPromptsUseCase
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
+
+class SavedPromptsViewModel(
+    observeSavedPromptsUseCase: ObserveSavedPromptsUseCase,
+    private val deleteSavedPromptUseCase: DeleteSavedPromptUseCase,
+) : ViewModel() {
+
+    val prompts: StateFlow<List<SavedPrompt>> =
+        observeSavedPromptsUseCase()
+            .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), emptyList())
+
+    fun delete(id: Long) {
+        viewModelScope.launch {
+            deleteSavedPromptUseCase(id)
+        }
+    }
+}

--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/search/ModelSearchScreen.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/search/ModelSearchScreen.kt
@@ -30,6 +30,7 @@ import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Clear
+import androidx.compose.material.icons.outlined.BookmarkBorder
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
@@ -69,6 +70,7 @@ import com.riox432.civitdeck.ui.theme.Spacing
 fun ModelSearchScreen(
     viewModel: ModelSearchViewModel,
     onModelClick: (Long, String?) -> Unit = { _, _ -> },
+    onSavedPromptsClick: () -> Unit = {},
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     val gridState = rememberLazyGridState()
@@ -90,6 +92,7 @@ fun ModelSearchScreen(
             SearchTopBar(
                 nsfwFilterLevel = uiState.nsfwFilterLevel,
                 onNsfwToggle = viewModel::onNsfwFilterChanged,
+                onSavedPromptsClick = onSavedPromptsClick,
             )
         },
     ) { padding ->
@@ -132,10 +135,14 @@ fun ModelSearchScreen(
 private fun SearchTopBar(
     nsfwFilterLevel: NsfwFilterLevel,
     onNsfwToggle: (NsfwFilterLevel) -> Unit,
+    onSavedPromptsClick: () -> Unit,
 ) {
     TopAppBar(
         title = { Text("CivitDeck") },
         actions = {
+            IconButton(onClick = onSavedPromptsClick) {
+                Icon(Icons.Outlined.BookmarkBorder, contentDescription = "Saved Prompts")
+            }
             NsfwToggle(
                 nsfwFilterLevel = nsfwFilterLevel,
                 onToggle = {

--- a/iosApp/iosApp.xcodeproj/project.pbxproj
+++ b/iosApp/iosApp.xcodeproj/project.pbxproj
@@ -30,6 +30,8 @@
 		CD0007032D000007000CD001 /* FavoritesScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD0007022D000007000CD001 /* FavoritesScreen.swift */; };
 		CD0008012D000008000CD001 /* CreatorProfileViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD0008002D000008000CD001 /* CreatorProfileViewModel.swift */; };
 		CD0008032D000008000CD001 /* CreatorProfileScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD0008022D000008000CD001 /* CreatorProfileScreen.swift */; };
+		CD0009012D000009000CD001 /* SavedPromptsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD0009002D000009000CD001 /* SavedPromptsViewModel.swift */; };
+		CD0009032D000009000CD001 /* SavedPromptsScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD0009022D000009000CD001 /* SavedPromptsScreen.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -59,6 +61,8 @@
 		CD0007022D000007000CD001 /* FavoritesScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FavoritesScreen.swift; sourceTree = "<group>"; };
 		CD0008002D000008000CD001 /* CreatorProfileViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreatorProfileViewModel.swift; sourceTree = "<group>"; };
 		CD0008022D000008000CD001 /* CreatorProfileScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreatorProfileScreen.swift; sourceTree = "<group>"; };
+		CD0009002D000009000CD001 /* SavedPromptsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SavedPromptsViewModel.swift; sourceTree = "<group>"; };
+		CD0009022D000009000CD001 /* SavedPromptsScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SavedPromptsScreen.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -148,6 +152,7 @@
 				CD0008042D000008000CD001 /* Creator */,
 				CD0004042D000004000CD001 /* Detail */,
 				CD0005082D000005000CD001 /* Gallery */,
+				CD0009042D000009000CD001 /* Prompts */,
 			);
 			path = Features;
 			sourceTree = "<group>";
@@ -168,6 +173,15 @@
 				CD0008022D000008000CD001 /* CreatorProfileScreen.swift */,
 			);
 			path = Creator;
+			sourceTree = "<group>";
+		};
+		CD0009042D000009000CD001 /* Prompts */ = {
+			isa = PBXGroup;
+			children = (
+				CD0009002D000009000CD001 /* SavedPromptsViewModel.swift */,
+				CD0009022D000009000CD001 /* SavedPromptsScreen.swift */,
+			);
+			path = Prompts;
 			sourceTree = "<group>";
 		};
 		CD0005082D000005000CD001 /* Gallery */ = {
@@ -314,6 +328,8 @@
 				CD0007032D000007000CD001 /* FavoritesScreen.swift in Sources */,
 				CD0008012D000008000CD001 /* CreatorProfileViewModel.swift in Sources */,
 				CD0008032D000008000CD001 /* CreatorProfileScreen.swift in Sources */,
+				CD0009012D000009000CD001 /* SavedPromptsViewModel.swift in Sources */,
+				CD0009032D000009000CD001 /* SavedPromptsScreen.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/iosApp/iosApp/Features/Gallery/ImageGalleryScreen.swift
+++ b/iosApp/iosApp/Features/Gallery/ImageGalleryScreen.swift
@@ -26,7 +26,8 @@ struct ImageGalleryScreen: View {
         )) {
             ImageViewerScreen(
                 images: viewModel.images,
-                selectedIndex: $viewModel.selectedImageIndex
+                selectedIndex: $viewModel.selectedImageIndex,
+                onSavePrompt: viewModel.savePrompt
             )
         }
     }

--- a/iosApp/iosApp/Features/Gallery/ImageGalleryViewModel.swift
+++ b/iosApp/iosApp/Features/Gallery/ImageGalleryViewModel.swift
@@ -18,6 +18,7 @@ final class ImageGalleryViewModel: ObservableObject {
 
     private let modelVersionId: Int64
     private let getImagesUseCase: GetImagesUseCase
+    private let savePromptUseCase: SavePromptUseCase
     private var nextCursor: String? = nil
     private var loadTask: Task<Void, Never>? = nil
 
@@ -27,6 +28,7 @@ final class ImageGalleryViewModel: ObservableObject {
     init(modelVersionId: Int64) {
         self.modelVersionId = modelVersionId
         self.getImagesUseCase = KoinHelper.shared.getImagesUseCase()
+        self.savePromptUseCase = KoinHelper.shared.getSavePromptUseCase()
         loadImages()
     }
 
@@ -72,6 +74,12 @@ final class ImageGalleryViewModel: ObservableObject {
 
     func retry() {
         loadImages()
+    }
+
+    func savePrompt(meta: ImageGenerationMeta, sourceImageUrl: String) {
+        Task {
+            try await savePromptUseCase.invoke(meta: meta, sourceImageUrl: sourceImageUrl)
+        }
     }
 
     private func loadImages(isLoadMore: Bool = false) {

--- a/iosApp/iosApp/Features/Gallery/ImageViewerScreen.swift
+++ b/iosApp/iosApp/Features/Gallery/ImageViewerScreen.swift
@@ -4,6 +4,7 @@ import Shared
 struct ImageViewerScreen: View {
     let images: [CivitImage]
     @Binding var selectedIndex: Int?
+    var onSavePrompt: (ImageGenerationMeta, String) -> Void = { _, _ in }
 
     @State private var showMetadata = false
     @State private var controlsVisible = true
@@ -35,8 +36,10 @@ struct ImageViewerScreen: View {
             }
             .sheet(isPresented: $showMetadata) {
                 if let meta = images[safe: index]?.meta {
-                    MetadataSheet(meta: meta)
-                        .presentationDetents([.medium, .large])
+                    MetadataSheet(meta: meta) {
+                        onSavePrompt(meta, images[safe: index]?.url ?? "")
+                    }
+                    .presentationDetents([.medium, .large])
                 }
             }
         }

--- a/iosApp/iosApp/Features/Gallery/MetadataSheet.swift
+++ b/iosApp/iosApp/Features/Gallery/MetadataSheet.swift
@@ -3,6 +3,7 @@ import Shared
 
 struct MetadataSheet: View {
     let meta: ImageGenerationMeta
+    var onSavePrompt: () -> Void = {}
 
     var body: some View {
         NavigationStack {
@@ -30,11 +31,19 @@ struct MetadataSheet: View {
                 Text(prompt)
                     .font(.callout)
 
-                Button("Copy Prompt") {
-                    UIPasteboard.general.string = prompt
+                HStack(spacing: 8) {
+                    Button("Copy Prompt") {
+                        UIPasteboard.general.string = prompt
+                    }
+                    .buttonStyle(.bordered)
+                    .controlSize(.small)
+
+                    Button("Save Prompt") {
+                        onSavePrompt()
+                    }
+                    .buttonStyle(.bordered)
+                    .controlSize(.small)
                 }
-                .buttonStyle(.bordered)
-                .controlSize(.small)
                 .padding(.top, 4)
             }
         }

--- a/iosApp/iosApp/Features/Prompts/SavedPromptsScreen.swift
+++ b/iosApp/iosApp/Features/Prompts/SavedPromptsScreen.swift
@@ -1,0 +1,105 @@
+import SwiftUI
+import Shared
+
+struct SavedPromptsScreen: View {
+    @StateObject private var viewModel = SavedPromptsViewModel()
+
+    var body: some View {
+        Group {
+            if viewModel.prompts.isEmpty {
+                emptyState
+            } else {
+                promptList
+            }
+        }
+        .navigationTitle("Saved Prompts")
+        .navigationBarTitleDisplayMode(.inline)
+    }
+
+    private var emptyState: some View {
+        VStack(spacing: Spacing.sm) {
+            SwiftUI.Image(systemName: "bookmark")
+                .font(.largeTitle)
+                .foregroundColor(.civitOnSurfaceVariant)
+            Text("No saved prompts yet")
+                .foregroundColor(.civitOnSurfaceVariant)
+        }
+        .frame(maxHeight: .infinity)
+    }
+
+    private var promptList: some View {
+        List {
+            ForEach(viewModel.prompts, id: \.id) { prompt in
+                PromptCardView(prompt: prompt) {
+                    viewModel.delete(id: prompt.id)
+                }
+            }
+        }
+        .listStyle(.plain)
+    }
+}
+
+// MARK: - Prompt Card
+
+private struct PromptCardView: View {
+    let prompt: SavedPrompt
+    let onDelete: () -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            if let modelName = prompt.modelName {
+                Text(modelName)
+                    .font(.caption)
+                    .foregroundColor(.civitPrimary)
+            }
+
+            Text(prompt.prompt)
+                .font(.callout)
+                .lineLimit(4)
+
+            if let neg = prompt.negativePrompt {
+                Text("Negative: \(neg)")
+                    .font(.caption)
+                    .foregroundColor(.civitOnSurfaceVariant)
+                    .lineLimit(2)
+            }
+
+            paramsText
+
+            HStack {
+                Button("Copy") {
+                    UIPasteboard.general.string = prompt.prompt
+                }
+                .buttonStyle(.bordered)
+                .controlSize(.small)
+
+                Spacer()
+
+                Button(role: .destructive) {
+                    onDelete()
+                } label: {
+                    SwiftUI.Image(systemName: "trash")
+                }
+                .buttonStyle(.borderless)
+            }
+        }
+        .padding(.vertical, 4)
+    }
+
+    @ViewBuilder
+    private var paramsText: some View {
+        let parts = [
+            prompt.sampler.map { "Sampler: \($0)" },
+            prompt.steps.map { "Steps: \($0)" },
+            prompt.cfgScale.map { "CFG: \($0)" },
+            prompt.seed.map { "Seed: \($0)" },
+            prompt.size.map { "Size: \($0)" },
+        ].compactMap { $0 }
+
+        if !parts.isEmpty {
+            Text(parts.joined(separator: " · "))
+                .font(.caption2)
+                .foregroundColor(.civitOnSurfaceVariant)
+        }
+    }
+}

--- a/iosApp/iosApp/Features/Prompts/SavedPromptsViewModel.swift
+++ b/iosApp/iosApp/Features/Prompts/SavedPromptsViewModel.swift
@@ -1,0 +1,29 @@
+import Foundation
+import Shared
+
+@MainActor
+final class SavedPromptsViewModel: ObservableObject {
+    @Published var prompts: [SavedPrompt] = []
+
+    private let observeSavedPromptsUseCase: ObserveSavedPromptsUseCase
+    private let deleteSavedPromptUseCase: DeleteSavedPromptUseCase
+
+    init() {
+        self.observeSavedPromptsUseCase = KoinHelper.shared.getObserveSavedPromptsUseCase()
+        self.deleteSavedPromptUseCase = KoinHelper.shared.getDeleteSavedPromptUseCase()
+        Task { await observe() }
+    }
+
+    func observe() async {
+        for await list in observeSavedPromptsUseCase.invoke() {
+            let items = list.compactMap { $0 as? SavedPrompt }
+            self.prompts = items
+        }
+    }
+
+    func delete(id: Int64) {
+        Task {
+            try await deleteSavedPromptUseCase.invoke(id: id)
+        }
+    }
+}

--- a/iosApp/iosApp/Features/Search/ModelSearchScreen.swift
+++ b/iosApp/iosApp/Features/Search/ModelSearchScreen.swift
@@ -40,6 +40,13 @@ struct ModelSearchScreen: View {
             .toolbarBackground(.visible, for: .navigationBar)
             .toolbar {
                 ToolbarItem(placement: .navigationBarTrailing) {
+                    NavigationLink {
+                        SavedPromptsScreen()
+                    } label: {
+                        Image(systemName: "bookmark")
+                    }
+                }
+                ToolbarItem(placement: .navigationBarTrailing) {
                     HStack(spacing: 4) {
                         Text("NSFW")
                             .font(.civitLabelSmall)

--- a/shared/src/commonMain/kotlin/com/riox432/civitdeck/data/local/CivitDeckDatabase.kt
+++ b/shared/src/commonMain/kotlin/com/riox432/civitdeck/data/local/CivitDeckDatabase.kt
@@ -10,9 +10,11 @@ import androidx.sqlite.driver.bundled.BundledSQLiteDriver
 import androidx.sqlite.execSQL
 import com.riox432.civitdeck.data.local.dao.CachedApiResponseDao
 import com.riox432.civitdeck.data.local.dao.FavoriteModelDao
+import com.riox432.civitdeck.data.local.dao.SavedPromptDao
 import com.riox432.civitdeck.data.local.dao.UserPreferencesDao
 import com.riox432.civitdeck.data.local.entity.CachedApiResponseEntity
 import com.riox432.civitdeck.data.local.entity.FavoriteModelEntity
+import com.riox432.civitdeck.data.local.entity.SavedPromptEntity
 import com.riox432.civitdeck.data.local.entity.UserPreferencesEntity
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.IO
@@ -22,6 +24,7 @@ import kotlinx.coroutines.IO
         FavoriteModelEntity::class,
         CachedApiResponseEntity::class,
         UserPreferencesEntity::class,
+        SavedPromptEntity::class,
     ],
     version = 2,
 )
@@ -30,6 +33,7 @@ abstract class CivitDeckDatabase : RoomDatabase() {
     abstract fun favoriteModelDao(): FavoriteModelDao
     abstract fun cachedApiResponseDao(): CachedApiResponseDao
     abstract fun userPreferencesDao(): UserPreferencesDao
+    abstract fun savedPromptDao(): SavedPromptDao
 }
 
 @Suppress("NO_ACTUAL_FOR_EXPECT")
@@ -41,6 +45,23 @@ val MIGRATION_1_2 = object : Migration(1, 2) {
             "CREATE TABLE IF NOT EXISTS `user_preferences` " +
                 "(`id` INTEGER NOT NULL DEFAULT 1, `nsfwFilterLevel` TEXT NOT NULL DEFAULT 'Off', " +
                 "PRIMARY KEY(`id`))",
+        )
+        connection.execSQL(
+            """
+            CREATE TABLE IF NOT EXISTS saved_prompts (
+                id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+                prompt TEXT NOT NULL,
+                negativePrompt TEXT,
+                sampler TEXT,
+                steps INTEGER,
+                cfgScale REAL,
+                seed INTEGER,
+                modelName TEXT,
+                size TEXT,
+                sourceImageUrl TEXT,
+                savedAt INTEGER NOT NULL
+            )
+            """.trimIndent(),
         )
     }
 }

--- a/shared/src/commonMain/kotlin/com/riox432/civitdeck/data/local/dao/SavedPromptDao.kt
+++ b/shared/src/commonMain/kotlin/com/riox432/civitdeck/data/local/dao/SavedPromptDao.kt
@@ -1,0 +1,19 @@
+package com.riox432.civitdeck.data.local.dao
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.Query
+import com.riox432.civitdeck.data.local.entity.SavedPromptEntity
+import kotlinx.coroutines.flow.Flow
+
+@Dao
+interface SavedPromptDao {
+    @Query("SELECT * FROM saved_prompts ORDER BY savedAt DESC")
+    fun observeAll(): Flow<List<SavedPromptEntity>>
+
+    @Insert
+    suspend fun insert(entity: SavedPromptEntity)
+
+    @Query("DELETE FROM saved_prompts WHERE id = :id")
+    suspend fun deleteById(id: Long)
+}

--- a/shared/src/commonMain/kotlin/com/riox432/civitdeck/data/local/entity/SavedPromptEntity.kt
+++ b/shared/src/commonMain/kotlin/com/riox432/civitdeck/data/local/entity/SavedPromptEntity.kt
@@ -1,0 +1,19 @@
+package com.riox432.civitdeck.data.local.entity
+
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+
+@Entity(tableName = "saved_prompts")
+data class SavedPromptEntity(
+    @PrimaryKey(autoGenerate = true) val id: Long = 0,
+    val prompt: String,
+    val negativePrompt: String?,
+    val sampler: String?,
+    val steps: Int?,
+    val cfgScale: Double?,
+    val seed: Long?,
+    val modelName: String?,
+    val size: String?,
+    val sourceImageUrl: String?,
+    val savedAt: Long,
+)

--- a/shared/src/commonMain/kotlin/com/riox432/civitdeck/data/repository/SavedPromptRepositoryImpl.kt
+++ b/shared/src/commonMain/kotlin/com/riox432/civitdeck/data/repository/SavedPromptRepositoryImpl.kt
@@ -1,0 +1,38 @@
+package com.riox432.civitdeck.data.repository
+
+import com.riox432.civitdeck.data.local.currentTimeMillis
+import com.riox432.civitdeck.data.local.dao.SavedPromptDao
+import com.riox432.civitdeck.data.local.entity.SavedPromptEntity
+import com.riox432.civitdeck.domain.model.ImageGenerationMeta
+import com.riox432.civitdeck.domain.model.SavedPrompt
+import com.riox432.civitdeck.domain.model.toDomain
+import com.riox432.civitdeck.domain.repository.SavedPromptRepository
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+
+class SavedPromptRepositoryImpl(
+    private val dao: SavedPromptDao,
+) : SavedPromptRepository {
+
+    override fun observeAll(): Flow<List<SavedPrompt>> =
+        dao.observeAll().map { list -> list.map { it.toDomain() } }
+
+    override suspend fun save(meta: ImageGenerationMeta, sourceImageUrl: String?) {
+        dao.insert(
+            SavedPromptEntity(
+                prompt = meta.prompt ?: "",
+                negativePrompt = meta.negativePrompt,
+                sampler = meta.sampler,
+                steps = meta.steps,
+                cfgScale = meta.cfgScale,
+                seed = meta.seed,
+                modelName = meta.model,
+                size = meta.size,
+                sourceImageUrl = sourceImageUrl,
+                savedAt = currentTimeMillis(),
+            ),
+        )
+    }
+
+    override suspend fun delete(id: Long) = dao.deleteById(id)
+}

--- a/shared/src/commonMain/kotlin/com/riox432/civitdeck/di/DataModule.kt
+++ b/shared/src/commonMain/kotlin/com/riox432/civitdeck/di/DataModule.kt
@@ -9,12 +9,14 @@ import com.riox432.civitdeck.data.repository.CreatorRepositoryImpl
 import com.riox432.civitdeck.data.repository.FavoriteRepositoryImpl
 import com.riox432.civitdeck.data.repository.ImageRepositoryImpl
 import com.riox432.civitdeck.data.repository.ModelRepositoryImpl
+import com.riox432.civitdeck.data.repository.SavedPromptRepositoryImpl
 import com.riox432.civitdeck.data.repository.TagRepositoryImpl
 import com.riox432.civitdeck.data.repository.UserPreferencesRepositoryImpl
 import com.riox432.civitdeck.domain.repository.CreatorRepository
 import com.riox432.civitdeck.domain.repository.FavoriteRepository
 import com.riox432.civitdeck.domain.repository.ImageRepository
 import com.riox432.civitdeck.domain.repository.ModelRepository
+import com.riox432.civitdeck.domain.repository.SavedPromptRepository
 import com.riox432.civitdeck.domain.repository.TagRepository
 import com.riox432.civitdeck.domain.repository.UserPreferencesRepository
 import kotlinx.serialization.json.Json
@@ -36,6 +38,7 @@ val dataModule = module {
     single { get<CivitDeckDatabase>().favoriteModelDao() }
     single { get<CivitDeckDatabase>().cachedApiResponseDao() }
     single { get<CivitDeckDatabase>().userPreferencesDao() }
+    single { get<CivitDeckDatabase>().savedPromptDao() }
 
     // Data Sources
     single { LocalCacheDataSource(get()) }
@@ -47,4 +50,5 @@ val dataModule = module {
     single<TagRepository> { TagRepositoryImpl(get()) }
     single<FavoriteRepository> { FavoriteRepositoryImpl(get()) }
     single<UserPreferencesRepository> { UserPreferencesRepositoryImpl(get()) }
+    single<SavedPromptRepository> { SavedPromptRepositoryImpl(get()) }
 }

--- a/shared/src/commonMain/kotlin/com/riox432/civitdeck/di/DomainModule.kt
+++ b/shared/src/commonMain/kotlin/com/riox432/civitdeck/di/DomainModule.kt
@@ -1,5 +1,6 @@
 package com.riox432.civitdeck.di
 
+import com.riox432.civitdeck.domain.usecase.DeleteSavedPromptUseCase
 import com.riox432.civitdeck.domain.usecase.GetCreatorModelsUseCase
 import com.riox432.civitdeck.domain.usecase.GetImagesUseCase
 import com.riox432.civitdeck.domain.usecase.GetModelDetailUseCase
@@ -7,6 +8,8 @@ import com.riox432.civitdeck.domain.usecase.GetModelsUseCase
 import com.riox432.civitdeck.domain.usecase.ObserveFavoritesUseCase
 import com.riox432.civitdeck.domain.usecase.ObserveIsFavoriteUseCase
 import com.riox432.civitdeck.domain.usecase.ObserveNsfwFilterUseCase
+import com.riox432.civitdeck.domain.usecase.ObserveSavedPromptsUseCase
+import com.riox432.civitdeck.domain.usecase.SavePromptUseCase
 import com.riox432.civitdeck.domain.usecase.SetNsfwFilterUseCase
 import com.riox432.civitdeck.domain.usecase.ToggleFavoriteUseCase
 import org.koin.dsl.module
@@ -21,4 +24,7 @@ val domainModule = module {
     factory { ObserveIsFavoriteUseCase(get()) }
     factory { ObserveNsfwFilterUseCase(get()) }
     factory { SetNsfwFilterUseCase(get()) }
+    factory { SavePromptUseCase(get()) }
+    factory { ObserveSavedPromptsUseCase(get()) }
+    factory { DeleteSavedPromptUseCase(get()) }
 }

--- a/shared/src/commonMain/kotlin/com/riox432/civitdeck/domain/model/SavedPrompt.kt
+++ b/shared/src/commonMain/kotlin/com/riox432/civitdeck/domain/model/SavedPrompt.kt
@@ -1,0 +1,31 @@
+package com.riox432.civitdeck.domain.model
+
+import com.riox432.civitdeck.data.local.entity.SavedPromptEntity
+
+data class SavedPrompt(
+    val id: Long,
+    val prompt: String,
+    val negativePrompt: String?,
+    val sampler: String?,
+    val steps: Int?,
+    val cfgScale: Double?,
+    val seed: Long?,
+    val modelName: String?,
+    val size: String?,
+    val sourceImageUrl: String?,
+    val savedAt: Long,
+)
+
+fun SavedPromptEntity.toDomain(): SavedPrompt = SavedPrompt(
+    id = id,
+    prompt = prompt,
+    negativePrompt = negativePrompt,
+    sampler = sampler,
+    steps = steps,
+    cfgScale = cfgScale,
+    seed = seed,
+    modelName = modelName,
+    size = size,
+    sourceImageUrl = sourceImageUrl,
+    savedAt = savedAt,
+)

--- a/shared/src/commonMain/kotlin/com/riox432/civitdeck/domain/repository/SavedPromptRepository.kt
+++ b/shared/src/commonMain/kotlin/com/riox432/civitdeck/domain/repository/SavedPromptRepository.kt
@@ -1,0 +1,11 @@
+package com.riox432.civitdeck.domain.repository
+
+import com.riox432.civitdeck.domain.model.ImageGenerationMeta
+import com.riox432.civitdeck.domain.model.SavedPrompt
+import kotlinx.coroutines.flow.Flow
+
+interface SavedPromptRepository {
+    fun observeAll(): Flow<List<SavedPrompt>>
+    suspend fun save(meta: ImageGenerationMeta, sourceImageUrl: String?)
+    suspend fun delete(id: Long)
+}

--- a/shared/src/commonMain/kotlin/com/riox432/civitdeck/domain/usecase/DeleteSavedPromptUseCase.kt
+++ b/shared/src/commonMain/kotlin/com/riox432/civitdeck/domain/usecase/DeleteSavedPromptUseCase.kt
@@ -1,0 +1,7 @@
+package com.riox432.civitdeck.domain.usecase
+
+import com.riox432.civitdeck.domain.repository.SavedPromptRepository
+
+class DeleteSavedPromptUseCase(private val repository: SavedPromptRepository) {
+    suspend operator fun invoke(id: Long) = repository.delete(id)
+}

--- a/shared/src/commonMain/kotlin/com/riox432/civitdeck/domain/usecase/ObserveSavedPromptsUseCase.kt
+++ b/shared/src/commonMain/kotlin/com/riox432/civitdeck/domain/usecase/ObserveSavedPromptsUseCase.kt
@@ -1,0 +1,9 @@
+package com.riox432.civitdeck.domain.usecase
+
+import com.riox432.civitdeck.domain.model.SavedPrompt
+import com.riox432.civitdeck.domain.repository.SavedPromptRepository
+import kotlinx.coroutines.flow.Flow
+
+class ObserveSavedPromptsUseCase(private val repository: SavedPromptRepository) {
+    operator fun invoke(): Flow<List<SavedPrompt>> = repository.observeAll()
+}

--- a/shared/src/commonMain/kotlin/com/riox432/civitdeck/domain/usecase/SavePromptUseCase.kt
+++ b/shared/src/commonMain/kotlin/com/riox432/civitdeck/domain/usecase/SavePromptUseCase.kt
@@ -1,0 +1,9 @@
+package com.riox432.civitdeck.domain.usecase
+
+import com.riox432.civitdeck.domain.model.ImageGenerationMeta
+import com.riox432.civitdeck.domain.repository.SavedPromptRepository
+
+class SavePromptUseCase(private val repository: SavedPromptRepository) {
+    suspend operator fun invoke(meta: ImageGenerationMeta, sourceImageUrl: String?) =
+        repository.save(meta, sourceImageUrl)
+}

--- a/shared/src/iosMain/kotlin/com/riox432/civitdeck/di/KoinHelper.kt
+++ b/shared/src/iosMain/kotlin/com/riox432/civitdeck/di/KoinHelper.kt
@@ -1,5 +1,6 @@
 package com.riox432.civitdeck.di
 
+import com.riox432.civitdeck.domain.usecase.DeleteSavedPromptUseCase
 import com.riox432.civitdeck.domain.usecase.GetCreatorModelsUseCase
 import com.riox432.civitdeck.domain.usecase.GetImagesUseCase
 import com.riox432.civitdeck.domain.usecase.GetModelDetailUseCase
@@ -7,10 +8,13 @@ import com.riox432.civitdeck.domain.usecase.GetModelsUseCase
 import com.riox432.civitdeck.domain.usecase.ObserveFavoritesUseCase
 import com.riox432.civitdeck.domain.usecase.ObserveIsFavoriteUseCase
 import com.riox432.civitdeck.domain.usecase.ObserveNsfwFilterUseCase
+import com.riox432.civitdeck.domain.usecase.ObserveSavedPromptsUseCase
+import com.riox432.civitdeck.domain.usecase.SavePromptUseCase
 import com.riox432.civitdeck.domain.usecase.SetNsfwFilterUseCase
 import com.riox432.civitdeck.domain.usecase.ToggleFavoriteUseCase
 import org.koin.mp.KoinPlatform.getKoin
 
+@Suppress("TooManyFunctions")
 object KoinHelper {
     fun getModelsUseCase(): GetModelsUseCase = getKoin().get()
     fun getCreatorModelsUseCase(): GetCreatorModelsUseCase = getKoin().get()
@@ -21,4 +25,7 @@ object KoinHelper {
     fun getObserveIsFavoriteUseCase(): ObserveIsFavoriteUseCase = getKoin().get()
     fun getObserveNsfwFilterUseCase(): ObserveNsfwFilterUseCase = getKoin().get()
     fun getSetNsfwFilterUseCase(): SetNsfwFilterUseCase = getKoin().get()
+    fun getSavePromptUseCase(): SavePromptUseCase = getKoin().get()
+    fun getObserveSavedPromptsUseCase(): ObserveSavedPromptsUseCase = getKoin().get()
+    fun getDeleteSavedPromptUseCase(): DeleteSavedPromptUseCase = getKoin().get()
 }


### PR DESCRIPTION
## Description

Add prompt collection feature allowing users to save, browse, and delete generation prompts from image metadata.

- Save prompt button in MetadataBottomSheet (Android) / MetadataSheet (iOS)
- SavedPromptsScreen with prompt cards showing model name, prompt, negative prompt, and generation params
- Copy and delete actions per saved prompt
- Bookmark icon in search screen toolbar for navigation to saved prompts
- Room DB migration v1→v2 with saved_prompts table
- Full shared layer: Entity, DAO, Repository, UseCases, DI

## Related Issues

Closes #49

## Screenshots / Video

<!-- If applicable, add screenshots or screen recordings -->

## Test Plan

- [ ] Save a prompt from image metadata bottom sheet
- [ ] Navigate to saved prompts via bookmark icon
- [ ] Verify saved prompts display with correct data
- [ ] Copy a saved prompt to clipboard
- [ ] Delete a saved prompt
- [ ] Verify empty state when no prompts saved

## Review Checklist

- [x] Code follows project architecture (Clean Architecture + MVVM)
- [x] Shared logic is in `commonMain`, platform-specific code only when necessary
- [x] No unnecessary dependencies added
- [ ] Tests added/updated as needed

## Breaking Changes

None