### PR TITLE
Expand Settings screen with preferences, data management, and licenses

### DIFF
--- a/androidApp/build.gradle.kts
+++ b/androidApp/build.gradle.kts
@@ -5,6 +5,7 @@ plugins {
     kotlin("android")
     alias(libs.plugins.compose.multiplatform)
     alias(libs.plugins.compose.compiler)
+    alias(libs.plugins.aboutlibraries)
 }
 
 android {
@@ -21,6 +22,7 @@ android {
 
     buildFeatures {
         compose = true
+        buildConfig = true
     }
 
     packaging {
@@ -64,4 +66,5 @@ dependencies {
     implementation(libs.androidx.navigation3.runtime)
     implementation(libs.androidx.navigation3.ui)
     implementation(libs.androidx.lifecycle.viewmodel.navigation3)
+    implementation(libs.aboutlibraries.compose.m3)
 }

--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/CivitDeckApplication.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/CivitDeckApplication.kt
@@ -51,12 +51,19 @@ val androidModule = module {
         ModelSearchViewModel(
             get(), get(), get(), get(), get(), get(),
             get(), get(), get(), get(), get(), get(),
+            get(), get(), get(),
         )
     }
-    viewModel { FavoritesViewModel(get()) }
+    viewModel { FavoritesViewModel(get(), get()) }
     viewModel { params -> ModelDetailViewModel(params.get(), get(), get(), get(), get(), get()) }
     viewModel { params -> CreatorProfileViewModel(params.get(), get()) }
     viewModel { params -> ImageGalleryViewModel(params.get(), get(), get(), get()) }
     viewModel { SavedPromptsViewModel(get(), get()) }
-    viewModel { SettingsViewModel(get(), get()) }
+    viewModel {
+        SettingsViewModel(
+            get(), get(), get(), get(), get(), get(),
+            get(), get(), get(), get(), get(), get(),
+            get(), get(), get(), get(),
+        )
+    }
 }

--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/components/ModelCard.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/components/ModelCard.kt
@@ -44,40 +44,55 @@ import com.riox432.civitdeck.util.FormatUtils
 @Composable
 fun ModelCard(
     model: Model,
-    onClick: () -> Unit,
+    onClick: (() -> Unit)? = null,
     modifier: Modifier = Modifier,
     sharedElementSuffix: String = "",
 ) {
-    Card(
-        onClick = onClick,
-        modifier = modifier.fillMaxWidth(),
-        shape = RoundedCornerShape(CornerRadius.card),
-        elevation = CardDefaults.cardElevation(defaultElevation = 2.dp),
-        colors = CardDefaults.cardColors(
-            containerColor = MaterialTheme.colorScheme.surface,
-        ),
-    ) {
-        Column {
-            val thumbnailUrl = model.modelVersions
-                .firstOrNull()?.images?.firstOrNull()?.url
+    val cardModifier = modifier.fillMaxWidth()
+    val shape = RoundedCornerShape(CornerRadius.card)
+    val elevation = CardDefaults.cardElevation(defaultElevation = 2.dp)
+    val colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface)
+    if (onClick != null) {
+        Card(
+            onClick = onClick,
+            modifier = cardModifier,
+            shape = shape,
+            elevation = elevation,
+            colors = colors,
+        ) { ModelCardContent(model, sharedElementSuffix) }
+    } else {
+        Card(
+            modifier = cardModifier,
+            shape = shape,
+            elevation = elevation,
+            colors = colors,
+        ) { ModelCardContent(model, sharedElementSuffix) }
+    }
+}
 
-            if (thumbnailUrl != null) {
-                ModelCardThumbnail(
-                    thumbnailUrl = thumbnailUrl,
-                    modelId = model.id,
-                    contentDescription = model.name,
-                    sharedElementSuffix = sharedElementSuffix,
-                )
-            } else {
-                ImageErrorPlaceholder(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .aspectRatio(1f),
-                )
-            }
+@OptIn(ExperimentalSharedTransitionApi::class)
+@Composable
+private fun ModelCardContent(model: Model, sharedElementSuffix: String) {
+    Column {
+        val thumbnailUrl = model.modelVersions
+            .firstOrNull()?.images?.firstOrNull()?.url
 
-            ModelCardInfo(model = model)
+        if (thumbnailUrl != null) {
+            ModelCardThumbnail(
+                thumbnailUrl = thumbnailUrl,
+                modelId = model.id,
+                contentDescription = model.name,
+                sharedElementSuffix = sharedElementSuffix,
+            )
+        } else {
+            ImageErrorPlaceholder(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .aspectRatio(1f),
+            )
         }
+
+        ModelCardInfo(model = model)
     }
 }
 

--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/favorites/FavoritesScreen.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/favorites/FavoritesScreen.kt
@@ -47,6 +47,7 @@ import com.riox432.civitdeck.util.FormatUtils
 fun FavoritesScreen(
     favorites: List<FavoriteModelSummary>,
     onModelClick: (Long) -> Unit,
+    gridColumns: Int = 2,
 ) {
     if (favorites.isEmpty()) {
         EmptyFavorites()
@@ -54,6 +55,7 @@ fun FavoritesScreen(
         FavoritesGrid(
             favorites = favorites,
             onModelClick = onModelClick,
+            gridColumns = gridColumns,
         )
     }
 }
@@ -84,9 +86,10 @@ private fun FavoritesGrid(
     favorites: List<FavoriteModelSummary>,
     onModelClick: (Long) -> Unit,
     topPadding: Dp = 0.dp,
+    gridColumns: Int = 2,
 ) {
     LazyVerticalGrid(
-        columns = GridCells.Fixed(2),
+        columns = GridCells.Fixed(gridColumns),
         contentPadding = PaddingValues(
             start = Spacing.md,
             end = Spacing.md,

--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/favorites/FavoritesViewModel.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/favorites/FavoritesViewModel.kt
@@ -4,15 +4,21 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.riox432.civitdeck.domain.model.FavoriteModelSummary
 import com.riox432.civitdeck.domain.usecase.ObserveFavoritesUseCase
+import com.riox432.civitdeck.domain.usecase.ObserveGridColumnsUseCase
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.stateIn
 
 class FavoritesViewModel(
     observeFavoritesUseCase: ObserveFavoritesUseCase,
+    observeGridColumnsUseCase: ObserveGridColumnsUseCase,
 ) : ViewModel() {
 
     val favorites: StateFlow<List<FavoriteModelSummary>> =
         observeFavoritesUseCase()
             .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), emptyList())
+
+    val gridColumns: StateFlow<Int> =
+        observeGridColumnsUseCase()
+            .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), 2)
 }

--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/navigation/CivitDeckNavGraph.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/navigation/CivitDeckNavGraph.kt
@@ -64,6 +64,7 @@ import com.riox432.civitdeck.ui.prompts.SavedPromptsScreen
 import com.riox432.civitdeck.ui.prompts.SavedPromptsViewModel
 import com.riox432.civitdeck.ui.search.ModelSearchScreen
 import com.riox432.civitdeck.ui.search.ModelSearchViewModel
+import com.riox432.civitdeck.ui.settings.LicensesScreen
 import com.riox432.civitdeck.ui.settings.SettingsScreen
 import com.riox432.civitdeck.ui.settings.SettingsViewModel
 import com.riox432.civitdeck.ui.theme.IconSize
@@ -88,6 +89,8 @@ data class CreatorRoute(val username: String)
 data object SavedPromptsRoute
 
 data object SettingsRoute
+
+data object LicensesRoute
 
 private enum class Tab { Search, Favorites, Prompts, Settings }
 
@@ -251,11 +254,13 @@ private fun CivitDeckNavDisplay(backStack: MutableList<Any>) {
             entry<FavoritesRoute> {
                 val viewModel: FavoritesViewModel = koinViewModel()
                 val favorites by viewModel.favorites.collectAsStateWithLifecycle()
+                val gridColumns by viewModel.gridColumns.collectAsStateWithLifecycle()
                 FavoritesScreen(
                     favorites = favorites,
                     onModelClick = { modelId ->
                         backStack.add(DetailRoute(modelId))
                     },
+                    gridColumns = gridColumns,
                 )
             }
             detailEntry(backStack)
@@ -267,7 +272,13 @@ private fun CivitDeckNavDisplay(backStack: MutableList<Any>) {
             }
             entry<SettingsRoute> {
                 val viewModel: SettingsViewModel = koinViewModel()
-                SettingsScreen(viewModel = viewModel)
+                SettingsScreen(
+                    viewModel = viewModel,
+                    onNavigateToLicenses = { backStack.add(LicensesRoute) },
+                )
+            }
+            entry<LicensesRoute> {
+                LicensesScreen(onBack = { backStack.removeLastOrNull() })
             }
         },
     )

--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/search/ModelSearchScreen.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/search/ModelSearchScreen.kt
@@ -124,6 +124,7 @@ fun ModelSearchScreen(
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     val searchHistory by viewModel.searchHistory.collectAsStateWithLifecycle()
+    val gridColumns by viewModel.gridColumns.collectAsStateWithLifecycle()
     val gridState = rememberLazyGridState()
     val headerState = rememberCollapsibleHeaderState()
 
@@ -149,6 +150,7 @@ fun ModelSearchScreen(
         gridState = gridState,
         viewModel = viewModel,
         onModelClick = onModelClick,
+        gridColumns = gridColumns,
     )
 }
 
@@ -189,6 +191,7 @@ private fun SearchScreenBody(
     gridState: LazyGridState,
     viewModel: ModelSearchViewModel,
     onModelClick: (Long, String?, String) -> Unit,
+    gridColumns: Int,
 ) {
     val layoutDirection = LocalLayoutDirection.current
     val density = LocalDensity.current
@@ -214,6 +217,7 @@ private fun SearchScreenBody(
             onHideModel = viewModel::onHideModel,
             topPadding = topPadding,
             bottomPadding = padding.calculateBottomPadding(),
+            gridColumns = gridColumns,
         )
 
         CollapsibleHeader(
@@ -728,6 +732,7 @@ private fun ModelSearchContent(
     onHideModel: (Long, String) -> Unit,
     topPadding: androidx.compose.ui.unit.Dp = 0.dp,
     bottomPadding: androidx.compose.ui.unit.Dp = 0.dp,
+    gridColumns: Int = 2,
 ) {
     val isInitialLoading = uiState.models.isEmpty() &&
         (uiState.isLoading || uiState.isLoadingRecommendations)
@@ -774,6 +779,7 @@ private fun ModelSearchContent(
                         onHideModel = onHideModel,
                         topPadding = topPadding,
                         bottomPadding = bottomPadding,
+                        gridColumns = gridColumns,
                     )
                 }
             }
@@ -792,9 +798,10 @@ private fun ModelGrid(
     onHideModel: (Long, String) -> Unit,
     topPadding: androidx.compose.ui.unit.Dp = 0.dp,
     bottomPadding: androidx.compose.ui.unit.Dp = 0.dp,
+    gridColumns: Int = 2,
 ) {
     LazyVerticalGrid(
-        columns = GridCells.Fixed(2),
+        columns = GridCells.Fixed(gridColumns),
         state = gridState,
         contentPadding = PaddingValues(
             start = Spacing.md,
@@ -808,7 +815,7 @@ private fun ModelGrid(
         recommendations.forEachIndexed { index, section ->
             item(
                 key = "rec_${section.title}",
-                span = { GridItemSpan(2) },
+                span = { GridItemSpan(maxLineSpan) },
             ) {
                 RecommendationRow(
                     section = section,
@@ -854,15 +861,13 @@ private fun ModelCardWithContextMenu(
 ) {
     var showMenu by remember { mutableStateOf(false) }
 
-    Box(modifier = modifier) {
-        ModelCard(
-            model = model,
+    Box(
+        modifier = modifier.combinedClickable(
             onClick = onClick,
-            modifier = Modifier.combinedClickable(
-                onClick = onClick,
-                onLongClick = { showMenu = true },
-            ),
-        )
+            onLongClick = { showMenu = true },
+        ),
+    ) {
+        ModelCard(model = model)
         DropdownMenu(
             expanded = showMenu,
             onDismissRequest = { showMenu = false },

--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/settings/LicensesScreen.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/settings/LicensesScreen.kt
@@ -1,0 +1,33 @@
+package com.riox432.civitdeck.ui.settings
+
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import com.mikepenz.aboutlibraries.ui.compose.m3.LibrariesContainer
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun LicensesScreen(onBack: () -> Unit) {
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("Open Source Licenses") },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                    }
+                },
+            )
+        },
+    ) { padding ->
+        LibrariesContainer(modifier = Modifier.padding(padding))
+    }
+}

--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/settings/SettingsScreen.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/settings/SettingsScreen.kt
@@ -1,47 +1,73 @@
 package com.riox432.civitdeck.ui.settings
 
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.riox432.civitdeck.BuildConfig
 import com.riox432.civitdeck.domain.model.NsfwFilterLevel
+import com.riox432.civitdeck.domain.model.SortOrder
+import com.riox432.civitdeck.domain.model.TimePeriod
 import com.riox432.civitdeck.ui.theme.Spacing
 
 @Composable
 fun SettingsScreen(
     viewModel: SettingsViewModel,
+    onNavigateToLicenses: () -> Unit = {},
 ) {
-    val nsfwFilterLevel by viewModel.nsfwFilterLevel.collectAsStateWithLifecycle()
+    val state by viewModel.uiState.collectAsStateWithLifecycle()
 
-    Column {
-        NsfwFilterRow(
-            nsfwFilterLevel = nsfwFilterLevel,
-            onToggle = {
-                val newLevel = if (nsfwFilterLevel == NsfwFilterLevel.Off) {
-                    NsfwFilterLevel.All
-                } else {
-                    NsfwFilterLevel.Off
-                }
-                viewModel.onNsfwFilterChanged(newLevel)
-            },
-        )
+    LazyColumn {
+        item { SectionHeader("Content Filter") }
+        item { NsfwToggleRow(state.nsfwFilterLevel, viewModel::onNsfwFilterChanged) }
+        item { SectionHeader("Display") }
+        item { SortOrderRow(state.defaultSortOrder, viewModel::onSortOrderChanged) }
+        item { TimePeriodRow(state.defaultTimePeriod, viewModel::onTimePeriodChanged) }
+        item { GridColumnsRow(state.gridColumns, viewModel::onGridColumnsChanged) }
+        item { SectionHeader("Data Management") }
+        item { HiddenModelsRow(state.hiddenModels.size, state.hiddenModels, viewModel::onUnhideModel) }
+        item { ExcludedTagsRow(state.excludedTags, viewModel::onAddExcludedTag, viewModel::onRemoveExcludedTag) }
+        item { ClearActionRow("Clear Search History", viewModel::onClearSearchHistory) }
+        item { ClearActionRow("Clear Browsing History", viewModel::onClearBrowsingHistory) }
+        item { ClearActionRow("Clear Cache", viewModel::onClearCache) }
+        item { SectionHeader("About") }
+        item { InfoRow("App Version", BuildConfig.VERSION_NAME) }
+        item { NavigationRow("Open Source Licenses", onNavigateToLicenses) }
     }
 }
 
 @Composable
-private fun NsfwFilterRow(
-    nsfwFilterLevel: NsfwFilterLevel,
-    onToggle: () -> Unit,
-) {
+private fun SectionHeader(title: String) {
+    Text(
+        text = title,
+        style = MaterialTheme.typography.titleSmall,
+        color = MaterialTheme.colorScheme.primary,
+        modifier = Modifier.padding(horizontal = Spacing.lg, vertical = Spacing.sm),
+    )
+}
+
+@Composable
+private fun NsfwToggleRow(level: NsfwFilterLevel, onToggle: (NsfwFilterLevel) -> Unit) {
     Row(
         modifier = Modifier
             .fillMaxWidth()
@@ -50,19 +76,288 @@ private fun NsfwFilterRow(
         verticalAlignment = Alignment.CenterVertically,
     ) {
         Column(modifier = Modifier.weight(1f)) {
+            Text("NSFW Content", style = MaterialTheme.typography.bodyLarge)
             Text(
-                text = "NSFW Content",
-                style = MaterialTheme.typography.bodyLarge,
-            )
-            Text(
-                text = "Show NSFW content in search results",
+                "Show NSFW content in search results",
                 style = MaterialTheme.typography.bodySmall,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
             )
         }
         Switch(
-            checked = nsfwFilterLevel != NsfwFilterLevel.Off,
-            onCheckedChange = { onToggle() },
+            checked = level != NsfwFilterLevel.Off,
+            onCheckedChange = {
+                onToggle(if (level == NsfwFilterLevel.Off) NsfwFilterLevel.All else NsfwFilterLevel.Off)
+            },
         )
     }
+}
+
+@Composable
+private fun SortOrderRow(selected: SortOrder, onChanged: (SortOrder) -> Unit) {
+    DropdownSettingRow(
+        label = "Default Sort",
+        value = selected.name,
+        options = SortOrder.entries.map { it.name },
+        onSelected = { onChanged(SortOrder.valueOf(it)) },
+    )
+}
+
+@Composable
+private fun TimePeriodRow(selected: TimePeriod, onChanged: (TimePeriod) -> Unit) {
+    DropdownSettingRow(
+        label = "Default Period",
+        value = selected.name,
+        options = TimePeriod.entries.map { it.name },
+        onSelected = { onChanged(TimePeriod.valueOf(it)) },
+    )
+}
+
+@Composable
+private fun DropdownSettingRow(
+    label: String,
+    value: String,
+    options: List<String>,
+    onSelected: (String) -> Unit,
+) {
+    var expanded by remember { mutableStateOf(false) }
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable { expanded = true }
+            .padding(horizontal = Spacing.lg, vertical = Spacing.md),
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Text(label, style = MaterialTheme.typography.bodyLarge)
+        Column {
+            Text(value, style = MaterialTheme.typography.bodyMedium, color = MaterialTheme.colorScheme.primary)
+            DropdownMenu(expanded = expanded, onDismissRequest = { expanded = false }) {
+                options.forEach { option ->
+                    DropdownMenuItem(
+                        text = { Text(option) },
+                        onClick = {
+                            onSelected(option)
+                            expanded = false
+                        },
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun GridColumnsRow(columns: Int, onChanged: (Int) -> Unit) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = Spacing.lg, vertical = Spacing.md),
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Text("Grid Columns", style = MaterialTheme.typography.bodyLarge)
+        Row(horizontalArrangement = Arrangement.spacedBy(Spacing.sm)) {
+            listOf(2, 3).forEach { count ->
+                TextButton(onClick = { onChanged(count) }) {
+                    Text(
+                        text = count.toString(),
+                        color = if (columns == count) {
+                            MaterialTheme.colorScheme.primary
+                        } else {
+                            MaterialTheme.colorScheme.onSurfaceVariant
+                        },
+                        style = MaterialTheme.typography.bodyLarge,
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun HiddenModelsRow(
+    count: Int,
+    models: List<com.riox432.civitdeck.data.local.entity.HiddenModelEntity>,
+    onUnhide: (Long) -> Unit,
+) {
+    var showDialog by remember { mutableStateOf(false) }
+    SettingsClickRow(label = "Hidden Models", detail = "$count models") { showDialog = true }
+    if (showDialog) {
+        HiddenModelsDialog(models = models, onUnhide = onUnhide, onDismiss = { showDialog = false })
+    }
+}
+
+@Composable
+private fun HiddenModelsDialog(
+    models: List<com.riox432.civitdeck.data.local.entity.HiddenModelEntity>,
+    onUnhide: (Long) -> Unit,
+    onDismiss: () -> Unit,
+) {
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text("Hidden Models") },
+        text = {
+            if (models.isEmpty()) {
+                Text("No hidden models.\nLong-press a model card on the Search screen to hide it.")
+            } else {
+                Column {
+                    models.forEach { model ->
+                        HiddenModelItem(model.modelName) { onUnhide(model.modelId) }
+                    }
+                }
+            }
+        },
+        confirmButton = { TextButton(onClick = onDismiss) { Text("Close") } },
+    )
+}
+
+@Composable
+private fun HiddenModelItem(name: String, onUnhide: () -> Unit) {
+    Row(
+        modifier = Modifier.fillMaxWidth().padding(vertical = Spacing.xs),
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Text(name, style = MaterialTheme.typography.bodyMedium, modifier = Modifier.weight(1f))
+        TextButton(onClick = onUnhide) { Text("Unhide") }
+    }
+}
+
+@Composable
+private fun ExcludedTagsRow(tags: List<String>, onAdd: (String) -> Unit, onRemove: (String) -> Unit) {
+    var showDialog by remember { mutableStateOf(false) }
+    SettingsClickRow(label = "Excluded Tags", detail = "${tags.size} tags") { showDialog = true }
+    if (showDialog) {
+        ExcludedTagsDialog(tags = tags, onAdd = onAdd, onRemove = onRemove, onDismiss = { showDialog = false })
+    }
+}
+
+@Composable
+private fun ExcludedTagsDialog(
+    tags: List<String>,
+    onAdd: (String) -> Unit,
+    onRemove: (String) -> Unit,
+    onDismiss: () -> Unit,
+) {
+    var newTag by remember { mutableStateOf("") }
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text("Excluded Tags") },
+        text = {
+            Column {
+                ExcludedTagInput(newTag, onValueChange = { newTag = it }) {
+                    onAdd(newTag)
+                    newTag = ""
+                }
+                if (tags.isEmpty()) {
+                    Text(
+                        "No excluded tags",
+                        modifier = Modifier.padding(top = Spacing.sm),
+                    )
+                } else {
+                    tags.forEach { tag ->
+                        ExcludedTagItem(tag) { onRemove(tag) }
+                    }
+                }
+            }
+        },
+        confirmButton = { TextButton(onClick = onDismiss) { Text("Close") } },
+    )
+}
+
+@Composable
+private fun ExcludedTagInput(value: String, onValueChange: (String) -> Unit, onAdd: () -> Unit) {
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(Spacing.sm),
+    ) {
+        OutlinedTextField(
+            value = value,
+            onValueChange = onValueChange,
+            placeholder = { Text("Add tag") },
+            singleLine = true,
+            modifier = Modifier.weight(1f),
+        )
+        TextButton(onClick = onAdd, enabled = value.isNotBlank()) { Text("Add") }
+    }
+}
+
+@Composable
+private fun ExcludedTagItem(tag: String, onRemove: () -> Unit) {
+    Row(
+        modifier = Modifier.fillMaxWidth().padding(vertical = Spacing.xs),
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Text(tag, style = MaterialTheme.typography.bodyMedium, modifier = Modifier.weight(1f))
+        TextButton(onClick = onRemove) { Text("Remove") }
+    }
+}
+
+@Composable
+private fun ClearActionRow(label: String, onConfirm: () -> Unit) {
+    var showDialog by remember { mutableStateOf(false) }
+    SettingsClickRow(label = label) { showDialog = true }
+    if (showDialog) {
+        AlertDialog(
+            onDismissRequest = { showDialog = false },
+            title = { Text(label) },
+            text = { Text("Are you sure? This cannot be undone.") },
+            confirmButton = {
+                TextButton(onClick = {
+                    onConfirm()
+                    showDialog = false
+                }) { Text("Clear") }
+            },
+            dismissButton = {
+                TextButton(onClick = { showDialog = false }) { Text("Cancel") }
+            },
+        )
+    }
+}
+
+@Composable
+private fun SettingsClickRow(label: String, detail: String? = null, onClick: () -> Unit) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable(onClick = onClick)
+            .padding(horizontal = Spacing.lg, vertical = Spacing.md),
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Text(label, style = MaterialTheme.typography.bodyLarge)
+        if (detail != null) {
+            Text(detail, style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+        }
+    }
+}
+
+@Composable
+private fun InfoRow(label: String, value: String) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = Spacing.lg, vertical = Spacing.md),
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Text(label, style = MaterialTheme.typography.bodyLarge)
+        Text(value, style = MaterialTheme.typography.bodyMedium, color = MaterialTheme.colorScheme.onSurfaceVariant)
+    }
+}
+
+@Composable
+private fun NavigationRow(label: String, onClick: () -> Unit) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable(onClick = onClick)
+            .padding(horizontal = Spacing.lg, vertical = Spacing.md),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Text(label, style = MaterialTheme.typography.bodyLarge, color = MaterialTheme.colorScheme.primary)
+    }
+    HorizontalDivider()
 }

--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/settings/SettingsViewModel.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/settings/SettingsViewModel.kt
@@ -2,26 +2,143 @@ package com.riox432.civitdeck.ui.settings
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.riox432.civitdeck.data.local.entity.HiddenModelEntity
 import com.riox432.civitdeck.domain.model.NsfwFilterLevel
+import com.riox432.civitdeck.domain.model.SortOrder
+import com.riox432.civitdeck.domain.model.TimePeriod
+import com.riox432.civitdeck.domain.usecase.AddExcludedTagUseCase
+import com.riox432.civitdeck.domain.usecase.ClearBrowsingHistoryUseCase
+import com.riox432.civitdeck.domain.usecase.ClearCacheUseCase
+import com.riox432.civitdeck.domain.usecase.ClearSearchHistoryUseCase
+import com.riox432.civitdeck.domain.usecase.GetExcludedTagsUseCase
+import com.riox432.civitdeck.domain.usecase.GetHiddenModelsUseCase
+import com.riox432.civitdeck.domain.usecase.ObserveDefaultSortOrderUseCase
+import com.riox432.civitdeck.domain.usecase.ObserveDefaultTimePeriodUseCase
+import com.riox432.civitdeck.domain.usecase.ObserveGridColumnsUseCase
 import com.riox432.civitdeck.domain.usecase.ObserveNsfwFilterUseCase
+import com.riox432.civitdeck.domain.usecase.RemoveExcludedTagUseCase
+import com.riox432.civitdeck.domain.usecase.SetDefaultSortOrderUseCase
+import com.riox432.civitdeck.domain.usecase.SetDefaultTimePeriodUseCase
+import com.riox432.civitdeck.domain.usecase.SetGridColumnsUseCase
 import com.riox432.civitdeck.domain.usecase.SetNsfwFilterUseCase
+import com.riox432.civitdeck.domain.usecase.UnhideModelUseCase
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 
+data class SettingsUiState(
+    val nsfwFilterLevel: NsfwFilterLevel = NsfwFilterLevel.Off,
+    val defaultSortOrder: SortOrder = SortOrder.MostDownloaded,
+    val defaultTimePeriod: TimePeriod = TimePeriod.AllTime,
+    val gridColumns: Int = 2,
+    val hiddenModels: List<HiddenModelEntity> = emptyList(),
+    val excludedTags: List<String> = emptyList(),
+)
+
+@Suppress("LongParameterList")
 class SettingsViewModel(
     observeNsfwFilterUseCase: ObserveNsfwFilterUseCase,
     private val setNsfwFilterUseCase: SetNsfwFilterUseCase,
+    observeDefaultSortOrderUseCase: ObserveDefaultSortOrderUseCase,
+    private val setDefaultSortOrderUseCase: SetDefaultSortOrderUseCase,
+    observeDefaultTimePeriodUseCase: ObserveDefaultTimePeriodUseCase,
+    private val setDefaultTimePeriodUseCase: SetDefaultTimePeriodUseCase,
+    observeGridColumnsUseCase: ObserveGridColumnsUseCase,
+    private val setGridColumnsUseCase: SetGridColumnsUseCase,
+    private val getHiddenModelsUseCase: GetHiddenModelsUseCase,
+    private val unhideModelUseCase: UnhideModelUseCase,
+    private val getExcludedTagsUseCase: GetExcludedTagsUseCase,
+    private val addExcludedTagUseCase: AddExcludedTagUseCase,
+    private val removeExcludedTagUseCase: RemoveExcludedTagUseCase,
+    private val clearSearchHistoryUseCase: ClearSearchHistoryUseCase,
+    private val clearBrowsingHistoryUseCase: ClearBrowsingHistoryUseCase,
+    private val clearCacheUseCase: ClearCacheUseCase,
 ) : ViewModel() {
 
-    val nsfwFilterLevel: StateFlow<NsfwFilterLevel> =
-        observeNsfwFilterUseCase()
-            .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), NsfwFilterLevel.Off)
+    private val _mutableState = MutableStateFlow(SettingsUiState())
+
+    val uiState: StateFlow<SettingsUiState> = combine(
+        observeNsfwFilterUseCase(),
+        observeDefaultSortOrderUseCase(),
+        observeDefaultTimePeriodUseCase(),
+        observeGridColumnsUseCase(),
+        _mutableState,
+    ) { nsfw, sort, period, columns, mutable ->
+        mutable.copy(
+            nsfwFilterLevel = nsfw,
+            defaultSortOrder = sort,
+            defaultTimePeriod = period,
+            gridColumns = columns,
+        )
+    }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), SettingsUiState())
+
+    init {
+        loadMutableData()
+    }
+
+    private fun loadMutableData() {
+        viewModelScope.launch {
+            val hidden = getHiddenModelsUseCase()
+            val tags = getExcludedTagsUseCase()
+            _mutableState.update { it.copy(hiddenModels = hidden, excludedTags = tags) }
+        }
+    }
 
     fun onNsfwFilterChanged(level: NsfwFilterLevel) {
+        viewModelScope.launch { setNsfwFilterUseCase(level) }
+    }
+
+    fun onSortOrderChanged(sort: SortOrder) {
+        viewModelScope.launch { setDefaultSortOrderUseCase(sort) }
+    }
+
+    fun onTimePeriodChanged(period: TimePeriod) {
+        viewModelScope.launch { setDefaultTimePeriodUseCase(period) }
+    }
+
+    fun onGridColumnsChanged(columns: Int) {
+        viewModelScope.launch { setGridColumnsUseCase(columns) }
+    }
+
+    fun onUnhideModel(modelId: Long) {
         viewModelScope.launch {
-            setNsfwFilterUseCase(level)
+            unhideModelUseCase(modelId)
+            val hidden = getHiddenModelsUseCase()
+            _mutableState.update { it.copy(hiddenModels = hidden) }
         }
+    }
+
+    fun onAddExcludedTag(tag: String) {
+        val trimmed = tag.trim().lowercase()
+        if (trimmed.isBlank()) return
+        viewModelScope.launch {
+            addExcludedTagUseCase(trimmed)
+            val tags = getExcludedTagsUseCase()
+            _mutableState.update { it.copy(excludedTags = tags) }
+        }
+    }
+
+    fun onRemoveExcludedTag(tag: String) {
+        viewModelScope.launch {
+            removeExcludedTagUseCase(tag)
+            val tags = getExcludedTagsUseCase()
+            _mutableState.update { it.copy(excludedTags = tags) }
+        }
+    }
+
+    fun onClearSearchHistory() {
+        viewModelScope.launch { clearSearchHistoryUseCase() }
+    }
+
+    fun onClearBrowsingHistory() {
+        viewModelScope.launch { clearBrowsingHistoryUseCase() }
+    }
+
+    fun onClearCache() {
+        viewModelScope.launch { clearCacheUseCase() }
     }
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,6 +8,7 @@ plugins {
     alias(libs.plugins.ksp) apply false
     alias(libs.plugins.androidx.room) apply false
     alias(libs.plugins.detekt)
+    alias(libs.plugins.aboutlibraries) apply false
 }
 
 allprojects {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -15,6 +15,7 @@ androidx-navigation3 = "1.0.0"
 androidx-lifecycle-viewmodel-navigation3 = "2.10.0"
 detekt = "1.23.8"
 skie = "0.10.9"
+aboutlibraries = "12.1.2"
 
 [libraries]
 # Ktor
@@ -51,6 +52,9 @@ androidx-navigation3-runtime = { module = "androidx.navigation3:navigation3-runt
 androidx-navigation3-ui = { module = "androidx.navigation3:navigation3-ui", version.ref = "androidx-navigation3" }
 androidx-lifecycle-viewmodel-navigation3 = { module = "androidx.lifecycle:lifecycle-viewmodel-navigation3", version.ref = "androidx-lifecycle-viewmodel-navigation3" }
 
+# AboutLibraries
+aboutlibraries-compose-m3 = { module = "com.mikepenz:aboutlibraries-compose-m3", version.ref = "aboutlibraries" }
+
 # Detekt
 detekt-formatting = { module = "io.gitlab.arturbosch.detekt:detekt-formatting", version.ref = "detekt" }
 
@@ -68,3 +72,4 @@ ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }
 androidx-room = { id = "androidx.room", version.ref = "room" }
 detekt = { id = "io.gitlab.arturbosch.detekt", version.ref = "detekt" }
 skie = { id = "co.touchlab.skie", version.ref = "skie" }
+aboutlibraries = { id = "com.mikepenz.aboutlibraries.plugin", version.ref = "aboutlibraries" }

--- a/iosApp/iosApp.xcodeproj/project.pbxproj
+++ b/iosApp/iosApp.xcodeproj/project.pbxproj
@@ -36,6 +36,9 @@
 		CD0009032D000009000CD001 /* SavedPromptsScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD0009022D000009000CD001 /* SavedPromptsScreen.swift */; };
 		CD000A012D00000A000CD001 /* SettingsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD000A002D00000A000CD001 /* SettingsViewModel.swift */; };
 		CD000A032D00000A000CD001 /* SettingsScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD000A022D00000A000CD001 /* SettingsScreen.swift */; };
+		CD000B012D00000B000CD001 /* HiddenModelsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD000B002D00000B000CD001 /* HiddenModelsView.swift */; };
+		CD000B032D00000B000CD001 /* ExcludedTagsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD000B022D00000B000CD001 /* ExcludedTagsView.swift */; };
+		CD000B052D00000B000CD001 /* LicensesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD000B042D00000B000CD001 /* LicensesView.swift */; };
 		CD00CA012D0CC001000CD001 /* CachedAsyncImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD00CA002D0CC001000CD001 /* CachedAsyncImage.swift */; };
 /* End PBXBuildFile section */
 
@@ -72,6 +75,9 @@
 		CD0009022D000009000CD001 /* SavedPromptsScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SavedPromptsScreen.swift; sourceTree = "<group>"; };
 		CD000A002D00000A000CD001 /* SettingsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsViewModel.swift; sourceTree = "<group>"; };
 		CD000A022D00000A000CD001 /* SettingsScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsScreen.swift; sourceTree = "<group>"; };
+		CD000B002D00000B000CD001 /* HiddenModelsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HiddenModelsView.swift; sourceTree = "<group>"; };
+		CD000B022D00000B000CD001 /* ExcludedTagsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExcludedTagsView.swift; sourceTree = "<group>"; };
+		CD000B042D00000B000CD001 /* LicensesView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LicensesView.swift; sourceTree = "<group>"; };
 		CD00CA002D0CC001000CD001 /* CachedAsyncImage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CachedAsyncImage.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -201,6 +207,9 @@
 			children = (
 				CD000A002D00000A000CD001 /* SettingsViewModel.swift */,
 				CD000A022D00000A000CD001 /* SettingsScreen.swift */,
+				CD000B002D00000B000CD001 /* HiddenModelsView.swift */,
+				CD000B022D00000B000CD001 /* ExcludedTagsView.swift */,
+				CD000B042D00000B000CD001 /* LicensesView.swift */,
 			);
 			path = Settings;
 			sourceTree = "<group>";
@@ -377,6 +386,9 @@
 				CD0009032D000009000CD001 /* SavedPromptsScreen.swift in Sources */,
 				CD000A012D00000A000CD001 /* SettingsViewModel.swift in Sources */,
 				CD000A032D00000A000CD001 /* SettingsScreen.swift in Sources */,
+				CD000B012D00000B000CD001 /* HiddenModelsView.swift in Sources */,
+				CD000B032D00000B000CD001 /* ExcludedTagsView.swift in Sources */,
+				CD000B052D00000B000CD001 /* LicensesView.swift in Sources */,
 				CD00CA012D0CC001000CD001 /* CachedAsyncImage.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/iosApp/iosApp/Features/Favorites/FavoritesScreen.swift
+++ b/iosApp/iosApp/Features/Favorites/FavoritesScreen.swift
@@ -4,10 +4,12 @@ import Shared
 struct FavoritesScreen: View {
     @StateObject private var viewModel = FavoritesViewModel()
 
-    private let columns = [
-        GridItem(.flexible(), spacing: Spacing.sm),
-        GridItem(.flexible(), spacing: Spacing.sm),
-    ]
+    private var columns: [GridItem] {
+        Array(
+            repeating: GridItem(.flexible(), spacing: Spacing.sm),
+            count: Int(viewModel.gridColumns)
+        )
+    }
 
     var body: some View {
         NavigationStack {
@@ -23,7 +25,7 @@ struct FavoritesScreen: View {
                 ModelDetailScreen(modelId: modelId)
             }
         }
-        // Observation starts automatically in ViewModel init
+        .task { await viewModel.observeGridColumns() }
     }
 
     private var favoritesGrid: some View {

--- a/iosApp/iosApp/Features/Favorites/FavoritesViewModel.swift
+++ b/iosApp/iosApp/Features/Favorites/FavoritesViewModel.swift
@@ -4,12 +4,15 @@ import Shared
 @MainActor
 final class FavoritesViewModel: ObservableObject {
     @Published var favorites: [FavoriteModelSummary] = []
+    @Published var gridColumns: Int32 = 2
 
     private let observeFavoritesUseCase: ObserveFavoritesUseCase
+    private let observeGridColumnsUseCase: ObserveGridColumnsUseCase
     private var observeTask: Task<Void, Never>?
 
     init() {
         self.observeFavoritesUseCase = KoinHelper.shared.getObserveFavoritesUseCase()
+        self.observeGridColumnsUseCase = KoinHelper.shared.getObserveGridColumnsUseCase()
         observeTask = Task { await observe() }
     }
 
@@ -21,6 +24,12 @@ final class FavoritesViewModel: ObservableObject {
         for await list in observeFavoritesUseCase.invoke() {
             let items = list.compactMap { $0 as? FavoriteModelSummary }
             self.favorites = items
+        }
+    }
+
+    func observeGridColumns() async {
+        for await value in observeGridColumnsUseCase.invoke() {
+            gridColumns = value.int32Value
         }
     }
 }

--- a/iosApp/iosApp/Features/Search/ModelSearchScreen.swift
+++ b/iosApp/iosApp/Features/Search/ModelSearchScreen.swift
@@ -13,10 +13,12 @@ struct ModelSearchScreen: View {
     @State private var excludeTagInput: String = ""
     @State private var showFilterSheet: Bool = false
 
-    private let columns = [
-        GridItem(.flexible(), spacing: Spacing.sm),
-        GridItem(.flexible(), spacing: Spacing.sm),
-    ]
+    private var columns: [GridItem] {
+        Array(
+            repeating: GridItem(.flexible(), spacing: Spacing.sm),
+            count: Int(viewModel.gridColumns)
+        )
+    }
 
     var body: some View {
         NavigationStack {
@@ -53,6 +55,7 @@ struct ModelSearchScreen: View {
                 CreatorProfileScreen(username: username)
             }
             .task { await viewModel.observeSearchHistory() }
+            .task { await viewModel.observeGridColumns() }
         }
     }
 

--- a/iosApp/iosApp/Features/Settings/ExcludedTagsView.swift
+++ b/iosApp/iosApp/Features/Settings/ExcludedTagsView.swift
@@ -1,0 +1,46 @@
+import SwiftUI
+
+struct ExcludedTagsView: View {
+    let tags: [String]
+    let onAdd: (String) -> Void
+    let onRemove: (String) -> Void
+
+    @State private var newTag = ""
+
+    var body: some View {
+        List {
+            Section {
+                HStack {
+                    TextField("Add tag", text: $newTag)
+                        .autocapitalization(.none)
+                        .disableAutocorrection(true)
+                    Button("Add") {
+                        onAdd(newTag)
+                        newTag = ""
+                    }
+                    .disabled(newTag.trimmingCharacters(in: .whitespaces).isEmpty)
+                }
+            }
+            Section {
+                if tags.isEmpty {
+                    Text("No excluded tags")
+                        .foregroundColor(.civitOnSurfaceVariant)
+                } else {
+                    ForEach(tags, id: \.self) { tag in
+                        HStack {
+                            Text(tag)
+                                .font(.civitBodyMedium)
+                            Spacer()
+                            Button("Remove") {
+                                onRemove(tag)
+                            }
+                            .foregroundColor(.civitError)
+                        }
+                    }
+                }
+            }
+        }
+        .navigationTitle("Excluded Tags")
+        .navigationBarTitleDisplayMode(.inline)
+    }
+}

--- a/iosApp/iosApp/Features/Settings/HiddenModelsView.swift
+++ b/iosApp/iosApp/Features/Settings/HiddenModelsView.swift
@@ -1,0 +1,30 @@
+import SwiftUI
+import Shared
+
+struct HiddenModelsView: View {
+    let models: [HiddenModelEntity]
+    let onUnhide: (Int64) -> Void
+
+    var body: some View {
+        List {
+            if models.isEmpty {
+                Text("No hidden models.\nLong-press a model card on the Search screen to hide it.")
+                    .foregroundColor(.civitOnSurfaceVariant)
+            } else {
+                ForEach(models, id: \.modelId) { model in
+                    HStack {
+                        Text(model.modelName)
+                            .font(.civitBodyMedium)
+                        Spacer()
+                        Button("Unhide") {
+                            onUnhide(model.modelId)
+                        }
+                        .foregroundColor(.civitPrimary)
+                    }
+                }
+            }
+        }
+        .navigationTitle("Hidden Models")
+        .navigationBarTitleDisplayMode(.inline)
+    }
+}

--- a/iosApp/iosApp/Features/Settings/LicensesView.swift
+++ b/iosApp/iosApp/Features/Settings/LicensesView.swift
@@ -1,0 +1,34 @@
+import SwiftUI
+
+struct LicensesView: View {
+    private let libraries = [
+        LibraryInfo(name: "Ktor", license: "Apache License 2.0", url: "https://ktor.io"),
+        LibraryInfo(name: "Koin", license: "Apache License 2.0", url: "https://insert-koin.io"),
+        LibraryInfo(name: "Room (AndroidX)", license: "Apache License 2.0", url: "https://developer.android.com/jetpack/androidx/releases/room"),
+        LibraryInfo(name: "Coil", license: "Apache License 2.0", url: "https://coil-kt.github.io/coil"),
+        LibraryInfo(name: "SKIE", license: "Apache License 2.0", url: "https://skie.touchlab.co"),
+        LibraryInfo(name: "kotlinx-serialization", license: "Apache License 2.0", url: "https://github.com/Kotlin/kotlinx.serialization"),
+        LibraryInfo(name: "SQLite (AndroidX)", license: "Apache License 2.0", url: "https://developer.android.com/jetpack/androidx/releases/sqlite"),
+    ]
+
+    var body: some View {
+        List(libraries) { library in
+            VStack(alignment: .leading, spacing: 4) {
+                Text(library.name)
+                    .font(.civitBodyMedium)
+                Text(library.license)
+                    .font(.civitBodySmall)
+                    .foregroundColor(.civitOnSurfaceVariant)
+            }
+        }
+        .navigationTitle("Open Source Licenses")
+        .navigationBarTitleDisplayMode(.inline)
+    }
+}
+
+private struct LibraryInfo: Identifiable {
+    let id = UUID()
+    let name: String
+    let license: String
+    let url: String
+}

--- a/iosApp/iosApp/Features/Settings/SettingsScreen.swift
+++ b/iosApp/iosApp/Features/Settings/SettingsScreen.swift
@@ -5,24 +5,147 @@ struct SettingsScreen: View {
     @StateObject private var viewModel = SettingsViewModel()
 
     var body: some View {
-        List {
-            Section {
-                Toggle(isOn: Binding(
-                    get: { viewModel.nsfwFilterLevel != .off },
-                    set: { _ in viewModel.onNsfwFilterToggle() }
-                )) {
-                    VStack(alignment: .leading, spacing: 4) {
-                        Text("NSFW Content")
-                            .font(.civitBodyMedium)
-                        Text("Show NSFW content in search results")
-                            .font(.civitBodySmall)
-                            .foregroundColor(.civitOnSurfaceVariant)
-                    }
+        NavigationStack {
+            List {
+                contentFilterSection
+                displaySection
+                dataManagementSection
+                aboutSection
+            }
+            .navigationTitle("Settings")
+            .navigationBarTitleDisplayMode(.inline)
+            .task { await viewModel.observeNsfwFilter() }
+            .task { await viewModel.observeSortOrder() }
+            .task { await viewModel.observeTimePeriod() }
+            .task { await viewModel.observeGridColumns() }
+        }
+    }
+
+    private var contentFilterSection: some View {
+        Section("Content Filter") {
+            Toggle(isOn: Binding(
+                get: { viewModel.nsfwFilterLevel != .off },
+                set: { _ in viewModel.onNsfwFilterToggle() }
+            )) {
+                VStack(alignment: .leading, spacing: 4) {
+                    Text("NSFW Content")
+                        .font(.civitBodyMedium)
+                    Text("Show NSFW content in search results")
+                        .font(.civitBodySmall)
+                        .foregroundColor(.civitOnSurfaceVariant)
                 }
             }
         }
-        .task {
-            await viewModel.observeNsfwFilter()
+    }
+
+    private var displaySection: some View {
+        Section("Display") {
+            sortOrderPicker
+            timePeriodPicker
+            gridColumnsPicker
+        }
+    }
+
+    private var sortOrderPicker: some View {
+        Picker("Default Sort", selection: Binding(
+            get: { viewModel.defaultSortOrder },
+            set: { viewModel.onSortOrderChanged($0) }
+        )) {
+            ForEach(SearchFilter.sortOptions, id: \.self) { sort in
+                Text(SearchFilter.sortLabel(sort)).tag(sort)
+            }
+        }
+    }
+
+    private var timePeriodPicker: some View {
+        Picker("Default Period", selection: Binding(
+            get: { viewModel.defaultTimePeriod },
+            set: { viewModel.onTimePeriodChanged($0) }
+        )) {
+            ForEach(SearchFilter.periodOptions, id: \.self) { period in
+                Text(SearchFilter.periodLabel(period)).tag(period)
+            }
+        }
+    }
+
+    private var gridColumnsPicker: some View {
+        Picker("Grid Columns", selection: Binding(
+            get: { viewModel.gridColumns },
+            set: { viewModel.onGridColumnsChanged($0) }
+        )) {
+            Text("2").tag(Int32(2))
+            Text("3").tag(Int32(3))
+        }
+        .pickerStyle(.segmented)
+    }
+
+    private var dataManagementSection: some View {
+        Section("Data Management") {
+            NavigationLink {
+                HiddenModelsView(
+                    models: viewModel.hiddenModels,
+                    onUnhide: viewModel.onUnhideModel
+                )
+            } label: {
+                HStack {
+                    Text("Hidden Models")
+                    Spacer()
+                    Text("\(viewModel.hiddenModels.count) models")
+                        .font(.civitBodySmall)
+                        .foregroundColor(.civitOnSurfaceVariant)
+                }
+            }
+            NavigationLink {
+                ExcludedTagsView(
+                    tags: viewModel.excludedTags,
+                    onAdd: viewModel.onAddExcludedTag,
+                    onRemove: viewModel.onRemoveExcludedTag
+                )
+            } label: {
+                HStack {
+                    Text("Excluded Tags")
+                    Spacer()
+                    Text("\(viewModel.excludedTags.count) tags")
+                        .font(.civitBodySmall)
+                        .foregroundColor(.civitOnSurfaceVariant)
+                }
+            }
+            ClearActionButton(label: "Clear Search History", action: viewModel.onClearSearchHistory)
+            ClearActionButton(label: "Clear Browsing History", action: viewModel.onClearBrowsingHistory)
+            ClearActionButton(label: "Clear Cache", action: viewModel.onClearCache)
+        }
+    }
+
+    private var aboutSection: some View {
+        Section("About") {
+            HStack {
+                Text("App Version")
+                Spacer()
+                Text(Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "1.0.0")
+                    .foregroundColor(.civitOnSurfaceVariant)
+            }
+            NavigationLink("Open Source Licenses") {
+                LicensesView()
+            }
+        }
+    }
+}
+
+private struct ClearActionButton: View {
+    let label: String
+    let action: () -> Void
+    @State private var showConfirmation = false
+
+    var body: some View {
+        Button(label) {
+            showConfirmation = true
+        }
+        .foregroundColor(.civitError)
+        .alert(label, isPresented: $showConfirmation) {
+            Button("Cancel", role: .cancel) {}
+            Button("Clear", role: .destructive) { action() }
+        } message: {
+            Text("Are you sure? This cannot be undone.")
         }
     }
 }

--- a/iosApp/iosApp/Features/Settings/SettingsViewModel.swift
+++ b/iosApp/iosApp/Features/Settings/SettingsViewModel.swift
@@ -4,13 +4,47 @@ import Shared
 @MainActor
 final class SettingsViewModel: ObservableObject {
     @Published var nsfwFilterLevel: NsfwFilterLevel = .off
+    @Published var defaultSortOrder: CivitSortOrder = .mostDownloaded
+    @Published var defaultTimePeriod: TimePeriod = .allTime
+    @Published var gridColumns: Int32 = 2
+    @Published var hiddenModels: [HiddenModelEntity] = []
+    @Published var excludedTags: [String] = []
 
     private let observeNsfwFilterUseCase: ObserveNsfwFilterUseCase
     private let setNsfwFilterUseCase: SetNsfwFilterUseCase
+    private let observeDefaultSortOrderUseCase: ObserveDefaultSortOrderUseCase
+    private let setDefaultSortOrderUseCase: SetDefaultSortOrderUseCase
+    private let observeDefaultTimePeriodUseCase: ObserveDefaultTimePeriodUseCase
+    private let setDefaultTimePeriodUseCase: SetDefaultTimePeriodUseCase
+    private let observeGridColumnsUseCase: ObserveGridColumnsUseCase
+    private let setGridColumnsUseCase: SetGridColumnsUseCase
+    private let getHiddenModelsUseCase: GetHiddenModelsUseCase
+    private let unhideModelUseCase: UnhideModelUseCase
+    private let getExcludedTagsUseCase: GetExcludedTagsUseCase
+    private let addExcludedTagUseCase: AddExcludedTagUseCase
+    private let removeExcludedTagUseCase: RemoveExcludedTagUseCase
+    private let clearSearchHistoryUseCase: ClearSearchHistoryUseCase
+    private let clearBrowsingHistoryUseCase: ClearBrowsingHistoryUseCase
+    private let clearCacheUseCase: ClearCacheUseCase
 
     init() {
         self.observeNsfwFilterUseCase = KoinHelper.shared.getObserveNsfwFilterUseCase()
         self.setNsfwFilterUseCase = KoinHelper.shared.getSetNsfwFilterUseCase()
+        self.observeDefaultSortOrderUseCase = KoinHelper.shared.getObserveDefaultSortOrderUseCase()
+        self.setDefaultSortOrderUseCase = KoinHelper.shared.getSetDefaultSortOrderUseCase()
+        self.observeDefaultTimePeriodUseCase = KoinHelper.shared.getObserveDefaultTimePeriodUseCase()
+        self.setDefaultTimePeriodUseCase = KoinHelper.shared.getSetDefaultTimePeriodUseCase()
+        self.observeGridColumnsUseCase = KoinHelper.shared.getObserveGridColumnsUseCase()
+        self.setGridColumnsUseCase = KoinHelper.shared.getSetGridColumnsUseCase()
+        self.getHiddenModelsUseCase = KoinHelper.shared.getHiddenModelsUseCase()
+        self.unhideModelUseCase = KoinHelper.shared.getUnhideModelUseCase()
+        self.getExcludedTagsUseCase = KoinHelper.shared.getExcludedTagsUseCase()
+        self.addExcludedTagUseCase = KoinHelper.shared.getAddExcludedTagUseCase()
+        self.removeExcludedTagUseCase = KoinHelper.shared.getRemoveExcludedTagUseCase()
+        self.clearSearchHistoryUseCase = KoinHelper.shared.getClearSearchHistoryUseCase()
+        self.clearBrowsingHistoryUseCase = KoinHelper.shared.getClearBrowsingHistoryUseCase()
+        self.clearCacheUseCase = KoinHelper.shared.getClearCacheUseCase()
+        loadMutableData()
     }
 
     func observeNsfwFilter() async {
@@ -20,11 +54,81 @@ final class SettingsViewModel: ObservableObject {
         }
     }
 
+    func observeSortOrder() async {
+        for await value in observeDefaultSortOrderUseCase.invoke() {
+            defaultSortOrder = value
+        }
+    }
+
+    func observeTimePeriod() async {
+        for await value in observeDefaultTimePeriodUseCase.invoke() {
+            defaultTimePeriod = value
+        }
+    }
+
+    func observeGridColumns() async {
+        for await value in observeGridColumnsUseCase.invoke() {
+            gridColumns = value.int32Value
+        }
+    }
+
     func onNsfwFilterToggle() {
         let newLevel: NsfwFilterLevel = nsfwFilterLevel == .off ? .all : .off
         nsfwFilterLevel = newLevel
+        Task { try? await setNsfwFilterUseCase.invoke(level: newLevel) }
+    }
+
+    func onSortOrderChanged(_ sort: CivitSortOrder) {
+        Task { try? await setDefaultSortOrderUseCase.invoke(sort: sort) }
+    }
+
+    func onTimePeriodChanged(_ period: TimePeriod) {
+        Task { try? await setDefaultTimePeriodUseCase.invoke(period: period) }
+    }
+
+    func onGridColumnsChanged(_ columns: Int32) {
+        Task { try? await setGridColumnsUseCase.invoke(columns: columns) }
+    }
+
+    func onUnhideModel(_ modelId: Int64) {
         Task {
-            try? await setNsfwFilterUseCase.invoke(level: newLevel)
+            try? await unhideModelUseCase.invoke(modelId: modelId)
+            loadMutableData()
+        }
+    }
+
+    func onAddExcludedTag(_ tag: String) {
+        let trimmed = tag.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        guard !trimmed.isEmpty else { return }
+        Task {
+            try? await addExcludedTagUseCase.invoke(tag: trimmed)
+            loadMutableData()
+        }
+    }
+
+    func onRemoveExcludedTag(_ tag: String) {
+        Task {
+            try? await removeExcludedTagUseCase.invoke(tag: tag)
+            loadMutableData()
+        }
+    }
+
+    func onClearSearchHistory() {
+        Task { try? await clearSearchHistoryUseCase.invoke() }
+    }
+
+    func onClearBrowsingHistory() {
+        Task { try? await clearBrowsingHistoryUseCase.invoke() }
+    }
+
+    func onClearCache() {
+        Task { try? await clearCacheUseCase.invoke() }
+    }
+
+    private func loadMutableData() {
+        Task {
+            hiddenModels = (try? await getHiddenModelsUseCase.invoke()) ?? []
+            excludedTags = (try? await getExcludedTagsUseCase.invoke()) ?? []
         }
     }
 }

--- a/shared/schemas/com.riox432.civitdeck.data.local.CivitDeckDatabase/5.json
+++ b/shared/schemas/com.riox432.civitdeck.data.local.CivitDeckDatabase/5.json
@@ -1,0 +1,387 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 5,
+    "identityHash": "9b7b5f5bbe0e28d6269423ba3c23855d",
+    "entities": [
+      {
+        "tableName": "favorite_models",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `name` TEXT NOT NULL, `type` TEXT NOT NULL, `nsfw` INTEGER NOT NULL, `thumbnailUrl` TEXT, `creatorName` TEXT, `downloadCount` INTEGER NOT NULL, `favoriteCount` INTEGER NOT NULL, `rating` REAL NOT NULL, `favoritedAt` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "nsfw",
+            "columnName": "nsfw",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "thumbnailUrl",
+            "columnName": "thumbnailUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "creatorName",
+            "columnName": "creatorName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "downloadCount",
+            "columnName": "downloadCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "favoriteCount",
+            "columnName": "favoriteCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "rating",
+            "columnName": "rating",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "favoritedAt",
+            "columnName": "favoritedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "cached_api_responses",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`cacheKey` TEXT NOT NULL, `responseJson` TEXT NOT NULL, `cachedAt` INTEGER NOT NULL, PRIMARY KEY(`cacheKey`))",
+        "fields": [
+          {
+            "fieldPath": "cacheKey",
+            "columnName": "cacheKey",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "responseJson",
+            "columnName": "responseJson",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cachedAt",
+            "columnName": "cachedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "cacheKey"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_cached_api_responses_cachedAt",
+            "unique": false,
+            "columnNames": [
+              "cachedAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_cached_api_responses_cachedAt` ON `${TABLE_NAME}` (`cachedAt`)"
+          }
+        ]
+      },
+      {
+        "tableName": "user_preferences",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `nsfwFilterLevel` TEXT NOT NULL, `defaultSortOrder` TEXT NOT NULL, `defaultTimePeriod` TEXT NOT NULL, `gridColumns` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "nsfwFilterLevel",
+            "columnName": "nsfwFilterLevel",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "defaultSortOrder",
+            "columnName": "defaultSortOrder",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "defaultTimePeriod",
+            "columnName": "defaultTimePeriod",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "gridColumns",
+            "columnName": "gridColumns",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "saved_prompts",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `prompt` TEXT NOT NULL, `negativePrompt` TEXT, `sampler` TEXT, `steps` INTEGER, `cfgScale` REAL, `seed` INTEGER, `modelName` TEXT, `size` TEXT, `sourceImageUrl` TEXT, `savedAt` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "prompt",
+            "columnName": "prompt",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "negativePrompt",
+            "columnName": "negativePrompt",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "sampler",
+            "columnName": "sampler",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "steps",
+            "columnName": "steps",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "cfgScale",
+            "columnName": "cfgScale",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "seed",
+            "columnName": "seed",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "modelName",
+            "columnName": "modelName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "size",
+            "columnName": "size",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "sourceImageUrl",
+            "columnName": "sourceImageUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "savedAt",
+            "columnName": "savedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "search_history",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `query` TEXT NOT NULL, `searchedAt` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "query",
+            "columnName": "query",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "searchedAt",
+            "columnName": "searchedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "browsing_history",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `modelId` INTEGER NOT NULL, `modelType` TEXT NOT NULL, `creatorName` TEXT, `tags` TEXT NOT NULL, `viewedAt` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "modelId",
+            "columnName": "modelId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "modelType",
+            "columnName": "modelType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "creatorName",
+            "columnName": "creatorName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "tags",
+            "columnName": "tags",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "viewedAt",
+            "columnName": "viewedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_browsing_history_modelId",
+            "unique": false,
+            "columnNames": [
+              "modelId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_browsing_history_modelId` ON `${TABLE_NAME}` (`modelId`)"
+          },
+          {
+            "name": "index_browsing_history_viewedAt",
+            "unique": false,
+            "columnNames": [
+              "viewedAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_browsing_history_viewedAt` ON `${TABLE_NAME}` (`viewedAt`)"
+          }
+        ]
+      },
+      {
+        "tableName": "excluded_tags",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`tag` TEXT NOT NULL, `addedAt` INTEGER NOT NULL, PRIMARY KEY(`tag`))",
+        "fields": [
+          {
+            "fieldPath": "tag",
+            "columnName": "tag",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "addedAt",
+            "columnName": "addedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "tag"
+          ]
+        }
+      },
+      {
+        "tableName": "hidden_models",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`modelId` INTEGER NOT NULL, `modelName` TEXT NOT NULL, `hiddenAt` INTEGER NOT NULL, PRIMARY KEY(`modelId`))",
+        "fields": [
+          {
+            "fieldPath": "modelId",
+            "columnName": "modelId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "modelName",
+            "columnName": "modelName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "hiddenAt",
+            "columnName": "hiddenAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "modelId"
+          ]
+        }
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '9b7b5f5bbe0e28d6269423ba3c23855d')"
+    ]
+  }
+}

--- a/shared/src/commonMain/kotlin/com/riox432/civitdeck/data/local/CivitDeckDatabase.kt
+++ b/shared/src/commonMain/kotlin/com/riox432/civitdeck/data/local/CivitDeckDatabase.kt
@@ -38,7 +38,7 @@ import kotlinx.coroutines.IO
         ExcludedTagEntity::class,
         HiddenModelEntity::class,
     ],
-    version = 4,
+    version = 5,
 )
 @ConstructedBy(CivitDeckDatabaseConstructor::class)
 abstract class CivitDeckDatabase : RoomDatabase() {
@@ -128,9 +128,23 @@ val MIGRATION_3_4 = object : Migration(3, 4) {
     }
 }
 
+val MIGRATION_4_5 = object : Migration(4, 5) {
+    override fun migrate(connection: SQLiteConnection) {
+        connection.execSQL(
+            "ALTER TABLE user_preferences ADD COLUMN defaultSortOrder TEXT NOT NULL DEFAULT 'MostDownloaded'",
+        )
+        connection.execSQL(
+            "ALTER TABLE user_preferences ADD COLUMN defaultTimePeriod TEXT NOT NULL DEFAULT 'AllTime'",
+        )
+        connection.execSQL(
+            "ALTER TABLE user_preferences ADD COLUMN gridColumns INTEGER NOT NULL DEFAULT 2",
+        )
+    }
+}
+
 fun getRoomDatabase(builder: RoomDatabase.Builder<CivitDeckDatabase>): CivitDeckDatabase {
     return builder
-        .addMigrations(MIGRATION_1_2, MIGRATION_2_3, MIGRATION_3_4)
+        .addMigrations(MIGRATION_1_2, MIGRATION_2_3, MIGRATION_3_4, MIGRATION_4_5)
         .setDriver(BundledSQLiteDriver())
         .setQueryCoroutineContext(Dispatchers.IO)
         .build()

--- a/shared/src/commonMain/kotlin/com/riox432/civitdeck/data/local/LocalCacheDataSource.kt
+++ b/shared/src/commonMain/kotlin/com/riox432/civitdeck/data/local/LocalCacheDataSource.kt
@@ -31,6 +31,10 @@ class LocalCacheDataSource(
         dao.deleteExpired(currentTimeMillis() - DEFAULT_TTL_MILLIS)
     }
 
+    suspend fun clearAll() {
+        dao.deleteAll()
+    }
+
     companion object {
         const val DEFAULT_TTL_MILLIS = 15L * 60L * 1000L // 15 minutes
     }

--- a/shared/src/commonMain/kotlin/com/riox432/civitdeck/data/local/dao/BrowsingHistoryDao.kt
+++ b/shared/src/commonMain/kotlin/com/riox432/civitdeck/data/local/dao/BrowsingHistoryDao.kt
@@ -22,4 +22,7 @@ interface BrowsingHistoryDao {
 
     @Query("SELECT COUNT(*) FROM browsing_history")
     suspend fun count(): Int
+
+    @Query("DELETE FROM browsing_history")
+    suspend fun deleteAll()
 }

--- a/shared/src/commonMain/kotlin/com/riox432/civitdeck/data/local/dao/CachedApiResponseDao.kt
+++ b/shared/src/commonMain/kotlin/com/riox432/civitdeck/data/local/dao/CachedApiResponseDao.kt
@@ -19,4 +19,7 @@ interface CachedApiResponseDao {
 
     @Query("DELETE FROM cached_api_responses WHERE cachedAt < :expiryTime")
     suspend fun deleteExpired(expiryTime: Long)
+
+    @Query("DELETE FROM cached_api_responses")
+    suspend fun deleteAll()
 }

--- a/shared/src/commonMain/kotlin/com/riox432/civitdeck/data/local/entity/UserPreferencesEntity.kt
+++ b/shared/src/commonMain/kotlin/com/riox432/civitdeck/data/local/entity/UserPreferencesEntity.kt
@@ -7,4 +7,7 @@ import androidx.room.PrimaryKey
 data class UserPreferencesEntity(
     @PrimaryKey val id: Int = 1,
     val nsfwFilterLevel: String = "Off",
+    val defaultSortOrder: String = "MostDownloaded",
+    val defaultTimePeriod: String = "AllTime",
+    val gridColumns: Int = 2,
 )

--- a/shared/src/commonMain/kotlin/com/riox432/civitdeck/data/repository/BrowsingHistoryRepositoryImpl.kt
+++ b/shared/src/commonMain/kotlin/com/riox432/civitdeck/data/repository/BrowsingHistoryRepositoryImpl.kt
@@ -53,4 +53,8 @@ class BrowsingHistoryRepositoryImpl(
     override suspend fun getAllViewedModelIds(): Set<Long> {
         return dao.getAllModelIds().toSet()
     }
+
+    override suspend fun clearAll() {
+        dao.deleteAll()
+    }
 }

--- a/shared/src/commonMain/kotlin/com/riox432/civitdeck/data/repository/HiddenModelRepositoryImpl.kt
+++ b/shared/src/commonMain/kotlin/com/riox432/civitdeck/data/repository/HiddenModelRepositoryImpl.kt
@@ -12,6 +12,9 @@ class HiddenModelRepositoryImpl(
     override suspend fun getHiddenModelIds(): Set<Long> =
         dao.getAllIds().toSet()
 
+    override suspend fun getHiddenModels(): List<HiddenModelEntity> =
+        dao.getAll()
+
     override suspend fun hideModel(modelId: Long, modelName: String) {
         dao.insert(
             HiddenModelEntity(

--- a/shared/src/commonMain/kotlin/com/riox432/civitdeck/data/repository/UserPreferencesRepositoryImpl.kt
+++ b/shared/src/commonMain/kotlin/com/riox432/civitdeck/data/repository/UserPreferencesRepositoryImpl.kt
@@ -3,6 +3,8 @@ package com.riox432.civitdeck.data.repository
 import com.riox432.civitdeck.data.local.dao.UserPreferencesDao
 import com.riox432.civitdeck.data.local.entity.UserPreferencesEntity
 import com.riox432.civitdeck.domain.model.NsfwFilterLevel
+import com.riox432.civitdeck.domain.model.SortOrder
+import com.riox432.civitdeck.domain.model.TimePeriod
 import com.riox432.civitdeck.domain.repository.UserPreferencesRepository
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
@@ -20,5 +22,35 @@ class UserPreferencesRepositoryImpl(
     override suspend fun setNsfwFilterLevel(level: NsfwFilterLevel) {
         val existing = dao.getPreferences() ?: UserPreferencesEntity()
         dao.upsert(existing.copy(nsfwFilterLevel = level.name))
+    }
+
+    override fun observeDefaultSortOrder(): Flow<SortOrder> =
+        dao.observePreferences().map { entity ->
+            runCatching { SortOrder.valueOf(entity?.defaultSortOrder ?: "") }.getOrDefault(SortOrder.MostDownloaded)
+        }
+
+    override suspend fun setDefaultSortOrder(sort: SortOrder) {
+        val existing = dao.getPreferences() ?: UserPreferencesEntity()
+        dao.upsert(existing.copy(defaultSortOrder = sort.name))
+    }
+
+    override fun observeDefaultTimePeriod(): Flow<TimePeriod> =
+        dao.observePreferences().map { entity ->
+            runCatching { TimePeriod.valueOf(entity?.defaultTimePeriod ?: "") }.getOrDefault(TimePeriod.AllTime)
+        }
+
+    override suspend fun setDefaultTimePeriod(period: TimePeriod) {
+        val existing = dao.getPreferences() ?: UserPreferencesEntity()
+        dao.upsert(existing.copy(defaultTimePeriod = period.name))
+    }
+
+    override fun observeGridColumns(): Flow<Int> =
+        dao.observePreferences().map { entity ->
+            entity?.gridColumns ?: 2
+        }
+
+    override suspend fun setGridColumns(columns: Int) {
+        val existing = dao.getPreferences() ?: UserPreferencesEntity()
+        dao.upsert(existing.copy(gridColumns = columns))
     }
 }

--- a/shared/src/commonMain/kotlin/com/riox432/civitdeck/di/DomainModule.kt
+++ b/shared/src/commonMain/kotlin/com/riox432/civitdeck/di/DomainModule.kt
@@ -2,24 +2,33 @@ package com.riox432.civitdeck.di
 
 import com.riox432.civitdeck.domain.usecase.AddExcludedTagUseCase
 import com.riox432.civitdeck.domain.usecase.AddSearchHistoryUseCase
+import com.riox432.civitdeck.domain.usecase.ClearBrowsingHistoryUseCase
+import com.riox432.civitdeck.domain.usecase.ClearCacheUseCase
 import com.riox432.civitdeck.domain.usecase.ClearSearchHistoryUseCase
 import com.riox432.civitdeck.domain.usecase.DeleteSavedPromptUseCase
 import com.riox432.civitdeck.domain.usecase.GetCreatorModelsUseCase
 import com.riox432.civitdeck.domain.usecase.GetExcludedTagsUseCase
 import com.riox432.civitdeck.domain.usecase.GetHiddenModelIdsUseCase
+import com.riox432.civitdeck.domain.usecase.GetHiddenModelsUseCase
 import com.riox432.civitdeck.domain.usecase.GetImagesUseCase
 import com.riox432.civitdeck.domain.usecase.GetModelDetailUseCase
 import com.riox432.civitdeck.domain.usecase.GetModelsUseCase
 import com.riox432.civitdeck.domain.usecase.GetRecommendationsUseCase
 import com.riox432.civitdeck.domain.usecase.GetViewedModelIdsUseCase
 import com.riox432.civitdeck.domain.usecase.HideModelUseCase
+import com.riox432.civitdeck.domain.usecase.ObserveDefaultSortOrderUseCase
+import com.riox432.civitdeck.domain.usecase.ObserveDefaultTimePeriodUseCase
 import com.riox432.civitdeck.domain.usecase.ObserveFavoritesUseCase
+import com.riox432.civitdeck.domain.usecase.ObserveGridColumnsUseCase
 import com.riox432.civitdeck.domain.usecase.ObserveIsFavoriteUseCase
 import com.riox432.civitdeck.domain.usecase.ObserveNsfwFilterUseCase
 import com.riox432.civitdeck.domain.usecase.ObserveSavedPromptsUseCase
 import com.riox432.civitdeck.domain.usecase.ObserveSearchHistoryUseCase
 import com.riox432.civitdeck.domain.usecase.RemoveExcludedTagUseCase
 import com.riox432.civitdeck.domain.usecase.SavePromptUseCase
+import com.riox432.civitdeck.domain.usecase.SetDefaultSortOrderUseCase
+import com.riox432.civitdeck.domain.usecase.SetDefaultTimePeriodUseCase
+import com.riox432.civitdeck.domain.usecase.SetGridColumnsUseCase
 import com.riox432.civitdeck.domain.usecase.SetNsfwFilterUseCase
 import com.riox432.civitdeck.domain.usecase.ToggleFavoriteUseCase
 import com.riox432.civitdeck.domain.usecase.TrackModelViewUseCase
@@ -51,4 +60,13 @@ val domainModule = module {
     factory { GetHiddenModelIdsUseCase(get()) }
     factory { HideModelUseCase(get()) }
     factory { UnhideModelUseCase(get()) }
+    factory { ObserveDefaultSortOrderUseCase(get()) }
+    factory { SetDefaultSortOrderUseCase(get()) }
+    factory { ObserveDefaultTimePeriodUseCase(get()) }
+    factory { SetDefaultTimePeriodUseCase(get()) }
+    factory { ObserveGridColumnsUseCase(get()) }
+    factory { SetGridColumnsUseCase(get()) }
+    factory { GetHiddenModelsUseCase(get()) }
+    factory { ClearBrowsingHistoryUseCase(get()) }
+    factory { ClearCacheUseCase(get()) }
 }

--- a/shared/src/commonMain/kotlin/com/riox432/civitdeck/domain/repository/BrowsingHistoryRepository.kt
+++ b/shared/src/commonMain/kotlin/com/riox432/civitdeck/domain/repository/BrowsingHistoryRepository.kt
@@ -13,4 +13,5 @@ interface BrowsingHistoryRepository {
     suspend fun getRecentTags(limit: Int = 100): Map<String, Int>
     suspend fun getRecentModelIds(limit: Int = 50): List<Long>
     suspend fun getAllViewedModelIds(): Set<Long>
+    suspend fun clearAll()
 }

--- a/shared/src/commonMain/kotlin/com/riox432/civitdeck/domain/repository/HiddenModelRepository.kt
+++ b/shared/src/commonMain/kotlin/com/riox432/civitdeck/domain/repository/HiddenModelRepository.kt
@@ -1,7 +1,10 @@
 package com.riox432.civitdeck.domain.repository
 
+import com.riox432.civitdeck.data.local.entity.HiddenModelEntity
+
 interface HiddenModelRepository {
     suspend fun getHiddenModelIds(): Set<Long>
+    suspend fun getHiddenModels(): List<HiddenModelEntity>
     suspend fun hideModel(modelId: Long, modelName: String)
     suspend fun unhideModel(modelId: Long)
 }

--- a/shared/src/commonMain/kotlin/com/riox432/civitdeck/domain/repository/UserPreferencesRepository.kt
+++ b/shared/src/commonMain/kotlin/com/riox432/civitdeck/domain/repository/UserPreferencesRepository.kt
@@ -1,9 +1,17 @@
 package com.riox432.civitdeck.domain.repository
 
 import com.riox432.civitdeck.domain.model.NsfwFilterLevel
+import com.riox432.civitdeck.domain.model.SortOrder
+import com.riox432.civitdeck.domain.model.TimePeriod
 import kotlinx.coroutines.flow.Flow
 
 interface UserPreferencesRepository {
     fun observeNsfwFilterLevel(): Flow<NsfwFilterLevel>
     suspend fun setNsfwFilterLevel(level: NsfwFilterLevel)
+    fun observeDefaultSortOrder(): Flow<SortOrder>
+    suspend fun setDefaultSortOrder(sort: SortOrder)
+    fun observeDefaultTimePeriod(): Flow<TimePeriod>
+    suspend fun setDefaultTimePeriod(period: TimePeriod)
+    fun observeGridColumns(): Flow<Int>
+    suspend fun setGridColumns(columns: Int)
 }

--- a/shared/src/commonMain/kotlin/com/riox432/civitdeck/domain/usecase/SettingsUseCases.kt
+++ b/shared/src/commonMain/kotlin/com/riox432/civitdeck/domain/usecase/SettingsUseCases.kt
@@ -1,0 +1,46 @@
+package com.riox432.civitdeck.domain.usecase
+
+import com.riox432.civitdeck.data.local.LocalCacheDataSource
+import com.riox432.civitdeck.data.local.entity.HiddenModelEntity
+import com.riox432.civitdeck.domain.model.SortOrder
+import com.riox432.civitdeck.domain.model.TimePeriod
+import com.riox432.civitdeck.domain.repository.BrowsingHistoryRepository
+import com.riox432.civitdeck.domain.repository.HiddenModelRepository
+import com.riox432.civitdeck.domain.repository.UserPreferencesRepository
+import kotlinx.coroutines.flow.Flow
+
+class ObserveDefaultSortOrderUseCase(private val repository: UserPreferencesRepository) {
+    operator fun invoke(): Flow<SortOrder> = repository.observeDefaultSortOrder()
+}
+
+class SetDefaultSortOrderUseCase(private val repository: UserPreferencesRepository) {
+    suspend operator fun invoke(sort: SortOrder) = repository.setDefaultSortOrder(sort)
+}
+
+class ObserveDefaultTimePeriodUseCase(private val repository: UserPreferencesRepository) {
+    operator fun invoke(): Flow<TimePeriod> = repository.observeDefaultTimePeriod()
+}
+
+class SetDefaultTimePeriodUseCase(private val repository: UserPreferencesRepository) {
+    suspend operator fun invoke(period: TimePeriod) = repository.setDefaultTimePeriod(period)
+}
+
+class ObserveGridColumnsUseCase(private val repository: UserPreferencesRepository) {
+    operator fun invoke(): Flow<Int> = repository.observeGridColumns()
+}
+
+class SetGridColumnsUseCase(private val repository: UserPreferencesRepository) {
+    suspend operator fun invoke(columns: Int) = repository.setGridColumns(columns)
+}
+
+class GetHiddenModelsUseCase(private val repository: HiddenModelRepository) {
+    suspend operator fun invoke(): List<HiddenModelEntity> = repository.getHiddenModels()
+}
+
+class ClearBrowsingHistoryUseCase(private val repository: BrowsingHistoryRepository) {
+    suspend operator fun invoke() = repository.clearAll()
+}
+
+class ClearCacheUseCase(private val cacheDataSource: LocalCacheDataSource) {
+    suspend operator fun invoke() = cacheDataSource.clearAll()
+}

--- a/shared/src/iosMain/kotlin/com/riox432/civitdeck/di/KoinHelper.kt
+++ b/shared/src/iosMain/kotlin/com/riox432/civitdeck/di/KoinHelper.kt
@@ -2,27 +2,37 @@ package com.riox432.civitdeck.di
 
 import com.riox432.civitdeck.domain.usecase.AddExcludedTagUseCase
 import com.riox432.civitdeck.domain.usecase.AddSearchHistoryUseCase
+import com.riox432.civitdeck.domain.usecase.ClearBrowsingHistoryUseCase
+import com.riox432.civitdeck.domain.usecase.ClearCacheUseCase
 import com.riox432.civitdeck.domain.usecase.ClearSearchHistoryUseCase
 import com.riox432.civitdeck.domain.usecase.DeleteSavedPromptUseCase
 import com.riox432.civitdeck.domain.usecase.GetCreatorModelsUseCase
 import com.riox432.civitdeck.domain.usecase.GetExcludedTagsUseCase
 import com.riox432.civitdeck.domain.usecase.GetHiddenModelIdsUseCase
+import com.riox432.civitdeck.domain.usecase.GetHiddenModelsUseCase
 import com.riox432.civitdeck.domain.usecase.GetImagesUseCase
 import com.riox432.civitdeck.domain.usecase.GetModelDetailUseCase
 import com.riox432.civitdeck.domain.usecase.GetModelsUseCase
 import com.riox432.civitdeck.domain.usecase.GetRecommendationsUseCase
 import com.riox432.civitdeck.domain.usecase.GetViewedModelIdsUseCase
 import com.riox432.civitdeck.domain.usecase.HideModelUseCase
+import com.riox432.civitdeck.domain.usecase.ObserveDefaultSortOrderUseCase
+import com.riox432.civitdeck.domain.usecase.ObserveDefaultTimePeriodUseCase
 import com.riox432.civitdeck.domain.usecase.ObserveFavoritesUseCase
+import com.riox432.civitdeck.domain.usecase.ObserveGridColumnsUseCase
 import com.riox432.civitdeck.domain.usecase.ObserveIsFavoriteUseCase
 import com.riox432.civitdeck.domain.usecase.ObserveNsfwFilterUseCase
 import com.riox432.civitdeck.domain.usecase.ObserveSavedPromptsUseCase
 import com.riox432.civitdeck.domain.usecase.ObserveSearchHistoryUseCase
 import com.riox432.civitdeck.domain.usecase.RemoveExcludedTagUseCase
 import com.riox432.civitdeck.domain.usecase.SavePromptUseCase
+import com.riox432.civitdeck.domain.usecase.SetDefaultSortOrderUseCase
+import com.riox432.civitdeck.domain.usecase.SetDefaultTimePeriodUseCase
+import com.riox432.civitdeck.domain.usecase.SetGridColumnsUseCase
 import com.riox432.civitdeck.domain.usecase.SetNsfwFilterUseCase
 import com.riox432.civitdeck.domain.usecase.ToggleFavoriteUseCase
 import com.riox432.civitdeck.domain.usecase.TrackModelViewUseCase
+import com.riox432.civitdeck.domain.usecase.UnhideModelUseCase
 import org.koin.mp.KoinPlatform.getKoin
 
 @Suppress("TooManyFunctions")
@@ -50,4 +60,14 @@ object KoinHelper {
     fun getRemoveExcludedTagUseCase(): RemoveExcludedTagUseCase = getKoin().get()
     fun getHiddenModelIdsUseCase(): GetHiddenModelIdsUseCase = getKoin().get()
     fun getHideModelUseCase(): HideModelUseCase = getKoin().get()
+    fun getUnhideModelUseCase(): UnhideModelUseCase = getKoin().get()
+    fun getObserveDefaultSortOrderUseCase(): ObserveDefaultSortOrderUseCase = getKoin().get()
+    fun getSetDefaultSortOrderUseCase(): SetDefaultSortOrderUseCase = getKoin().get()
+    fun getObserveDefaultTimePeriodUseCase(): ObserveDefaultTimePeriodUseCase = getKoin().get()
+    fun getSetDefaultTimePeriodUseCase(): SetDefaultTimePeriodUseCase = getKoin().get()
+    fun getObserveGridColumnsUseCase(): ObserveGridColumnsUseCase = getKoin().get()
+    fun getSetGridColumnsUseCase(): SetGridColumnsUseCase = getKoin().get()
+    fun getHiddenModelsUseCase(): GetHiddenModelsUseCase = getKoin().get()
+    fun getClearBrowsingHistoryUseCase(): ClearBrowsingHistoryUseCase = getKoin().get()
+    fun getClearCacheUseCase(): ClearCacheUseCase = getKoin().get()
 }


### PR DESCRIPTION
## Summary
- Add display preferences (default sort order, time period, grid columns) persisted in Room DB (migration 4→5)
- Add data management section: clear search/browsing history, clear cache, manage hidden models and excluded tags (with inline add for tags)
- Add Open Source Licenses screen using aboutlibraries-compose-m3
- Propagate saved grid columns and default sort/period to Search and Favorites screens
- Fix model card long-press context menu (Card onClick was consuming touch events)
- Full implementation for both Android (Compose) and iOS (SwiftUI)

## Test plan
- [ ] Settings → change default sort/period → Search screen uses new defaults
- [ ] Settings → change grid columns → Search and Favorites grids update
- [ ] Settings → Hidden Models → shows hint when empty, unhide works
- [ ] Settings → Excluded Tags → add/remove tags works
- [ ] Settings → Clear history/cache → no crash
- [ ] Settings → Open Source Licenses → renders library list
- [ ] Search → long-press model card → "Hide model" context menu appears