### PR TITLE
Fix removeLast() lint error for API < 35

### DIFF
--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/navigation/CivitDeckNavGraph.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/navigation/CivitDeckNavGraph.kt
@@ -112,7 +112,7 @@ fun CivitDeckNavGraph() {
                     if (tab == selectedTab) {
                         // Pop to root on re-select
                         val stack = if (tab == Tab.Search) searchBackStack else favoritesBackStack
-                        while (stack.size > 1) stack.removeLast()
+                        while (stack.size > 1) stack.removeAt(stack.lastIndex)
                     } else {
                         selectedTab = tab
                     }


### PR DESCRIPTION
## Description

Replace `stack.removeLast()` with `stack.removeAt(stack.lastIndex)` to avoid `NewApi` lint error. `java.util.List#removeLast` requires API 35, but the Kotlin stdlib extension was being shadowed.

## Related Issues

<!-- Link related GitHub issues: Closes #123, Fixes #456 -->

## Screenshots / Video

<!-- If applicable, add screenshots or screen recordings -->

## Test Plan

- [x] `lintDebug` no longer reports `removeLast` NewApi error

## Review Checklist

- [x] Code follows project architecture (Clean Architecture + MVVM)
- [x] Shared logic is in `commonMain`, platform-specific code only when necessary
- [x] No unnecessary dependencies added
- [x] Tests added/updated as needed

## Breaking Changes

None