### PR TITLE
Add CivitAI API key authentication foundation

### DIFF
--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/CivitDeckApplication.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/CivitDeckApplication.kt
@@ -8,6 +8,7 @@ import coil3.disk.directory
 import coil3.memory.MemoryCache
 import coil3.request.crossfade
 import com.riox432.civitdeck.di.initKoin
+import com.riox432.civitdeck.di.initializeAuth
 import com.riox432.civitdeck.ui.creator.CreatorProfileViewModel
 import com.riox432.civitdeck.ui.detail.ModelDetailViewModel
 import com.riox432.civitdeck.ui.favorites.FavoritesViewModel
@@ -15,6 +16,9 @@ import com.riox432.civitdeck.ui.gallery.ImageGalleryViewModel
 import com.riox432.civitdeck.ui.prompts.SavedPromptsViewModel
 import com.riox432.civitdeck.ui.search.ModelSearchViewModel
 import com.riox432.civitdeck.ui.settings.SettingsViewModel
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
 import org.koin.android.ext.koin.androidContext
 import org.koin.core.module.dsl.viewModel
 import org.koin.dsl.module
@@ -26,6 +30,7 @@ class CivitDeckApplication : Application(), SingletonImageLoader.Factory {
             androidContext(this@CivitDeckApplication)
             modules(androidModule)
         }
+        CoroutineScope(Dispatchers.IO).launch { initializeAuth() }
     }
 
     override fun newImageLoader(context: coil3.PlatformContext): ImageLoader {
@@ -63,7 +68,7 @@ val androidModule = module {
         SettingsViewModel(
             get(), get(), get(), get(), get(), get(),
             get(), get(), get(), get(), get(), get(),
-            get(), get(), get(), get(),
+            get(), get(), get(), get(), get(), get(), get(),
         )
     }
 }

--- a/iosApp/iosApp/iOSApp.swift
+++ b/iosApp/iosApp/iOSApp.swift
@@ -5,6 +5,7 @@ import Shared
 struct iOSApp: App {
     init() {
         KoinKt.doInitKoin(appDeclaration: { _ in })
+        Task { try? await KoinKt.doInitializeAuth() }
     }
 
     var body: some Scene {

--- a/shared/schemas/com.riox432.civitdeck.data.local.CivitDeckDatabase/6.json
+++ b/shared/schemas/com.riox432.civitdeck.data.local.CivitDeckDatabase/6.json
@@ -1,0 +1,392 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 6,
+    "identityHash": "7e6c6b0c84c766ec21452645e61a736e",
+    "entities": [
+      {
+        "tableName": "favorite_models",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `name` TEXT NOT NULL, `type` TEXT NOT NULL, `nsfw` INTEGER NOT NULL, `thumbnailUrl` TEXT, `creatorName` TEXT, `downloadCount` INTEGER NOT NULL, `favoriteCount` INTEGER NOT NULL, `rating` REAL NOT NULL, `favoritedAt` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "nsfw",
+            "columnName": "nsfw",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "thumbnailUrl",
+            "columnName": "thumbnailUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "creatorName",
+            "columnName": "creatorName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "downloadCount",
+            "columnName": "downloadCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "favoriteCount",
+            "columnName": "favoriteCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "rating",
+            "columnName": "rating",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "favoritedAt",
+            "columnName": "favoritedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "cached_api_responses",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`cacheKey` TEXT NOT NULL, `responseJson` TEXT NOT NULL, `cachedAt` INTEGER NOT NULL, PRIMARY KEY(`cacheKey`))",
+        "fields": [
+          {
+            "fieldPath": "cacheKey",
+            "columnName": "cacheKey",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "responseJson",
+            "columnName": "responseJson",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cachedAt",
+            "columnName": "cachedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "cacheKey"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_cached_api_responses_cachedAt",
+            "unique": false,
+            "columnNames": [
+              "cachedAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_cached_api_responses_cachedAt` ON `${TABLE_NAME}` (`cachedAt`)"
+          }
+        ]
+      },
+      {
+        "tableName": "user_preferences",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `nsfwFilterLevel` TEXT NOT NULL, `defaultSortOrder` TEXT NOT NULL, `defaultTimePeriod` TEXT NOT NULL, `gridColumns` INTEGER NOT NULL, `apiKey` TEXT, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "nsfwFilterLevel",
+            "columnName": "nsfwFilterLevel",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "defaultSortOrder",
+            "columnName": "defaultSortOrder",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "defaultTimePeriod",
+            "columnName": "defaultTimePeriod",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "gridColumns",
+            "columnName": "gridColumns",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "apiKey",
+            "columnName": "apiKey",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "saved_prompts",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `prompt` TEXT NOT NULL, `negativePrompt` TEXT, `sampler` TEXT, `steps` INTEGER, `cfgScale` REAL, `seed` INTEGER, `modelName` TEXT, `size` TEXT, `sourceImageUrl` TEXT, `savedAt` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "prompt",
+            "columnName": "prompt",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "negativePrompt",
+            "columnName": "negativePrompt",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "sampler",
+            "columnName": "sampler",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "steps",
+            "columnName": "steps",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "cfgScale",
+            "columnName": "cfgScale",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "seed",
+            "columnName": "seed",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "modelName",
+            "columnName": "modelName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "size",
+            "columnName": "size",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "sourceImageUrl",
+            "columnName": "sourceImageUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "savedAt",
+            "columnName": "savedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "search_history",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `query` TEXT NOT NULL, `searchedAt` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "query",
+            "columnName": "query",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "searchedAt",
+            "columnName": "searchedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "browsing_history",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `modelId` INTEGER NOT NULL, `modelType` TEXT NOT NULL, `creatorName` TEXT, `tags` TEXT NOT NULL, `viewedAt` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "modelId",
+            "columnName": "modelId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "modelType",
+            "columnName": "modelType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "creatorName",
+            "columnName": "creatorName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "tags",
+            "columnName": "tags",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "viewedAt",
+            "columnName": "viewedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_browsing_history_modelId",
+            "unique": false,
+            "columnNames": [
+              "modelId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_browsing_history_modelId` ON `${TABLE_NAME}` (`modelId`)"
+          },
+          {
+            "name": "index_browsing_history_viewedAt",
+            "unique": false,
+            "columnNames": [
+              "viewedAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_browsing_history_viewedAt` ON `${TABLE_NAME}` (`viewedAt`)"
+          }
+        ]
+      },
+      {
+        "tableName": "excluded_tags",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`tag` TEXT NOT NULL, `addedAt` INTEGER NOT NULL, PRIMARY KEY(`tag`))",
+        "fields": [
+          {
+            "fieldPath": "tag",
+            "columnName": "tag",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "addedAt",
+            "columnName": "addedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "tag"
+          ]
+        }
+      },
+      {
+        "tableName": "hidden_models",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`modelId` INTEGER NOT NULL, `modelName` TEXT NOT NULL, `hiddenAt` INTEGER NOT NULL, PRIMARY KEY(`modelId`))",
+        "fields": [
+          {
+            "fieldPath": "modelId",
+            "columnName": "modelId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "modelName",
+            "columnName": "modelName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "hiddenAt",
+            "columnName": "hiddenAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "modelId"
+          ]
+        }
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '7e6c6b0c84c766ec21452645e61a736e')"
+    ]
+  }
+}

--- a/shared/src/commonMain/kotlin/com/riox432/civitdeck/data/api/ApiKeyProvider.kt
+++ b/shared/src/commonMain/kotlin/com/riox432/civitdeck/data/api/ApiKeyProvider.kt
@@ -1,0 +1,5 @@
+package com.riox432.civitdeck.data.api
+
+class ApiKeyProvider {
+    var apiKey: String? = null
+}

--- a/shared/src/commonMain/kotlin/com/riox432/civitdeck/data/api/CivitAiApi.kt
+++ b/shared/src/commonMain/kotlin/com/riox432/civitdeck/data/api/CivitAiApi.kt
@@ -6,10 +6,13 @@ import com.riox432.civitdeck.data.api.dto.ModelListResponse
 import com.riox432.civitdeck.data.api.dto.ModelResponse
 import com.riox432.civitdeck.data.api.dto.ModelVersionResponse
 import com.riox432.civitdeck.data.api.dto.TagListResponse
+import com.riox432.civitdeck.data.api.dto.UserMeResponse
 import io.ktor.client.HttpClient
 import io.ktor.client.call.body
 import io.ktor.client.request.get
+import io.ktor.client.request.header
 import io.ktor.client.request.parameter
+import io.ktor.http.HttpHeaders
 
 class CivitAiApi(private val client: HttpClient) {
 
@@ -99,6 +102,12 @@ class CivitAiApi(private val client: HttpClient) {
             query?.let { parameter("query", it) }
             page?.let { parameter("page", it) }
             limit?.let { parameter("limit", it) }
+        }.body()
+    }
+
+    suspend fun getMe(apiKey: String): UserMeResponse {
+        return client.get("$BASE_URL/me") {
+            header(HttpHeaders.Authorization, "Bearer $apiKey")
         }.body()
     }
 }

--- a/shared/src/commonMain/kotlin/com/riox432/civitdeck/data/api/HttpClientFactory.kt
+++ b/shared/src/commonMain/kotlin/com/riox432/civitdeck/data/api/HttpClientFactory.kt
@@ -18,7 +18,7 @@ private const val SOCKET_TIMEOUT_MS = 30_000L
 private const val MAX_RETRIES = 2
 private const val RETRY_BASE_DELAY_MS = 1000L
 
-fun createHttpClient(): HttpClient {
+fun createHttpClient(apiKeyProvider: ApiKeyProvider): HttpClient {
     return HttpClient {
         install(ContentNegotiation) {
             json(
@@ -45,6 +45,9 @@ fun createHttpClient(): HttpClient {
         }
         defaultRequest {
             header(HttpHeaders.Accept, "application/json")
+            apiKeyProvider.apiKey?.let {
+                header(HttpHeaders.Authorization, "Bearer $it")
+            }
         }
     }
 }

--- a/shared/src/commonMain/kotlin/com/riox432/civitdeck/data/api/dto/UserMeResponse.kt
+++ b/shared/src/commonMain/kotlin/com/riox432/civitdeck/data/api/dto/UserMeResponse.kt
@@ -1,0 +1,10 @@
+package com.riox432.civitdeck.data.api.dto
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class UserMeResponse(
+    val id: Long,
+    val username: String,
+    val image: String? = null,
+)

--- a/shared/src/commonMain/kotlin/com/riox432/civitdeck/data/local/CivitDeckDatabase.kt
+++ b/shared/src/commonMain/kotlin/com/riox432/civitdeck/data/local/CivitDeckDatabase.kt
@@ -38,7 +38,7 @@ import kotlinx.coroutines.IO
         ExcludedTagEntity::class,
         HiddenModelEntity::class,
     ],
-    version = 5,
+    version = 6,
 )
 @ConstructedBy(CivitDeckDatabaseConstructor::class)
 abstract class CivitDeckDatabase : RoomDatabase() {
@@ -142,9 +142,17 @@ val MIGRATION_4_5 = object : Migration(4, 5) {
     }
 }
 
+val MIGRATION_5_6 = object : Migration(5, 6) {
+    override fun migrate(connection: SQLiteConnection) {
+        connection.execSQL(
+            "ALTER TABLE user_preferences ADD COLUMN apiKey TEXT DEFAULT NULL",
+        )
+    }
+}
+
 fun getRoomDatabase(builder: RoomDatabase.Builder<CivitDeckDatabase>): CivitDeckDatabase {
     return builder
-        .addMigrations(MIGRATION_1_2, MIGRATION_2_3, MIGRATION_3_4, MIGRATION_4_5)
+        .addMigrations(MIGRATION_1_2, MIGRATION_2_3, MIGRATION_3_4, MIGRATION_4_5, MIGRATION_5_6)
         .setDriver(BundledSQLiteDriver())
         .setQueryCoroutineContext(Dispatchers.IO)
         .build()

--- a/shared/src/commonMain/kotlin/com/riox432/civitdeck/data/local/entity/UserPreferencesEntity.kt
+++ b/shared/src/commonMain/kotlin/com/riox432/civitdeck/data/local/entity/UserPreferencesEntity.kt
@@ -10,4 +10,5 @@ data class UserPreferencesEntity(
     val defaultSortOrder: String = "MostDownloaded",
     val defaultTimePeriod: String = "AllTime",
     val gridColumns: Int = 2,
+    val apiKey: String? = null,
 )

--- a/shared/src/commonMain/kotlin/com/riox432/civitdeck/data/repository/UserPreferencesRepositoryImpl.kt
+++ b/shared/src/commonMain/kotlin/com/riox432/civitdeck/data/repository/UserPreferencesRepositoryImpl.kt
@@ -1,5 +1,6 @@
 package com.riox432.civitdeck.data.repository
 
+import com.riox432.civitdeck.data.api.ApiKeyProvider
 import com.riox432.civitdeck.data.local.dao.UserPreferencesDao
 import com.riox432.civitdeck.data.local.entity.UserPreferencesEntity
 import com.riox432.civitdeck.domain.model.NsfwFilterLevel
@@ -11,6 +12,7 @@ import kotlinx.coroutines.flow.map
 
 class UserPreferencesRepositoryImpl(
     private val dao: UserPreferencesDao,
+    private val apiKeyProvider: ApiKeyProvider,
 ) : UserPreferencesRepository {
 
     override fun observeNsfwFilterLevel(): Flow<NsfwFilterLevel> =
@@ -53,4 +55,16 @@ class UserPreferencesRepositoryImpl(
         val existing = dao.getPreferences() ?: UserPreferencesEntity()
         dao.upsert(existing.copy(gridColumns = columns))
     }
+
+    override fun observeApiKey(): Flow<String?> =
+        dao.observePreferences().map { it?.apiKey }
+
+    override suspend fun setApiKey(apiKey: String?) {
+        val existing = dao.getPreferences() ?: UserPreferencesEntity()
+        dao.upsert(existing.copy(apiKey = apiKey))
+        apiKeyProvider.apiKey = apiKey
+    }
+
+    override suspend fun getApiKey(): String? =
+        dao.getPreferences()?.apiKey
 }

--- a/shared/src/commonMain/kotlin/com/riox432/civitdeck/di/DataModule.kt
+++ b/shared/src/commonMain/kotlin/com/riox432/civitdeck/di/DataModule.kt
@@ -1,5 +1,6 @@
 package com.riox432.civitdeck.di
 
+import com.riox432.civitdeck.data.api.ApiKeyProvider
 import com.riox432.civitdeck.data.api.CivitAiApi
 import com.riox432.civitdeck.data.api.createHttpClient
 import com.riox432.civitdeck.data.local.CivitDeckDatabase
@@ -31,7 +32,8 @@ import kotlinx.serialization.json.Json
 import org.koin.dsl.module
 
 val dataModule = module {
-    single { createHttpClient() }
+    single { ApiKeyProvider() }
+    single { createHttpClient(get()) }
     single { CivitAiApi(get()) }
     single {
         Json {
@@ -61,7 +63,7 @@ val dataModule = module {
     single<CreatorRepository> { CreatorRepositoryImpl(get()) }
     single<TagRepository> { TagRepositoryImpl(get()) }
     single<FavoriteRepository> { FavoriteRepositoryImpl(get()) }
-    single<UserPreferencesRepository> { UserPreferencesRepositoryImpl(get()) }
+    single<UserPreferencesRepository> { UserPreferencesRepositoryImpl(get(), get()) }
     single<SavedPromptRepository> { SavedPromptRepositoryImpl(get()) }
     single<SearchHistoryRepository> { SearchHistoryRepositoryImpl(get()) }
     single<BrowsingHistoryRepository> { BrowsingHistoryRepositoryImpl(get()) }

--- a/shared/src/commonMain/kotlin/com/riox432/civitdeck/di/DomainModule.kt
+++ b/shared/src/commonMain/kotlin/com/riox432/civitdeck/di/DomainModule.kt
@@ -17,6 +17,7 @@ import com.riox432.civitdeck.domain.usecase.GetModelsUseCase
 import com.riox432.civitdeck.domain.usecase.GetRecommendationsUseCase
 import com.riox432.civitdeck.domain.usecase.GetViewedModelIdsUseCase
 import com.riox432.civitdeck.domain.usecase.HideModelUseCase
+import com.riox432.civitdeck.domain.usecase.ObserveApiKeyUseCase
 import com.riox432.civitdeck.domain.usecase.ObserveDefaultSortOrderUseCase
 import com.riox432.civitdeck.domain.usecase.ObserveDefaultTimePeriodUseCase
 import com.riox432.civitdeck.domain.usecase.ObserveFavoritesUseCase
@@ -27,6 +28,7 @@ import com.riox432.civitdeck.domain.usecase.ObserveSavedPromptsUseCase
 import com.riox432.civitdeck.domain.usecase.ObserveSearchHistoryUseCase
 import com.riox432.civitdeck.domain.usecase.RemoveExcludedTagUseCase
 import com.riox432.civitdeck.domain.usecase.SavePromptUseCase
+import com.riox432.civitdeck.domain.usecase.SetApiKeyUseCase
 import com.riox432.civitdeck.domain.usecase.SetDefaultSortOrderUseCase
 import com.riox432.civitdeck.domain.usecase.SetDefaultTimePeriodUseCase
 import com.riox432.civitdeck.domain.usecase.SetGridColumnsUseCase
@@ -34,6 +36,7 @@ import com.riox432.civitdeck.domain.usecase.SetNsfwFilterUseCase
 import com.riox432.civitdeck.domain.usecase.ToggleFavoriteUseCase
 import com.riox432.civitdeck.domain.usecase.TrackModelViewUseCase
 import com.riox432.civitdeck.domain.usecase.UnhideModelUseCase
+import com.riox432.civitdeck.domain.usecase.ValidateApiKeyUseCase
 import org.koin.dsl.module
 
 val domainModule = module {
@@ -71,4 +74,7 @@ val domainModule = module {
     factory { GetHiddenModelsUseCase(get()) }
     factory { ClearBrowsingHistoryUseCase(get()) }
     factory { ClearCacheUseCase(get()) }
+    factory { ObserveApiKeyUseCase(get()) }
+    factory { SetApiKeyUseCase(get()) }
+    factory { ValidateApiKeyUseCase(get()) }
 }

--- a/shared/src/commonMain/kotlin/com/riox432/civitdeck/di/Koin.kt
+++ b/shared/src/commonMain/kotlin/com/riox432/civitdeck/di/Koin.kt
@@ -1,8 +1,11 @@
 package com.riox432.civitdeck.di
 
+import com.riox432.civitdeck.data.api.ApiKeyProvider
+import com.riox432.civitdeck.domain.repository.UserPreferencesRepository
 import org.koin.core.context.startKoin
 import org.koin.core.module.Module
 import org.koin.dsl.KoinAppDeclaration
+import org.koin.mp.KoinPlatform
 
 val sharedModules: List<Module>
     get() = listOf(
@@ -16,4 +19,10 @@ fun initKoin(appDeclaration: KoinAppDeclaration = {}) {
         appDeclaration()
         modules(sharedModules)
     }
+}
+
+suspend fun initializeAuth() {
+    val repository: UserPreferencesRepository = KoinPlatform.getKoin().get()
+    val provider: ApiKeyProvider = KoinPlatform.getKoin().get()
+    provider.apiKey = repository.getApiKey()
 }

--- a/shared/src/commonMain/kotlin/com/riox432/civitdeck/domain/repository/UserPreferencesRepository.kt
+++ b/shared/src/commonMain/kotlin/com/riox432/civitdeck/domain/repository/UserPreferencesRepository.kt
@@ -5,6 +5,7 @@ import com.riox432.civitdeck.domain.model.SortOrder
 import com.riox432.civitdeck.domain.model.TimePeriod
 import kotlinx.coroutines.flow.Flow
 
+@Suppress("TooManyFunctions")
 interface UserPreferencesRepository {
     fun observeNsfwFilterLevel(): Flow<NsfwFilterLevel>
     suspend fun setNsfwFilterLevel(level: NsfwFilterLevel)
@@ -14,4 +15,7 @@ interface UserPreferencesRepository {
     suspend fun setDefaultTimePeriod(period: TimePeriod)
     fun observeGridColumns(): Flow<Int>
     suspend fun setGridColumns(columns: Int)
+    fun observeApiKey(): Flow<String?>
+    suspend fun setApiKey(apiKey: String?)
+    suspend fun getApiKey(): String?
 }

--- a/shared/src/commonMain/kotlin/com/riox432/civitdeck/domain/usecase/AuthUseCases.kt
+++ b/shared/src/commonMain/kotlin/com/riox432/civitdeck/domain/usecase/AuthUseCases.kt
@@ -1,0 +1,19 @@
+package com.riox432.civitdeck.domain.usecase
+
+import com.riox432.civitdeck.data.api.CivitAiApi
+import com.riox432.civitdeck.domain.repository.UserPreferencesRepository
+import kotlinx.coroutines.flow.Flow
+
+class ObserveApiKeyUseCase(private val repository: UserPreferencesRepository) {
+    operator fun invoke(): Flow<String?> = repository.observeApiKey()
+}
+
+class SetApiKeyUseCase(private val repository: UserPreferencesRepository) {
+    suspend operator fun invoke(apiKey: String?) = repository.setApiKey(apiKey)
+}
+
+class ValidateApiKeyUseCase(private val api: CivitAiApi) {
+    suspend operator fun invoke(apiKey: String): String {
+        return api.getMe(apiKey).username
+    }
+}

--- a/shared/src/iosMain/kotlin/com/riox432/civitdeck/di/KoinHelper.kt
+++ b/shared/src/iosMain/kotlin/com/riox432/civitdeck/di/KoinHelper.kt
@@ -1,5 +1,6 @@
 package com.riox432.civitdeck.di
 
+import com.riox432.civitdeck.data.api.ApiKeyProvider
 import com.riox432.civitdeck.domain.usecase.AddExcludedTagUseCase
 import com.riox432.civitdeck.domain.usecase.AddSearchHistoryUseCase
 import com.riox432.civitdeck.domain.usecase.ClearBrowsingHistoryUseCase
@@ -17,6 +18,7 @@ import com.riox432.civitdeck.domain.usecase.GetModelsUseCase
 import com.riox432.civitdeck.domain.usecase.GetRecommendationsUseCase
 import com.riox432.civitdeck.domain.usecase.GetViewedModelIdsUseCase
 import com.riox432.civitdeck.domain.usecase.HideModelUseCase
+import com.riox432.civitdeck.domain.usecase.ObserveApiKeyUseCase
 import com.riox432.civitdeck.domain.usecase.ObserveDefaultSortOrderUseCase
 import com.riox432.civitdeck.domain.usecase.ObserveDefaultTimePeriodUseCase
 import com.riox432.civitdeck.domain.usecase.ObserveFavoritesUseCase
@@ -27,6 +29,7 @@ import com.riox432.civitdeck.domain.usecase.ObserveSavedPromptsUseCase
 import com.riox432.civitdeck.domain.usecase.ObserveSearchHistoryUseCase
 import com.riox432.civitdeck.domain.usecase.RemoveExcludedTagUseCase
 import com.riox432.civitdeck.domain.usecase.SavePromptUseCase
+import com.riox432.civitdeck.domain.usecase.SetApiKeyUseCase
 import com.riox432.civitdeck.domain.usecase.SetDefaultSortOrderUseCase
 import com.riox432.civitdeck.domain.usecase.SetDefaultTimePeriodUseCase
 import com.riox432.civitdeck.domain.usecase.SetGridColumnsUseCase
@@ -34,6 +37,7 @@ import com.riox432.civitdeck.domain.usecase.SetNsfwFilterUseCase
 import com.riox432.civitdeck.domain.usecase.ToggleFavoriteUseCase
 import com.riox432.civitdeck.domain.usecase.TrackModelViewUseCase
 import com.riox432.civitdeck.domain.usecase.UnhideModelUseCase
+import com.riox432.civitdeck.domain.usecase.ValidateApiKeyUseCase
 import org.koin.mp.KoinPlatform.getKoin
 
 @Suppress("TooManyFunctions")
@@ -72,4 +76,8 @@ object KoinHelper {
     fun getClearBrowsingHistoryUseCase(): ClearBrowsingHistoryUseCase = getKoin().get()
     fun getClearCacheUseCase(): ClearCacheUseCase = getKoin().get()
     fun getEnrichModelImagesUseCase(): EnrichModelImagesUseCase = getKoin().get()
+    fun getObserveApiKeyUseCase(): ObserveApiKeyUseCase = getKoin().get()
+    fun getSetApiKeyUseCase(): SetApiKeyUseCase = getKoin().get()
+    fun getValidateApiKeyUseCase(): ValidateApiKeyUseCase = getKoin().get()
+    fun getApiKeyProvider(): ApiKeyProvider = getKoin().get()
 }


### PR DESCRIPTION
## Description

Foundation implementation of CivitAI API key authentication. Adds an Account section to the Settings screen, enabling API key input, verification, storage, and deletion. Authenticated requests automatically include an `Authorization: Bearer` header.

- `ApiKeyProvider` + `HttpClientFactory` auto-inject Bearer token into all API requests
- Key verification via `GET /api/v1/me`; displays username on success
- API key persisted in Room DB (MIGRATION_5_6)
- Account section added to Settings on both Android and iOS

## Related Issues

Closes #119

<!-- ## Screenshots / Video -->

<!-- If applicable, add screenshots or screen recordings -->

## Test Plan

- [ ] Android: Settings → Account section is displayed
- [ ] Enter API key → Verify → Username shown on success
- [ ] Invalid key shows error message
- [ ] Disconnect → Confirmation dialog → Key deleted
- [ ] API key persists after app restart
- [ ] iOS: Same as above

## Review Checklist

- [x] Code follows project architecture (Clean Architecture + MVVM)
- [x] Shared logic is in `commonMain`, platform-specific code only when necessary
- [x] No unnecessary dependencies added
- [ ] Tests added/updated as needed

## Breaking Changes

DB version 5 → 6 (auto-migration via MIGRATION_5_6)