### PR TITLE
Fix recommendation row cell height clipping content

### DIFF
--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/search/ModelSearchScreen.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/search/ModelSearchScreen.kt
@@ -16,7 +16,6 @@ import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyRow
@@ -577,8 +576,7 @@ private fun RecommendationRow(
                     model = model,
                     onClick = { onModelClick(model.id, thumbnailUrl, sharedElementSuffix) },
                     modifier = Modifier
-                        .width(160.dp)
-                        .height(220.dp),
+                        .width(160.dp),
                     sharedElementSuffix = sharedElementSuffix,
                 )
             }


### PR DESCRIPTION
## Description

Remove fixed `220.dp` height constraint from recommendation row cells. The card content (thumbnail at 1:1 aspect ratio + info section) exceeds 220dp, causing stats and model type badge to be clipped. Cards now size to their content naturally, which is consistent since all cards share the same structure and `maxLines = 1`.

Closes #84

## Related Issues

Fixes #84

## Screenshots / Video

<!-- If applicable, add screenshots or screen recordings -->

## Test Plan

- [ ] Verify recommendation row cards show all content (thumbnail, title, type badge, stats)
- [ ] Verify cards in the row have consistent height

## Review Checklist

- [x] Code follows project architecture (Clean Architecture + MVVM)
- [x] Shared logic is in `commonMain`, platform-specific code only when necessary
- [x] No unnecessary dependencies added
- [ ] Tests added/updated as needed

## Breaking Changes

None