### PR TITLE
Add Fresh Only filter to exclude viewed models

### DIFF
--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/CivitDeckApplication.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/CivitDeckApplication.kt
@@ -23,7 +23,7 @@ class CivitDeckApplication : Application() {
 }
 
 val androidModule = module {
-    viewModel { ModelSearchViewModel(get(), get(), get(), get(), get(), get(), get()) }
+    viewModel { ModelSearchViewModel(get(), get(), get(), get(), get(), get(), get(), get()) }
     viewModel { FavoritesViewModel(get()) }
     viewModel { params -> ModelDetailViewModel(params.get(), get(), get(), get(), get()) }
     viewModel { params -> CreatorProfileViewModel(params.get(), get()) }

--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/search/ModelSearchScreen.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/search/ModelSearchScreen.kt
@@ -129,6 +129,7 @@ fun ModelSearchScreen(
                 onBaseModelToggled = viewModel::onBaseModelToggled,
                 onSortSelected = viewModel::onSortSelected,
                 onPeriodSelected = viewModel::onPeriodSelected,
+                onFreshFindToggled = viewModel::onFreshFindToggled,
             )
             ModelSearchContent(
                 uiState = uiState,
@@ -176,14 +177,17 @@ private fun SearchFilters(
     onBaseModelToggled: (BaseModel) -> Unit,
     onSortSelected: (SortOrder) -> Unit,
     onPeriodSelected: (TimePeriod) -> Unit,
+    onFreshFindToggled: () -> Unit,
 ) {
     TypeFilterChips(selectedType = uiState.selectedType, onTypeSelected = onTypeSelected)
     BaseModelFilterChips(selectedBaseModels = uiState.selectedBaseModels, onBaseModelToggled = onBaseModelToggled)
     SortAndPeriodFilters(
         selectedSort = uiState.selectedSort,
         selectedPeriod = uiState.selectedPeriod,
+        isFreshFindEnabled = uiState.isFreshFindEnabled,
         onSortSelected = onSortSelected,
         onPeriodSelected = onPeriodSelected,
+        onFreshFindToggled = onFreshFindToggled,
     )
 }
 
@@ -375,13 +379,22 @@ private fun BaseModelFilterChips(
 private fun SortAndPeriodFilters(
     selectedSort: SortOrder,
     selectedPeriod: TimePeriod,
+    isFreshFindEnabled: Boolean,
     onSortSelected: (SortOrder) -> Unit,
     onPeriodSelected: (TimePeriod) -> Unit,
+    onFreshFindToggled: () -> Unit,
 ) {
     LazyRow(
         contentPadding = PaddingValues(horizontal = Spacing.lg),
         horizontalArrangement = Arrangement.spacedBy(Spacing.sm),
     ) {
+        item {
+            FilterChipItem(
+                label = "Fresh Only",
+                isSelected = isFreshFindEnabled,
+                onClick = onFreshFindToggled,
+            )
+        }
         items(SortOrder.entries.toList()) { sort ->
             FilterChipItem(
                 label = sort.name,

--- a/iosApp/iosApp/Features/Search/ModelSearchScreen.swift
+++ b/iosApp/iosApp/Features/Search/ModelSearchScreen.swift
@@ -228,6 +228,9 @@ struct ModelSearchScreen: View {
     private var sortAndPeriodChips: some View {
         ScrollView(.horizontal, showsIndicators: false) {
             HStack(spacing: Spacing.sm) {
+                chipButton(label: "Fresh Only", isSelected: viewModel.isFreshFindEnabled) {
+                    viewModel.onFreshFindToggled()
+                }
                 ForEach(sortOptions, id: \.self) { sort in
                     chipButton(label: sortLabel(sort), isSelected: viewModel.selectedSort == sort) {
                         viewModel.onSortSelected(sort)

--- a/shared/src/commonMain/kotlin/com/riox432/civitdeck/data/local/dao/BrowsingHistoryDao.kt
+++ b/shared/src/commonMain/kotlin/com/riox432/civitdeck/data/local/dao/BrowsingHistoryDao.kt
@@ -17,6 +17,9 @@ interface BrowsingHistoryDao {
     @Query("SELECT DISTINCT modelId FROM browsing_history ORDER BY viewedAt DESC LIMIT :limit")
     suspend fun getRecentModelIds(limit: Int = 50): List<Long>
 
+    @Query("SELECT DISTINCT modelId FROM browsing_history")
+    suspend fun getAllModelIds(): List<Long>
+
     @Query("SELECT COUNT(*) FROM browsing_history")
     suspend fun count(): Int
 }

--- a/shared/src/commonMain/kotlin/com/riox432/civitdeck/data/repository/BrowsingHistoryRepositoryImpl.kt
+++ b/shared/src/commonMain/kotlin/com/riox432/civitdeck/data/repository/BrowsingHistoryRepositoryImpl.kt
@@ -49,4 +49,8 @@ class BrowsingHistoryRepositoryImpl(
     override suspend fun getRecentModelIds(limit: Int): List<Long> {
         return dao.getRecentModelIds(limit)
     }
+
+    override suspend fun getAllViewedModelIds(): Set<Long> {
+        return dao.getAllModelIds().toSet()
+    }
 }

--- a/shared/src/commonMain/kotlin/com/riox432/civitdeck/di/DomainModule.kt
+++ b/shared/src/commonMain/kotlin/com/riox432/civitdeck/di/DomainModule.kt
@@ -8,6 +8,7 @@ import com.riox432.civitdeck.domain.usecase.GetImagesUseCase
 import com.riox432.civitdeck.domain.usecase.GetModelDetailUseCase
 import com.riox432.civitdeck.domain.usecase.GetModelsUseCase
 import com.riox432.civitdeck.domain.usecase.GetRecommendationsUseCase
+import com.riox432.civitdeck.domain.usecase.GetViewedModelIdsUseCase
 import com.riox432.civitdeck.domain.usecase.ObserveFavoritesUseCase
 import com.riox432.civitdeck.domain.usecase.ObserveIsFavoriteUseCase
 import com.riox432.civitdeck.domain.usecase.ObserveNsfwFilterUseCase
@@ -37,4 +38,5 @@ val domainModule = module {
     factory { ClearSearchHistoryUseCase(get()) }
     factory { TrackModelViewUseCase(get()) }
     factory { GetRecommendationsUseCase(get(), get(), get()) }
+    factory { GetViewedModelIdsUseCase(get()) }
 }

--- a/shared/src/commonMain/kotlin/com/riox432/civitdeck/domain/repository/BrowsingHistoryRepository.kt
+++ b/shared/src/commonMain/kotlin/com/riox432/civitdeck/domain/repository/BrowsingHistoryRepository.kt
@@ -12,4 +12,5 @@ interface BrowsingHistoryRepository {
     suspend fun getRecentCreators(limit: Int = 100): Map<String, Int>
     suspend fun getRecentTags(limit: Int = 100): Map<String, Int>
     suspend fun getRecentModelIds(limit: Int = 50): List<Long>
+    suspend fun getAllViewedModelIds(): Set<Long>
 }

--- a/shared/src/commonMain/kotlin/com/riox432/civitdeck/domain/usecase/GetViewedModelIdsUseCase.kt
+++ b/shared/src/commonMain/kotlin/com/riox432/civitdeck/domain/usecase/GetViewedModelIdsUseCase.kt
@@ -1,0 +1,7 @@
+package com.riox432.civitdeck.domain.usecase
+
+import com.riox432.civitdeck.domain.repository.BrowsingHistoryRepository
+
+class GetViewedModelIdsUseCase(private val repository: BrowsingHistoryRepository) {
+    suspend operator fun invoke(): Set<Long> = repository.getAllViewedModelIds()
+}

--- a/shared/src/iosMain/kotlin/com/riox432/civitdeck/di/KoinHelper.kt
+++ b/shared/src/iosMain/kotlin/com/riox432/civitdeck/di/KoinHelper.kt
@@ -8,6 +8,7 @@ import com.riox432.civitdeck.domain.usecase.GetImagesUseCase
 import com.riox432.civitdeck.domain.usecase.GetModelDetailUseCase
 import com.riox432.civitdeck.domain.usecase.GetModelsUseCase
 import com.riox432.civitdeck.domain.usecase.GetRecommendationsUseCase
+import com.riox432.civitdeck.domain.usecase.GetViewedModelIdsUseCase
 import com.riox432.civitdeck.domain.usecase.ObserveFavoritesUseCase
 import com.riox432.civitdeck.domain.usecase.ObserveIsFavoriteUseCase
 import com.riox432.civitdeck.domain.usecase.ObserveNsfwFilterUseCase
@@ -38,4 +39,5 @@ object KoinHelper {
     fun getClearSearchHistoryUseCase(): ClearSearchHistoryUseCase = getKoin().get()
     fun getTrackModelViewUseCase(): TrackModelViewUseCase = getKoin().get()
     fun getRecommendationsUseCase(): GetRecommendationsUseCase = getKoin().get()
+    fun getViewedModelIdsUseCase(): GetViewedModelIdsUseCase = getKoin().get()
 }


### PR DESCRIPTION
## Description

Add a "Fresh Only" toggle chip to the search screen that excludes previously viewed models from search results, showing only unseen models.

- Shared: Add `GetViewedModelIdsUseCase` + `getAllViewedModelIds()` to DAO/Repository
- Android/iOS: Place "Fresh Only" chip in the `SortAndPeriodFilters` row
- Follows the same client-side filtering pattern as the NSFW filter
- Session-only state (no persistence)

## Related Issues

Closes #74

## Screenshots / Video

<!-- If applicable, add screenshots or screen recordings -->

## Test Plan

- [ ] Fresh Only OFF → All models displayed (default behavior)
- [ ] Fresh Only ON → Previously viewed models are excluded from results
- [ ] Toggling triggers a full list reload
- [ ] Pagination (loadMore) also applies the filter
- [ ] Verify equivalent behavior on iOS

## Review Checklist

- [x] Code follows project architecture (Clean Architecture + MVVM)
- [x] Shared logic is in `commonMain`, platform-specific code only when necessary
- [x] No unnecessary dependencies added
- [ ] Tests added/updated as needed

## Breaking Changes

None