### PR TITLE
Add search history and suggestions

### DIFF
--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/CivitDeckApplication.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/CivitDeckApplication.kt
@@ -23,7 +23,7 @@ class CivitDeckApplication : Application() {
 }
 
 val androidModule = module {
-    viewModel { ModelSearchViewModel(get(), get(), get()) }
+    viewModel { ModelSearchViewModel(get(), get(), get(), get(), get(), get()) }
     viewModel { FavoritesViewModel(get()) }
     viewModel { params -> ModelDetailViewModel(params.get(), get(), get(), get()) }
     viewModel { params -> CreatorProfileViewModel(params.get(), get()) }

--- a/shared/src/commonMain/kotlin/com/riox432/civitdeck/data/local/CivitDeckDatabase.kt
+++ b/shared/src/commonMain/kotlin/com/riox432/civitdeck/data/local/CivitDeckDatabase.kt
@@ -11,10 +11,12 @@ import androidx.sqlite.execSQL
 import com.riox432.civitdeck.data.local.dao.CachedApiResponseDao
 import com.riox432.civitdeck.data.local.dao.FavoriteModelDao
 import com.riox432.civitdeck.data.local.dao.SavedPromptDao
+import com.riox432.civitdeck.data.local.dao.SearchHistoryDao
 import com.riox432.civitdeck.data.local.dao.UserPreferencesDao
 import com.riox432.civitdeck.data.local.entity.CachedApiResponseEntity
 import com.riox432.civitdeck.data.local.entity.FavoriteModelEntity
 import com.riox432.civitdeck.data.local.entity.SavedPromptEntity
+import com.riox432.civitdeck.data.local.entity.SearchHistoryEntity
 import com.riox432.civitdeck.data.local.entity.UserPreferencesEntity
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.IO
@@ -25,6 +27,7 @@ import kotlinx.coroutines.IO
         CachedApiResponseEntity::class,
         UserPreferencesEntity::class,
         SavedPromptEntity::class,
+        SearchHistoryEntity::class,
     ],
     version = 2,
 )
@@ -34,6 +37,7 @@ abstract class CivitDeckDatabase : RoomDatabase() {
     abstract fun cachedApiResponseDao(): CachedApiResponseDao
     abstract fun userPreferencesDao(): UserPreferencesDao
     abstract fun savedPromptDao(): SavedPromptDao
+    abstract fun searchHistoryDao(): SearchHistoryDao
 }
 
 @Suppress("NO_ACTUAL_FOR_EXPECT")
@@ -62,6 +66,11 @@ val MIGRATION_1_2 = object : Migration(1, 2) {
                 savedAt INTEGER NOT NULL
             )
             """.trimIndent(),
+        )
+        connection.execSQL(
+            "CREATE TABLE IF NOT EXISTS `search_history` " +
+                "(`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, " +
+                "`query` TEXT NOT NULL, `searchedAt` INTEGER NOT NULL)",
         )
     }
 }

--- a/shared/src/commonMain/kotlin/com/riox432/civitdeck/data/local/dao/SearchHistoryDao.kt
+++ b/shared/src/commonMain/kotlin/com/riox432/civitdeck/data/local/dao/SearchHistoryDao.kt
@@ -1,0 +1,26 @@
+package com.riox432.civitdeck.data.local.dao
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import com.riox432.civitdeck.data.local.entity.SearchHistoryEntity
+import kotlinx.coroutines.flow.Flow
+
+@Dao
+interface SearchHistoryDao {
+    @Query("SELECT * FROM search_history ORDER BY searchedAt DESC LIMIT :limit")
+    fun observeRecent(limit: Int = 20): Flow<List<SearchHistoryEntity>>
+
+    @Query("DELETE FROM search_history WHERE query = :query")
+    suspend fun deleteByQuery(query: String)
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insert(entity: SearchHistoryEntity)
+
+    @Query("DELETE FROM search_history")
+    suspend fun clearAll()
+
+    @Query("DELETE FROM search_history WHERE id = :id")
+    suspend fun deleteById(id: Long)
+}

--- a/shared/src/commonMain/kotlin/com/riox432/civitdeck/data/local/entity/SearchHistoryEntity.kt
+++ b/shared/src/commonMain/kotlin/com/riox432/civitdeck/data/local/entity/SearchHistoryEntity.kt
@@ -1,0 +1,11 @@
+package com.riox432.civitdeck.data.local.entity
+
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+
+@Entity(tableName = "search_history")
+data class SearchHistoryEntity(
+    @PrimaryKey(autoGenerate = true) val id: Long = 0,
+    val query: String,
+    val searchedAt: Long,
+)

--- a/shared/src/commonMain/kotlin/com/riox432/civitdeck/data/repository/SearchHistoryRepositoryImpl.kt
+++ b/shared/src/commonMain/kotlin/com/riox432/civitdeck/data/repository/SearchHistoryRepositoryImpl.kt
@@ -1,0 +1,29 @@
+package com.riox432.civitdeck.data.repository
+
+import com.riox432.civitdeck.data.local.currentTimeMillis
+import com.riox432.civitdeck.data.local.dao.SearchHistoryDao
+import com.riox432.civitdeck.data.local.entity.SearchHistoryEntity
+import com.riox432.civitdeck.domain.repository.SearchHistoryRepository
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+
+class SearchHistoryRepositoryImpl(
+    private val dao: SearchHistoryDao,
+) : SearchHistoryRepository {
+
+    override fun observeRecentSearches(): Flow<List<String>> =
+        dao.observeRecent().map { entities -> entities.map { it.query } }
+
+    override suspend fun addSearch(query: String) {
+        dao.deleteByQuery(query)
+        dao.insert(SearchHistoryEntity(query = query, searchedAt = currentTimeMillis()))
+    }
+
+    override suspend fun deleteSearch(query: String) {
+        dao.deleteByQuery(query)
+    }
+
+    override suspend fun clearAll() {
+        dao.clearAll()
+    }
+}

--- a/shared/src/commonMain/kotlin/com/riox432/civitdeck/di/DataModule.kt
+++ b/shared/src/commonMain/kotlin/com/riox432/civitdeck/di/DataModule.kt
@@ -10,6 +10,7 @@ import com.riox432.civitdeck.data.repository.FavoriteRepositoryImpl
 import com.riox432.civitdeck.data.repository.ImageRepositoryImpl
 import com.riox432.civitdeck.data.repository.ModelRepositoryImpl
 import com.riox432.civitdeck.data.repository.SavedPromptRepositoryImpl
+import com.riox432.civitdeck.data.repository.SearchHistoryRepositoryImpl
 import com.riox432.civitdeck.data.repository.TagRepositoryImpl
 import com.riox432.civitdeck.data.repository.UserPreferencesRepositoryImpl
 import com.riox432.civitdeck.domain.repository.CreatorRepository
@@ -17,6 +18,7 @@ import com.riox432.civitdeck.domain.repository.FavoriteRepository
 import com.riox432.civitdeck.domain.repository.ImageRepository
 import com.riox432.civitdeck.domain.repository.ModelRepository
 import com.riox432.civitdeck.domain.repository.SavedPromptRepository
+import com.riox432.civitdeck.domain.repository.SearchHistoryRepository
 import com.riox432.civitdeck.domain.repository.TagRepository
 import com.riox432.civitdeck.domain.repository.UserPreferencesRepository
 import kotlinx.serialization.json.Json
@@ -39,6 +41,7 @@ val dataModule = module {
     single { get<CivitDeckDatabase>().cachedApiResponseDao() }
     single { get<CivitDeckDatabase>().userPreferencesDao() }
     single { get<CivitDeckDatabase>().savedPromptDao() }
+    single { get<CivitDeckDatabase>().searchHistoryDao() }
 
     // Data Sources
     single { LocalCacheDataSource(get()) }
@@ -51,4 +54,5 @@ val dataModule = module {
     single<FavoriteRepository> { FavoriteRepositoryImpl(get()) }
     single<UserPreferencesRepository> { UserPreferencesRepositoryImpl(get()) }
     single<SavedPromptRepository> { SavedPromptRepositoryImpl(get()) }
+    single<SearchHistoryRepository> { SearchHistoryRepositoryImpl(get()) }
 }

--- a/shared/src/commonMain/kotlin/com/riox432/civitdeck/di/DomainModule.kt
+++ b/shared/src/commonMain/kotlin/com/riox432/civitdeck/di/DomainModule.kt
@@ -1,5 +1,7 @@
 package com.riox432.civitdeck.di
 
+import com.riox432.civitdeck.domain.usecase.AddSearchHistoryUseCase
+import com.riox432.civitdeck.domain.usecase.ClearSearchHistoryUseCase
 import com.riox432.civitdeck.domain.usecase.DeleteSavedPromptUseCase
 import com.riox432.civitdeck.domain.usecase.GetCreatorModelsUseCase
 import com.riox432.civitdeck.domain.usecase.GetImagesUseCase
@@ -9,6 +11,7 @@ import com.riox432.civitdeck.domain.usecase.ObserveFavoritesUseCase
 import com.riox432.civitdeck.domain.usecase.ObserveIsFavoriteUseCase
 import com.riox432.civitdeck.domain.usecase.ObserveNsfwFilterUseCase
 import com.riox432.civitdeck.domain.usecase.ObserveSavedPromptsUseCase
+import com.riox432.civitdeck.domain.usecase.ObserveSearchHistoryUseCase
 import com.riox432.civitdeck.domain.usecase.SavePromptUseCase
 import com.riox432.civitdeck.domain.usecase.SetNsfwFilterUseCase
 import com.riox432.civitdeck.domain.usecase.ToggleFavoriteUseCase
@@ -27,4 +30,7 @@ val domainModule = module {
     factory { SavePromptUseCase(get()) }
     factory { ObserveSavedPromptsUseCase(get()) }
     factory { DeleteSavedPromptUseCase(get()) }
+    factory { ObserveSearchHistoryUseCase(get()) }
+    factory { AddSearchHistoryUseCase(get()) }
+    factory { ClearSearchHistoryUseCase(get()) }
 }

--- a/shared/src/commonMain/kotlin/com/riox432/civitdeck/domain/repository/SearchHistoryRepository.kt
+++ b/shared/src/commonMain/kotlin/com/riox432/civitdeck/domain/repository/SearchHistoryRepository.kt
@@ -1,0 +1,10 @@
+package com.riox432.civitdeck.domain.repository
+
+import kotlinx.coroutines.flow.Flow
+
+interface SearchHistoryRepository {
+    fun observeRecentSearches(): Flow<List<String>>
+    suspend fun addSearch(query: String)
+    suspend fun deleteSearch(query: String)
+    suspend fun clearAll()
+}

--- a/shared/src/commonMain/kotlin/com/riox432/civitdeck/domain/usecase/SearchHistoryUseCases.kt
+++ b/shared/src/commonMain/kotlin/com/riox432/civitdeck/domain/usecase/SearchHistoryUseCases.kt
@@ -1,0 +1,16 @@
+package com.riox432.civitdeck.domain.usecase
+
+import com.riox432.civitdeck.domain.repository.SearchHistoryRepository
+import kotlinx.coroutines.flow.Flow
+
+class ObserveSearchHistoryUseCase(private val repository: SearchHistoryRepository) {
+    operator fun invoke(): Flow<List<String>> = repository.observeRecentSearches()
+}
+
+class AddSearchHistoryUseCase(private val repository: SearchHistoryRepository) {
+    suspend operator fun invoke(query: String) = repository.addSearch(query)
+}
+
+class ClearSearchHistoryUseCase(private val repository: SearchHistoryRepository) {
+    suspend operator fun invoke() = repository.clearAll()
+}

--- a/shared/src/iosMain/kotlin/com/riox432/civitdeck/di/KoinHelper.kt
+++ b/shared/src/iosMain/kotlin/com/riox432/civitdeck/di/KoinHelper.kt
@@ -1,5 +1,7 @@
 package com.riox432.civitdeck.di
 
+import com.riox432.civitdeck.domain.usecase.AddSearchHistoryUseCase
+import com.riox432.civitdeck.domain.usecase.ClearSearchHistoryUseCase
 import com.riox432.civitdeck.domain.usecase.DeleteSavedPromptUseCase
 import com.riox432.civitdeck.domain.usecase.GetCreatorModelsUseCase
 import com.riox432.civitdeck.domain.usecase.GetImagesUseCase
@@ -9,6 +11,7 @@ import com.riox432.civitdeck.domain.usecase.ObserveFavoritesUseCase
 import com.riox432.civitdeck.domain.usecase.ObserveIsFavoriteUseCase
 import com.riox432.civitdeck.domain.usecase.ObserveNsfwFilterUseCase
 import com.riox432.civitdeck.domain.usecase.ObserveSavedPromptsUseCase
+import com.riox432.civitdeck.domain.usecase.ObserveSearchHistoryUseCase
 import com.riox432.civitdeck.domain.usecase.SavePromptUseCase
 import com.riox432.civitdeck.domain.usecase.SetNsfwFilterUseCase
 import com.riox432.civitdeck.domain.usecase.ToggleFavoriteUseCase
@@ -28,4 +31,7 @@ object KoinHelper {
     fun getSavePromptUseCase(): SavePromptUseCase = getKoin().get()
     fun getObserveSavedPromptsUseCase(): ObserveSavedPromptsUseCase = getKoin().get()
     fun getDeleteSavedPromptUseCase(): DeleteSavedPromptUseCase = getKoin().get()
+    fun getObserveSearchHistoryUseCase(): ObserveSearchHistoryUseCase = getKoin().get()
+    fun getAddSearchHistoryUseCase(): AddSearchHistoryUseCase = getKoin().get()
+    fun getClearSearchHistoryUseCase(): ClearSearchHistoryUseCase = getKoin().get()
 }


### PR DESCRIPTION
## Description

Add persistent search history with Room database storage and dropdown UI on both Android and iOS. Recent searches are shown when the search field is focused with an empty query. Users can tap a history item to re-search or clear all history.

**Shared layer:**
- SearchHistoryEntity + SearchHistoryDao (Room)
- SearchHistoryRepository + Impl with deduplication (delete-then-insert)
- ObserveSearchHistoryUseCase, AddSearchHistoryUseCase, ClearSearchHistoryUseCase
- Database migration v1→v2

**Android:**
- SearchBarWithHistory composable with focus-aware dropdown
- ViewModel wired with search history use cases

**iOS:**
- Search history dropdown with clock icon and clear button
- ViewModel observes search history via SKIE Flow

## Related Issues

Closes #52

## Screenshots / Video

<!-- If applicable, add screenshots or screen recordings -->

## Test Plan

- [ ] Search for a term, verify it appears in history on next focus
- [ ] Tap history item to re-search
- [ ] Clear history removes all items
- [ ] Database migration from v1 to v2 works without data loss

## Review Checklist

- [x] Code follows project architecture (Clean Architecture + MVVM)
- [x] Shared logic is in `commonMain`, platform-specific code only when necessary
- [x] No unnecessary dependencies added
- [ ] Tests added/updated as needed

## Breaking Changes

None