### PR TITLE
Fix tech debt: task leaks, HTTP timeout, DB indices, tag trim, refreshable

### DIFF
--- a/iosApp/iosApp/Features/Creator/CreatorProfileScreen.swift
+++ b/iosApp/iosApp/Features/Creator/CreatorProfileScreen.swift
@@ -50,7 +50,7 @@ struct CreatorProfileScreen: View {
             }
         }
         .refreshable {
-            viewModel.refresh()
+            await viewModel.refresh()
         }
     }
 
@@ -60,7 +60,7 @@ struct CreatorProfileScreen: View {
                 .foregroundColor(.civitError)
                 .multilineTextAlignment(.center)
             Button("Retry") {
-                viewModel.refresh()
+                Task { await viewModel.refresh() }
             }
             .buttonStyle(.bordered)
         }

--- a/iosApp/iosApp/Features/Creator/CreatorProfileViewModel.swift
+++ b/iosApp/iosApp/Features/Creator/CreatorProfileViewModel.swift
@@ -28,11 +28,12 @@ final class CreatorProfileViewModel: ObservableObject {
         loadModels(isLoadMore: true)
     }
 
-    func refresh() {
+    func refresh() async {
         loadTask?.cancel()
         nextCursor = nil
         hasMore = true
         loadModels(isRefresh: true)
+        await loadTask?.value
     }
 
     private func loadModels(isLoadMore: Bool = false, isRefresh: Bool = false) {

--- a/iosApp/iosApp/Features/Detail/ModelDetailComponents.swift
+++ b/iosApp/iosApp/Features/Detail/ModelDetailComponents.swift
@@ -92,7 +92,7 @@ struct ImageGridSheet: View {
                 onImageSelected(index)
             }
         } label: {
-            AsyncImage(url: URL(string: image.url)) { phase in
+            CachedAsyncImage(url: URL(string: image.url)) { phase in
                 switch phase {
                 case .success(let img):
                     img.resizable().scaledToFill().transition(.opacity)

--- a/iosApp/iosApp/Features/Favorites/FavoritesScreen.swift
+++ b/iosApp/iosApp/Features/Favorites/FavoritesScreen.swift
@@ -25,9 +25,7 @@ struct FavoritesScreen: View {
                 ModelDetailScreen(modelId: modelId)
             }
         }
-        .task {
-            await viewModel.observe()
-        }
+        // Observation starts automatically in ViewModel init
     }
 
     private var favoritesGrid: some View {

--- a/iosApp/iosApp/Features/Favorites/FavoritesViewModel.swift
+++ b/iosApp/iosApp/Features/Favorites/FavoritesViewModel.swift
@@ -6,12 +6,18 @@ final class FavoritesViewModel: ObservableObject {
     @Published var favorites: [FavoriteModelSummary] = []
 
     private let observeFavoritesUseCase: ObserveFavoritesUseCase
+    private var observeTask: Task<Void, Never>?
 
     init() {
         self.observeFavoritesUseCase = KoinHelper.shared.getObserveFavoritesUseCase()
+        observeTask = Task { await observe() }
     }
 
-    func observe() async {
+    deinit {
+        observeTask?.cancel()
+    }
+
+    private func observe() async {
         for await list in observeFavoritesUseCase.invoke() {
             let items = list.compactMap { $0 as? FavoriteModelSummary }
             self.favorites = items

--- a/iosApp/iosApp/Features/Search/ModelSearchScreen.swift
+++ b/iosApp/iosApp/Features/Search/ModelSearchScreen.swift
@@ -315,7 +315,7 @@ struct ModelSearchScreen: View {
         )
         .animation(MotionAnimation.standard, value: viewModel.isLoadingMore)
         .refreshable {
-            viewModel.refresh()
+            await viewModel.refresh()
         }
     }
 
@@ -400,7 +400,7 @@ struct ModelSearchScreen: View {
                 .foregroundColor(.civitError)
                 .multilineTextAlignment(.center)
             Button("Retry") {
-                viewModel.refresh()
+                Task { await viewModel.refresh() }
             }
             .buttonStyle(.bordered)
         }

--- a/iosApp/iosApp/Features/Search/ModelSearchViewModel.swift
+++ b/iosApp/iosApp/Features/Search/ModelSearchViewModel.swift
@@ -216,11 +216,12 @@ final class ModelSearchViewModel: ObservableObject {
         loadModels(isLoadMore: true)
     }
 
-    func refresh() {
+    func refresh() async {
         loadTask?.cancel()
         nextCursor = nil
         hasMore = true
         loadModels(isRefresh: true)
+        await loadTask?.value
     }
 
     private func loadModels(isLoadMore: Bool = false, isRefresh: Bool = false) {

--- a/shared/schemas/com.riox432.civitdeck.data.local.CivitDeckDatabase/4.json
+++ b/shared/schemas/com.riox432.civitdeck.data.local.CivitDeckDatabase/4.json
@@ -1,0 +1,369 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 4,
+    "identityHash": "51e00bf7facbf229791c4c04f50a4503",
+    "entities": [
+      {
+        "tableName": "favorite_models",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `name` TEXT NOT NULL, `type` TEXT NOT NULL, `nsfw` INTEGER NOT NULL, `thumbnailUrl` TEXT, `creatorName` TEXT, `downloadCount` INTEGER NOT NULL, `favoriteCount` INTEGER NOT NULL, `rating` REAL NOT NULL, `favoritedAt` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "nsfw",
+            "columnName": "nsfw",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "thumbnailUrl",
+            "columnName": "thumbnailUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "creatorName",
+            "columnName": "creatorName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "downloadCount",
+            "columnName": "downloadCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "favoriteCount",
+            "columnName": "favoriteCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "rating",
+            "columnName": "rating",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "favoritedAt",
+            "columnName": "favoritedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "cached_api_responses",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`cacheKey` TEXT NOT NULL, `responseJson` TEXT NOT NULL, `cachedAt` INTEGER NOT NULL, PRIMARY KEY(`cacheKey`))",
+        "fields": [
+          {
+            "fieldPath": "cacheKey",
+            "columnName": "cacheKey",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "responseJson",
+            "columnName": "responseJson",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cachedAt",
+            "columnName": "cachedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "cacheKey"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_cached_api_responses_cachedAt",
+            "unique": false,
+            "columnNames": [
+              "cachedAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_cached_api_responses_cachedAt` ON `${TABLE_NAME}` (`cachedAt`)"
+          }
+        ]
+      },
+      {
+        "tableName": "user_preferences",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `nsfwFilterLevel` TEXT NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "nsfwFilterLevel",
+            "columnName": "nsfwFilterLevel",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "saved_prompts",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `prompt` TEXT NOT NULL, `negativePrompt` TEXT, `sampler` TEXT, `steps` INTEGER, `cfgScale` REAL, `seed` INTEGER, `modelName` TEXT, `size` TEXT, `sourceImageUrl` TEXT, `savedAt` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "prompt",
+            "columnName": "prompt",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "negativePrompt",
+            "columnName": "negativePrompt",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "sampler",
+            "columnName": "sampler",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "steps",
+            "columnName": "steps",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "cfgScale",
+            "columnName": "cfgScale",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "seed",
+            "columnName": "seed",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "modelName",
+            "columnName": "modelName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "size",
+            "columnName": "size",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "sourceImageUrl",
+            "columnName": "sourceImageUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "savedAt",
+            "columnName": "savedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "search_history",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `query` TEXT NOT NULL, `searchedAt` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "query",
+            "columnName": "query",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "searchedAt",
+            "columnName": "searchedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "browsing_history",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `modelId` INTEGER NOT NULL, `modelType` TEXT NOT NULL, `creatorName` TEXT, `tags` TEXT NOT NULL, `viewedAt` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "modelId",
+            "columnName": "modelId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "modelType",
+            "columnName": "modelType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "creatorName",
+            "columnName": "creatorName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "tags",
+            "columnName": "tags",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "viewedAt",
+            "columnName": "viewedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_browsing_history_modelId",
+            "unique": false,
+            "columnNames": [
+              "modelId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_browsing_history_modelId` ON `${TABLE_NAME}` (`modelId`)"
+          },
+          {
+            "name": "index_browsing_history_viewedAt",
+            "unique": false,
+            "columnNames": [
+              "viewedAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_browsing_history_viewedAt` ON `${TABLE_NAME}` (`viewedAt`)"
+          }
+        ]
+      },
+      {
+        "tableName": "excluded_tags",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`tag` TEXT NOT NULL, `addedAt` INTEGER NOT NULL, PRIMARY KEY(`tag`))",
+        "fields": [
+          {
+            "fieldPath": "tag",
+            "columnName": "tag",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "addedAt",
+            "columnName": "addedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "tag"
+          ]
+        }
+      },
+      {
+        "tableName": "hidden_models",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`modelId` INTEGER NOT NULL, `modelName` TEXT NOT NULL, `hiddenAt` INTEGER NOT NULL, PRIMARY KEY(`modelId`))",
+        "fields": [
+          {
+            "fieldPath": "modelId",
+            "columnName": "modelId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "modelName",
+            "columnName": "modelName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "hiddenAt",
+            "columnName": "hiddenAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "modelId"
+          ]
+        }
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '51e00bf7facbf229791c4c04f50a4503')"
+    ]
+  }
+}

--- a/shared/src/commonMain/kotlin/com/riox432/civitdeck/data/api/HttpClientFactory.kt
+++ b/shared/src/commonMain/kotlin/com/riox432/civitdeck/data/api/HttpClientFactory.kt
@@ -1,6 +1,8 @@
 package com.riox432.civitdeck.data.api
 
 import io.ktor.client.HttpClient
+import io.ktor.client.plugins.HttpRequestRetry
+import io.ktor.client.plugins.HttpTimeout
 import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
 import io.ktor.client.plugins.defaultRequest
 import io.ktor.client.plugins.logging.LogLevel
@@ -9,6 +11,12 @@ import io.ktor.client.request.header
 import io.ktor.http.HttpHeaders
 import io.ktor.serialization.kotlinx.json.json
 import kotlinx.serialization.json.Json
+
+private const val CONNECT_TIMEOUT_MS = 15_000L
+private const val REQUEST_TIMEOUT_MS = 30_000L
+private const val SOCKET_TIMEOUT_MS = 30_000L
+private const val MAX_RETRIES = 2
+private const val RETRY_BASE_DELAY_MS = 1000L
 
 fun createHttpClient(): HttpClient {
     return HttpClient {
@@ -20,6 +28,16 @@ fun createHttpClient(): HttpClient {
                     encodeDefaults = true
                 }
             )
+        }
+        install(HttpTimeout) {
+            connectTimeoutMillis = CONNECT_TIMEOUT_MS
+            requestTimeoutMillis = REQUEST_TIMEOUT_MS
+            socketTimeoutMillis = SOCKET_TIMEOUT_MS
+        }
+        install(HttpRequestRetry) {
+            retryOnServerErrors(maxRetries = MAX_RETRIES)
+            retryOnException(maxRetries = MAX_RETRIES, retryOnTimeout = true)
+            exponentialDelay(baseDelayMs = RETRY_BASE_DELAY_MS)
         }
         install(Logging) {
             level = LogLevel.NONE

--- a/shared/src/commonMain/kotlin/com/riox432/civitdeck/data/local/CivitDeckDatabase.kt
+++ b/shared/src/commonMain/kotlin/com/riox432/civitdeck/data/local/CivitDeckDatabase.kt
@@ -38,7 +38,7 @@ import kotlinx.coroutines.IO
         ExcludedTagEntity::class,
         HiddenModelEntity::class,
     ],
-    version = 3,
+    version = 4,
 )
 @ConstructedBy(CivitDeckDatabaseConstructor::class)
 abstract class CivitDeckDatabase : RoomDatabase() {
@@ -111,9 +111,26 @@ val MIGRATION_2_3 = object : Migration(2, 3) {
     }
 }
 
+val MIGRATION_3_4 = object : Migration(3, 4) {
+    override fun migrate(connection: SQLiteConnection) {
+        connection.execSQL(
+            "CREATE INDEX IF NOT EXISTS `index_browsing_history_modelId` " +
+                "ON `browsing_history` (`modelId`)",
+        )
+        connection.execSQL(
+            "CREATE INDEX IF NOT EXISTS `index_browsing_history_viewedAt` " +
+                "ON `browsing_history` (`viewedAt`)",
+        )
+        connection.execSQL(
+            "CREATE INDEX IF NOT EXISTS `index_cached_api_responses_cachedAt` " +
+                "ON `cached_api_responses` (`cachedAt`)",
+        )
+    }
+}
+
 fun getRoomDatabase(builder: RoomDatabase.Builder<CivitDeckDatabase>): CivitDeckDatabase {
     return builder
-        .addMigrations(MIGRATION_1_2, MIGRATION_2_3)
+        .addMigrations(MIGRATION_1_2, MIGRATION_2_3, MIGRATION_3_4)
         .setDriver(BundledSQLiteDriver())
         .setQueryCoroutineContext(Dispatchers.IO)
         .build()

--- a/shared/src/commonMain/kotlin/com/riox432/civitdeck/data/local/entity/BrowsingHistoryEntity.kt
+++ b/shared/src/commonMain/kotlin/com/riox432/civitdeck/data/local/entity/BrowsingHistoryEntity.kt
@@ -1,9 +1,16 @@
 package com.riox432.civitdeck.data.local.entity
 
 import androidx.room.Entity
+import androidx.room.Index
 import androidx.room.PrimaryKey
 
-@Entity(tableName = "browsing_history")
+@Entity(
+    tableName = "browsing_history",
+    indices = [
+        Index(value = ["modelId"]),
+        Index(value = ["viewedAt"]),
+    ],
+)
 data class BrowsingHistoryEntity(
     @PrimaryKey(autoGenerate = true) val id: Long = 0,
     val modelId: Long,

--- a/shared/src/commonMain/kotlin/com/riox432/civitdeck/data/local/entity/CachedApiResponseEntity.kt
+++ b/shared/src/commonMain/kotlin/com/riox432/civitdeck/data/local/entity/CachedApiResponseEntity.kt
@@ -1,9 +1,15 @@
 package com.riox432.civitdeck.data.local.entity
 
 import androidx.room.Entity
+import androidx.room.Index
 import androidx.room.PrimaryKey
 
-@Entity(tableName = "cached_api_responses")
+@Entity(
+    tableName = "cached_api_responses",
+    indices = [
+        Index(value = ["cachedAt"]),
+    ],
+)
 data class CachedApiResponseEntity(
     @PrimaryKey
     val cacheKey: String,

--- a/shared/src/commonMain/kotlin/com/riox432/civitdeck/data/repository/BrowsingHistoryRepositoryImpl.kt
+++ b/shared/src/commonMain/kotlin/com/riox432/civitdeck/data/repository/BrowsingHistoryRepositoryImpl.kt
@@ -41,7 +41,7 @@ class BrowsingHistoryRepositoryImpl(
 
     override suspend fun getRecentTags(limit: Int): Map<String, Int> {
         return dao.getRecent(limit)
-            .flatMap { it.tags.split(",").filter { tag -> tag.isNotBlank() } }
+            .flatMap { it.tags.split(",").map { tag -> tag.trim() }.filter { tag -> tag.isNotBlank() } }
             .groupingBy { it }
             .eachCount()
     }


### PR DESCRIPTION
## Description

Address multiple tech debt items and bugs found during deep code review:

- **iOS FavoritesViewModel task leak**: Store `Task` reference and cancel in `deinit` (same pattern as SavedPromptsViewModel)
- **iOS ImageGridSheet cache bypass**: Replace `AsyncImage` with `CachedAsyncImage` to use shared URLSession cache
- **HTTP timeout/retry**: Add `HttpTimeout` (15s connect, 30s request/socket) and `HttpRequestRetry` (2 retries with exponential backoff) to Ktor client
- **Database indices**: Add indices on `browsing_history.modelId`, `browsing_history.viewedAt`, and `cached_api_responses.cachedAt` with migration 3→4
- **Tag trim**: Add `.trim()` to tag splitting in `BrowsingHistoryRepositoryImpl.getRecentTags()` to prevent phantom tags
- **iOS .refreshable**: Make `refresh()` async so `.refreshable` properly awaits completion instead of dismissing spinner immediately (ModelSearch + CreatorProfile)

## Related Issues

Closes #106, Closes #107, Closes #108, Closes #109, Closes #110, Closes #111

## Screenshots / Video

<!-- If applicable, add screenshots or screen recordings -->

## Test Plan

- [x] Android debug build passes
- [x] iOS debug build passes
- [x] Detekt passes with no errors
- [x] Room schema v4 generated correctly

## Review Checklist

- [x] Code follows project architecture (Clean Architecture + MVVM)
- [x] Shared logic is in `commonMain`, platform-specific code only when necessary
- [x] No unnecessary dependencies added
- [ ] Tests added/updated as needed

## Breaking Changes

Database schema version bumped from 3 to 4 (migration included, no data loss).