### PR TITLE
Add scroll-to-top on bottom navigation tab re-tap

### DIFF
--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/favorites/FavoritesScreen.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/favorites/FavoritesScreen.kt
@@ -14,6 +14,7 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.lazy.grid.items
+import androidx.compose.foundation.lazy.grid.rememberLazyGridState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.Download
@@ -25,6 +26,11 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
@@ -48,7 +54,18 @@ fun FavoritesScreen(
     favorites: List<FavoriteModelSummary>,
     onModelClick: (Long) -> Unit,
     gridColumns: Int = 2,
+    scrollToTopTrigger: Int = 0,
 ) {
+    val gridState = rememberLazyGridState()
+
+    var lastHandledTrigger by rememberSaveable { mutableIntStateOf(scrollToTopTrigger) }
+    LaunchedEffect(scrollToTopTrigger) {
+        if (scrollToTopTrigger != lastHandledTrigger) {
+            lastHandledTrigger = scrollToTopTrigger
+            gridState.animateScrollToItem(0)
+        }
+    }
+
     if (favorites.isEmpty()) {
         EmptyFavorites()
     } else {
@@ -56,6 +73,7 @@ fun FavoritesScreen(
             favorites = favorites,
             onModelClick = onModelClick,
             gridColumns = gridColumns,
+            gridState = gridState,
         )
     }
 }
@@ -87,9 +105,11 @@ private fun FavoritesGrid(
     onModelClick: (Long) -> Unit,
     topPadding: Dp = 0.dp,
     gridColumns: Int = 2,
+    gridState: androidx.compose.foundation.lazy.grid.LazyGridState = rememberLazyGridState(),
 ) {
     LazyVerticalGrid(
         columns = GridCells.Fixed(gridColumns),
+        state = gridState,
         contentPadding = PaddingValues(
             start = Spacing.md,
             end = Spacing.md,

--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/prompts/SavedPromptsScreen.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/prompts/SavedPromptsScreen.kt
@@ -15,7 +15,9 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Delete
@@ -27,7 +29,11 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
@@ -41,8 +47,18 @@ import com.riox432.civitdeck.ui.theme.Spacing
 @Composable
 fun SavedPromptsScreen(
     viewModel: SavedPromptsViewModel,
+    scrollToTopTrigger: Int = 0,
 ) {
     val prompts by viewModel.prompts.collectAsStateWithLifecycle()
+    val listState = rememberLazyListState()
+
+    var lastHandledTrigger by rememberSaveable { mutableIntStateOf(scrollToTopTrigger) }
+    LaunchedEffect(scrollToTopTrigger) {
+        if (scrollToTopTrigger != lastHandledTrigger) {
+            lastHandledTrigger = scrollToTopTrigger
+            listState.animateScrollToItem(0)
+        }
+    }
 
     if (prompts.isEmpty()) {
         EmptyState()
@@ -50,6 +66,7 @@ fun SavedPromptsScreen(
         PromptList(
             prompts = prompts,
             onDelete = viewModel::delete,
+            listState = listState,
         )
     }
 }
@@ -90,10 +107,12 @@ private fun PromptList(
     prompts: List<SavedPrompt>,
     onDelete: (Long) -> Unit,
     modifier: Modifier = Modifier,
+    listState: LazyListState = rememberLazyListState(),
 ) {
     val context = LocalContext.current
     LazyColumn(
         modifier = modifier.fillMaxSize(),
+        state = listState,
         contentPadding = androidx.compose.foundation.layout.PaddingValues(Spacing.lg),
         verticalArrangement = Arrangement.spacedBy(Spacing.sm),
     ) {

--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/search/ModelSearchScreen.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/search/ModelSearchScreen.kt
@@ -72,8 +72,10 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
@@ -134,6 +136,7 @@ private fun rememberCollapsibleHeaderState(): CollapsibleHeaderState {
 fun ModelSearchScreen(
     viewModel: ModelSearchViewModel,
     onModelClick: (Long, String?, String) -> Unit = { _, _, _ -> },
+    scrollToTopTrigger: Int = 0,
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     val searchHistory by viewModel.searchHistory.collectAsStateWithLifecycle()
@@ -154,6 +157,15 @@ fun ModelSearchScreen(
     }
 
     HeaderSnapEffect(gridState = gridState, headerState = headerState)
+
+    var lastHandledTrigger by rememberSaveable { mutableIntStateOf(scrollToTopTrigger) }
+    LaunchedEffect(scrollToTopTrigger) {
+        if (scrollToTopTrigger != lastHandledTrigger) {
+            lastHandledTrigger = scrollToTopTrigger
+            gridState.animateScrollToItem(0)
+            headerState.offsetPx = 0f
+        }
+    }
 
     SearchScreenBody(
         padding = PaddingValues(),

--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/settings/SettingsScreen.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/settings/SettingsScreen.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
@@ -17,9 +18,12 @@ import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -34,10 +38,20 @@ import com.riox432.civitdeck.ui.theme.Spacing
 fun SettingsScreen(
     viewModel: SettingsViewModel,
     onNavigateToLicenses: () -> Unit = {},
+    scrollToTopTrigger: Int = 0,
 ) {
     val state by viewModel.uiState.collectAsStateWithLifecycle()
+    val listState = rememberLazyListState()
 
-    LazyColumn {
+    var lastHandledTrigger by rememberSaveable { mutableIntStateOf(scrollToTopTrigger) }
+    LaunchedEffect(scrollToTopTrigger) {
+        if (scrollToTopTrigger != lastHandledTrigger) {
+            lastHandledTrigger = scrollToTopTrigger
+            listState.animateScrollToItem(0)
+        }
+    }
+
+    LazyColumn(state = listState) {
         item { SectionHeader("Content Filter") }
         item { NsfwToggleRow(state.nsfwFilterLevel, viewModel::onNsfwFilterChanged) }
         item { SectionHeader("Display") }


### PR DESCRIPTION
## Description

Re-tapping the currently selected bottom navigation tab now scrolls the screen to the top with animation. This is a standard iOS/Android UX pattern.

- When the back stack has depth > 1: pops to root (existing behavior, unchanged)
- When already at root: animates scroll to top
- Search tab also expands the collapsible header on scroll-to-top

Introduces `TabState` class to manage per-tab back stack and scroll trigger counter, reducing cyclomatic complexity in `CivitDeckNavGraph`.

## Related Issues

<!-- Link related GitHub issues: Closes #123, Fixes #456 -->

## Screenshots / Video

<!-- If applicable, add screenshots or screen recordings -->

## Test Plan

- [ ] Search tab re-tap → grid scrolls to top + header expands
- [ ] Favorites tab re-tap → grid scrolls to top
- [ ] Prompts tab re-tap → list scrolls to top
- [ ] Settings tab re-tap → list scrolls to top
- [ ] Switching tabs and returning does not cause spurious scrolling
- [ ] Detail screen → tab re-tap → pops to root (no scroll)

## Review Checklist

- [x] Code follows project architecture (Clean Architecture + MVVM)
- [x] Shared logic is in `commonMain`, platform-specific code only when necessary
- [x] No unnecessary dependencies added
- [ ] Tests added/updated as needed

## Breaking Changes

None