### PR TITLE
Add image error placeholders and fix shared element collisions

### DIFF
--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/components/ImageErrorPlaceholder.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/components/ImageErrorPlaceholder.kt
@@ -1,0 +1,33 @@
+package com.riox432.civitdeck.ui.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.BrokenImage
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import com.riox432.civitdeck.ui.theme.IconSize
+
+@Composable
+fun ImageErrorPlaceholder(
+    modifier: Modifier = Modifier,
+    iconTint: Color = MaterialTheme.colorScheme.onSurfaceVariant,
+    backgroundColor: Color = MaterialTheme.colorScheme.surfaceVariant,
+) {
+    Box(
+        modifier = modifier.background(backgroundColor),
+        contentAlignment = Alignment.Center,
+    ) {
+        Icon(
+            imageVector = Icons.Outlined.BrokenImage,
+            contentDescription = null,
+            modifier = Modifier.size(IconSize.errorPlaceholder),
+            tint = iconTint,
+        )
+    }
+}

--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/detail/ModelDetailScreen.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/detail/ModelDetailScreen.kt
@@ -68,6 +68,7 @@ import com.riox432.civitdeck.domain.model.Model
 import com.riox432.civitdeck.domain.model.ModelFile
 import com.riox432.civitdeck.domain.model.ModelImage
 import com.riox432.civitdeck.domain.model.ModelVersion
+import com.riox432.civitdeck.ui.components.ImageErrorPlaceholder
 import com.riox432.civitdeck.ui.gallery.ImageViewerOverlay
 import com.riox432.civitdeck.ui.gallery.ViewerImage
 import com.riox432.civitdeck.ui.navigation.LocalSharedTransitionScope
@@ -86,6 +87,7 @@ fun ModelDetailScreen(
     onBack: () -> Unit,
     onViewImages: (Long) -> Unit = {},
     onCreatorClick: (String) -> Unit = {},
+    sharedElementSuffix: String = "",
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
 
@@ -102,6 +104,7 @@ fun ModelDetailScreen(
             uiState = uiState,
             modelId = modelId,
             initialThumbnailUrl = initialThumbnailUrl,
+            sharedElementSuffix = sharedElementSuffix,
             onRetry = viewModel::retry,
             onVersionSelected = viewModel::onVersionSelected,
             onViewImages = onViewImages,
@@ -170,6 +173,7 @@ private fun ModelDetailBody(
     uiState: ModelDetailUiState,
     modelId: Long,
     initialThumbnailUrl: String?,
+    sharedElementSuffix: String,
     onRetry: () -> Unit,
     onVersionSelected: (Int) -> Unit,
     onViewImages: (Long) -> Unit,
@@ -192,6 +196,7 @@ private fun ModelDetailBody(
                 ImageCarousel(
                     images = images,
                     modelId = modelId,
+                    sharedElementSuffix = sharedElementSuffix,
                     onImageClick = { index -> selectedCarouselIndex = index },
                 )
             }
@@ -199,6 +204,7 @@ private fun ModelDetailBody(
                 SharedThumbnailPlaceholder(
                     thumbnailUrl = initialThumbnailUrl,
                     modelId = modelId,
+                    sharedElementSuffix = sharedElementSuffix,
                 )
             }
         }
@@ -298,6 +304,7 @@ private fun DetailStateContent(
 private fun SharedThumbnailPlaceholder(
     thumbnailUrl: String,
     modelId: Long,
+    sharedElementSuffix: String = "",
 ) {
     val sharedTransitionScope = LocalSharedTransitionScope.current
     val animatedContentScope = LocalNavAnimatedContentScope.current
@@ -309,7 +316,7 @@ private fun SharedThumbnailPlaceholder(
                 .aspectRatio(CAROUSEL_ASPECT_RATIO)
                 .sharedElement(
                     rememberSharedContentState(
-                        key = SharedElementKeys.modelThumbnail(modelId),
+                        key = SharedElementKeys.modelThumbnail(modelId, sharedElementSuffix),
                     ),
                     animatedVisibilityScope = animatedContentScope,
                 )
@@ -335,6 +342,13 @@ private fun SharedThumbnailPlaceholder(
                     .fillMaxWidth()
                     .aspectRatio(CAROUSEL_ASPECT_RATIO)
                     .shimmer(),
+            )
+        },
+        error = {
+            ImageErrorPlaceholder(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .aspectRatio(CAROUSEL_ASPECT_RATIO),
             )
         },
     )
@@ -427,6 +441,7 @@ private fun ViewImagesButton(onClick: () -> Unit) {
 private fun ImageCarousel(
     images: List<ModelImage>,
     modelId: Long,
+    sharedElementSuffix: String = "",
     onImageClick: (Int) -> Unit = {},
 ) {
     if (images.isEmpty()) return
@@ -441,6 +456,7 @@ private fun ImageCarousel(
             CarouselPage(
                 image = images[page],
                 modelId = modelId,
+                sharedElementSuffix = sharedElementSuffix,
                 applySharedElement = page == pagerState.currentPage,
                 onClick = { onImageClick(page) },
             )
@@ -463,6 +479,7 @@ private fun ImageCarousel(
 private fun CarouselPage(
     image: ModelImage,
     modelId: Long,
+    sharedElementSuffix: String = "",
     applySharedElement: Boolean,
     onClick: () -> Unit = {},
 ) {
@@ -477,7 +494,7 @@ private fun CarouselPage(
                 .clip(MaterialTheme.shapes.medium)
                 .sharedElement(
                     rememberSharedContentState(
-                        key = SharedElementKeys.modelThumbnail(modelId),
+                        key = SharedElementKeys.modelThumbnail(modelId, sharedElementSuffix),
                     ),
                     animatedVisibilityScope = animatedContentScope,
                 )
@@ -505,6 +522,13 @@ private fun CarouselPage(
                     .fillMaxWidth()
                     .aspectRatio(CAROUSEL_ASPECT_RATIO)
                     .shimmer(),
+            )
+        },
+        error = {
+            ImageErrorPlaceholder(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .aspectRatio(CAROUSEL_ASPECT_RATIO),
             )
         },
     )

--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/favorites/FavoritesScreen.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/favorites/FavoritesScreen.kt
@@ -38,6 +38,7 @@ import androidx.compose.ui.unit.dp
 import coil3.compose.SubcomposeAsyncImage
 import coil3.request.crossfade
 import com.riox432.civitdeck.domain.model.FavoriteModelSummary
+import com.riox432.civitdeck.ui.components.ImageErrorPlaceholder
 import com.riox432.civitdeck.ui.theme.CornerRadius
 import com.riox432.civitdeck.ui.theme.Duration
 import com.riox432.civitdeck.ui.theme.IconSize
@@ -149,6 +150,13 @@ private fun FavoriteCard(
                                 .fillMaxWidth()
                                 .aspectRatio(1f)
                                 .shimmer(),
+                        )
+                    },
+                    error = {
+                        ImageErrorPlaceholder(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .aspectRatio(1f),
                         )
                     },
                 )

--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/gallery/ImageGalleryScreen.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/gallery/ImageGalleryScreen.kt
@@ -49,6 +49,7 @@ import coil3.request.crossfade
 import com.riox432.civitdeck.domain.model.Image
 import com.riox432.civitdeck.domain.model.SortOrder
 import com.riox432.civitdeck.domain.model.TimePeriod
+import com.riox432.civitdeck.ui.components.ImageErrorPlaceholder
 import com.riox432.civitdeck.ui.theme.CornerRadius
 import com.riox432.civitdeck.ui.theme.Duration
 import com.riox432.civitdeck.ui.theme.Easing
@@ -327,6 +328,13 @@ private fun ImageGridItem(
                     .fillMaxWidth()
                     .aspectRatio(aspectRatio)
                     .shimmer(),
+            )
+        },
+        error = {
+            ImageErrorPlaceholder(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .aspectRatio(aspectRatio),
             )
         },
     )

--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/navigation/CivitDeckNavGraph.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/navigation/CivitDeckNavGraph.kt
@@ -50,7 +50,11 @@ data object SearchRoute
 
 data object FavoritesRoute
 
-data class DetailRoute(val modelId: Long, val thumbnailUrl: String? = null)
+data class DetailRoute(
+    val modelId: Long,
+    val thumbnailUrl: String? = null,
+    val sharedElementSuffix: String = "",
+)
 
 data class ImageGalleryRoute(val modelVersionId: Long)
 
@@ -156,8 +160,8 @@ private fun CivitDeckNavDisplay(backStack: MutableList<Any>) {
                 val viewModel: ModelSearchViewModel = koinViewModel()
                 ModelSearchScreen(
                     viewModel = viewModel,
-                    onModelClick = { modelId, thumbnailUrl ->
-                        backStack.add(DetailRoute(modelId, thumbnailUrl))
+                    onModelClick = { modelId, thumbnailUrl, suffix ->
+                        backStack.add(DetailRoute(modelId, thumbnailUrl, suffix))
                     },
                     onSavedPromptsClick = { backStack.add(SavedPromptsRoute) },
                     onSettingsClick = { backStack.add(SettingsRoute) },
@@ -203,6 +207,7 @@ private fun EntryProviderScope<Any>.detailEntry(backStack: MutableList<Any>) {
             viewModel = viewModel,
             modelId = key.modelId,
             initialThumbnailUrl = key.thumbnailUrl,
+            sharedElementSuffix = key.sharedElementSuffix,
             onBack = { backStack.removeLastOrNull() },
             onViewImages = { modelVersionId ->
                 backStack.add(ImageGalleryRoute(modelVersionId))

--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/navigation/SharedElementKeys.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/navigation/SharedElementKeys.kt
@@ -5,7 +5,12 @@ import androidx.compose.animation.SharedTransitionScope
 import androidx.compose.runtime.staticCompositionLocalOf
 
 object SharedElementKeys {
-    fun modelThumbnail(modelId: Long): String = "model_thumbnail_$modelId"
+    fun modelThumbnail(modelId: Long, suffix: String = ""): String =
+        if (suffix.isEmpty()) {
+            "model_thumbnail_$modelId"
+        } else {
+            "model_thumbnail_${modelId}_$suffix"
+        }
 }
 
 @OptIn(ExperimentalSharedTransitionApi::class)

--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/search/ModelSearchScreen.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/search/ModelSearchScreen.kt
@@ -76,7 +76,7 @@ import com.riox432.civitdeck.ui.theme.Spacing
 @Composable
 fun ModelSearchScreen(
     viewModel: ModelSearchViewModel,
-    onModelClick: (Long, String?) -> Unit = { _, _ -> },
+    onModelClick: (Long, String?, String) -> Unit = { _, _, _ -> },
     onSavedPromptsClick: () -> Unit = {},
     onSettingsClick: () -> Unit = {},
 ) {
@@ -437,11 +437,13 @@ private fun ModelSearchContent(
     uiState: ModelSearchUiState,
     gridState: LazyGridState,
     onRefresh: () -> Unit,
-    onModelClick: (Long, String?) -> Unit,
+    onModelClick: (Long, String?, String) -> Unit,
     bottomPadding: androidx.compose.ui.unit.Dp = 0.dp,
 ) {
+    val isInitialLoading = uiState.models.isEmpty() &&
+        (uiState.isLoading || uiState.isLoadingRecommendations)
     val stateKey = when {
-        uiState.isLoading && uiState.models.isEmpty() -> "loading"
+        isInitialLoading -> "loading"
         uiState.error != null && uiState.models.isEmpty() -> "error"
         else -> "content"
     }
@@ -494,7 +496,7 @@ private fun ModelGrid(
     recommendations: List<RecommendationSection>,
     gridState: LazyGridState,
     isLoadingMore: Boolean,
-    onModelClick: (Long, String?) -> Unit,
+    onModelClick: (Long, String?, String) -> Unit,
     bottomPadding: androidx.compose.ui.unit.Dp = 0.dp,
 ) {
     LazyVerticalGrid(
@@ -509,13 +511,14 @@ private fun ModelGrid(
         horizontalArrangement = Arrangement.spacedBy(Spacing.sm),
         verticalArrangement = Arrangement.spacedBy(Spacing.sm),
     ) {
-        recommendations.forEach { section ->
+        recommendations.forEachIndexed { index, section ->
             item(
                 key = "rec_${section.title}",
                 span = { GridItemSpan(2) },
             ) {
                 RecommendationRow(
                     section = section,
+                    sharedElementSuffix = "rec$index",
                     onModelClick = onModelClick,
                 )
             }
@@ -525,7 +528,7 @@ private fun ModelGrid(
                 .firstOrNull()?.images?.firstOrNull()?.url
             ModelCard(
                 model = model,
-                onClick = { onModelClick(model.id, thumbnailUrl) },
+                onClick = { onModelClick(model.id, thumbnailUrl, "") },
                 modifier = Modifier.animateItem(),
             )
         }
@@ -549,7 +552,8 @@ private fun ModelGrid(
 @Composable
 private fun RecommendationRow(
     section: RecommendationSection,
-    onModelClick: (Long, String?) -> Unit,
+    sharedElementSuffix: String,
+    onModelClick: (Long, String?, String) -> Unit,
 ) {
     Column(modifier = Modifier.padding(bottom = Spacing.sm)) {
         Text(
@@ -571,10 +575,11 @@ private fun RecommendationRow(
                     .firstOrNull()?.images?.firstOrNull()?.url
                 ModelCard(
                     model = model,
-                    onClick = { onModelClick(model.id, thumbnailUrl) },
+                    onClick = { onModelClick(model.id, thumbnailUrl, sharedElementSuffix) },
                     modifier = Modifier
                         .width(160.dp)
                         .height(220.dp),
+                    sharedElementSuffix = sharedElementSuffix,
                 )
             }
         }

--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/search/ModelSearchViewModel.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/search/ModelSearchViewModel.kt
@@ -67,6 +67,7 @@ class ModelSearchViewModel(
     init {
         observeNsfwFilter()
         loadModels()
+        loadRecommendations()
     }
 
     private fun observeNsfwFilter() {

--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/theme/Shape.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/theme/Shape.kt
@@ -26,4 +26,5 @@ object CornerRadius {
 
 object IconSize {
     val statIcon = 10.dp
+    val errorPlaceholder = 36.dp
 }


### PR DESCRIPTION
## Description

Add error state handling to all `SubcomposeAsyncImage` call sites and fix shared element transition issues when the same model appears in multiple locations on the search screen.

**Error placeholders:**
- New `ImageErrorPlaceholder` composable (centered `BrokenImage` icon on `surfaceVariant` background)
- Added `error` parameter to all 6 `SubcomposeAsyncImage` call sites (ModelCard, ModelDetailScreen x2, FavoritesScreen, ImageGalleryScreen, ImageViewerOverlay)
- Show placeholder when `thumbnailUrl` is null in ModelCard

**Recommendation row fixes:**
- Fix `loadRecommendations()` not called on init (only triggered on NSFW filter change)
- Wait for both models and recommendations to load before showing content, preventing scroll position issues

**Shared element transition fixes:**
- Add `sharedElementSuffix` to `SharedElementKeys.modelThumbnail()` for per-instance unique keys
- Grid cards use suffix `""`, recommendation section cards use `"rec0"`, `"rec1"`, etc.
- Pass suffix through `DetailRoute` → `ModelDetailScreen` so the tapped card correctly animates to detail
- Extract `ModelCardThumbnail` and `ZoomableAsyncImage` to fix detekt LongMethod violations

## Related Issues

Closes #79

<!-- ## Screenshots / Video -->

<!-- If applicable, add screenshots or screen recordings -->

## Test Plan

- [ ] Verify broken images show `BrokenImage` icon instead of blank space
- [ ] Verify recommendation rows appear on app launch without scrolling up
- [ ] Verify same model in recommendation row AND grid both display thumbnails
- [ ] Verify tapping a recommendation card animates correctly to detail screen
- [ ] Verify tapping a grid card animates correctly to detail screen

## Review Checklist

- [x] Code follows project architecture (Clean Architecture + MVVM)
- [x] Shared logic is in `commonMain`, platform-specific code only when necessary
- [x] No unnecessary dependencies added
- [ ] Tests added/updated as needed

## Breaking Changes

None