### PR TITLE
Add multi-tag inclusion filter for model search

### DIFF
--- a/iosApp/iosApp/Features/Search/ModelSearchScreen.swift
+++ b/iosApp/iosApp/Features/Search/ModelSearchScreen.swift
@@ -10,6 +10,7 @@ struct ModelSearchScreen: View {
     @State private var previousDragY: CGFloat = 0
     @State private var accumulatedDelta: CGFloat = 0
     @State private var isDraggingDown: Bool = false
+    @State private var includeTagInput: String = ""
     @State private var excludeTagInput: String = ""
     @State private var showFilterSheet: Bool = false
 
@@ -66,6 +67,7 @@ struct ModelSearchScreen: View {
         if viewModel.selectedSort != .mostDownloaded { count += 1 }
         if viewModel.selectedPeriod != .allTime { count += 1 }
         if viewModel.isFreshFindEnabled { count += 1 }
+        if !viewModel.includedTags.isEmpty { count += 1 }
         if !viewModel.excludedTags.isEmpty { count += 1 }
         return count
     }
@@ -162,6 +164,7 @@ struct ModelSearchScreen: View {
                     typeFilterChips
                     baseModelFilterChips
                     sortAndPeriodChips
+                    includedTagsSection
                     excludedTagsSection
                 }
                 .padding(.vertical, Spacing.sm)
@@ -406,6 +409,72 @@ struct ModelSearchScreen: View {
 // MARK: - Extracted Subviews
 
 extension ModelSearchScreen {
+    var includedTagsSection: some View {
+        VStack(alignment: .leading, spacing: Spacing.xs) {
+            Text("Tags (include)")
+                .font(.civitLabelMedium)
+                .foregroundColor(.civitOnSurfaceVariant)
+                .padding(.horizontal, Spacing.lg)
+
+            HStack(spacing: Spacing.sm) {
+                TextField("Include tag...", text: $includeTagInput)
+                    .font(.civitBodySmall)
+                    .submitLabel(.done)
+                    .onSubmit {
+                        if !includeTagInput.isEmpty {
+                            viewModel.addIncludedTag(includeTagInput)
+                            includeTagInput = ""
+                        }
+                    }
+                    .padding(8)
+                    .overlay(
+                        RoundedRectangle(cornerRadius: CornerRadius.searchBar)
+                            .stroke(Color.civitOutlineVariant, lineWidth: 1)
+                    )
+                Button {
+                    if !includeTagInput.isEmpty {
+                        viewModel.addIncludedTag(includeTagInput)
+                        includeTagInput = ""
+                    }
+                } label: {
+                    Image(systemName: "plus")
+                        .font(.civitBodyMedium)
+                }
+            }
+            .padding(.horizontal, Spacing.lg)
+
+            if !viewModel.includedTags.isEmpty {
+                includedTagChips
+            }
+        }
+        .padding(.bottom, Spacing.sm)
+    }
+
+    var includedTagChips: some View {
+        ScrollView(.horizontal, showsIndicators: false) {
+            HStack(spacing: Spacing.xs) {
+                ForEach(viewModel.includedTags, id: \.self) { tag in
+                    HStack(spacing: 4) {
+                        Text(tag)
+                            .font(.civitLabelSmall)
+                        Button {
+                            viewModel.removeIncludedTag(tag)
+                        } label: {
+                            Image(systemName: "xmark")
+                                .font(.system(size: 10, weight: .bold))
+                        }
+                    }
+                    .padding(.horizontal, Spacing.sm)
+                    .padding(.vertical, 4)
+                    .background(Color.civitPrimary.opacity(0.15))
+                    .foregroundColor(.civitPrimary)
+                    .clipShape(Capsule())
+                }
+            }
+            .padding(.horizontal, Spacing.lg)
+        }
+    }
+
     var excludedTagsSection: some View {
         VStack(alignment: .leading, spacing: Spacing.xs) {
             HStack(spacing: Spacing.sm) {


### PR DESCRIPTION
## Description

Add "Included Tags" multi-selection filter to Model Search. Users can specify tags that models must contain. Uses a hybrid server + client-side strategy: the first tag is sent as the API `tag` parameter (server-side), and additional tags are filtered client-side against `Model.tags`.

- Refactored ExcludedTagsSection/ExcludedTagChip into reusable TagFilterSection/TagChip components (Android)
- Included tag chips use `primaryContainer` colors to distinguish from excluded tags (`errorContainer`)
- Tags are session-only state (not persisted to DB)
- Reset Filters clears included tags
- Filter badge count includes included tags

<!-- Link related GitHub issues: Closes #123, Fixes #456 -->

## Screenshots / Video

<!-- If applicable, add screenshots or screen recordings -->

## Test Plan

- [ ] Add 1 tag → API filters by that tag
- [ ] Add 2+ tags → first via API, rest client-side filtered
- [ ] Remove tag → filter updated, models reload
- [ ] Reset Filters → included tags cleared
- [ ] Filter badge reflects included tag count
- [ ] Excluded tags still work alongside included tags
- [ ] Verify on both Android and iOS

## Review Checklist

- [x] Code follows project architecture (Clean Architecture + MVVM)
- [x] Shared logic is in `commonMain`, platform-specific code only when necessary
- [x] No unnecessary dependencies added
- [ ] Tests added/updated as needed

## Breaking Changes

None