### PR TITLE
Move Saved Prompts and Settings to bottom navigation tabs

### DIFF
--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/favorites/FavoritesScreen.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/favorites/FavoritesScreen.kt
@@ -21,12 +21,9 @@ import androidx.compose.material.icons.outlined.FavoriteBorder
 import androidx.compose.material.icons.outlined.Star
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
-import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
-import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -46,24 +43,18 @@ import com.riox432.civitdeck.ui.theme.Spacing
 import com.riox432.civitdeck.ui.theme.shimmer
 import com.riox432.civitdeck.util.FormatUtils
 
-@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun FavoritesScreen(
     favorites: List<FavoriteModelSummary>,
     onModelClick: (Long) -> Unit,
 ) {
-    Scaffold(
-        topBar = { TopAppBar(title = { Text("Favorites") }) },
-    ) { padding ->
-        if (favorites.isEmpty()) {
-            EmptyFavorites()
-        } else {
-            FavoritesGrid(
-                favorites = favorites,
-                onModelClick = onModelClick,
-                topPadding = padding.calculateTopPadding(),
-            )
-        }
+    if (favorites.isEmpty()) {
+        EmptyFavorites()
+    } else {
+        FavoritesGrid(
+            favorites = favorites,
+            onModelClick = onModelClick,
+        )
     }
 }
 

--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/navigation/CivitDeckNavGraph.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/navigation/CivitDeckNavGraph.kt
@@ -2,24 +2,28 @@ package com.riox432.civitdeck.ui.navigation
 
 import androidx.compose.animation.ExperimentalSharedTransitionApi
 import androidx.compose.animation.SharedTransitionLayout
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.RowScope
 import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.navigationBars
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.windowInsetsPadding
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.clickable
-import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Favorite
 import androidx.compose.material.icons.filled.Explore
+import androidx.compose.material.icons.filled.Favorite
+import androidx.compose.material.icons.filled.Settings
+import androidx.compose.material.icons.outlined.BookmarkBorder
+import androidx.compose.material.icons.outlined.Bookmarks
 import androidx.compose.material.icons.outlined.Explore
 import androidx.compose.material.icons.outlined.FavoriteBorder
+import androidx.compose.material.icons.outlined.Settings
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.NavigationBarDefaults
@@ -85,7 +89,7 @@ data object SavedPromptsRoute
 
 data object SettingsRoute
 
-private enum class Tab { Search, Favorites }
+private enum class Tab { Search, Favorites, Prompts, Settings }
 
 @OptIn(ExperimentalSharedTransitionApi::class)
 @Composable
@@ -98,10 +102,14 @@ fun CivitDeckNavGraph() {
     ) { mutableStateOf(Tab.Search) }
     val searchBackStack = remember { mutableStateListOf<Any>(SearchRoute) }
     val favoritesBackStack = remember { mutableStateListOf<Any>(FavoritesRoute) }
+    val promptsBackStack = remember { mutableStateListOf<Any>(SavedPromptsRoute) }
+    val settingsBackStack = remember { mutableStateListOf<Any>(SettingsRoute) }
 
     val activeBackStack = when (selectedTab) {
         Tab.Search -> searchBackStack
         Tab.Favorites -> favoritesBackStack
+        Tab.Prompts -> promptsBackStack
+        Tab.Settings -> settingsBackStack
     }
 
     Scaffold(
@@ -110,8 +118,12 @@ fun CivitDeckNavGraph() {
                 selectedTab = selectedTab,
                 onTabSelected = { tab ->
                     if (tab == selectedTab) {
-                        // Pop to root on re-select
-                        val stack = if (tab == Tab.Search) searchBackStack else favoritesBackStack
+                        val stack = when (tab) {
+                            Tab.Search -> searchBackStack
+                            Tab.Favorites -> favoritesBackStack
+                            Tab.Prompts -> promptsBackStack
+                            Tab.Settings -> settingsBackStack
+                        }
                         while (stack.size > 1) stack.removeAt(stack.lastIndex)
                     } else {
                         selectedTab = tab
@@ -120,7 +132,7 @@ fun CivitDeckNavGraph() {
             )
         },
     ) { padding ->
-        SharedTransitionLayout(modifier = Modifier.padding(bottom = padding.calculateBottomPadding())) {
+        SharedTransitionLayout(modifier = Modifier.padding(padding)) {
             CompositionLocalProvider(LocalSharedTransitionScope provides this) {
                 CivitDeckNavDisplay(activeBackStack)
             }
@@ -157,6 +169,20 @@ private fun BottomNavBar(
                 activeIcon = Icons.Filled.Favorite,
                 inactiveIcon = Icons.Outlined.FavoriteBorder,
                 label = "Favorites",
+            )
+            BottomNavItem(
+                selected = selectedTab == Tab.Prompts,
+                onClick = { onTabSelected(Tab.Prompts) },
+                activeIcon = Icons.Outlined.Bookmarks,
+                inactiveIcon = Icons.Outlined.BookmarkBorder,
+                label = "Prompts",
+            )
+            BottomNavItem(
+                selected = selectedTab == Tab.Settings,
+                onClick = { onTabSelected(Tab.Settings) },
+                activeIcon = Icons.Filled.Settings,
+                inactiveIcon = Icons.Outlined.Settings,
+                label = "Settings",
             )
         }
     }
@@ -220,8 +246,6 @@ private fun CivitDeckNavDisplay(backStack: MutableList<Any>) {
                     onModelClick = { modelId, thumbnailUrl, suffix ->
                         backStack.add(DetailRoute(modelId, thumbnailUrl, suffix))
                     },
-                    onSavedPromptsClick = { backStack.add(SavedPromptsRoute) },
-                    onSettingsClick = { backStack.add(SettingsRoute) },
                 )
             }
             entry<FavoritesRoute> {
@@ -239,17 +263,11 @@ private fun CivitDeckNavDisplay(backStack: MutableList<Any>) {
             galleryEntry(backStack)
             entry<SavedPromptsRoute> {
                 val viewModel: SavedPromptsViewModel = koinViewModel()
-                SavedPromptsScreen(
-                    viewModel = viewModel,
-                    onBack = { backStack.removeLastOrNull() },
-                )
+                SavedPromptsScreen(viewModel = viewModel)
             }
             entry<SettingsRoute> {
                 val viewModel: SettingsViewModel = koinViewModel()
-                SettingsScreen(
-                    viewModel = viewModel,
-                    onBack = { backStack.removeLastOrNull() },
-                )
+                SettingsScreen(viewModel = viewModel)
             }
         },
     )

--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/prompts/SavedPromptsScreen.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/prompts/SavedPromptsScreen.kt
@@ -18,18 +18,14 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.outlined.BookmarkBorder
 import androidx.compose.material3.Card
-import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
-import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
-import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
@@ -42,35 +38,19 @@ import com.riox432.civitdeck.domain.model.SavedPrompt
 import com.riox432.civitdeck.ui.theme.CornerRadius
 import com.riox432.civitdeck.ui.theme.Spacing
 
-@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun SavedPromptsScreen(
     viewModel: SavedPromptsViewModel,
-    onBack: () -> Unit,
 ) {
     val prompts by viewModel.prompts.collectAsStateWithLifecycle()
 
-    Scaffold(
-        topBar = {
-            TopAppBar(
-                title = { Text("Saved Prompts") },
-                navigationIcon = {
-                    IconButton(onClick = onBack) {
-                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
-                    }
-                },
-            )
-        },
-    ) { padding ->
-        if (prompts.isEmpty()) {
-            EmptyState(modifier = Modifier.padding(padding))
-        } else {
-            PromptList(
-                prompts = prompts,
-                onDelete = viewModel::delete,
-                modifier = Modifier.padding(padding),
-            )
-        }
+    if (prompts.isEmpty()) {
+        EmptyState()
+    } else {
+        PromptList(
+            prompts = prompts,
+            onDelete = viewModel::delete,
+        )
     }
 }
 

--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/search/ModelSearchScreen.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/search/ModelSearchScreen.kt
@@ -39,9 +39,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.Clear
 import androidx.compose.material.icons.filled.Close
-import androidx.compose.material.icons.outlined.BookmarkBorder
 import androidx.compose.material.icons.outlined.FilterList
-import androidx.compose.material.icons.outlined.Settings
 import androidx.compose.material3.Badge
 import androidx.compose.material3.BadgedBox
 import androidx.compose.material3.CircularProgressIndicator
@@ -53,10 +51,8 @@ import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.OutlinedTextField
-import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
-import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.pulltorefresh.PullToRefreshBox
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
@@ -125,8 +121,6 @@ private fun rememberCollapsibleHeaderState(): CollapsibleHeaderState {
 fun ModelSearchScreen(
     viewModel: ModelSearchViewModel,
     onModelClick: (Long, String?, String) -> Unit = { _, _, _ -> },
-    onSavedPromptsClick: () -> Unit = {},
-    onSettingsClick: () -> Unit = {},
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     val searchHistory by viewModel.searchHistory.collectAsStateWithLifecycle()
@@ -147,24 +141,15 @@ fun ModelSearchScreen(
 
     HeaderSnapEffect(gridState = gridState, headerState = headerState)
 
-    Scaffold(
-        topBar = {
-            SearchTopBar(
-                onSavedPromptsClick = onSavedPromptsClick,
-                onSettingsClick = onSettingsClick,
-            )
-        },
-    ) { padding ->
-        SearchScreenBody(
-            padding = padding,
-            headerState = headerState,
-            uiState = uiState,
-            searchHistory = searchHistory,
-            gridState = gridState,
-            viewModel = viewModel,
-            onModelClick = onModelClick,
-        )
-    }
+    SearchScreenBody(
+        padding = PaddingValues(),
+        headerState = headerState,
+        uiState = uiState,
+        searchHistory = searchHistory,
+        gridState = gridState,
+        viewModel = viewModel,
+        onModelClick = onModelClick,
+    )
 }
 
 @Composable
@@ -290,25 +275,6 @@ private fun countActiveFilters(uiState: ModelSearchUiState): Int {
     if (uiState.isFreshFindEnabled) count++
     if (uiState.excludedTags.isNotEmpty()) count++
     return count
-}
-
-@OptIn(ExperimentalMaterial3Api::class)
-@Composable
-private fun SearchTopBar(
-    onSavedPromptsClick: () -> Unit,
-    onSettingsClick: () -> Unit,
-) {
-    TopAppBar(
-        title = { Text("CivitDeck") },
-        actions = {
-            IconButton(onClick = onSavedPromptsClick) {
-                Icon(Icons.Outlined.BookmarkBorder, contentDescription = "Saved Prompts")
-            }
-            IconButton(onClick = onSettingsClick) {
-                Icon(Icons.Outlined.Settings, contentDescription = "Settings")
-            }
-        },
-    )
 }
 
 @Composable

--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/settings/SettingsScreen.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/settings/SettingsScreen.kt
@@ -5,16 +5,9 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.filled.ArrowBack
-import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
-import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
@@ -23,39 +16,24 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.riox432.civitdeck.domain.model.NsfwFilterLevel
 import com.riox432.civitdeck.ui.theme.Spacing
 
-@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun SettingsScreen(
     viewModel: SettingsViewModel,
-    onBack: () -> Unit,
 ) {
     val nsfwFilterLevel by viewModel.nsfwFilterLevel.collectAsStateWithLifecycle()
 
-    Scaffold(
-        topBar = {
-            TopAppBar(
-                title = { Text("Settings") },
-                navigationIcon = {
-                    IconButton(onClick = onBack) {
-                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
-                    }
-                },
-            )
-        },
-    ) { padding ->
-        Column(modifier = Modifier.padding(padding)) {
-            NsfwFilterRow(
-                nsfwFilterLevel = nsfwFilterLevel,
-                onToggle = {
-                    val newLevel = if (nsfwFilterLevel == NsfwFilterLevel.Off) {
-                        NsfwFilterLevel.All
-                    } else {
-                        NsfwFilterLevel.Off
-                    }
-                    viewModel.onNsfwFilterChanged(newLevel)
-                },
-            )
-        }
+    Column {
+        NsfwFilterRow(
+            nsfwFilterLevel = nsfwFilterLevel,
+            onToggle = {
+                val newLevel = if (nsfwFilterLevel == NsfwFilterLevel.Off) {
+                    NsfwFilterLevel.All
+                } else {
+                    NsfwFilterLevel.Off
+                }
+                viewModel.onNsfwFilterChanged(newLevel)
+            },
+        )
     }
 }
 

--- a/iosApp/iosApp/ContentView.swift
+++ b/iosApp/iosApp/ContentView.swift
@@ -12,6 +12,16 @@ struct ContentView: View {
                 .tabItem {
                     Label("Favorites", systemImage: "heart")
                 }
+
+            SavedPromptsScreen()
+                .tabItem {
+                    Label("Prompts", systemImage: "bookmark")
+                }
+
+            SettingsScreen()
+                .tabItem {
+                    Label("Settings", systemImage: "gearshape")
+                }
         }
     }
 }

--- a/iosApp/iosApp/Features/Favorites/FavoritesScreen.swift
+++ b/iosApp/iosApp/Features/Favorites/FavoritesScreen.swift
@@ -18,9 +18,7 @@ struct FavoritesScreen: View {
                     favoritesGrid
                 }
             }
-            .navigationTitle("Favorites")
-            .navigationBarTitleDisplayMode(.inline)
-            .toolbarBackground(.visible, for: .navigationBar)
+            .navigationBarHidden(true)
             .navigationDestination(for: Int64.self) { modelId in
                 ModelDetailScreen(modelId: modelId)
             }

--- a/iosApp/iosApp/Features/Prompts/SavedPromptsScreen.swift
+++ b/iosApp/iosApp/Features/Prompts/SavedPromptsScreen.swift
@@ -12,8 +12,6 @@ struct SavedPromptsScreen: View {
                 promptList
             }
         }
-        .navigationTitle("Saved Prompts")
-        .navigationBarTitleDisplayMode(.inline)
     }
 
     private var emptyState: some View {

--- a/iosApp/iosApp/Features/Search/ModelSearchScreen.swift
+++ b/iosApp/iosApp/Features/Search/ModelSearchScreen.swift
@@ -42,25 +42,7 @@ struct ModelSearchScreen: View {
                 .animation(MotionAnimation.standard, value: viewModel.error == nil)
                 .frame(maxHeight: .infinity)
             }
-            .navigationTitle("CivitDeck")
-            .navigationBarTitleDisplayMode(.inline)
-            .toolbarBackground(.visible, for: .navigationBar)
-            .toolbar {
-                ToolbarItem(placement: .navigationBarTrailing) {
-                    NavigationLink {
-                        SavedPromptsScreen()
-                    } label: {
-                        Image(systemName: "bookmark")
-                    }
-                }
-                ToolbarItem(placement: .navigationBarTrailing) {
-                    NavigationLink {
-                        SettingsScreen()
-                    } label: {
-                        Image(systemName: "gearshape")
-                    }
-                }
-            }
+            .navigationBarHidden(true)
             .task {
                 await viewModel.observeNsfwFilter()
             }

--- a/iosApp/iosApp/Features/Settings/SettingsScreen.swift
+++ b/iosApp/iosApp/Features/Settings/SettingsScreen.swift
@@ -21,8 +21,6 @@ struct SettingsScreen: View {
                 }
             }
         }
-        .navigationTitle("Settings")
-        .navigationBarTitleDisplayMode(.inline)
         .task {
             await viewModel.observeNsfwFilter()
         }


### PR DESCRIPTION
## Summary
- Add Prompts and Settings as bottom navigation tabs (4-tab layout replacing 2-tab + TopAppBar actions)
- Remove TopAppBar/navigation titles from all tab root screens (Search, Favorites, Prompts, Settings)
- Apply full Scaffold padding for proper edge-to-edge status bar support
- Mirror changes on both Android (Compose) and iOS (SwiftUI TabView)

## Test plan
- [ ] Verify 4 tabs appear in bottom nav (Search, Favorites, Prompts, Settings)
- [ ] Verify no title bar on any tab screen
- [ ] Verify status bar padding is correct on all tab screens
- [ ] Verify tab re-select pops to root
- [ ] Verify navigation from Search → Detail → Gallery still works
- [ ] Verify iOS tab layout matches Android