### PR TITLE
Move search filter to FAB and fix collapsible header overlap

### DIFF
--- a/iosApp/iosApp/Features/Detail/ModelDetailViewModel.swift
+++ b/iosApp/iosApp/Features/Detail/ModelDetailViewModel.swift
@@ -89,8 +89,9 @@ final class ModelDetailViewModel: ObservableObject {
                 )
                 let metaByImageId = Dictionary(
                     uniqueKeysWithValues: result.items
-                        .compactMap { img -> (String, ImageGenerationMeta)? in
-                            guard let meta = img.meta,
+                        .compactMap { item -> (String, ImageGenerationMeta)? in
+                            guard let img = item as? Image,
+                                  let meta = img.meta,
                                   let imageId = Self.extractImageId(img.url)
                             else { return nil }
                             return (imageId, meta)
@@ -107,7 +108,7 @@ final class ModelDetailViewModel: ObservableObject {
                             nsfwLevel: image.nsfwLevel,
                             width: image.width,
                             height: image.height,
-                            hash: image.hash,
+                            hash: image.hash_,
                             meta: meta
                         )
                     }


### PR DESCRIPTION
## Description

Improve the Search screen UX with two key changes:

1. **Fix collapsible header overlapping system bar**: The search bar was rendering into the status bar area when collapsing on scroll. Added `clipToBounds()` (Android) and `.clipped()` (iOS) to the parent container to prevent overflow.

2. **Move filter button to FAB**: Relocated the filter icon from the search bar header to a Floating Action Button at the bottom-end of the screen. This frees up header space for a wider search bar and places the filter action in the thumb-friendly zone.

   - FAB uses Surface variant colors (`surfaceContainerHigh` + `primary` icon) for a natural look
   - Badge shows active filter count
   - FAB hides on scroll down and reappears on scroll up (Android: tied to header collapse state via `derivedStateOf`; iOS: tied to `headerVisible`)
   - Slide + fade animation for FAB enter/exit

Also fixes a pre-existing iOS build error in `ModelDetailViewModel.swift` (KMP generics type erasure: `Any` → `Image` cast, SKIE `hash` → `hash_` rename).

## Related Issues

<!-- Link related GitHub issues: Closes #123, Fixes #456 -->

## Screenshots / Video

<!-- If applicable, add screenshots or screen recordings -->

## Test Plan

- [ ] Scroll the search screen and verify the search bar no longer overlaps the status bar
- [ ] Verify the filter FAB appears at the bottom-right
- [ ] Tap the FAB and verify the filter bottom sheet opens
- [ ] Apply filters and verify the badge count updates on the FAB
- [ ] Scroll down and verify the FAB hides; scroll up and verify it reappears
- [ ] Verify the search bar fills the full width (no gap where filter button used to be)
- [ ] Test on both Android and iOS

## Review Checklist

- [x] Code follows project architecture (Clean Architecture + MVVM)
- [x] Shared logic is in `commonMain`, platform-specific code only when necessary
- [x] No unnecessary dependencies added
- [ ] Tests added/updated as needed

## Breaking Changes

None