### PR TITLE
Fix lint androidTest dependency resolution

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -12,7 +12,7 @@ ksp = "2.2.0-2.0.2"
 androidx-activity-compose = "1.10.1"
 androidx-lifecycle = "2.9.0"
 androidx-navigation3 = "1.0.0"
-androidx-lifecycle-viewmodel-navigation3 = "1.0.0"
+androidx-lifecycle-viewmodel-navigation3 = "2.10.0"
 detekt = "1.23.8"
 skie = "0.10.9"
 


### PR DESCRIPTION
## Description

Fix `lifecycle-viewmodel-navigation3` version from `1.0.0` to `2.10.0`. The artifact was absorbed into the lifecycle group and version `1.0.0` doesn't exist on Google Maven. Main classpath resolved it via BOM constraints, but androidTest classpath lacked those constraints, causing `generateDebugAndroidTestLintModel` to fail.

## Related Issues

<!-- Link related GitHub issues: Closes #123, Fixes #456 -->

## Screenshots / Video

<!-- If applicable, add screenshots or screen recordings -->

## Test Plan

- [x] `lintDebug` no longer fails on androidTest dependency resolution
- [x] Build and unit tests pass

## Review Checklist

- [x] Code follows project architecture (Clean Architecture + MVVM)
- [x] Shared logic is in `commonMain`, platform-specific code only when necessary
- [x] No unnecessary dependencies added
- [x] Tests added/updated as needed

## Breaking Changes

None