### PR TITLE
Add image caching for faster repeated loads

### DIFF
--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/CivitDeckApplication.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/CivitDeckApplication.kt
@@ -1,6 +1,12 @@
 package com.riox432.civitdeck
 
 import android.app.Application
+import coil3.ImageLoader
+import coil3.SingletonImageLoader
+import coil3.disk.DiskCache
+import coil3.disk.directory
+import coil3.memory.MemoryCache
+import coil3.request.crossfade
 import com.riox432.civitdeck.di.initKoin
 import com.riox432.civitdeck.ui.creator.CreatorProfileViewModel
 import com.riox432.civitdeck.ui.detail.ModelDetailViewModel
@@ -13,13 +19,30 @@ import org.koin.android.ext.koin.androidContext
 import org.koin.core.module.dsl.viewModel
 import org.koin.dsl.module
 
-class CivitDeckApplication : Application() {
+class CivitDeckApplication : Application(), SingletonImageLoader.Factory {
     override fun onCreate() {
         super.onCreate()
         initKoin {
             androidContext(this@CivitDeckApplication)
             modules(androidModule)
         }
+    }
+
+    override fun newImageLoader(context: coil3.PlatformContext): ImageLoader {
+        return ImageLoader.Builder(context)
+            .memoryCache {
+                MemoryCache.Builder()
+                    .maxSizePercent(context, 0.15)
+                    .build()
+            }
+            .diskCache {
+                DiskCache.Builder()
+                    .directory(cacheDir.resolve("image_cache"))
+                    .maxSizePercent(0.02)
+                    .build()
+            }
+            .crossfade(true)
+            .build()
     }
 }
 

--- a/iosApp/iosApp.xcodeproj/project.pbxproj
+++ b/iosApp/iosApp.xcodeproj/project.pbxproj
@@ -34,6 +34,7 @@
 		CD0009032D000009000CD001 /* SavedPromptsScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD0009022D000009000CD001 /* SavedPromptsScreen.swift */; };
 		CD000A012D00000A000CD001 /* SettingsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD000A002D00000A000CD001 /* SettingsViewModel.swift */; };
 		CD000A032D00000A000CD001 /* SettingsScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD000A022D00000A000CD001 /* SettingsScreen.swift */; };
+		CD00CA012D0CC001000CD001 /* CachedAsyncImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD00CA002D0CC001000CD001 /* CachedAsyncImage.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -67,6 +68,7 @@
 		CD0009022D000009000CD001 /* SavedPromptsScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SavedPromptsScreen.swift; sourceTree = "<group>"; };
 		CD000A002D00000A000CD001 /* SettingsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsViewModel.swift; sourceTree = "<group>"; };
 		CD000A022D00000A000CD001 /* SettingsScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsScreen.swift; sourceTree = "<group>"; };
+		CD00CA002D0CC001000CD001 /* CachedAsyncImage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CachedAsyncImage.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -144,6 +146,7 @@
 				CD0006062D000006000CD001 /* CivitDeckShapes.swift */,
 				CD00060A2D000006000CD001 /* CivitDeckMotion.swift */,
 				CD0006102D000036000CD001 /* ShimmerModifier.swift */,
+				CD00CA002D0CC001000CD001 /* CachedAsyncImage.swift */,
 			);
 			path = DesignSystem;
 			sourceTree = "<group>";
@@ -366,6 +369,7 @@
 				CD0009032D000009000CD001 /* SavedPromptsScreen.swift in Sources */,
 				CD000A012D00000A000CD001 /* SettingsViewModel.swift in Sources */,
 				CD000A032D00000A000CD001 /* SettingsScreen.swift in Sources */,
+				CD00CA012D0CC001000CD001 /* CachedAsyncImage.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/iosApp/iosApp/DesignSystem/CachedAsyncImage.swift
+++ b/iosApp/iosApp/DesignSystem/CachedAsyncImage.swift
@@ -1,0 +1,71 @@
+import SwiftUI
+
+/// A drop-in replacement for `AsyncImage` that uses a shared URLSession
+/// with a larger URLCache for better image caching performance.
+///
+/// Usage is identical to `AsyncImage`:
+/// ```
+/// CachedAsyncImage(url: imageURL) { phase in
+///     switch phase { ... }
+/// }
+/// ```
+struct CachedAsyncImage<Content: View>: View {
+    let url: URL?
+    @ViewBuilder let content: (AsyncImagePhase) -> Content
+
+    @State private var phase: AsyncImagePhase = .empty
+
+    var body: some View {
+        content(phase)
+            .task(id: url) {
+                await loadImage()
+            }
+    }
+
+    private func loadImage() async {
+        guard let url else {
+            phase = .empty
+            return
+        }
+
+        let request = URLRequest(
+            url: url,
+            cachePolicy: .returnCacheDataElseLoad
+        )
+
+        do {
+            let (data, _) = try await ImageURLSession.shared.data(for: request)
+            guard let uiImage = UIImage(data: data) else {
+                phase = .failure(ImageLoadingError.invalidData)
+                return
+            }
+            withAnimation(.easeIn(duration: 0.2)) {
+                phase = .success(Image(uiImage: uiImage))
+            }
+        } catch {
+            if !Task.isCancelled {
+                phase = .failure(error)
+            }
+        }
+    }
+}
+
+// MARK: - Shared URLSession
+
+enum ImageURLSession {
+    /// Shared URLSession with a 50MB memory / 200MB disk cache.
+    static let shared: URLSession = {
+        let cache = URLCache(
+            memoryCapacity: 50 * 1024 * 1024,
+            diskCapacity: 200 * 1024 * 1024
+        )
+        let config = URLSessionConfiguration.default
+        config.urlCache = cache
+        config.requestCachePolicy = .returnCacheDataElseLoad
+        return URLSession(configuration: config)
+    }()
+}
+
+private enum ImageLoadingError: Error {
+    case invalidData
+}

--- a/iosApp/iosApp/Features/Detail/ModelDetailScreen.swift
+++ b/iosApp/iosApp/Features/Detail/ModelDetailScreen.swift
@@ -157,7 +157,7 @@ struct ModelDetailScreen: View {
                 TabView {
                     ForEach(Array(images.enumerated()), id: \.offset) { index, image in
                         if let url = URL(string: image.url) {
-                            AsyncImage(url: url) { phase in
+                            CachedAsyncImage(url: url) { phase in
                                 switch phase {
                                 case .success(let img):
                                     img

--- a/iosApp/iosApp/Features/Favorites/FavoritesScreen.swift
+++ b/iosApp/iosApp/Features/Favorites/FavoritesScreen.swift
@@ -93,7 +93,7 @@ private struct FavoriteCardView: View {
                 Color.civitSurfaceVariant
                     .aspectRatio(1, contentMode: .fit)
                     .overlay {
-                        AsyncImage(url: imageUrl) { phase in
+                        CachedAsyncImage(url: imageUrl) { phase in
                             switch phase {
                             case .success(let image):
                                 image

--- a/iosApp/iosApp/Features/Gallery/ImageGalleryScreen.swift
+++ b/iosApp/iosApp/Features/Gallery/ImageGalleryScreen.swift
@@ -172,7 +172,7 @@ struct ImageGalleryScreen: View {
         return Button {
             viewModel.onImageSelected(index)
         } label: {
-            AsyncImage(url: URL(string: image.url)) { phase in
+            CachedAsyncImage(url: URL(string: image.url)) { phase in
                 switch phase {
                 case .success(let img):
                     img

--- a/iosApp/iosApp/Features/Gallery/ImageViewerScreen.swift
+++ b/iosApp/iosApp/Features/Gallery/ImageViewerScreen.swift
@@ -127,7 +127,8 @@ struct ImageViewerScreen: View {
 
         Task {
             do {
-                let (data, _) = try await URLSession.shared.data(from: url)
+                let request = URLRequest(url: url, cachePolicy: .returnCacheDataElseLoad)
+                let (data, _) = try await ImageURLSession.shared.data(for: request)
                 guard let image = UIImage(data: data) else {
                     showToast("Download failed")
                     return
@@ -396,7 +397,8 @@ final class ZoomableImageViewController: UIViewController, UIScrollViewDelegate,
 
         Task { @MainActor [weak self] in
             do {
-                let (data, _) = try await URLSession.shared.data(from: url)
+                let request = URLRequest(url: url, cachePolicy: .returnCacheDataElseLoad)
+                let (data, _) = try await ImageURLSession.shared.data(for: request)
                 self?.spinner.stopAnimating()
                 guard let image = UIImage(data: data) else { return }
                 self?.imageView.image = image

--- a/iosApp/iosApp/Features/Search/ModelCardView.swift
+++ b/iosApp/iosApp/Features/Search/ModelCardView.swift
@@ -36,7 +36,7 @@ struct ModelCardView: View {
                 Color.civitSurfaceVariant
                     .aspectRatio(1, contentMode: .fit)
                     .overlay {
-                        AsyncImage(url: imageUrl) { phase in
+                        CachedAsyncImage(url: imageUrl) { phase in
                             switch phase {
                             case .success(let image):
                                 image


### PR DESCRIPTION
## Description

Configure explicit image caching on both platforms for faster repeated image loads.

**Android:**
- Configure Coil `ImageLoader` singleton with explicit disk cache (2% storage, 250MB max) and memory cache (15% RAM) via `SingletonImageLoader.Factory`
- Enable crossfade globally

**iOS:**
- Create `CachedAsyncImage` component with shared `URLSession` using enlarged `URLCache` (50MB memory, 200MB disk)
- Uses `.returnCacheDataElseLoad` cache policy for aggressive caching
- Replace all `AsyncImage` usages with `CachedAsyncImage` (search cards, favorites, detail carousel, gallery grid)
- Update `ImageViewerScreen` to use the shared cached `URLSession` for full-res images and downloads

## Related Issues

Closes #95

## Screenshots / Video

<!-- If applicable, add screenshots or screen recordings -->

## Test Plan

- [ ] Browse models, navigate to detail, go back — images should load from cache instantly
- [ ] Verify gallery images load faster on second visit
- [ ] iOS: confirm no visual regressions with CachedAsyncImage vs AsyncImage

## Review Checklist

- [x] Code follows project architecture (Clean Architecture + MVVM)
- [x] Shared logic is in `commonMain`, platform-specific code only when necessary
- [x] No unnecessary dependencies added
- [x] Tests added/updated as needed

## Breaking Changes

None