### PR TITLE
Improve saved prompts empty state UX

### DIFF
--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/prompts/SavedPromptsScreen.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/prompts/SavedPromptsScreen.kt
@@ -13,12 +13,14 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material.icons.outlined.BookmarkBorder
 import androidx.compose.material3.Card
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
@@ -34,6 +36,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.riox432.civitdeck.domain.model.SavedPrompt
 import com.riox432.civitdeck.ui.theme.CornerRadius
@@ -77,10 +80,28 @@ private fun EmptyState(modifier: Modifier = Modifier) {
         modifier = modifier.fillMaxSize(),
         contentAlignment = Alignment.Center,
     ) {
-        Text(
-            text = "No saved prompts yet",
-            color = MaterialTheme.colorScheme.onSurfaceVariant,
-        )
+        Column(
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.spacedBy(Spacing.sm),
+        ) {
+            Icon(
+                imageVector = Icons.Outlined.BookmarkBorder,
+                contentDescription = null,
+                modifier = Modifier.size(48.dp),
+                tint = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            Text(
+                text = "No saved prompts yet",
+                style = MaterialTheme.typography.titleMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            Text(
+                text = "Save prompts from the image viewer's info panel\nto reference them later.",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                textAlign = androidx.compose.ui.text.style.TextAlign.Center,
+            )
+        }
     }
 }
 

--- a/iosApp/iosApp/Features/Prompts/SavedPromptsScreen.swift
+++ b/iosApp/iosApp/Features/Prompts/SavedPromptsScreen.swift
@@ -19,10 +19,15 @@ struct SavedPromptsScreen: View {
     private var emptyState: some View {
         VStack(spacing: Spacing.sm) {
             SwiftUI.Image(systemName: "bookmark")
-                .font(.largeTitle)
+                .font(.system(size: 48))
                 .foregroundColor(.civitOnSurfaceVariant)
             Text("No saved prompts yet")
+                .font(.headline)
                 .foregroundColor(.civitOnSurfaceVariant)
+            Text("Save prompts from the image viewer's info panel\nto reference them later.")
+                .font(.caption)
+                .foregroundColor(.civitOnSurfaceVariant)
+                .multilineTextAlignment(.center)
         }
         .frame(maxHeight: .infinity)
     }


### PR DESCRIPTION
## Description

Improve the empty state on the Saved Prompts screen to be more informative. The previous empty state only showed "No saved prompts yet" — now it includes a bookmark icon, headline text, and a helpful subtitle explaining how to save prompts (from the image viewer's info panel).

Changes on both Android (Compose) and iOS (SwiftUI).

## Related Issues

Closes #94

## Screenshots / Video

<!-- If applicable, add screenshots or screen recordings -->

## Test Plan

- [ ] Open Saved Prompts with no saved prompts — verify improved empty state
- [ ] Save a prompt from image viewer — verify list still renders correctly

## Review Checklist

- [x] Code follows project architecture (Clean Architecture + MVVM)
- [x] Shared logic is in `commonMain`, platform-specific code only when necessary
- [x] No unnecessary dependencies added
- [x] Tests added/updated as needed

## Breaking Changes

None