### PR TITLE
Enrich model detail images with metadata from images API

### DIFF
--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/CivitDeckApplication.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/CivitDeckApplication.kt
@@ -55,7 +55,7 @@ val androidModule = module {
         )
     }
     viewModel { FavoritesViewModel(get(), get()) }
-    viewModel { params -> ModelDetailViewModel(params.get(), get(), get(), get(), get(), get()) }
+    viewModel { params -> ModelDetailViewModel(params.get(), get(), get(), get(), get(), get(), get()) }
     viewModel { params -> CreatorProfileViewModel(params.get(), get()) }
     viewModel { params -> ImageGalleryViewModel(params.get(), get(), get(), get()) }
     viewModel { SavedPromptsViewModel(get(), get()) }

--- a/shared/src/commonMain/kotlin/com/riox432/civitdeck/di/DomainModule.kt
+++ b/shared/src/commonMain/kotlin/com/riox432/civitdeck/di/DomainModule.kt
@@ -6,6 +6,7 @@ import com.riox432.civitdeck.domain.usecase.ClearBrowsingHistoryUseCase
 import com.riox432.civitdeck.domain.usecase.ClearCacheUseCase
 import com.riox432.civitdeck.domain.usecase.ClearSearchHistoryUseCase
 import com.riox432.civitdeck.domain.usecase.DeleteSavedPromptUseCase
+import com.riox432.civitdeck.domain.usecase.EnrichModelImagesUseCase
 import com.riox432.civitdeck.domain.usecase.GetCreatorModelsUseCase
 import com.riox432.civitdeck.domain.usecase.GetExcludedTagsUseCase
 import com.riox432.civitdeck.domain.usecase.GetHiddenModelIdsUseCase
@@ -40,6 +41,7 @@ val domainModule = module {
     factory { GetCreatorModelsUseCase(get()) }
     factory { GetModelDetailUseCase(get()) }
     factory { GetImagesUseCase(get()) }
+    factory { EnrichModelImagesUseCase(get()) }
     factory { ToggleFavoriteUseCase(get()) }
     factory { ObserveFavoritesUseCase(get()) }
     factory { ObserveIsFavoriteUseCase(get()) }

--- a/shared/src/commonMain/kotlin/com/riox432/civitdeck/domain/usecase/EnrichModelImagesUseCase.kt
+++ b/shared/src/commonMain/kotlin/com/riox432/civitdeck/domain/usecase/EnrichModelImagesUseCase.kt
@@ -1,0 +1,28 @@
+package com.riox432.civitdeck.domain.usecase
+
+import com.riox432.civitdeck.domain.model.ModelImage
+import com.riox432.civitdeck.domain.repository.ImageRepository
+
+class EnrichModelImagesUseCase(private val repository: ImageRepository) {
+    suspend operator fun invoke(
+        modelVersionId: Long,
+        images: List<ModelImage>,
+    ): List<ModelImage> {
+        val result = repository.getImages(modelVersionId = modelVersionId, limit = 20)
+        val metaByImageId = result.items
+            .filter { it.meta != null }
+            .mapNotNull { img -> extractImageId(img.url)?.let { it to img.meta } }
+            .toMap()
+        return images.map { image ->
+            if (image.meta == null) {
+                val meta = extractImageId(image.url)?.let { metaByImageId[it] }
+                if (meta != null) image.copy(meta = meta) else image
+            } else {
+                image
+            }
+        }
+    }
+
+    // URL format: https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/{uuid}/...
+    private fun extractImageId(url: String): String? = url.split("/").getOrNull(4)
+}

--- a/shared/src/iosMain/kotlin/com/riox432/civitdeck/di/KoinHelper.kt
+++ b/shared/src/iosMain/kotlin/com/riox432/civitdeck/di/KoinHelper.kt
@@ -6,6 +6,7 @@ import com.riox432.civitdeck.domain.usecase.ClearBrowsingHistoryUseCase
 import com.riox432.civitdeck.domain.usecase.ClearCacheUseCase
 import com.riox432.civitdeck.domain.usecase.ClearSearchHistoryUseCase
 import com.riox432.civitdeck.domain.usecase.DeleteSavedPromptUseCase
+import com.riox432.civitdeck.domain.usecase.EnrichModelImagesUseCase
 import com.riox432.civitdeck.domain.usecase.GetCreatorModelsUseCase
 import com.riox432.civitdeck.domain.usecase.GetExcludedTagsUseCase
 import com.riox432.civitdeck.domain.usecase.GetHiddenModelIdsUseCase
@@ -70,4 +71,5 @@ object KoinHelper {
     fun getHiddenModelsUseCase(): GetHiddenModelsUseCase = getKoin().get()
     fun getClearBrowsingHistoryUseCase(): ClearBrowsingHistoryUseCase = getKoin().get()
     fun getClearCacheUseCase(): ClearCacheUseCase = getKoin().get()
+    fun getEnrichModelImagesUseCase(): EnrichModelImagesUseCase = getKoin().get()
 }


### PR DESCRIPTION
## Description

Model detail images from `/api/v1/models/{id}` have `meta: null`, so the Info button in the image viewer was hidden. This PR background-fetches image metadata via `/api/v1/images` endpoint after model loads, matches by image UUID extracted from URLs, and merges `meta` into `ModelImage` objects.

## Related Issues

<!-- Link related GitHub issues: Closes #123, Fixes #456 -->

## Screenshots / Video

<!-- If applicable, add screenshots or screen recordings -->

## Test Plan

- [x] Android: Open Model Detail → tap carousel image → Info button appears in viewer
- [x] Android: Switch version tab → tap image → Info button appears after brief load
- [x] Image Gallery Info button still works as before (no regression)

## Review Checklist

- [x] Code follows project architecture (Clean Architecture + MVVM)
- [x] Shared logic is in `commonMain`, platform-specific code only when necessary
- [x] No unnecessary dependencies added
- [x] Tests added/updated as needed

## Breaking Changes

None