### PR TITLE
Fix detail screen image regressions

### DIFF
--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/detail/ModelDetailScreen.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/detail/ModelDetailScreen.kt
@@ -78,6 +78,7 @@ import com.riox432.civitdeck.domain.model.ModelFile
 import com.riox432.civitdeck.domain.model.ModelImage
 import com.riox432.civitdeck.domain.model.ModelVersion
 import com.riox432.civitdeck.domain.model.filterByNsfwLevel
+import com.riox432.civitdeck.domain.model.stripCdnWidth
 import com.riox432.civitdeck.ui.components.ImageErrorPlaceholder
 import com.riox432.civitdeck.ui.gallery.ImageViewerOverlay
 import com.riox432.civitdeck.ui.gallery.ViewerImage
@@ -187,7 +188,8 @@ private fun prepareImages(
 ): List<ModelImage> {
     val filtered = (allImages ?: emptyList()).filterByNsfwLevel(uiState.nsfwFilterLevel)
     if (initialThumbnailUrl == null || uiState.selectedVersionIndex != 0) return filtered
-    val idx = filtered.indexOfFirst { it.url == initialThumbnailUrl }
+    val normalizedThumbnail = initialThumbnailUrl.stripCdnWidth()
+    val idx = filtered.indexOfFirst { it.url.stripCdnWidth() == normalizedThumbnail }
     if (idx <= 0) return filtered
     return listOf(filtered[idx]) + filtered.subList(0, idx) + filtered.subList(idx + 1, filtered.size)
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -64,6 +64,7 @@ detekt-formatting = { module = "io.gitlab.arturbosch.detekt:detekt-formatting", 
 
 # Test
 kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotlin" }
+kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version = "1.10.2" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }

--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -50,6 +50,7 @@ kotlin {
 
         commonTest.dependencies {
             implementation(libs.kotlin.test)
+            implementation(libs.kotlinx.coroutines.test)
         }
     }
 }

--- a/shared/src/commonMain/kotlin/com/riox432/civitdeck/domain/model/ModelVersion.kt
+++ b/shared/src/commonMain/kotlin/com/riox432/civitdeck/domain/model/ModelVersion.kt
@@ -59,6 +59,12 @@ fun ModelImage.thumbnailUrl(width: Int = 450): String {
     return parts.joinToString("/")
 }
 
+/** Strip CDN width parameter so raw and thumbnail URLs can be compared. */
+fun String.stripCdnWidth(): String {
+    if (!contains("image.civitai.com")) return this
+    return split("/").filter { !it.startsWith("width=") }.joinToString("/")
+}
+
 fun ModelImage.isAllowed(filterLevel: NsfwFilterLevel): Boolean = when (filterLevel) {
     NsfwFilterLevel.Off -> nsfwLevel == NsfwLevel.None
     NsfwFilterLevel.Soft -> nsfwLevel == NsfwLevel.None || nsfwLevel == NsfwLevel.Soft

--- a/shared/src/commonMain/kotlin/com/riox432/civitdeck/domain/usecase/EnrichModelImagesUseCase.kt
+++ b/shared/src/commonMain/kotlin/com/riox432/civitdeck/domain/usecase/EnrichModelImagesUseCase.kt
@@ -1,15 +1,15 @@
 package com.riox432.civitdeck.domain.usecase
 
 import com.riox432.civitdeck.domain.model.ModelImage
-import com.riox432.civitdeck.domain.repository.ImageRepository
+import com.riox432.civitdeck.domain.repository.ModelRepository
 
-class EnrichModelImagesUseCase(private val repository: ImageRepository) {
+class EnrichModelImagesUseCase(private val repository: ModelRepository) {
     suspend operator fun invoke(
         modelVersionId: Long,
         images: List<ModelImage>,
     ): List<ModelImage> {
-        val result = repository.getImages(modelVersionId = modelVersionId, limit = 20)
-        val metaByImageId = result.items
+        val version = repository.getModelVersion(modelVersionId)
+        val metaByImageId = version.images
             .filter { it.meta != null }
             .mapNotNull { img -> extractImageId(img.url)?.let { it to img.meta } }
             .toMap()

--- a/shared/src/commonTest/kotlin/com/riox432/civitdeck/domain/model/ModelImageUrlTest.kt
+++ b/shared/src/commonTest/kotlin/com/riox432/civitdeck/domain/model/ModelImageUrlTest.kt
@@ -1,0 +1,79 @@
+package com.riox432.civitdeck.domain.model
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class ModelImageUrlTest {
+
+    private fun image(url: String) = ModelImage(
+        url = url,
+        nsfw = false,
+        nsfwLevel = NsfwLevel.None,
+        width = 512,
+        height = 512,
+        hash = null,
+        meta = null,
+    )
+
+    // -- thumbnailUrl --
+
+    @Test
+    fun thumbnailUrl_inserts_width_for_civitai_cdn() {
+        val img = image("https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/abc-123/original=true/photo.jpeg")
+        val result = img.thumbnailUrl(450)
+        assertEquals(
+            "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/abc-123/width=450/original=true/photo.jpeg",
+            result,
+        )
+    }
+
+    @Test
+    fun thumbnailUrl_replaces_existing_width() {
+        val img = image("https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/abc-123/width=200/photo.jpeg")
+        val result = img.thumbnailUrl(450)
+        assertEquals(
+            "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/abc-123/width=450/photo.jpeg",
+            result,
+        )
+    }
+
+    @Test
+    fun thumbnailUrl_returns_unchanged_for_non_civitai_url() {
+        val img = image("https://example.com/image.png")
+        assertEquals("https://example.com/image.png", img.thumbnailUrl())
+    }
+
+    // -- stripCdnWidth --
+
+    @Test
+    fun stripCdnWidth_removes_width_segment() {
+        val url = "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/abc-123/width=450/photo.jpeg"
+        assertEquals(
+            "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/abc-123/photo.jpeg",
+            url.stripCdnWidth(),
+        )
+    }
+
+    @Test
+    fun stripCdnWidth_noop_when_no_width() {
+        val url = "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/abc-123/original=true/photo.jpeg"
+        assertEquals(url, url.stripCdnWidth())
+    }
+
+    @Test
+    fun stripCdnWidth_noop_for_non_civitai_url() {
+        val url = "https://example.com/width=450/image.png"
+        assertEquals(url, url.stripCdnWidth())
+    }
+
+    // -- Roundtrip: thumbnailUrl -> stripCdnWidth should recover comparable URL --
+
+    @Test
+    fun thumbnailUrl_then_stripCdnWidth_matches_original_stripped() {
+        val rawUrl = "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/abc-123/original=true/photo.jpeg"
+        val img = image(rawUrl)
+        val thumbnailUrl = img.thumbnailUrl(450)
+
+        assertEquals(rawUrl.stripCdnWidth(), thumbnailUrl.stripCdnWidth())
+    }
+}

--- a/shared/src/commonTest/kotlin/com/riox432/civitdeck/domain/usecase/EnrichModelImagesUseCaseTest.kt
+++ b/shared/src/commonTest/kotlin/com/riox432/civitdeck/domain/usecase/EnrichModelImagesUseCaseTest.kt
@@ -1,0 +1,134 @@
+package com.riox432.civitdeck.domain.usecase
+
+import com.riox432.civitdeck.domain.model.BaseModel
+import com.riox432.civitdeck.domain.model.ImageGenerationMeta
+import com.riox432.civitdeck.domain.model.Model
+import com.riox432.civitdeck.domain.model.ModelImage
+import com.riox432.civitdeck.domain.model.ModelType
+import com.riox432.civitdeck.domain.model.ModelVersion
+import com.riox432.civitdeck.domain.model.NsfwLevel
+import com.riox432.civitdeck.domain.model.PaginatedResult
+import com.riox432.civitdeck.domain.model.SortOrder
+import com.riox432.civitdeck.domain.model.TimePeriod
+import com.riox432.civitdeck.domain.repository.ModelRepository
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+
+class EnrichModelImagesUseCaseTest {
+
+    private val sampleMeta = ImageGenerationMeta(
+        prompt = "1girl, white hair",
+        negativePrompt = "bad quality",
+        sampler = "Euler a",
+        cfgScale = 7.0,
+        steps = 20,
+        seed = 12345L,
+        model = "TestModel",
+        size = "512x512",
+    )
+
+    private fun image(uuid: String, meta: ImageGenerationMeta? = null) = ModelImage(
+        url = "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/$uuid/original=true/photo.jpeg",
+        nsfw = false,
+        nsfwLevel = NsfwLevel.None,
+        width = 512,
+        height = 512,
+        hash = null,
+        meta = meta,
+    )
+
+    private fun fakeRepository(versionImages: List<ModelImage>) = object : ModelRepository {
+        override suspend fun getModelVersion(id: Long) = ModelVersion(
+            id = id,
+            modelId = 1L,
+            name = "v1",
+            description = null,
+            createdAt = "",
+            baseModel = null,
+            trainedWords = emptyList(),
+            downloadUrl = "",
+            files = emptyList(),
+            images = versionImages,
+            stats = null,
+        )
+
+        override suspend fun getModels(
+            query: String?,
+            tag: String?,
+            type: ModelType?,
+            sort: SortOrder?,
+            period: TimePeriod?,
+            baseModels: List<BaseModel>?,
+            cursor: String?,
+            limit: Int?,
+            username: String?,
+            nsfw: Boolean?,
+        ): PaginatedResult<Model> = error("not used")
+
+        override suspend fun getModel(id: Long): Model = error("not used")
+        override suspend fun getModelVersionByHash(hash: String): ModelVersion = error("not used")
+    }
+
+    @Test
+    fun enriches_images_with_matching_uuid() = runTest {
+        val uuid = "abc-123-def"
+        val enrichedImage = image(uuid, meta = sampleMeta)
+        val repo = fakeRepository(listOf(enrichedImage))
+        val useCase = EnrichModelImagesUseCase(repo)
+
+        val input = listOf(image(uuid, meta = null))
+        val result = useCase(modelVersionId = 1L, images = input)
+
+        assertEquals(1, result.size)
+        assertNotNull(result[0].meta)
+        assertEquals("1girl, white hair", result[0].meta?.prompt)
+    }
+
+    @Test
+    fun preserves_existing_meta() = runTest {
+        val uuid = "abc-123-def"
+        val existingMeta = sampleMeta.copy(prompt = "original prompt")
+        val repo = fakeRepository(listOf(image(uuid, meta = sampleMeta)))
+        val useCase = EnrichModelImagesUseCase(repo)
+
+        val input = listOf(image(uuid, meta = existingMeta))
+        val result = useCase(modelVersionId = 1L, images = input)
+
+        assertEquals("original prompt", result[0].meta?.prompt)
+    }
+
+    @Test
+    fun leaves_meta_null_when_no_match() = runTest {
+        val repo = fakeRepository(listOf(image("uuid-a", meta = sampleMeta)))
+        val useCase = EnrichModelImagesUseCase(repo)
+
+        val input = listOf(image("uuid-b", meta = null))
+        val result = useCase(modelVersionId = 1L, images = input)
+
+        assertNull(result[0].meta)
+    }
+
+    @Test
+    fun handles_multiple_images() = runTest {
+        val enrichedImages = listOf(
+            image("uuid-1", meta = sampleMeta.copy(prompt = "prompt1")),
+            image("uuid-2", meta = sampleMeta.copy(prompt = "prompt2")),
+        )
+        val repo = fakeRepository(enrichedImages)
+        val useCase = EnrichModelImagesUseCase(repo)
+
+        val input = listOf(
+            image("uuid-1", meta = null),
+            image("uuid-2", meta = null),
+            image("uuid-3", meta = null),
+        )
+        val result = useCase(modelVersionId = 1L, images = input)
+
+        assertEquals("prompt1", result[0].meta?.prompt)
+        assertEquals("prompt2", result[1].meta?.prompt)
+        assertNull(result[2].meta)
+    }
+}


### PR DESCRIPTION
## Summary
- Fix thumbnail mismatch between search and detail screen caused by CDN width parameter in URL comparison (regression from Paging 3 migration in #140)
- Fix image metadata enrichment by using `/v1/model-versions` endpoint instead of `/v1/images` which returns a different image set with non-matching UUIDs
- iOS: replace local enrichment implementation with shared `EnrichModelImagesUseCase`
- Add unit tests for URL utilities (`thumbnailUrl`/`stripCdnWidth` roundtrip) and `EnrichModelImagesUseCase`

## Test plan
- [x] Verified on Samsung SM-S938Z (Android 16) that both issues are resolved
- [x] 11 unit tests pass (`shared:testDebugUnitTest`)
- [x] Detekt lint passes
- [x] Android debug build succeeds