### PR TITLE
Improve image error handling and pull-to-refresh indicator

### DIFF
--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/search/ModelSearchScreen.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/search/ModelSearchScreen.kt
@@ -64,6 +64,8 @@ import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.pulltorefresh.PullToRefreshBox
+import androidx.compose.material3.pulltorefresh.PullToRefreshDefaults
+import androidx.compose.material3.pulltorefresh.rememberPullToRefreshState
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -888,6 +890,7 @@ private fun FilterChipItem(
     }
 }
 
+@Suppress("LongMethod")
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 private fun ModelSearchContent(
@@ -908,10 +911,22 @@ private fun ModelSearchContent(
         else -> "content"
     }
 
+    val pullToRefreshState = rememberPullToRefreshState()
+
     PullToRefreshBox(
         isRefreshing = uiState.isRefreshing,
         onRefresh = onRefresh,
         modifier = Modifier.fillMaxSize(),
+        state = pullToRefreshState,
+        indicator = {
+            PullToRefreshDefaults.Indicator(
+                state = pullToRefreshState,
+                isRefreshing = uiState.isRefreshing,
+                modifier = Modifier
+                    .align(Alignment.TopCenter)
+                    .padding(top = topPadding),
+            )
+        },
     ) {
         androidx.compose.animation.Crossfade(
             targetState = stateKey,


### PR DESCRIPTION
## Description

- **ModelCard thumbnail fallback**: When the first image fails to load, automatically try subsequent images from the version's image list instead of showing an error placeholder
- **Detail carousel error skip**: Filter out images that fail to load from the carousel, dynamically updating the page count
- **Detail carousel image reordering**: Reorder carousel images to place the search thumbnail first for consistent Shared Element Transition
- **Pull-to-refresh indicator**: Position the indicator below the collapsible header so it's visible during refresh (was hidden behind the header's zIndex + opaque background)

## Related Issues

<!-- Link related GitHub issues: Closes #123, Fixes #456 -->

## Screenshots / Video

<!-- If applicable, add screenshots or screen recordings -->

## Test Plan

- [ ] Search screen: models with broken first image show next available image as thumbnail
- [ ] Detail screen: broken images are removed from the carousel automatically
- [ ] Detail screen: first carousel image matches the search thumbnail
- [ ] Pull-to-refresh indicator appears below the search bar, not behind it

## Review Checklist

- [x] Code follows project architecture (Clean Architecture + MVVM)
- [x] Shared logic is in `commonMain`, platform-specific code only when necessary
- [x] No unnecessary dependencies added
- [ ] Tests added/updated as needed

## Breaking Changes

None