### PR TITLE
Fix double status bar padding on detail screen TopAppBar

### DIFF
--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/detail/ModelDetailScreen.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/detail/ModelDetailScreen.kt
@@ -19,6 +19,7 @@ import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -108,6 +109,7 @@ fun ModelDetailScreen(
                 onFavoriteToggle = viewModel::onFavoriteToggle,
             )
         },
+        contentWindowInsets = WindowInsets(0, 0, 0, 0),
     ) { padding ->
         ModelDetailBody(
             uiState = uiState,
@@ -132,6 +134,7 @@ private fun ModelDetailTopBar(
 ) {
     val context = LocalContext.current
     TopAppBar(
+        windowInsets = WindowInsets(0, 0, 0, 0),
         title = {
             Text(
                 text = uiState.model?.name ?: "",


### PR DESCRIPTION
## Description

Fix extra padding above the TopAppBar on the Model Detail screen. The outer Scaffold in CivitDeckNavGraph already applies status bar insets to the content area, but the inner Scaffold's TopAppBar was also adding its own status bar insets, resulting in double padding. Set `windowInsets = WindowInsets(0)` on the TopAppBar and `contentWindowInsets = WindowInsets(0)` on the inner Scaffold to prevent this.

<!-- Link related GitHub issues: Closes #123, Fixes #456 -->

## Screenshots / Video

<!-- If applicable, add screenshots or screen recordings -->

## Test Plan

- [ ] Open any model detail screen and verify TopAppBar sits flush below the status bar
- [ ] Verify navigation back button and actions are properly positioned

## Review Checklist

- [x] Code follows project architecture (Clean Architecture + MVVM)
- [x] Shared logic is in `commonMain`, platform-specific code only when necessary
- [x] No unnecessary dependencies added
- [ ] Tests added/updated as needed

## Breaking Changes

None