### PR TITLE
Replace ASCII art diagrams with Mermaid

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -39,39 +39,17 @@ CivitDeck/
 
 ## Data Flow
 
-```
-CivitAI REST API
-       │
-       ▼
-  ┌─────────┐     ┌──────────┐
-  │  Ktor   │────▶│   DTOs   │
-  │ Client  │     │ (data/)  │
-  └─────────┘     └────┬─────┘
-                       │ map to domain
-                       ▼
-               ┌──────────────┐     ┌───────────┐
-               │  Repository  │◀───▶│ Room KMP  │
-               │ (impl)       │     │ (cache)   │
-               └──────┬───────┘     └───────────┘
-                      │
-                      ▼
-               ┌──────────────┐
-               │   Use Case   │  ← Returns Flow<T>
-               └──────┬───────┘
-                      │
-        ┌─────────────┼─────────────┐
-        ▼                           ▼
-  ┌───────────┐              ┌───────────┐
-  │ Android   │              │   iOS     │
-  │ ViewModel │              │ ViewModel │
-  │ (Compose) │              │ (SwiftUI) │
-  └─────┬─────┘              └─────┬─────┘
-        │                          │
-        ▼                          ▼
-  ┌───────────┐              ┌───────────┐
-  │  Jetpack  │              │  SwiftUI  │
-  │  Compose  │              │   Views   │
-  └───────────┘              └───────────┘
+```mermaid
+graph TB
+    api["CivitAI REST API"] --> ktor["Ktor Client"]
+    ktor --> dto["DTOs (data/)"]
+    dto -- "map to domain" --> repo["Repository (impl)"]
+    room["Room KMP (cache)"] <--> repo
+    repo --> usecase["Use Case"]
+    usecase -- "Flow&lt;T&gt;" --> avm["Android ViewModel"]
+    usecase -- "Flow&lt;T&gt;" --> ivm["iOS ViewModel"]
+    avm --> compose["Jetpack Compose"]
+    ivm --> swiftui["SwiftUI Views"]
 ```
 
 ## Layer Responsibilities

--- a/README.ja.md
+++ b/README.ja.md
@@ -55,23 +55,20 @@ CivitDeck がそのギャップを埋めます。モデルの閲覧、画像の�
 
 詳細は [ARCHITECTURE.md](ARCHITECTURE.md) を参照。
 
-```
-┌──────────────────────────────────────────┐
-│              Shared (KMP)                │
-│                                          │
-│  ┌──────────┐ ┌──────────┐ ┌─────────┐  │
-│  │   Ktor   │ │Repository│ │ Room KMP │  │
-│  │  Client  │ │          │ │ (Cache)  │  │
-│  └────┬─────┘ └────┬─────┘ └────┬────┘  │
-│       └──────┬─────┘            │        │
-│         ┌────▼─────┐     ┌─────▼─────┐  │
-│         │ Use Case │     │  Entity   │  │
-│         └────┬─────┘     └───────────┘  │
-├──────────────┼───────────────────────────┤
-│   Android    │          iOS              │
-│   Compose    │        SwiftUI            │
-│   ViewModel  │       ViewModel           │
-└──────────────┴───────────────────────────┘
+```mermaid
+graph TB
+    subgraph shared["Shared (KMP)"]
+        ktor["Ktor Client"] & repo["Repository"] --> usecase["Use Case"]
+        room["Room KMP (Cache)"] --> entity["Entity"]
+    end
+    subgraph android["Android"]
+        avm["ViewModel"] --> compose["Compose"]
+    end
+    subgraph ios["iOS"]
+        ivm["ViewModel"] --> swiftui["SwiftUI"]
+    end
+    usecase --> avm
+    usecase --> ivm
 ```
 
 ## はじめに

--- a/README.md
+++ b/README.md
@@ -55,23 +55,20 @@ CivitDeck fills that gap. Browse models, explore images, read prompts, and save 
 
 See [ARCHITECTURE.md](ARCHITECTURE.md) for detailed documentation.
 
-```
-┌──────────────────────────────────────────┐
-│              Shared (KMP)                │
-│                                          │
-│  ┌──────────┐ ┌──────────┐ ┌─────────┐  │
-│  │   Ktor   │ │Repository│ │ Room KMP │  │
-│  │  Client  │ │          │ │ (Cache)  │  │
-│  └────┬─────┘ └────┬─────┘ └────┬────┘  │
-│       └──────┬─────┘            │        │
-│         ┌────▼─────┐     ┌─────▼─────┐  │
-│         │ Use Case │     │  Entity   │  │
-│         └────┬─────┘     └───────────┘  │
-├──────────────┼───────────────────────────┤
-│   Android    │          iOS              │
-│   Compose    │        SwiftUI            │
-│   ViewModel  │       ViewModel           │
-└──────────────┴───────────────────────────┘
+```mermaid
+graph TB
+    subgraph shared["Shared (KMP)"]
+        ktor["Ktor Client"] & repo["Repository"] --> usecase["Use Case"]
+        room["Room KMP (Cache)"] --> entity["Entity"]
+    end
+    subgraph android["Android"]
+        avm["ViewModel"] --> compose["Compose"]
+    end
+    subgraph ios["iOS"]
+        ivm["ViewModel"] --> swiftui["SwiftUI"]
+    end
+    usecase --> avm
+    usecase --> ivm
 ```
 
 ## Getting Started


### PR DESCRIPTION
## Description

Replace ASCII art architecture diagrams with Mermaid syntax for proper rendering on GitHub.

**Changed files:**
- `README.md` — Architecture overview diagram
- `README.ja.md` — Architecture overview diagram (Japanese)
- `ARCHITECTURE.md` — Data flow diagram

The module structure file tree in ARCHITECTURE.md is kept as-is since Mermaid doesn't handle tree structures well.