### PR TITLE
Add personalized model discovery (For You)

### DIFF
--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/CivitDeckApplication.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/CivitDeckApplication.kt
@@ -23,9 +23,9 @@ class CivitDeckApplication : Application() {
 }
 
 val androidModule = module {
-    viewModel { ModelSearchViewModel(get(), get(), get(), get(), get(), get()) }
+    viewModel { ModelSearchViewModel(get(), get(), get(), get(), get(), get(), get()) }
     viewModel { FavoritesViewModel(get()) }
-    viewModel { params -> ModelDetailViewModel(params.get(), get(), get(), get()) }
+    viewModel { params -> ModelDetailViewModel(params.get(), get(), get(), get(), get()) }
     viewModel { params -> CreatorProfileViewModel(params.get(), get()) }
     viewModel { params -> ImageGalleryViewModel(params.get(), get(), get()) }
     viewModel { SavedPromptsViewModel(get(), get()) }

--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/detail/ModelDetailViewModel.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/detail/ModelDetailViewModel.kt
@@ -6,6 +6,7 @@ import com.riox432.civitdeck.domain.model.Model
 import com.riox432.civitdeck.domain.usecase.GetModelDetailUseCase
 import com.riox432.civitdeck.domain.usecase.ObserveIsFavoriteUseCase
 import com.riox432.civitdeck.domain.usecase.ToggleFavoriteUseCase
+import com.riox432.civitdeck.domain.usecase.TrackModelViewUseCase
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -26,6 +27,7 @@ class ModelDetailViewModel(
     private val getModelDetailUseCase: GetModelDetailUseCase,
     private val observeIsFavoriteUseCase: ObserveIsFavoriteUseCase,
     private val toggleFavoriteUseCase: ToggleFavoriteUseCase,
+    private val trackModelViewUseCase: TrackModelViewUseCase,
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow(ModelDetailUiState())
@@ -65,6 +67,12 @@ class ModelDetailViewModel(
                 _uiState.update {
                     it.copy(model = model, isLoading = false)
                 }
+                trackModelViewUseCase(
+                    modelId = model.id,
+                    modelType = model.type.name,
+                    creatorName = model.creator?.username,
+                    tags = model.tags,
+                )
             } catch (e: CancellationException) {
                 throw e
             } catch (e: Exception) {

--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/search/ModelSearchScreen.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/search/ModelSearchScreen.kt
@@ -16,7 +16,9 @@ import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.GridItemSpan
@@ -62,6 +64,7 @@ import com.riox432.civitdeck.domain.model.BaseModel
 import com.riox432.civitdeck.domain.model.Model
 import com.riox432.civitdeck.domain.model.ModelType
 import com.riox432.civitdeck.domain.model.NsfwFilterLevel
+import com.riox432.civitdeck.domain.model.RecommendationSection
 import com.riox432.civitdeck.domain.model.SortOrder
 import com.riox432.civitdeck.domain.model.TimePeriod
 import com.riox432.civitdeck.ui.components.ModelCard
@@ -486,6 +489,7 @@ private fun ModelSearchContent(
                 else -> {
                     ModelGrid(
                         models = uiState.models,
+                        recommendations = uiState.recommendations,
                         gridState = gridState,
                         isLoadingMore = uiState.isLoadingMore,
                         onModelClick = onModelClick,
@@ -500,6 +504,7 @@ private fun ModelSearchContent(
 @Composable
 private fun ModelGrid(
     models: List<Model>,
+    recommendations: List<RecommendationSection>,
     gridState: LazyGridState,
     isLoadingMore: Boolean,
     onModelClick: (Long, String?) -> Unit,
@@ -517,6 +522,17 @@ private fun ModelGrid(
         horizontalArrangement = Arrangement.spacedBy(Spacing.sm),
         verticalArrangement = Arrangement.spacedBy(Spacing.sm),
     ) {
+        recommendations.forEach { section ->
+            item(
+                key = "rec_${section.title}",
+                span = { GridItemSpan(2) },
+            ) {
+                RecommendationRow(
+                    section = section,
+                    onModelClick = onModelClick,
+                )
+            }
+        }
         items(items = models, key = { it.id }) { model ->
             val thumbnailUrl = model.modelVersions
                 .firstOrNull()?.images?.firstOrNull()?.url
@@ -538,6 +554,41 @@ private fun ModelGrid(
                 ) {
                     CircularProgressIndicator()
                 }
+            }
+        }
+    }
+}
+
+@Composable
+private fun RecommendationRow(
+    section: RecommendationSection,
+    onModelClick: (Long, String?) -> Unit,
+) {
+    Column(modifier = Modifier.padding(bottom = Spacing.sm)) {
+        Text(
+            text = section.title,
+            style = MaterialTheme.typography.titleMedium,
+            modifier = Modifier.padding(horizontal = Spacing.xs, vertical = Spacing.xs),
+        )
+        Text(
+            text = section.reason,
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier.padding(start = Spacing.xs, end = Spacing.xs, bottom = Spacing.sm),
+        )
+        LazyRow(
+            horizontalArrangement = Arrangement.spacedBy(Spacing.sm),
+        ) {
+            items(items = section.models, key = { it.id }) { model ->
+                val thumbnailUrl = model.modelVersions
+                    .firstOrNull()?.images?.firstOrNull()?.url
+                ModelCard(
+                    model = model,
+                    onClick = { onModelClick(model.id, thumbnailUrl) },
+                    modifier = Modifier
+                        .width(160.dp)
+                        .height(220.dp),
+                )
             }
         }
     }

--- a/iosApp/iosApp/Features/Detail/ModelDetailViewModel.swift
+++ b/iosApp/iosApp/Features/Detail/ModelDetailViewModel.swift
@@ -13,6 +13,7 @@ final class ModelDetailViewModel: ObservableObject {
     private let getModelDetailUseCase: GetModelDetailUseCase
     private let observeIsFavoriteUseCase: ObserveIsFavoriteUseCase
     private let toggleFavoriteUseCase: ToggleFavoriteUseCase
+    private let trackModelViewUseCase: TrackModelViewUseCase
 
     var selectedVersion: ModelVersion? {
         guard let model else { return nil }
@@ -26,6 +27,7 @@ final class ModelDetailViewModel: ObservableObject {
         self.getModelDetailUseCase = KoinHelper.shared.getModelDetailUseCase()
         self.observeIsFavoriteUseCase = KoinHelper.shared.getObserveIsFavoriteUseCase()
         self.toggleFavoriteUseCase = KoinHelper.shared.getToggleFavoriteUseCase()
+        self.trackModelViewUseCase = KoinHelper.shared.getTrackModelViewUseCase()
         loadModel()
     }
 
@@ -59,6 +61,12 @@ final class ModelDetailViewModel: ObservableObject {
                 let result = try await getModelDetailUseCase.invoke(modelId: modelId)
                 model = result
                 isLoading = false
+                try? await trackModelViewUseCase.invoke(
+                    modelId: result.id,
+                    modelType: result.type.name,
+                    creatorName: result.creator?.username,
+                    tags: result.tags
+                )
             } catch is CancellationError {
                 return
             } catch {

--- a/iosApp/iosApp/Features/Search/ModelSearchScreen.swift
+++ b/iosApp/iosApp/Features/Search/ModelSearchScreen.swift
@@ -159,6 +159,10 @@ struct ModelSearchScreen: View {
 
     private var modelGrid: some View {
         ScrollView {
+            if !viewModel.recommendations.isEmpty {
+                recommendationSections
+            }
+
             LazyVGrid(columns: columns, spacing: Spacing.sm) {
                 ForEach(Array(viewModel.models.enumerated()), id: \.element.id) { index, model in
                     NavigationLink(value: model.id) {
@@ -278,6 +282,34 @@ struct ModelSearchScreen: View {
                 .foregroundColor(.civitOnSurfaceVariant)
             Text("No models found")
                 .foregroundColor(.civitOnSurfaceVariant)
+        }
+    }
+
+    private var recommendationSections: some View {
+        ForEach(viewModel.recommendations, id: \.title) { section in
+            VStack(alignment: .leading, spacing: Spacing.xs) {
+                Text(section.title)
+                    .font(.civitTitleMedium)
+                    .padding(.horizontal, Spacing.md)
+                Text(section.reason)
+                    .font(.civitBodySmall)
+                    .foregroundColor(.civitOnSurfaceVariant)
+                    .padding(.horizontal, Spacing.md)
+
+                ScrollView(.horizontal, showsIndicators: false) {
+                    HStack(spacing: Spacing.sm) {
+                        ForEach(section.models, id: \.id) { model in
+                            NavigationLink(value: model.id) {
+                                ModelCardView(model: model)
+                                    .frame(width: 160, height: 220)
+                            }
+                            .buttonStyle(.plain)
+                        }
+                    }
+                    .padding(.horizontal, Spacing.md)
+                }
+            }
+            .padding(.bottom, Spacing.sm)
         }
     }
 }

--- a/iosApp/iosApp/Features/Search/ModelSearchViewModel.swift
+++ b/iosApp/iosApp/Features/Search/ModelSearchViewModel.swift
@@ -15,8 +15,10 @@ final class ModelSearchViewModel: ObservableObject {
     @Published var error: String? = nil
     @Published var hasMore: Bool = true
     @Published var searchHistory: [String] = []
+    @Published var recommendations: [RecommendationSection] = []
 
     private let getModelsUseCase: GetModelsUseCase
+    private let getRecommendationsUseCase: GetRecommendationsUseCase
     private let observeNsfwFilterUseCase: ObserveNsfwFilterUseCase
     private let setNsfwFilterUseCase: SetNsfwFilterUseCase
     private let observeSearchHistoryUseCase: ObserveSearchHistoryUseCase
@@ -29,12 +31,25 @@ final class ModelSearchViewModel: ObservableObject {
 
     init() {
         self.getModelsUseCase = KoinHelper.shared.getModelsUseCase()
+        self.getRecommendationsUseCase = KoinHelper.shared.getRecommendationsUseCase()
         self.observeNsfwFilterUseCase = KoinHelper.shared.getObserveNsfwFilterUseCase()
         self.setNsfwFilterUseCase = KoinHelper.shared.getSetNsfwFilterUseCase()
         self.observeSearchHistoryUseCase = KoinHelper.shared.getObserveSearchHistoryUseCase()
         self.addSearchHistoryUseCase = KoinHelper.shared.getAddSearchHistoryUseCase()
         self.clearSearchHistoryUseCase = KoinHelper.shared.getClearSearchHistoryUseCase()
         loadModels()
+        loadRecommendations()
+    }
+
+    private func loadRecommendations() {
+        Task {
+            do {
+                let sections = try await getRecommendationsUseCase.invoke()
+                recommendations = sections
+            } catch {
+                // Non-critical, silently fail
+            }
+        }
     }
 
     func observeNsfwFilter() async {

--- a/shared/schemas/com.riox432.civitdeck.data.local.CivitDeckDatabase/2.json
+++ b/shared/schemas/com.riox432.civitdeck.data.local.CivitDeckDatabase/2.json
@@ -2,7 +2,7 @@
   "formatVersion": 1,
   "database": {
     "version": 2,
-    "identityHash": "af4abcf11c20ec6b15e9e2e3df2c6cf0",
+    "identityHash": "30bea86efd99e8ee7c55a0b71393b8d5",
     "entities": [
       {
         "tableName": "favorite_models",
@@ -197,11 +197,88 @@
             "id"
           ]
         }
+      },
+      {
+        "tableName": "search_history",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `query` TEXT NOT NULL, `searchedAt` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "query",
+            "columnName": "query",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "searchedAt",
+            "columnName": "searchedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "browsing_history",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `modelId` INTEGER NOT NULL, `modelType` TEXT NOT NULL, `creatorName` TEXT, `tags` TEXT NOT NULL, `viewedAt` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "modelId",
+            "columnName": "modelId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "modelType",
+            "columnName": "modelType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "creatorName",
+            "columnName": "creatorName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "tags",
+            "columnName": "tags",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "viewedAt",
+            "columnName": "viewedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
       }
     ],
     "setupQueries": [
       "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
-      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'af4abcf11c20ec6b15e9e2e3df2c6cf0')"
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '30bea86efd99e8ee7c55a0b71393b8d5')"
     ]
   }
 }

--- a/shared/src/commonMain/kotlin/com/riox432/civitdeck/data/local/CivitDeckDatabase.kt
+++ b/shared/src/commonMain/kotlin/com/riox432/civitdeck/data/local/CivitDeckDatabase.kt
@@ -8,11 +8,13 @@ import androidx.room.migration.Migration
 import androidx.sqlite.SQLiteConnection
 import androidx.sqlite.driver.bundled.BundledSQLiteDriver
 import androidx.sqlite.execSQL
+import com.riox432.civitdeck.data.local.dao.BrowsingHistoryDao
 import com.riox432.civitdeck.data.local.dao.CachedApiResponseDao
 import com.riox432.civitdeck.data.local.dao.FavoriteModelDao
 import com.riox432.civitdeck.data.local.dao.SavedPromptDao
 import com.riox432.civitdeck.data.local.dao.SearchHistoryDao
 import com.riox432.civitdeck.data.local.dao.UserPreferencesDao
+import com.riox432.civitdeck.data.local.entity.BrowsingHistoryEntity
 import com.riox432.civitdeck.data.local.entity.CachedApiResponseEntity
 import com.riox432.civitdeck.data.local.entity.FavoriteModelEntity
 import com.riox432.civitdeck.data.local.entity.SavedPromptEntity
@@ -28,6 +30,7 @@ import kotlinx.coroutines.IO
         UserPreferencesEntity::class,
         SavedPromptEntity::class,
         SearchHistoryEntity::class,
+        BrowsingHistoryEntity::class,
     ],
     version = 2,
 )
@@ -38,6 +41,7 @@ abstract class CivitDeckDatabase : RoomDatabase() {
     abstract fun userPreferencesDao(): UserPreferencesDao
     abstract fun savedPromptDao(): SavedPromptDao
     abstract fun searchHistoryDao(): SearchHistoryDao
+    abstract fun browsingHistoryDao(): BrowsingHistoryDao
 }
 
 @Suppress("NO_ACTUAL_FOR_EXPECT")
@@ -71,6 +75,15 @@ val MIGRATION_1_2 = object : Migration(1, 2) {
             "CREATE TABLE IF NOT EXISTS `search_history` " +
                 "(`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, " +
                 "`query` TEXT NOT NULL, `searchedAt` INTEGER NOT NULL)",
+        )
+        connection.execSQL(
+            "CREATE TABLE IF NOT EXISTS `browsing_history` " +
+                "(`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, " +
+                "`modelId` INTEGER NOT NULL, " +
+                "`modelType` TEXT NOT NULL, " +
+                "`creatorName` TEXT, " +
+                "`tags` TEXT NOT NULL, " +
+                "`viewedAt` INTEGER NOT NULL)",
         )
     }
 }

--- a/shared/src/commonMain/kotlin/com/riox432/civitdeck/data/local/dao/BrowsingHistoryDao.kt
+++ b/shared/src/commonMain/kotlin/com/riox432/civitdeck/data/local/dao/BrowsingHistoryDao.kt
@@ -1,0 +1,22 @@
+package com.riox432.civitdeck.data.local.dao
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import com.riox432.civitdeck.data.local.entity.BrowsingHistoryEntity
+
+@Dao
+interface BrowsingHistoryDao {
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insert(entity: BrowsingHistoryEntity)
+
+    @Query("SELECT * FROM browsing_history ORDER BY viewedAt DESC LIMIT :limit")
+    suspend fun getRecent(limit: Int = 100): List<BrowsingHistoryEntity>
+
+    @Query("SELECT DISTINCT modelId FROM browsing_history ORDER BY viewedAt DESC LIMIT :limit")
+    suspend fun getRecentModelIds(limit: Int = 50): List<Long>
+
+    @Query("SELECT COUNT(*) FROM browsing_history")
+    suspend fun count(): Int
+}

--- a/shared/src/commonMain/kotlin/com/riox432/civitdeck/data/local/dao/FavoriteModelDao.kt
+++ b/shared/src/commonMain/kotlin/com/riox432/civitdeck/data/local/dao/FavoriteModelDao.kt
@@ -26,4 +26,12 @@ interface FavoriteModelDao {
 
     @Query("SELECT COUNT(*) FROM favorite_models")
     suspend fun count(): Int
+
+    @Query("SELECT id FROM favorite_models")
+    suspend fun getAllIds(): List<Long>
+
+    @Query("SELECT type, COUNT(*) as cnt FROM favorite_models GROUP BY type")
+    suspend fun getTypeCounts(): List<TypeCount>
 }
+
+data class TypeCount(val type: String, val cnt: Int)

--- a/shared/src/commonMain/kotlin/com/riox432/civitdeck/data/local/entity/BrowsingHistoryEntity.kt
+++ b/shared/src/commonMain/kotlin/com/riox432/civitdeck/data/local/entity/BrowsingHistoryEntity.kt
@@ -1,0 +1,14 @@
+package com.riox432.civitdeck.data.local.entity
+
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+
+@Entity(tableName = "browsing_history")
+data class BrowsingHistoryEntity(
+    @PrimaryKey(autoGenerate = true) val id: Long = 0,
+    val modelId: Long,
+    val modelType: String,
+    val creatorName: String?,
+    val tags: String,
+    val viewedAt: Long,
+)

--- a/shared/src/commonMain/kotlin/com/riox432/civitdeck/data/repository/BrowsingHistoryRepositoryImpl.kt
+++ b/shared/src/commonMain/kotlin/com/riox432/civitdeck/data/repository/BrowsingHistoryRepositoryImpl.kt
@@ -1,0 +1,52 @@
+package com.riox432.civitdeck.data.repository
+
+import com.riox432.civitdeck.data.local.currentTimeMillis
+import com.riox432.civitdeck.data.local.dao.BrowsingHistoryDao
+import com.riox432.civitdeck.data.local.entity.BrowsingHistoryEntity
+import com.riox432.civitdeck.domain.repository.BrowsingHistoryRepository
+
+class BrowsingHistoryRepositoryImpl(
+    private val dao: BrowsingHistoryDao,
+) : BrowsingHistoryRepository {
+
+    override suspend fun trackView(
+        modelId: Long,
+        modelType: String,
+        creatorName: String?,
+        tags: List<String>,
+    ) {
+        dao.insert(
+            BrowsingHistoryEntity(
+                modelId = modelId,
+                modelType = modelType,
+                creatorName = creatorName,
+                tags = tags.joinToString(","),
+                viewedAt = currentTimeMillis(),
+            ),
+        )
+    }
+
+    override suspend fun getRecentTypes(limit: Int): Map<String, Int> {
+        return dao.getRecent(limit)
+            .groupingBy { it.modelType }
+            .eachCount()
+    }
+
+    override suspend fun getRecentCreators(limit: Int): Map<String, Int> {
+        return dao.getRecent(limit)
+            .mapNotNull { it.creatorName }
+            .groupingBy { it }
+            .eachCount()
+    }
+
+    override suspend fun getRecentTags(limit: Int): Map<String, Int> {
+        return dao.getRecent(limit)
+            .flatMap { it.tags.split(",").filter { tag -> tag.isNotBlank() } }
+            .groupingBy { it }
+            .eachCount()
+    }
+
+    override suspend fun getRecentModelIds(limit: Int): List<Long> {
+        return dao.getRecentModelIds(limit)
+    }
+}

--- a/shared/src/commonMain/kotlin/com/riox432/civitdeck/data/repository/FavoriteRepositoryImpl.kt
+++ b/shared/src/commonMain/kotlin/com/riox432/civitdeck/data/repository/FavoriteRepositoryImpl.kt
@@ -36,4 +36,10 @@ class FavoriteRepositoryImpl(
     override suspend fun removeFavorite(modelId: Long) {
         dao.deleteById(modelId)
     }
+
+    override suspend fun getAllFavoriteIds(): Set<Long> =
+        dao.getAllIds().toSet()
+
+    override suspend fun getFavoriteTypeCounts(): Map<String, Int> =
+        dao.getTypeCounts().associate { it.type to it.cnt }
 }

--- a/shared/src/commonMain/kotlin/com/riox432/civitdeck/di/DataModule.kt
+++ b/shared/src/commonMain/kotlin/com/riox432/civitdeck/di/DataModule.kt
@@ -5,6 +5,7 @@ import com.riox432.civitdeck.data.api.createHttpClient
 import com.riox432.civitdeck.data.local.CivitDeckDatabase
 import com.riox432.civitdeck.data.local.LocalCacheDataSource
 import com.riox432.civitdeck.data.local.getRoomDatabase
+import com.riox432.civitdeck.data.repository.BrowsingHistoryRepositoryImpl
 import com.riox432.civitdeck.data.repository.CreatorRepositoryImpl
 import com.riox432.civitdeck.data.repository.FavoriteRepositoryImpl
 import com.riox432.civitdeck.data.repository.ImageRepositoryImpl
@@ -13,6 +14,7 @@ import com.riox432.civitdeck.data.repository.SavedPromptRepositoryImpl
 import com.riox432.civitdeck.data.repository.SearchHistoryRepositoryImpl
 import com.riox432.civitdeck.data.repository.TagRepositoryImpl
 import com.riox432.civitdeck.data.repository.UserPreferencesRepositoryImpl
+import com.riox432.civitdeck.domain.repository.BrowsingHistoryRepository
 import com.riox432.civitdeck.domain.repository.CreatorRepository
 import com.riox432.civitdeck.domain.repository.FavoriteRepository
 import com.riox432.civitdeck.domain.repository.ImageRepository
@@ -42,6 +44,7 @@ val dataModule = module {
     single { get<CivitDeckDatabase>().userPreferencesDao() }
     single { get<CivitDeckDatabase>().savedPromptDao() }
     single { get<CivitDeckDatabase>().searchHistoryDao() }
+    single { get<CivitDeckDatabase>().browsingHistoryDao() }
 
     // Data Sources
     single { LocalCacheDataSource(get()) }
@@ -55,4 +58,5 @@ val dataModule = module {
     single<UserPreferencesRepository> { UserPreferencesRepositoryImpl(get()) }
     single<SavedPromptRepository> { SavedPromptRepositoryImpl(get()) }
     single<SearchHistoryRepository> { SearchHistoryRepositoryImpl(get()) }
+    single<BrowsingHistoryRepository> { BrowsingHistoryRepositoryImpl(get()) }
 }

--- a/shared/src/commonMain/kotlin/com/riox432/civitdeck/di/DomainModule.kt
+++ b/shared/src/commonMain/kotlin/com/riox432/civitdeck/di/DomainModule.kt
@@ -7,6 +7,7 @@ import com.riox432.civitdeck.domain.usecase.GetCreatorModelsUseCase
 import com.riox432.civitdeck.domain.usecase.GetImagesUseCase
 import com.riox432.civitdeck.domain.usecase.GetModelDetailUseCase
 import com.riox432.civitdeck.domain.usecase.GetModelsUseCase
+import com.riox432.civitdeck.domain.usecase.GetRecommendationsUseCase
 import com.riox432.civitdeck.domain.usecase.ObserveFavoritesUseCase
 import com.riox432.civitdeck.domain.usecase.ObserveIsFavoriteUseCase
 import com.riox432.civitdeck.domain.usecase.ObserveNsfwFilterUseCase
@@ -15,6 +16,7 @@ import com.riox432.civitdeck.domain.usecase.ObserveSearchHistoryUseCase
 import com.riox432.civitdeck.domain.usecase.SavePromptUseCase
 import com.riox432.civitdeck.domain.usecase.SetNsfwFilterUseCase
 import com.riox432.civitdeck.domain.usecase.ToggleFavoriteUseCase
+import com.riox432.civitdeck.domain.usecase.TrackModelViewUseCase
 import org.koin.dsl.module
 
 val domainModule = module {
@@ -33,4 +35,6 @@ val domainModule = module {
     factory { ObserveSearchHistoryUseCase(get()) }
     factory { AddSearchHistoryUseCase(get()) }
     factory { ClearSearchHistoryUseCase(get()) }
+    factory { TrackModelViewUseCase(get()) }
+    factory { GetRecommendationsUseCase(get(), get(), get()) }
 }

--- a/shared/src/commonMain/kotlin/com/riox432/civitdeck/domain/model/RecommendationSection.kt
+++ b/shared/src/commonMain/kotlin/com/riox432/civitdeck/domain/model/RecommendationSection.kt
@@ -1,0 +1,7 @@
+package com.riox432.civitdeck.domain.model
+
+data class RecommendationSection(
+    val title: String,
+    val reason: String,
+    val models: List<Model>,
+)

--- a/shared/src/commonMain/kotlin/com/riox432/civitdeck/domain/repository/BrowsingHistoryRepository.kt
+++ b/shared/src/commonMain/kotlin/com/riox432/civitdeck/domain/repository/BrowsingHistoryRepository.kt
@@ -1,0 +1,15 @@
+package com.riox432.civitdeck.domain.repository
+
+interface BrowsingHistoryRepository {
+    suspend fun trackView(
+        modelId: Long,
+        modelType: String,
+        creatorName: String?,
+        tags: List<String>,
+    )
+
+    suspend fun getRecentTypes(limit: Int = 100): Map<String, Int>
+    suspend fun getRecentCreators(limit: Int = 100): Map<String, Int>
+    suspend fun getRecentTags(limit: Int = 100): Map<String, Int>
+    suspend fun getRecentModelIds(limit: Int = 50): List<Long>
+}

--- a/shared/src/commonMain/kotlin/com/riox432/civitdeck/domain/repository/FavoriteRepository.kt
+++ b/shared/src/commonMain/kotlin/com/riox432/civitdeck/domain/repository/FavoriteRepository.kt
@@ -10,4 +10,6 @@ interface FavoriteRepository {
     suspend fun toggleFavorite(model: Model)
     suspend fun addFavorite(model: Model)
     suspend fun removeFavorite(modelId: Long)
+    suspend fun getAllFavoriteIds(): Set<Long>
+    suspend fun getFavoriteTypeCounts(): Map<String, Int>
 }

--- a/shared/src/commonMain/kotlin/com/riox432/civitdeck/domain/usecase/GetRecommendationsUseCase.kt
+++ b/shared/src/commonMain/kotlin/com/riox432/civitdeck/domain/usecase/GetRecommendationsUseCase.kt
@@ -1,0 +1,108 @@
+package com.riox432.civitdeck.domain.usecase
+
+import com.riox432.civitdeck.domain.model.ModelType
+import com.riox432.civitdeck.domain.model.RecommendationSection
+import com.riox432.civitdeck.domain.model.SortOrder
+import com.riox432.civitdeck.domain.model.TimePeriod
+import com.riox432.civitdeck.domain.repository.BrowsingHistoryRepository
+import com.riox432.civitdeck.domain.repository.FavoriteRepository
+import com.riox432.civitdeck.domain.repository.ModelRepository
+
+class GetRecommendationsUseCase(
+    private val modelRepository: ModelRepository,
+    private val favoriteRepository: FavoriteRepository,
+    private val browsingHistoryRepository: BrowsingHistoryRepository,
+) {
+    suspend operator fun invoke(): List<RecommendationSection> {
+        val sections = mutableListOf<RecommendationSection>()
+        val seenIds = mutableSetOf<Long>()
+
+        val favIds = favoriteRepository.getAllFavoriteIds()
+        seenIds.addAll(favIds)
+
+        val viewedIds = browsingHistoryRepository.getRecentModelIds()
+        seenIds.addAll(viewedIds)
+
+        val typeSection = buildTypeSection(seenIds)
+        if (typeSection != null) sections.add(typeSection)
+
+        val tagSection = buildTagSection(seenIds)
+        if (tagSection != null) sections.add(tagSection)
+
+        if (sections.isEmpty()) {
+            val trendingSection = buildTrendingFallback(seenIds)
+            if (trendingSection != null) sections.add(trendingSection)
+        }
+
+        return sections
+    }
+
+    private suspend fun buildTypeSection(seenIds: Set<Long>): RecommendationSection? {
+        val favTypes = favoriteRepository.getFavoriteTypeCounts()
+        val browseTypes = browsingHistoryRepository.getRecentTypes()
+
+        val merged = mutableMapOf<String, Int>()
+        for ((type, count) in favTypes) merged[type] = (merged[type] ?: 0) + count * FAVORITE_WEIGHT
+        for ((type, count) in browseTypes) merged[type] = (merged[type] ?: 0) + count
+
+        val topType = merged.entries.maxByOrNull { it.value }?.key ?: return null
+        val modelType = runCatching { ModelType.valueOf(topType) }.getOrNull() ?: return null
+
+        val result = modelRepository.getModels(
+            type = modelType,
+            sort = SortOrder.HighestRated,
+            period = TimePeriod.Month,
+            limit = SECTION_SIZE + seenIds.size.coerceAtMost(BUFFER),
+        )
+        val filtered = result.items.filterNot { it.id in seenIds }.take(SECTION_SIZE)
+        if (filtered.isEmpty()) return null
+
+        return RecommendationSection(
+            title = "Trending ${modelType.name}",
+            reason = "Based on your preferences",
+            models = filtered,
+        )
+    }
+
+    private suspend fun buildTagSection(seenIds: Set<Long>): RecommendationSection? {
+        val browseTags = browsingHistoryRepository.getRecentTags()
+        val topTag = browseTags.entries.maxByOrNull { it.value }?.key ?: return null
+
+        val result = modelRepository.getModels(
+            tag = topTag,
+            sort = SortOrder.HighestRated,
+            period = TimePeriod.Month,
+            limit = SECTION_SIZE + seenIds.size.coerceAtMost(BUFFER),
+        )
+        val filtered = result.items.filterNot { it.id in seenIds }.take(SECTION_SIZE)
+        if (filtered.isEmpty()) return null
+
+        return RecommendationSection(
+            title = "Popular in \"$topTag\"",
+            reason = "Based on your browsing",
+            models = filtered,
+        )
+    }
+
+    private suspend fun buildTrendingFallback(seenIds: Set<Long>): RecommendationSection? {
+        val result = modelRepository.getModels(
+            sort = SortOrder.MostDownloaded,
+            period = TimePeriod.Week,
+            limit = SECTION_SIZE + seenIds.size.coerceAtMost(BUFFER),
+        )
+        val filtered = result.items.filterNot { it.id in seenIds }.take(SECTION_SIZE)
+        if (filtered.isEmpty()) return null
+
+        return RecommendationSection(
+            title = "Trending This Week",
+            reason = "Popular models",
+            models = filtered,
+        )
+    }
+
+    companion object {
+        private const val SECTION_SIZE = 10
+        private const val BUFFER = 20
+        private const val FAVORITE_WEIGHT = 3
+    }
+}

--- a/shared/src/commonMain/kotlin/com/riox432/civitdeck/domain/usecase/TrackModelViewUseCase.kt
+++ b/shared/src/commonMain/kotlin/com/riox432/civitdeck/domain/usecase/TrackModelViewUseCase.kt
@@ -1,0 +1,12 @@
+package com.riox432.civitdeck.domain.usecase
+
+import com.riox432.civitdeck.domain.repository.BrowsingHistoryRepository
+
+class TrackModelViewUseCase(private val repository: BrowsingHistoryRepository) {
+    suspend operator fun invoke(
+        modelId: Long,
+        modelType: String,
+        creatorName: String?,
+        tags: List<String>,
+    ) = repository.trackView(modelId, modelType, creatorName, tags)
+}

--- a/shared/src/iosMain/kotlin/com/riox432/civitdeck/di/KoinHelper.kt
+++ b/shared/src/iosMain/kotlin/com/riox432/civitdeck/di/KoinHelper.kt
@@ -7,6 +7,7 @@ import com.riox432.civitdeck.domain.usecase.GetCreatorModelsUseCase
 import com.riox432.civitdeck.domain.usecase.GetImagesUseCase
 import com.riox432.civitdeck.domain.usecase.GetModelDetailUseCase
 import com.riox432.civitdeck.domain.usecase.GetModelsUseCase
+import com.riox432.civitdeck.domain.usecase.GetRecommendationsUseCase
 import com.riox432.civitdeck.domain.usecase.ObserveFavoritesUseCase
 import com.riox432.civitdeck.domain.usecase.ObserveIsFavoriteUseCase
 import com.riox432.civitdeck.domain.usecase.ObserveNsfwFilterUseCase
@@ -15,6 +16,7 @@ import com.riox432.civitdeck.domain.usecase.ObserveSearchHistoryUseCase
 import com.riox432.civitdeck.domain.usecase.SavePromptUseCase
 import com.riox432.civitdeck.domain.usecase.SetNsfwFilterUseCase
 import com.riox432.civitdeck.domain.usecase.ToggleFavoriteUseCase
+import com.riox432.civitdeck.domain.usecase.TrackModelViewUseCase
 import org.koin.mp.KoinPlatform.getKoin
 
 @Suppress("TooManyFunctions")
@@ -34,4 +36,6 @@ object KoinHelper {
     fun getObserveSearchHistoryUseCase(): ObserveSearchHistoryUseCase = getKoin().get()
     fun getAddSearchHistoryUseCase(): AddSearchHistoryUseCase = getKoin().get()
     fun getClearSearchHistoryUseCase(): ClearSearchHistoryUseCase = getKoin().get()
+    fun getTrackModelViewUseCase(): TrackModelViewUseCase = getKoin().get()
+    fun getRecommendationsUseCase(): GetRecommendationsUseCase = getKoin().get()
 }


### PR DESCRIPTION
## Description

Add a personalized model discovery feature that tracks user browsing behavior and surfaces relevant model recommendations on the home screen.

**Shared layer:**
- BrowsingHistoryEntity + BrowsingHistoryDao for tracking model views
- BrowsingHistoryRepository to extract preference signals (types, tags, creators)
- RecommendationSection domain model
- GetRecommendationsUseCase with 3 strategies:
  - Type-based: Trending models in user's preferred type
  - Tag-based: Popular models matching user's browsing tags
  - Fallback: Trending this week (cold start)
- TrackModelViewUseCase for recording model detail views
- FavoriteRepository extended with type count queries
- Database migration v1→v2 for browsing_history table

**Android:**
- ModelDetailViewModel tracks model views on load
- ModelSearchViewModel loads recommendations on init
- Horizontal "For You" carousels above the model grid

**iOS:**
- ModelDetailViewModel tracks model views on load
- ModelSearchViewModel loads recommendations on init
- Horizontal recommendation ScrollViews above the grid

## Related Issues

Closes #55

## Screenshots / Video

<!-- If applicable, add screenshots or screen recordings -->

## Test Plan

- [ ] Open model detail → verify browsing history is recorded
- [ ] After viewing several models → recommendations appear on home screen
- [ ] Cold start (no history) → trending fallback is shown
- [ ] Recommendations filter out already-seen models

## Review Checklist

- [x] Code follows project architecture (Clean Architecture + MVVM)
- [x] Shared logic is in `commonMain`, platform-specific code only when necessary
- [x] No unnecessary dependencies added
- [ ] Tests added/updated as needed

## Breaking Changes

Database migration v1→v2 (adds browsing_history table). Note: if merged alongside #52 (search history), migrations will need reconciliation.