### PR TITLE
Fix overlapping filter chip rows on search screen

### DIFF
--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/search/ModelSearchScreen.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/search/ModelSearchScreen.kt
@@ -179,16 +179,18 @@ private fun SearchFilters(
     onPeriodSelected: (TimePeriod) -> Unit,
     onFreshFindToggled: () -> Unit,
 ) {
-    TypeFilterChips(selectedType = uiState.selectedType, onTypeSelected = onTypeSelected)
-    BaseModelFilterChips(selectedBaseModels = uiState.selectedBaseModels, onBaseModelToggled = onBaseModelToggled)
-    SortAndPeriodFilters(
-        selectedSort = uiState.selectedSort,
-        selectedPeriod = uiState.selectedPeriod,
-        isFreshFindEnabled = uiState.isFreshFindEnabled,
-        onSortSelected = onSortSelected,
-        onPeriodSelected = onPeriodSelected,
-        onFreshFindToggled = onFreshFindToggled,
-    )
+    Column(verticalArrangement = Arrangement.spacedBy(Spacing.sm)) {
+        TypeFilterChips(selectedType = uiState.selectedType, onTypeSelected = onTypeSelected)
+        BaseModelFilterChips(selectedBaseModels = uiState.selectedBaseModels, onBaseModelToggled = onBaseModelToggled)
+        SortAndPeriodFilters(
+            selectedSort = uiState.selectedSort,
+            selectedPeriod = uiState.selectedPeriod,
+            isFreshFindEnabled = uiState.isFreshFindEnabled,
+            onSortSelected = onSortSelected,
+            onPeriodSelected = onPeriodSelected,
+            onFreshFindToggled = onFreshFindToggled,
+        )
+    }
 }
 
 @Composable


### PR DESCRIPTION
## Description

Wrap filter chip rows (TypeFilterChips, BaseModelFilterChips, SortAndPeriodFilters) in a `Column` with `verticalArrangement = Arrangement.spacedBy(Spacing.sm)` to add 8dp vertical spacing between rows, preventing visual overlap.

## Related Issues

Closes #75

## Screenshots / Video

<!-- If applicable, add screenshots or screen recordings -->

## Test Plan

- [ ] Open search screen on Android and verify filter chip rows no longer overlap

## Review Checklist

- [x] Code follows project architecture (Clean Architecture + MVVM)
- [x] Shared logic is in `commonMain`, platform-specific code only when necessary
- [x] No unnecessary dependencies added
- [ ] Tests added/updated as needed

## Breaking Changes

None