### PR TITLE
Add sort and period filters to model search

### DIFF
--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/search/ModelSearchScreen.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/search/ModelSearchScreen.kt
@@ -59,6 +59,8 @@ import com.riox432.civitdeck.domain.model.BaseModel
 import com.riox432.civitdeck.domain.model.Model
 import com.riox432.civitdeck.domain.model.ModelType
 import com.riox432.civitdeck.domain.model.NsfwFilterLevel
+import com.riox432.civitdeck.domain.model.SortOrder
+import com.riox432.civitdeck.domain.model.TimePeriod
 import com.riox432.civitdeck.ui.components.ModelCard
 import com.riox432.civitdeck.ui.theme.CornerRadius
 import com.riox432.civitdeck.ui.theme.Duration
@@ -111,13 +113,12 @@ fun ModelSearchScreen(
                 onQueryChange = viewModel::onQueryChange,
                 onSearch = viewModel::onSearch,
             )
-            TypeFilterChips(
-                selectedType = uiState.selectedType,
+            SearchFilters(
+                uiState = uiState,
                 onTypeSelected = viewModel::onTypeSelected,
-            )
-            BaseModelFilterChips(
-                selectedBaseModels = uiState.selectedBaseModels,
                 onBaseModelToggled = viewModel::onBaseModelToggled,
+                onSortSelected = viewModel::onSortSelected,
+                onPeriodSelected = viewModel::onPeriodSelected,
             )
             ModelSearchContent(
                 uiState = uiState,
@@ -155,6 +156,24 @@ private fun SearchTopBar(
                 },
             )
         },
+    )
+}
+
+@Composable
+private fun SearchFilters(
+    uiState: ModelSearchUiState,
+    onTypeSelected: (ModelType?) -> Unit,
+    onBaseModelToggled: (BaseModel) -> Unit,
+    onSortSelected: (SortOrder) -> Unit,
+    onPeriodSelected: (TimePeriod) -> Unit,
+) {
+    TypeFilterChips(selectedType = uiState.selectedType, onTypeSelected = onTypeSelected)
+    BaseModelFilterChips(selectedBaseModels = uiState.selectedBaseModels, onBaseModelToggled = onBaseModelToggled)
+    SortAndPeriodFilters(
+        selectedSort = uiState.selectedSort,
+        selectedPeriod = uiState.selectedPeriod,
+        onSortSelected = onSortSelected,
+        onPeriodSelected = onPeriodSelected,
     )
 }
 
@@ -258,6 +277,34 @@ private fun BaseModelFilterChips(
                 label = baseModel.displayName,
                 isSelected = baseModel in selectedBaseModels,
                 onClick = { onBaseModelToggled(baseModel) },
+            )
+        }
+    }
+}
+
+@Composable
+private fun SortAndPeriodFilters(
+    selectedSort: SortOrder,
+    selectedPeriod: TimePeriod,
+    onSortSelected: (SortOrder) -> Unit,
+    onPeriodSelected: (TimePeriod) -> Unit,
+) {
+    LazyRow(
+        contentPadding = PaddingValues(horizontal = Spacing.lg),
+        horizontalArrangement = Arrangement.spacedBy(Spacing.sm),
+    ) {
+        items(SortOrder.entries.toList()) { sort ->
+            FilterChipItem(
+                label = sort.name,
+                isSelected = selectedSort == sort,
+                onClick = { onSortSelected(sort) },
+            )
+        }
+        items(TimePeriod.entries.toList()) { period ->
+            FilterChipItem(
+                label = period.name,
+                isSelected = selectedPeriod == period,
+                onClick = { onPeriodSelected(period) },
             )
         }
     }

--- a/iosApp/iosApp/Features/Search/ModelSearchScreen.swift
+++ b/iosApp/iosApp/Features/Search/ModelSearchScreen.swift
@@ -15,6 +15,7 @@ struct ModelSearchScreen: View {
                 searchBar
                 typeFilterChips
                 baseModelFilterChips
+                sortAndPeriodChips
 
                 ZStack {
                     if viewModel.isLoading && viewModel.models.isEmpty {
@@ -161,6 +162,25 @@ struct ModelSearchScreen: View {
         }
     }
 
+    private var sortAndPeriodChips: some View {
+        ScrollView(.horizontal, showsIndicators: false) {
+            HStack(spacing: Spacing.sm) {
+                ForEach(sortOptions, id: \.self) { sort in
+                    chipButton(label: sortLabel(sort), isSelected: viewModel.selectedSort == sort) {
+                        viewModel.onSortSelected(sort)
+                    }
+                }
+                ForEach(periodOptions, id: \.self) { period in
+                    chipButton(label: periodLabel(period), isSelected: viewModel.selectedPeriod == period) {
+                        viewModel.onPeriodSelected(period)
+                    }
+                }
+            }
+            .padding(.horizontal, Spacing.lg)
+            .padding(.bottom, Spacing.sm)
+        }
+    }
+
     private func chipButton(label: String, isSelected: Bool, action: @escaping () -> Void) -> some View {
         Button(action: action) {
             Text(label)
@@ -204,6 +224,26 @@ struct ModelSearchScreen: View {
 }
 
 private let baseModelOptions: [BaseModel] = [.sd15, .sdxl10, .pony, .flux1D, .flux1S, .sd21, .svd]
+private let sortOptions: [CivitSortOrder] = [.mostDownloaded, .highestRated, .newest]
+private let periodOptions: [TimePeriod] = [.allTime, .year, .month, .week, .day]
+
+private func sortLabel(_ sort: CivitSortOrder) -> String {
+    switch sort {
+    case .highestRated: return "Highest Rated"
+    case .mostDownloaded: return "Most Downloaded"
+    case .newest: return "Newest"
+    }
+}
+
+private func periodLabel(_ period: TimePeriod) -> String {
+    switch period {
+    case .allTime: return "All"
+    case .year: return "Year"
+    case .month: return "Month"
+    case .week: return "Week"
+    case .day: return "Day"
+    }
+}
 
 private let modelTypeOptions: [ModelType] = [
     .checkpoint, .lora, .loCon, .controlnet,

--- a/iosApp/iosApp/Features/Search/ModelSearchViewModel.swift
+++ b/iosApp/iosApp/Features/Search/ModelSearchViewModel.swift
@@ -8,6 +8,8 @@ final class ModelSearchViewModel: ObservableObject {
     @Published var selectedType: ModelType? = nil
     @Published var selectedBaseModels: Set<BaseModel> = []
     @Published var nsfwFilterLevel: NsfwFilterLevel = .off
+    @Published var selectedSort: CivitSortOrder = .mostDownloaded
+    @Published var selectedPeriod: TimePeriod = .allTime
     @Published var isLoading: Bool = false
     @Published var isLoadingMore: Bool = false
     @Published var error: String? = nil
@@ -78,6 +80,24 @@ final class ModelSearchViewModel: ObservableObject {
         loadModels()
     }
 
+    func onSortSelected(_ sort: CivitSortOrder) {
+        loadTask?.cancel()
+        selectedSort = sort
+        models = []
+        nextCursor = nil
+        hasMore = true
+        loadModels()
+    }
+
+    func onPeriodSelected(_ period: TimePeriod) {
+        loadTask?.cancel()
+        selectedPeriod = period
+        models = []
+        nextCursor = nil
+        hasMore = true
+        loadModels()
+    }
+
     func loadMore() {
         guard !isLoading, !isLoadingMore, hasMore else { return }
         loadModels(isLoadMore: true)
@@ -105,8 +125,8 @@ final class ModelSearchViewModel: ObservableObject {
                     query: query.isEmpty ? nil : query,
                     tag: nil,
                     type: selectedType,
-                    sort: nil,
-                    period: nil,
+                    sort: selectedSort,
+                    period: selectedPeriod,
                     baseModels: baseModelList,
                     cursor: isLoadMore ? nextCursor : nil,
                     limit: KotlinInt(int: pageSize)

--- a/shared/schemas/com.riox432.civitdeck.data.local.CivitDeckDatabase/2.json
+++ b/shared/schemas/com.riox432.civitdeck.data.local.CivitDeckDatabase/2.json
@@ -2,7 +2,7 @@
   "formatVersion": 1,
   "database": {
     "version": 2,
-    "identityHash": "1147c981e907cade9a72d505b511c685",
+    "identityHash": "af4abcf11c20ec6b15e9e2e3df2c6cf0",
     "entities": [
       {
         "tableName": "favorite_models",
@@ -127,11 +127,81 @@
             "id"
           ]
         }
+      },
+      {
+        "tableName": "saved_prompts",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `prompt` TEXT NOT NULL, `negativePrompt` TEXT, `sampler` TEXT, `steps` INTEGER, `cfgScale` REAL, `seed` INTEGER, `modelName` TEXT, `size` TEXT, `sourceImageUrl` TEXT, `savedAt` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "prompt",
+            "columnName": "prompt",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "negativePrompt",
+            "columnName": "negativePrompt",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "sampler",
+            "columnName": "sampler",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "steps",
+            "columnName": "steps",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "cfgScale",
+            "columnName": "cfgScale",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "seed",
+            "columnName": "seed",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "modelName",
+            "columnName": "modelName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "size",
+            "columnName": "size",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "sourceImageUrl",
+            "columnName": "sourceImageUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "savedAt",
+            "columnName": "savedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
       }
     ],
     "setupQueries": [
       "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
-      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '1147c981e907cade9a72d505b511c685')"
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'af4abcf11c20ec6b15e9e2e3df2c6cf0')"
     ]
   }
 }


### PR DESCRIPTION
## Description

Add sort order (Highest Rated, Most Downloaded, Newest) and time period (All, Year, Month, Week, Day) filter chips to the model search screen on both Android and iOS.

- Android: ViewModel already had sort/period state — added UI filter chip row below type filters
- iOS: Added sort/period state to ViewModel and filter chip row to SearchScreen

## Related Issues

Closes #47

## Screenshots / Video

<!-- If applicable, add screenshots or screen recordings -->

## Test Plan

- [ ] Sort chips appear below type filter chips
- [ ] Selecting a sort order reloads results with new sort
- [ ] Selecting a time period reloads results with new period
- [ ] Pagination works correctly with filters applied
- [ ] Pull to refresh preserves selected filters

## Review Checklist

- [x] Code follows project architecture (Clean Architecture + MVVM)
- [x] Shared logic is in `commonMain`, platform-specific code only when necessary
- [x] No unnecessary dependencies added
- [ ] Tests added/updated as needed

## Breaking Changes

None