### PR TITLE
Fix NSFW content leaking in detail carousel and recommendations

### DIFF
--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/CivitDeckApplication.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/CivitDeckApplication.kt
@@ -31,7 +31,7 @@ val androidModule = module {
         )
     }
     viewModel { FavoritesViewModel(get()) }
-    viewModel { params -> ModelDetailViewModel(params.get(), get(), get(), get(), get()) }
+    viewModel { params -> ModelDetailViewModel(params.get(), get(), get(), get(), get(), get()) }
     viewModel { params -> CreatorProfileViewModel(params.get(), get()) }
     viewModel { params -> ImageGalleryViewModel(params.get(), get(), get()) }
     viewModel { SavedPromptsViewModel(get(), get()) }

--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/detail/ModelDetailScreen.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/detail/ModelDetailScreen.kt
@@ -68,6 +68,7 @@ import com.riox432.civitdeck.domain.model.Model
 import com.riox432.civitdeck.domain.model.ModelFile
 import com.riox432.civitdeck.domain.model.ModelImage
 import com.riox432.civitdeck.domain.model.ModelVersion
+import com.riox432.civitdeck.domain.model.NsfwFilterLevel
 import com.riox432.civitdeck.ui.components.ImageErrorPlaceholder
 import com.riox432.civitdeck.ui.gallery.ImageViewerOverlay
 import com.riox432.civitdeck.ui.gallery.ViewerImage
@@ -182,7 +183,9 @@ private fun ModelDetailBody(
 ) {
     val model = uiState.model
     val selectedVersion = model?.modelVersions?.getOrNull(uiState.selectedVersionIndex)
-    val images = selectedVersion?.images ?: emptyList()
+    val images = (selectedVersion?.images ?: emptyList()).let { allImages ->
+        if (uiState.nsfwFilterLevel == NsfwFilterLevel.Off) allImages.filter { !it.nsfw } else allImages
+    }
     var selectedCarouselIndex by remember { mutableStateOf<Int?>(null) }
 
     Column(

--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/detail/ModelDetailViewModel.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/detail/ModelDetailViewModel.kt
@@ -3,8 +3,10 @@ package com.riox432.civitdeck.ui.detail
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.riox432.civitdeck.domain.model.Model
+import com.riox432.civitdeck.domain.model.NsfwFilterLevel
 import com.riox432.civitdeck.domain.usecase.GetModelDetailUseCase
 import com.riox432.civitdeck.domain.usecase.ObserveIsFavoriteUseCase
+import com.riox432.civitdeck.domain.usecase.ObserveNsfwFilterUseCase
 import com.riox432.civitdeck.domain.usecase.ToggleFavoriteUseCase
 import com.riox432.civitdeck.domain.usecase.TrackModelViewUseCase
 import kotlinx.coroutines.CancellationException
@@ -20,6 +22,7 @@ data class ModelDetailUiState(
     val isLoading: Boolean = true,
     val error: String? = null,
     val selectedVersionIndex: Int = 0,
+    val nsfwFilterLevel: NsfwFilterLevel = NsfwFilterLevel.Off,
 )
 
 class ModelDetailViewModel(
@@ -28,6 +31,7 @@ class ModelDetailViewModel(
     private val observeIsFavoriteUseCase: ObserveIsFavoriteUseCase,
     private val toggleFavoriteUseCase: ToggleFavoriteUseCase,
     private val trackModelViewUseCase: TrackModelViewUseCase,
+    private val observeNsfwFilterUseCase: ObserveNsfwFilterUseCase,
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow(ModelDetailUiState())
@@ -36,6 +40,7 @@ class ModelDetailViewModel(
     init {
         loadModel()
         observeFavorite()
+        observeNsfwFilter()
     }
 
     fun onVersionSelected(index: Int) {
@@ -87,6 +92,14 @@ class ModelDetailViewModel(
         viewModelScope.launch {
             observeIsFavoriteUseCase(modelId).collect { isFavorite ->
                 _uiState.update { it.copy(isFavorite = isFavorite) }
+            }
+        }
+    }
+
+    private fun observeNsfwFilter() {
+        viewModelScope.launch {
+            observeNsfwFilterUseCase().collect { level ->
+                _uiState.update { it.copy(nsfwFilterLevel = level) }
             }
         }
     }

--- a/iosApp/iosApp/Features/Detail/ModelDetailScreen.swift
+++ b/iosApp/iosApp/Features/Detail/ModelDetailScreen.swift
@@ -31,6 +31,9 @@ struct ModelDetailScreen: View {
         .task {
             await viewModel.observeFavorite()
         }
+        .task {
+            await viewModel.observeNsfwFilter()
+        }
         .toolbar {
             ToolbarItem(placement: .navigationBarTrailing) {
                 if let model = viewModel.model,
@@ -61,7 +64,7 @@ struct ModelDetailScreen: View {
 
     @ViewBuilder
     private var carouselViewer: some View {
-        let images = viewModel.selectedVersion?.images ?? []
+        let images = filteredImages
         if let startIndex = selectedCarouselIndex, !images.isEmpty {
             ZStack {
                 Color.black.ignoresSafeArea()
@@ -139,8 +142,16 @@ struct ModelDetailScreen: View {
 
     // MARK: - Image Carousel
 
+    private var filteredImages: [ModelImage] {
+        let allImages = viewModel.selectedVersion?.images ?? []
+        if viewModel.nsfwFilterLevel == .off {
+            return allImages.filter { !$0.nsfw }
+        }
+        return Array(allImages)
+    }
+
     private func imageCarousel(model: Model) -> some View {
-        let images = viewModel.selectedVersion?.images ?? []
+        let images = filteredImages
         return Group {
             if !images.isEmpty {
                 TabView {
@@ -435,23 +446,23 @@ struct ModelDetailScreen: View {
         }
         .padding()
     }
+}
 
-    // MARK: - Helpers
+// MARK: - Helpers
 
-    private func htmlToPlainText(_ html: String) -> String {
-        guard let data = html.data(using: .utf8),
-              let attributedString = try? NSAttributedString(
-                data: data,
-                options: [
-                    .documentType: NSAttributedString.DocumentType.html,
-                    .characterEncoding: String.Encoding.utf8.rawValue,
-                ],
-                documentAttributes: nil
-              ) else {
-            return html
-        }
-        return attributedString.string
+private func htmlToPlainText(_ html: String) -> String {
+    guard let data = html.data(using: .utf8),
+          let attributedString = try? NSAttributedString(
+            data: data,
+            options: [
+                .documentType: NSAttributedString.DocumentType.html,
+                .characterEncoding: String.Encoding.utf8.rawValue,
+            ],
+            documentAttributes: nil
+          ) else {
+        return html
     }
+    return attributedString.string
 }
 
 // MARK: - Wrapping HStack for Tags

--- a/iosApp/iosApp/Features/Detail/ModelDetailViewModel.swift
+++ b/iosApp/iosApp/Features/Detail/ModelDetailViewModel.swift
@@ -8,12 +8,14 @@ final class ModelDetailViewModel: ObservableObject {
     @Published var isLoading: Bool = true
     @Published var error: String?
     @Published var selectedVersionIndex: Int = 0
+    @Published var nsfwFilterLevel: NsfwFilterLevel = .off
 
     private let modelId: Int64
     private let getModelDetailUseCase: GetModelDetailUseCase
     private let observeIsFavoriteUseCase: ObserveIsFavoriteUseCase
     private let toggleFavoriteUseCase: ToggleFavoriteUseCase
     private let trackModelViewUseCase: TrackModelViewUseCase
+    private let observeNsfwFilterUseCase: ObserveNsfwFilterUseCase
 
     var selectedVersion: ModelVersion? {
         guard let model else { return nil }
@@ -28,6 +30,7 @@ final class ModelDetailViewModel: ObservableObject {
         self.observeIsFavoriteUseCase = KoinHelper.shared.getObserveIsFavoriteUseCase()
         self.toggleFavoriteUseCase = KoinHelper.shared.getToggleFavoriteUseCase()
         self.trackModelViewUseCase = KoinHelper.shared.getTrackModelViewUseCase()
+        self.observeNsfwFilterUseCase = KoinHelper.shared.getObserveNsfwFilterUseCase()
         loadModel()
     }
 
@@ -35,6 +38,13 @@ final class ModelDetailViewModel: ObservableObject {
     func observeFavorite() async {
         for await value in observeIsFavoriteUseCase.invoke(modelId: modelId) {
             isFavorite = value.boolValue
+        }
+    }
+
+    func observeNsfwFilter() async {
+        let flow = SkieSwiftFlow<NsfwFilterLevel>(observeNsfwFilterUseCase.invoke())
+        for await value in flow {
+            nsfwFilterLevel = value
         }
     }
 

--- a/shared/src/commonMain/kotlin/com/riox432/civitdeck/di/DomainModule.kt
+++ b/shared/src/commonMain/kotlin/com/riox432/civitdeck/di/DomainModule.kt
@@ -43,7 +43,7 @@ val domainModule = module {
     factory { AddSearchHistoryUseCase(get()) }
     factory { ClearSearchHistoryUseCase(get()) }
     factory { TrackModelViewUseCase(get()) }
-    factory { GetRecommendationsUseCase(get(), get(), get()) }
+    factory { GetRecommendationsUseCase(get(), get(), get(), get()) }
     factory { GetViewedModelIdsUseCase(get()) }
     factory { GetExcludedTagsUseCase(get()) }
     factory { AddExcludedTagUseCase(get()) }


### PR DESCRIPTION
## Description

When NSFW filter is set to "Off", NSFW content was still visible in two places:
1. **Detail screen carousel** — NSFW images in model version galleries were not filtered
2. **Recommendations section** — NSFW models appeared in all recommendation sections (type-based, tag-based, trending fallback)

**Detail carousel fix:** Added `ObserveNsfwFilterUseCase` to `ModelDetailViewModel` on both Android and iOS. When the filter is Off, images with `nsfw=true` are excluded from the carousel and fullscreen viewer.

**Recommendations fix:** Added `UserPreferencesRepository` to `GetRecommendationsUseCase` in shared code. Reads the current NSFW filter level and excludes NSFW models from all 3 recommendation sections when filter is Off.

## Related Issues

Closes #93

<!-- ## Screenshots / Video -->

## Test Plan

- [x] `./gradlew :shared:testDebugUnitTest` passes
- [x] `./gradlew detekt` passes (no violations)
- [x] `swiftlint --strict` passes (no violations)
- [ ] Set NSFW to Off → open model detail → carousel should not show NSFW images
- [ ] Set NSFW to Off → search screen recommendations should not show NSFW models

## Review Checklist

- [x] Code follows project architecture (Clean Architecture + MVVM)
- [x] Shared logic is in `commonMain`, platform-specific code only when necessary
- [x] No unnecessary dependencies added
- [x] Tests added/updated as needed

## Breaking Changes

None