### PR TITLE
Fix NewApi lint error for isNavigationBarContrastEnforced

### DIFF
--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/MainActivity.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/MainActivity.kt
@@ -1,5 +1,6 @@
 package com.riox432.civitdeck
 
+import android.os.Build
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
@@ -10,7 +11,9 @@ import com.riox432.civitdeck.ui.theme.CivitDeckTheme
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         enableEdgeToEdge()
-        window.isNavigationBarContrastEnforced = false
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            window.isNavigationBarContrastEnforced = false
+        }
         super.onCreate(savedInstanceState)
         setContent {
             CivitDeckTheme {


### PR DESCRIPTION
## Description

Wrap `window.isNavigationBarContrastEnforced = false` with `Build.VERSION.SDK_INT >= Q` check. The API requires Android 10 (API 29) but minSdk is 24.

## Related Issues

<!-- Link related GitHub issues: Closes #123, Fixes #456 -->

## Screenshots / Video

<!-- If applicable, add screenshots or screen recordings -->

## Test Plan

- [x] `lintDebug` passes with zero errors

## Review Checklist

- [x] Code follows project architecture (Clean Architecture + MVVM)
- [x] Shared logic is in `commonMain`, platform-specific code only when necessary
- [x] No unnecessary dependencies added
- [x] Tests added/updated as needed

## Breaking Changes

None