### PR TITLE
Fix iOS SwiftLint violations

### DIFF
--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/search/ModelSearchScreen.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/search/ModelSearchScreen.kt
@@ -930,7 +930,7 @@ private fun ModelSearchContent(
         indicator = {
             PullToRefreshDefaults.Indicator(
                 state = pullToRefreshState,
-                isRefreshing = uiState.isRefreshing,
+                isRefreshing = refreshState is LoadState.Loading && lazyPagingItems.itemCount > 0,
                 modifier = Modifier
                     .align(Alignment.TopCenter)
                     .padding(top = topPadding),

--- a/iosApp/iosApp.xcodeproj/project.pbxproj
+++ b/iosApp/iosApp.xcodeproj/project.pbxproj
@@ -15,6 +15,7 @@
 		CD0002032D000002000CD001 /* ModelSearchScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD0002022D000002000CD001 /* ModelSearchScreen.swift */; };
 		CD0002052D000002000CD001 /* ModelCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD0002042D000002000CD001 /* ModelCardView.swift */; };
 		CD00DC032D0DD003000CD001 /* SearchFilterConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD00DC022D0DD003000CD001 /* SearchFilterConstants.swift */; };
+		CD00DC052D0DD004000CD001 /* TagFilterSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD00DC042D0DD004000CD001 /* TagFilterSection.swift */; };
 		CD0004012D000004000CD001 /* ModelDetailViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD0004002D000004000CD001 /* ModelDetailViewModel.swift */; };
 		CD0004032D000004000CD001 /* ModelDetailScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD0004022D000004000CD001 /* ModelDetailScreen.swift */; };
 		CD00DC012D0DD001000CD001 /* ModelDetailComponents.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD00DC002D0DD001000CD001 /* ModelDetailComponents.swift */; };
@@ -54,6 +55,7 @@
 		CD0002022D000002000CD001 /* ModelSearchScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModelSearchScreen.swift; sourceTree = "<group>"; };
 		CD0002042D000002000CD001 /* ModelCardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModelCardView.swift; sourceTree = "<group>"; };
 		CD00DC022D0DD003000CD001 /* SearchFilterConstants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchFilterConstants.swift; sourceTree = "<group>"; };
+		CD00DC042D0DD004000CD001 /* TagFilterSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TagFilterSection.swift; sourceTree = "<group>"; };
 		CD0004002D000004000CD001 /* ModelDetailViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModelDetailViewModel.swift; sourceTree = "<group>"; };
 		CD0004022D000004000CD001 /* ModelDetailScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModelDetailScreen.swift; sourceTree = "<group>"; };
 		CD00DC002D0DD001000CD001 /* ModelDetailComponents.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModelDetailComponents.swift; sourceTree = "<group>"; };
@@ -242,6 +244,7 @@
 				CD0002022D000002000CD001 /* ModelSearchScreen.swift */,
 				CD0002042D000002000CD001 /* ModelCardView.swift */,
 				CD00DC022D0DD003000CD001 /* SearchFilterConstants.swift */,
+				CD00DC042D0DD004000CD001 /* TagFilterSection.swift */,
 			);
 			path = Search;
 			sourceTree = "<group>";
@@ -365,6 +368,7 @@
 				CD0002032D000002000CD001 /* ModelSearchScreen.swift in Sources */,
 				CD0002052D000002000CD001 /* ModelCardView.swift in Sources */,
 				CD00DC032D0DD003000CD001 /* SearchFilterConstants.swift in Sources */,
+				CD00DC052D0DD004000CD001 /* TagFilterSection.swift in Sources */,
 				CD0004012D000004000CD001 /* ModelDetailViewModel.swift in Sources */,
 				CD0004032D000004000CD001 /* ModelDetailScreen.swift in Sources */,
 				CD00DC012D0DD001000CD001 /* ModelDetailComponents.swift in Sources */,

--- a/iosApp/iosApp/Features/Search/ModelSearchScreen.swift
+++ b/iosApp/iosApp/Features/Search/ModelSearchScreen.swift
@@ -425,130 +425,27 @@ extension ModelSearchScreen {
 
 extension ModelSearchScreen {
     var includedTagsSection: some View {
-        VStack(alignment: .leading, spacing: Spacing.xs) {
-            Text("Tags (include)")
-                .font(.civitLabelMedium)
-                .foregroundColor(.civitOnSurfaceVariant)
-                .padding(.horizontal, Spacing.lg)
-
-            HStack(spacing: Spacing.sm) {
-                TextField("Include tag...", text: $includeTagInput)
-                    .font(.civitBodySmall)
-                    .submitLabel(.done)
-                    .onSubmit {
-                        if !includeTagInput.isEmpty {
-                            viewModel.addIncludedTag(includeTagInput)
-                            includeTagInput = ""
-                        }
-                    }
-                    .padding(8)
-                    .overlay(
-                        RoundedRectangle(cornerRadius: CornerRadius.searchBar)
-                            .stroke(Color.civitOutlineVariant, lineWidth: 1)
-                    )
-                Button {
-                    if !includeTagInput.isEmpty {
-                        viewModel.addIncludedTag(includeTagInput)
-                        includeTagInput = ""
-                    }
-                } label: {
-                    Image(systemName: "plus")
-                        .font(.civitBodyMedium)
-                }
-            }
-            .padding(.horizontal, Spacing.lg)
-
-            if !viewModel.includedTags.isEmpty {
-                includedTagChips
-            }
-        }
-        .padding(.bottom, Spacing.sm)
-    }
-
-    var includedTagChips: some View {
-        ScrollView(.horizontal, showsIndicators: false) {
-            HStack(spacing: Spacing.xs) {
-                ForEach(viewModel.includedTags, id: \.self) { tag in
-                    HStack(spacing: 4) {
-                        Text(tag)
-                            .font(.civitLabelSmall)
-                        Button {
-                            viewModel.removeIncludedTag(tag)
-                        } label: {
-                            Image(systemName: "xmark")
-                                .font(.system(size: 10, weight: .bold))
-                        }
-                    }
-                    .padding(.horizontal, Spacing.sm)
-                    .padding(.vertical, 4)
-                    .background(Color.civitPrimary.opacity(0.15))
-                    .foregroundColor(.civitPrimary)
-                    .clipShape(Capsule())
-                }
-            }
-            .padding(.horizontal, Spacing.lg)
-        }
+        TagFilterSection(
+            title: "Tags (include)",
+            input: $includeTagInput,
+            placeholder: "Include tag...",
+            tags: viewModel.includedTags,
+            chipColor: .civitPrimary,
+            onAdd: { viewModel.addIncludedTag($0) },
+            onRemove: { viewModel.removeIncludedTag($0) }
+        )
     }
 
     var excludedTagsSection: some View {
-        VStack(alignment: .leading, spacing: Spacing.xs) {
-            HStack(spacing: Spacing.sm) {
-                TextField("Exclude tag...", text: $excludeTagInput)
-                    .font(.civitBodySmall)
-                    .submitLabel(.done)
-                    .onSubmit {
-                        if !excludeTagInput.isEmpty {
-                            viewModel.addExcludedTag(excludeTagInput)
-                            excludeTagInput = ""
-                        }
-                    }
-                    .padding(8)
-                    .overlay(
-                        RoundedRectangle(cornerRadius: CornerRadius.searchBar)
-                            .stroke(Color.civitOutlineVariant, lineWidth: 1)
-                    )
-                Button {
-                    if !excludeTagInput.isEmpty {
-                        viewModel.addExcludedTag(excludeTagInput)
-                        excludeTagInput = ""
-                    }
-                } label: {
-                    Image(systemName: "plus")
-                        .font(.civitBodyMedium)
-                }
-            }
-            .padding(.horizontal, Spacing.lg)
-
-            if !viewModel.excludedTags.isEmpty {
-                excludedTagChips
-            }
-        }
-        .padding(.bottom, Spacing.sm)
-    }
-
-    var excludedTagChips: some View {
-        ScrollView(.horizontal, showsIndicators: false) {
-            HStack(spacing: Spacing.xs) {
-                ForEach(viewModel.excludedTags, id: \.self) { tag in
-                    HStack(spacing: 4) {
-                        Text(tag)
-                            .font(.civitLabelSmall)
-                        Button {
-                            viewModel.removeExcludedTag(tag)
-                        } label: {
-                            Image(systemName: "xmark")
-                                .font(.system(size: 10, weight: .bold))
-                        }
-                    }
-                    .padding(.horizontal, Spacing.sm)
-                    .padding(.vertical, 4)
-                    .background(Color.civitError.opacity(0.15))
-                    .foregroundColor(.civitError)
-                    .clipShape(Capsule())
-                }
-            }
-            .padding(.horizontal, Spacing.lg)
-        }
+        TagFilterSection(
+            title: nil,
+            input: $excludeTagInput,
+            placeholder: "Exclude tag...",
+            tags: viewModel.excludedTags,
+            chipColor: .civitError,
+            onAdd: { viewModel.addExcludedTag($0) },
+            onRemove: { viewModel.removeExcludedTag($0) }
+        )
     }
 
     var recommendationSections: some View {

--- a/iosApp/iosApp/Features/Search/TagFilterSection.swift
+++ b/iosApp/iosApp/Features/Search/TagFilterSection.swift
@@ -1,0 +1,79 @@
+import SwiftUI
+
+struct TagFilterSection: View {
+    let title: String?
+    @Binding var input: String
+    let placeholder: String
+    let tags: [String]
+    let chipColor: Color
+    let onAdd: (String) -> Void
+    let onRemove: (String) -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: Spacing.xs) {
+            if let title {
+                Text(title)
+                    .font(.civitLabelMedium)
+                    .foregroundColor(.civitOnSurfaceVariant)
+                    .padding(.horizontal, Spacing.lg)
+            }
+
+            tagInputRow
+
+            if !tags.isEmpty {
+                tagChips
+            }
+        }
+        .padding(.bottom, Spacing.sm)
+    }
+
+    private var tagInputRow: some View {
+        HStack(spacing: Spacing.sm) {
+            TextField(placeholder, text: $input)
+                .font(.civitBodySmall)
+                .submitLabel(.done)
+                .onSubmit(submitTag)
+                .padding(8)
+                .overlay(
+                    RoundedRectangle(cornerRadius: CornerRadius.searchBar)
+                        .stroke(Color.civitOutlineVariant, lineWidth: 1)
+                )
+            Button(action: submitTag) {
+                Image(systemName: "plus")
+                    .font(.civitBodyMedium)
+            }
+        }
+        .padding(.horizontal, Spacing.lg)
+    }
+
+    private var tagChips: some View {
+        ScrollView(.horizontal, showsIndicators: false) {
+            HStack(spacing: Spacing.xs) {
+                ForEach(tags, id: \.self) { tag in
+                    HStack(spacing: 4) {
+                        Text(tag)
+                            .font(.civitLabelSmall)
+                        Button {
+                            onRemove(tag)
+                        } label: {
+                            Image(systemName: "xmark")
+                                .font(.system(size: 10, weight: .bold))
+                        }
+                    }
+                    .padding(.horizontal, Spacing.sm)
+                    .padding(.vertical, 4)
+                    .background(chipColor.opacity(0.15))
+                    .foregroundColor(chipColor)
+                    .clipShape(Capsule())
+                }
+            }
+            .padding(.horizontal, Spacing.lg)
+        }
+    }
+
+    private func submitTag() {
+        guard !input.isEmpty else { return }
+        onAdd(input)
+        input = ""
+    }
+}


### PR DESCRIPTION
## Description

Fix 3 pre-existing SwiftLint violations that were failing CI on every PR:

1. **ModelSearchScreen.swift** (file_length: 559 → 456 lines): Extract duplicated tag input + chips UI into reusable `TagFilterSection` component
2. **ModelDetailViewModel.swift** (function_body_length: 82 → ~15 lines): Split `enrichCurrentVersion()` into `fetchImageMeta()` and `applyEnrichedMeta()`
3. **ModelSearchViewModel.swift** (function_body_length: 64 → ~30 lines): Extract `fetchModels()` and `applyFilters()` from `loadModels()`

## Related Issues

<!-- Link related GitHub issues: Closes #123, Fixes #456 -->

## Screenshots / Video

<!-- If applicable, add screenshots or screen recordings -->

## Test Plan

- [ ] SwiftLint passes with 0 violations
- [ ] iOS build succeeds
- [ ] Search filter tag UI works as before (include/exclude)
- [ ] Model detail enrichment still loads image metadata
- [ ] Search model loading and filtering unchanged

## Review Checklist

- [x] Code follows project architecture (Clean Architecture + MVVM)
- [x] Shared logic is in `commonMain`, platform-specific code only when necessary
- [x] No unnecessary dependencies added
- [ ] Tests added/updated as needed

## Breaking Changes

None