### PR TITLE
Add unit tests for use cases, repositories, and ViewModels

### DIFF
--- a/androidApp/build.gradle.kts
+++ b/androidApp/build.gradle.kts
@@ -50,6 +50,10 @@ kotlin {
 }
 
 dependencies {
+    testImplementation(libs.kotlin.test)
+    testImplementation(libs.kotlinx.coroutines.test)
+    testImplementation(libs.turbine)
+
     implementation(project(":shared"))
     implementation(compose.material3)
     implementation(compose.materialIconsExtended)

--- a/androidApp/src/test/kotlin/com/riox432/civitdeck/ui/creator/CreatorProfileViewModelTest.kt
+++ b/androidApp/src/test/kotlin/com/riox432/civitdeck/ui/creator/CreatorProfileViewModelTest.kt
@@ -1,0 +1,172 @@
+package com.riox432.civitdeck.ui.creator
+
+import com.riox432.civitdeck.domain.model.BaseModel
+import com.riox432.civitdeck.domain.model.Creator
+import com.riox432.civitdeck.domain.model.Model
+import com.riox432.civitdeck.domain.model.ModelStats
+import com.riox432.civitdeck.domain.model.ModelType
+import com.riox432.civitdeck.domain.model.PageMetadata
+import com.riox432.civitdeck.domain.model.PaginatedResult
+import com.riox432.civitdeck.domain.model.SortOrder
+import com.riox432.civitdeck.domain.model.TimePeriod
+import com.riox432.civitdeck.domain.repository.ModelRepository
+import com.riox432.civitdeck.domain.usecase.GetCreatorModelsUseCase
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.setMain
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class CreatorProfileViewModelTest {
+
+    private val testDispatcher = UnconfinedTestDispatcher()
+
+    @BeforeTest
+    fun setup() {
+        Dispatchers.setMain(testDispatcher)
+    }
+
+    @AfterTest
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    private fun testModel(id: Long) = Model(
+        id = id, name = "Model $id", description = null,
+        type = ModelType.Checkpoint, nsfw = false, tags = emptyList(), mode = null,
+        creator = Creator("testuser", null, null, null),
+        stats = ModelStats(100, 50, 10, 20, 4.5),
+        modelVersions = emptyList(),
+    )
+
+    private class FakeRepo(
+        private val pages: List<PaginatedResult<Model>>,
+    ) : ModelRepository {
+        var callCount = 0
+
+        override suspend fun getModels(
+            query: String?,
+            tag: String?,
+            type: ModelType?,
+            sort: SortOrder?,
+            period: TimePeriod?,
+            baseModels: List<BaseModel>?,
+            cursor: String?,
+            limit: Int?,
+            username: String?,
+            nsfw: Boolean?,
+        ): PaginatedResult<Model> {
+            val result = pages.getOrElse(callCount) { pages.last() }
+            callCount++
+            return result
+        }
+
+        override suspend fun getModel(id: Long) = error("not used")
+        override suspend fun getModelVersion(id: Long) = error("not used")
+        override suspend fun getModelVersionByHash(hash: String) = error("not used")
+    }
+
+    @Test
+    fun loads_initial_models() {
+        val models = listOf(testModel(1L), testModel(2L))
+        val repo = FakeRepo(
+            listOf(PaginatedResult(models, PageMetadata(nextCursor = null, nextPage = null))),
+        )
+        val vm = CreatorProfileViewModel("testuser", GetCreatorModelsUseCase(repo))
+        val state = vm.uiState.value
+        assertEquals(2, state.models.size)
+        assertFalse(state.isLoading)
+        assertFalse(state.hasMore) // no nextCursor
+    }
+
+    @Test
+    fun loadMore_appends_models() {
+        val page1 = PaginatedResult(
+            listOf(testModel(1L)),
+            PageMetadata(nextCursor = "cursor2", nextPage = null),
+        )
+        val page2 = PaginatedResult(
+            listOf(testModel(2L)),
+            PageMetadata(nextCursor = null, nextPage = null),
+        )
+        val repo = FakeRepo(listOf(page1, page2))
+        val vm = CreatorProfileViewModel("testuser", GetCreatorModelsUseCase(repo))
+        assertEquals(1, vm.uiState.value.models.size)
+        assertTrue(vm.uiState.value.hasMore)
+
+        vm.loadMore()
+        assertEquals(2, vm.uiState.value.models.size)
+        assertFalse(vm.uiState.value.hasMore)
+    }
+
+    @Test
+    fun error_state_on_failure() {
+        val failingRepo = object : ModelRepository {
+            override suspend fun getModels(
+                query: String?,
+                tag: String?,
+                type: ModelType?,
+                sort: SortOrder?,
+                period: TimePeriod?,
+                baseModels: List<BaseModel>?,
+                cursor: String?,
+                limit: Int?,
+                username: String?,
+                nsfw: Boolean?,
+            ): PaginatedResult<Model> = error("Network error")
+            override suspend fun getModel(id: Long) = error("not used")
+            override suspend fun getModelVersion(id: Long) = error("not used")
+            override suspend fun getModelVersionByHash(hash: String) = error("not used")
+        }
+        val vm = CreatorProfileViewModel("testuser", GetCreatorModelsUseCase(failingRepo))
+        assertEquals("Network error", vm.uiState.value.error)
+        assertFalse(vm.uiState.value.isLoading)
+    }
+
+    @Test
+    fun refresh_reloads_from_scratch() {
+        val page1 = PaginatedResult(
+            listOf(testModel(1L)),
+            PageMetadata(nextCursor = "cursor2", nextPage = null),
+        )
+        val page2 = PaginatedResult(
+            listOf(testModel(10L), testModel(11L)),
+            PageMetadata(nextCursor = null, nextPage = null),
+        )
+        val repo = FakeRepo(listOf(page1, page2))
+        val vm = CreatorProfileViewModel("testuser", GetCreatorModelsUseCase(repo))
+        assertEquals(1, vm.uiState.value.models.size)
+
+        vm.refresh()
+        // After refresh, should have page2 content
+        assertEquals(2, vm.uiState.value.models.size)
+        assertEquals(10L, vm.uiState.value.models[0].id)
+    }
+
+    @Test
+    fun loadMore_noop_when_no_more_pages() {
+        val repo = FakeRepo(
+            listOf(PaginatedResult(listOf(testModel(1L)), PageMetadata(null, null))),
+        )
+        val vm = CreatorProfileViewModel("testuser", GetCreatorModelsUseCase(repo))
+        assertFalse(vm.uiState.value.hasMore)
+        vm.loadMore() // should not call repo again
+        assertEquals(1, repo.callCount) // only initial load
+    }
+
+    @Test
+    fun username_is_set_in_state() {
+        val repo = FakeRepo(
+            listOf(PaginatedResult(emptyList(), PageMetadata(null, null))),
+        )
+        val vm = CreatorProfileViewModel("artist123", GetCreatorModelsUseCase(repo))
+        assertEquals("artist123", vm.uiState.value.username)
+    }
+}

--- a/androidApp/src/test/kotlin/com/riox432/civitdeck/ui/detail/ModelDetailViewModelTest.kt
+++ b/androidApp/src/test/kotlin/com/riox432/civitdeck/ui/detail/ModelDetailViewModelTest.kt
@@ -1,0 +1,257 @@
+package com.riox432.civitdeck.ui.detail
+
+import com.riox432.civitdeck.domain.model.BaseModel
+import com.riox432.civitdeck.domain.model.Creator
+import com.riox432.civitdeck.domain.model.Model
+import com.riox432.civitdeck.domain.model.ModelImage
+import com.riox432.civitdeck.domain.model.ModelStats
+import com.riox432.civitdeck.domain.model.ModelType
+import com.riox432.civitdeck.domain.model.ModelVersion
+import com.riox432.civitdeck.domain.model.NsfwFilterLevel
+import com.riox432.civitdeck.domain.model.NsfwLevel
+import com.riox432.civitdeck.domain.model.PaginatedResult
+import com.riox432.civitdeck.domain.model.SortOrder
+import com.riox432.civitdeck.domain.model.TimePeriod
+import com.riox432.civitdeck.domain.repository.BrowsingHistoryRepository
+import com.riox432.civitdeck.domain.repository.FavoriteRepository
+import com.riox432.civitdeck.domain.repository.ModelRepository
+import com.riox432.civitdeck.domain.repository.UserPreferencesRepository
+import com.riox432.civitdeck.domain.usecase.EnrichModelImagesUseCase
+import com.riox432.civitdeck.domain.usecase.GetModelDetailUseCase
+import com.riox432.civitdeck.domain.usecase.ObserveIsFavoriteUseCase
+import com.riox432.civitdeck.domain.usecase.ObserveNsfwFilterUseCase
+import com.riox432.civitdeck.domain.usecase.ToggleFavoriteUseCase
+import com.riox432.civitdeck.domain.usecase.TrackModelViewUseCase
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.setMain
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class ModelDetailViewModelTest {
+
+    private val testDispatcher = UnconfinedTestDispatcher()
+
+    @BeforeTest
+    fun setup() {
+        Dispatchers.setMain(testDispatcher)
+    }
+
+    @AfterTest
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    private fun testModel(id: Long = 1L) = Model(
+        id = id,
+        name = "Test Model",
+        description = "A test model",
+        type = ModelType.Checkpoint,
+        nsfw = false,
+        tags = listOf("anime"),
+        mode = null,
+        creator = Creator("testuser", null, null, null),
+        stats = ModelStats(100, 50, 10, 20, 4.5),
+        modelVersions = listOf(
+            ModelVersion(
+                id = 10L, modelId = id, name = "v1.0", description = null,
+                createdAt = "2024-01-01", baseModel = "SD 1.5",
+                trainedWords = emptyList(), downloadUrl = "https://example.com",
+                files = emptyList(),
+                images = listOf(
+                    ModelImage(
+                        url = "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/uuid1/photo.jpeg",
+                        nsfw = false,
+                        nsfwLevel = NsfwLevel.None,
+                        width = 512,
+                        height = 512,
+                        hash = null,
+                        meta = null,
+                    ),
+                ),
+                stats = null,
+            ),
+        ),
+    )
+
+    private class FakeModelRepo(val model: Model) : ModelRepository {
+        var getModelCalled = false
+
+        override suspend fun getModels(
+            query: String?,
+            tag: String?,
+            type: ModelType?,
+            sort: SortOrder?,
+            period: TimePeriod?,
+            baseModels: List<BaseModel>?,
+            cursor: String?,
+            limit: Int?,
+            username: String?,
+            nsfw: Boolean?,
+        ): PaginatedResult<Model> = error("not used")
+
+        override suspend fun getModel(id: Long): Model {
+            getModelCalled = true
+            return model
+        }
+
+        override suspend fun getModelVersion(id: Long) = model.modelVersions.first()
+        override suspend fun getModelVersionByHash(hash: String): ModelVersion =
+            error("not used")
+    }
+
+    private class FakeFavoriteRepo(
+        private val isFav: MutableStateFlow<Boolean> = MutableStateFlow(false),
+    ) : FavoriteRepository {
+        var toggleCalled = false
+
+        override fun observeFavorites() =
+            flowOf(emptyList<com.riox432.civitdeck.domain.model.FavoriteModelSummary>())
+        override fun observeIsFavorite(modelId: Long): Flow<Boolean> = isFav
+        override suspend fun toggleFavorite(model: Model) { toggleCalled = true }
+        override suspend fun addFavorite(model: Model) = error("not used")
+        override suspend fun removeFavorite(modelId: Long) = error("not used")
+        override suspend fun getAllFavoriteIds() = error("not used")
+        override suspend fun getFavoriteTypeCounts() = error("not used")
+    }
+
+    private class FakeBrowsingRepo : BrowsingHistoryRepository {
+        var trackCalled = false
+        override suspend fun trackView(
+            modelId: Long,
+            modelType: String,
+            creatorName: String?,
+            tags: List<String>,
+        ) { trackCalled = true }
+        override suspend fun getRecentTypes(limit: Int) = error("not used")
+        override suspend fun getRecentCreators(limit: Int) = error("not used")
+        override suspend fun getRecentTags(limit: Int) = error("not used")
+        override suspend fun getRecentModelIds(limit: Int) = error("not used")
+        override suspend fun getAllViewedModelIds() = error("not used")
+        override suspend fun clearAll() = error("not used")
+    }
+
+    @Suppress("TooManyFunctions")
+    private class FakePrefsRepo : UserPreferencesRepository {
+        override fun observeNsfwFilterLevel() = flowOf(NsfwFilterLevel.Off)
+        override suspend fun setNsfwFilterLevel(level: NsfwFilterLevel) = error("not used")
+        override fun observeDefaultSortOrder(): Flow<SortOrder> = error("not used")
+        override suspend fun setDefaultSortOrder(sort: SortOrder) = error("not used")
+        override fun observeDefaultTimePeriod(): Flow<TimePeriod> = error("not used")
+        override suspend fun setDefaultTimePeriod(period: TimePeriod) = error("not used")
+        override fun observeGridColumns(): Flow<Int> = error("not used")
+        override suspend fun setGridColumns(columns: Int) = error("not used")
+        override fun observeApiKey(): Flow<String?> = error("not used")
+        override suspend fun setApiKey(apiKey: String?) = error("not used")
+        override suspend fun getApiKey() = error("not used")
+    }
+
+    private fun createViewModel(
+        model: Model = testModel(),
+        isFavorite: Boolean = false,
+    ): Triple<ModelDetailViewModel, FakeModelRepo, FakeFavoriteRepo> {
+        val modelRepo = FakeModelRepo(model)
+        val favRepo = FakeFavoriteRepo(MutableStateFlow(isFavorite))
+        val browsingRepo = FakeBrowsingRepo()
+        val prefsRepo = FakePrefsRepo()
+
+        val vm = ModelDetailViewModel(
+            modelId = model.id,
+            getModelDetailUseCase = GetModelDetailUseCase(modelRepo),
+            observeIsFavoriteUseCase = ObserveIsFavoriteUseCase(favRepo),
+            toggleFavoriteUseCase = ToggleFavoriteUseCase(favRepo),
+            trackModelViewUseCase = TrackModelViewUseCase(browsingRepo),
+            observeNsfwFilterUseCase = ObserveNsfwFilterUseCase(prefsRepo),
+            enrichModelImagesUseCase = EnrichModelImagesUseCase(modelRepo),
+        )
+        return Triple(vm, modelRepo, favRepo)
+    }
+
+    @Test
+    fun loads_model_on_init() {
+        val (vm, modelRepo, _) = createViewModel()
+        val state = vm.uiState.value
+        assertFalse(state.isLoading)
+        assertNull(state.error)
+        assertEquals("Test Model", state.model?.name)
+        assertTrue(modelRepo.getModelCalled)
+    }
+
+    @Test
+    fun shows_error_on_load_failure() {
+        val failingRepo = object : ModelRepository {
+            override suspend fun getModels(
+                query: String?,
+                tag: String?,
+                type: ModelType?,
+                sort: SortOrder?,
+                period: TimePeriod?,
+                baseModels: List<BaseModel>?,
+                cursor: String?,
+                limit: Int?,
+                username: String?,
+                nsfw: Boolean?,
+            ): PaginatedResult<Model> = error("not used")
+            override suspend fun getModel(id: Long): Model = error("API error")
+            override suspend fun getModelVersion(id: Long): ModelVersion = error("not used")
+            override suspend fun getModelVersionByHash(hash: String): ModelVersion =
+                error("not used")
+        }
+
+        val vm = ModelDetailViewModel(
+            modelId = 1L,
+            getModelDetailUseCase = GetModelDetailUseCase(failingRepo),
+            observeIsFavoriteUseCase = ObserveIsFavoriteUseCase(FakeFavoriteRepo()),
+            toggleFavoriteUseCase = ToggleFavoriteUseCase(FakeFavoriteRepo()),
+            trackModelViewUseCase = TrackModelViewUseCase(FakeBrowsingRepo()),
+            observeNsfwFilterUseCase = ObserveNsfwFilterUseCase(FakePrefsRepo()),
+            enrichModelImagesUseCase = EnrichModelImagesUseCase(failingRepo),
+        )
+
+        val state = vm.uiState.value
+        assertFalse(state.isLoading)
+        assertEquals("API error", state.error)
+        assertNull(state.model)
+    }
+
+    @Test
+    fun observes_favorite_state() {
+        val (vm, _, _) = createViewModel(isFavorite = true)
+        assertTrue(vm.uiState.value.isFavorite)
+    }
+
+    @Test
+    fun toggle_favorite_calls_use_case() {
+        val (vm, _, favRepo) = createViewModel()
+        vm.onFavoriteToggle()
+        assertTrue(favRepo.toggleCalled)
+    }
+
+    @Test
+    fun version_selection_updates_state() {
+        val model = testModel().let { m ->
+            m.copy(
+                modelVersions = m.modelVersions + ModelVersion(
+                    id = 20L, modelId = m.id, name = "v2.0", description = null,
+                    createdAt = "2024-02-01", baseModel = "SD 1.5",
+                    trainedWords = emptyList(), downloadUrl = "https://example.com",
+                    files = emptyList(), images = emptyList(), stats = null,
+                ),
+            )
+        }
+        val (vm, _, _) = createViewModel(model = model)
+        vm.onVersionSelected(1)
+        assertEquals(1, vm.uiState.value.selectedVersionIndex)
+    }
+}

--- a/androidApp/src/test/kotlin/com/riox432/civitdeck/ui/favorites/FavoritesViewModelTest.kt
+++ b/androidApp/src/test/kotlin/com/riox432/civitdeck/ui/favorites/FavoritesViewModelTest.kt
@@ -1,0 +1,109 @@
+package com.riox432.civitdeck.ui.favorites
+
+import com.riox432.civitdeck.domain.model.FavoriteModelSummary
+import com.riox432.civitdeck.domain.model.ModelType
+import com.riox432.civitdeck.domain.model.NsfwFilterLevel
+import com.riox432.civitdeck.domain.model.SortOrder
+import com.riox432.civitdeck.domain.model.TimePeriod
+import com.riox432.civitdeck.domain.repository.FavoriteRepository
+import com.riox432.civitdeck.domain.repository.UserPreferencesRepository
+import com.riox432.civitdeck.domain.usecase.ObserveFavoritesUseCase
+import com.riox432.civitdeck.domain.usecase.ObserveGridColumnsUseCase
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class FavoritesViewModelTest {
+
+    private val testDispatcher = UnconfinedTestDispatcher()
+
+    @BeforeTest
+    fun setup() {
+        Dispatchers.setMain(testDispatcher)
+    }
+
+    @AfterTest
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    private val testFavorites = listOf(
+        FavoriteModelSummary(
+            id = 1L, name = "Model A", type = ModelType.Checkpoint,
+            nsfw = false, thumbnailUrl = null, creatorName = "artist",
+            downloadCount = 100, favoriteCount = 50, rating = 4.5, favoritedAt = 1000L,
+        ),
+    )
+
+    private fun createViewModel(
+        favorites: List<FavoriteModelSummary> = testFavorites,
+        gridColumns: Int = 2,
+    ): FavoritesViewModel {
+        val favRepo = object : FavoriteRepository {
+            override fun observeFavorites() = flowOf(favorites)
+            override fun observeIsFavorite(modelId: Long) = flowOf(false)
+            override suspend fun toggleFavorite(model: com.riox432.civitdeck.domain.model.Model) =
+                error("not used")
+            override suspend fun addFavorite(model: com.riox432.civitdeck.domain.model.Model) =
+                error("not used")
+            override suspend fun removeFavorite(modelId: Long) = error("not used")
+            override suspend fun getAllFavoriteIds() = error("not used")
+            override suspend fun getFavoriteTypeCounts() = error("not used")
+        }
+
+        @Suppress("TooManyFunctions")
+        val prefsRepo = object : UserPreferencesRepository {
+            override fun observeNsfwFilterLevel(): Flow<NsfwFilterLevel> = error("not used")
+            override suspend fun setNsfwFilterLevel(level: NsfwFilterLevel) = error("not used")
+            override fun observeDefaultSortOrder(): Flow<SortOrder> = error("not used")
+            override suspend fun setDefaultSortOrder(sort: SortOrder) = error("not used")
+            override fun observeDefaultTimePeriod(): Flow<TimePeriod> = error("not used")
+            override suspend fun setDefaultTimePeriod(period: TimePeriod) = error("not used")
+            override fun observeGridColumns(): Flow<Int> = flowOf(gridColumns)
+            override suspend fun setGridColumns(columns: Int) = error("not used")
+            override fun observeApiKey(): Flow<String?> = error("not used")
+            override suspend fun setApiKey(apiKey: String?) = error("not used")
+            override suspend fun getApiKey() = error("not used")
+        }
+
+        return FavoritesViewModel(
+            observeFavoritesUseCase = ObserveFavoritesUseCase(favRepo),
+            observeGridColumnsUseCase = ObserveGridColumnsUseCase(prefsRepo),
+        )
+    }
+
+    @Test
+    fun favorites_flow_emits_list() = runTest(testDispatcher) {
+        val vm = createViewModel()
+        // WhileSubscribed requires an active subscriber to start
+        val job = backgroundScope.launch(testDispatcher) { vm.favorites.collect {} }
+        assertEquals(testFavorites, vm.favorites.value)
+        job.cancel()
+    }
+
+    @Test
+    fun gridColumns_flow_emits_value() = runTest(testDispatcher) {
+        val vm = createViewModel(gridColumns = 3)
+        val job = backgroundScope.launch(testDispatcher) { vm.gridColumns.collect {} }
+        assertEquals(3, vm.gridColumns.value)
+        job.cancel()
+    }
+
+    @Test
+    fun empty_favorites_emits_empty_list() {
+        val vm = createViewModel(favorites = emptyList())
+        // Empty is the initial value, so no subscriber needed
+        assertEquals(emptyList(), vm.favorites.value)
+    }
+}

--- a/androidApp/src/test/kotlin/com/riox432/civitdeck/ui/gallery/ImageGalleryViewModelTest.kt
+++ b/androidApp/src/test/kotlin/com/riox432/civitdeck/ui/gallery/ImageGalleryViewModelTest.kt
@@ -1,0 +1,247 @@
+package com.riox432.civitdeck.ui.gallery
+
+import com.riox432.civitdeck.domain.model.Image
+import com.riox432.civitdeck.domain.model.ImageGenerationMeta
+import com.riox432.civitdeck.domain.model.NsfwFilterLevel
+import com.riox432.civitdeck.domain.model.NsfwLevel
+import com.riox432.civitdeck.domain.model.PageMetadata
+import com.riox432.civitdeck.domain.model.PaginatedResult
+import com.riox432.civitdeck.domain.model.SortOrder
+import com.riox432.civitdeck.domain.model.TimePeriod
+import com.riox432.civitdeck.domain.repository.ImageRepository
+import com.riox432.civitdeck.domain.repository.SavedPromptRepository
+import com.riox432.civitdeck.domain.repository.UserPreferencesRepository
+import com.riox432.civitdeck.domain.usecase.GetImagesUseCase
+import com.riox432.civitdeck.domain.usecase.ObserveNsfwFilterUseCase
+import com.riox432.civitdeck.domain.usecase.SavePromptUseCase
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.setMain
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class ImageGalleryViewModelTest {
+
+    private val testDispatcher = UnconfinedTestDispatcher()
+
+    @BeforeTest
+    fun setup() {
+        Dispatchers.setMain(testDispatcher)
+    }
+
+    @AfterTest
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    private fun testImage(id: Long, width: Int = 512, height: Int = 768) = Image(
+        id = id, url = "https://example.com/$id.png", hash = null,
+        width = width, height = height, nsfw = false, nsfwLevel = NsfwLevel.None,
+        createdAt = "2024-01-01", postId = null, username = "user",
+        stats = null, meta = null,
+    )
+
+    private class FakeImageRepo(
+        private val pages: List<PaginatedResult<Image>>,
+    ) : ImageRepository {
+        var callCount = 0
+
+        override suspend fun getImages(
+            modelId: Long?,
+            modelVersionId: Long?,
+            username: String?,
+            sort: SortOrder?,
+            period: TimePeriod?,
+            nsfwLevel: NsfwLevel?,
+            limit: Int?,
+            cursor: String?,
+        ): PaginatedResult<Image> {
+            val result = pages.getOrElse(callCount) { pages.last() }
+            callCount++
+            return result
+        }
+    }
+
+    private class FakeSavedPromptRepo : SavedPromptRepository {
+        var savedMeta: ImageGenerationMeta? = null
+
+        override suspend fun save(meta: ImageGenerationMeta, sourceImageUrl: String?) {
+            savedMeta = meta
+        }
+
+        override fun observeAll() = flowOf(emptyList<com.riox432.civitdeck.domain.model.SavedPrompt>())
+        override suspend fun delete(id: Long) = Unit
+    }
+
+    private fun fakePrefsRepo(
+        nsfwFlow: MutableStateFlow<NsfwFilterLevel> = MutableStateFlow(NsfwFilterLevel.Off),
+    ): UserPreferencesRepository = object : UserPreferencesRepository {
+        override fun observeNsfwFilterLevel() = nsfwFlow
+        override fun observeDefaultSortOrder() = flowOf(SortOrder.HighestRated)
+        override fun observeDefaultTimePeriod() = flowOf(TimePeriod.AllTime)
+        override fun observeGridColumns() = flowOf(2)
+        override fun observeApiKey() = flowOf(null)
+        override suspend fun setNsfwFilterLevel(level: NsfwFilterLevel) = Unit
+        override suspend fun setDefaultSortOrder(sort: SortOrder) = Unit
+        override suspend fun setDefaultTimePeriod(period: TimePeriod) = Unit
+        override suspend fun setGridColumns(columns: Int) = Unit
+        override suspend fun setApiKey(apiKey: String?) = Unit
+        override suspend fun getApiKey(): String? = null
+    }
+
+    private fun createVm(
+        imageRepo: FakeImageRepo,
+        savedPromptRepo: FakeSavedPromptRepo = FakeSavedPromptRepo(),
+        prefsRepo: UserPreferencesRepository = fakePrefsRepo(),
+    ): ImageGalleryViewModel = ImageGalleryViewModel(
+        modelVersionId = 100L,
+        getImagesUseCase = GetImagesUseCase(imageRepo),
+        savePromptUseCase = SavePromptUseCase(savedPromptRepo),
+        observeNsfwFilterUseCase = ObserveNsfwFilterUseCase(prefsRepo),
+    )
+
+    @Test
+    fun loads_initial_images() {
+        val images = listOf(testImage(1L), testImage(2L))
+        val repo = FakeImageRepo(
+            listOf(PaginatedResult(images, PageMetadata(null, null))),
+        )
+        val vm = createVm(repo)
+        assertEquals(2, vm.uiState.value.allImages.size)
+        assertFalse(vm.uiState.value.isLoading)
+        assertFalse(vm.uiState.value.hasMore)
+    }
+
+    @Test
+    fun loadMore_appends_images() {
+        val page1 = PaginatedResult(
+            listOf(testImage(1L)),
+            PageMetadata(nextCursor = "c2", nextPage = null),
+        )
+        val page2 = PaginatedResult(
+            listOf(testImage(2L)),
+            PageMetadata(nextCursor = null, nextPage = null),
+        )
+        val repo = FakeImageRepo(listOf(page1, page2))
+        val vm = createVm(repo)
+        assertTrue(vm.uiState.value.hasMore)
+
+        vm.loadMore()
+        assertEquals(2, vm.uiState.value.allImages.size)
+        assertFalse(vm.uiState.value.hasMore)
+    }
+
+    @Test
+    fun error_state_on_failure() {
+        val failingRepo = object : ImageRepository {
+            override suspend fun getImages(
+                modelId: Long?,
+                modelVersionId: Long?,
+                username: String?,
+                sort: SortOrder?,
+                period: TimePeriod?,
+                nsfwLevel: NsfwLevel?,
+                limit: Int?,
+                cursor: String?,
+            ) = error("API error")
+        }
+        val vm = ImageGalleryViewModel(
+            modelVersionId = 1L,
+            getImagesUseCase = GetImagesUseCase(failingRepo),
+            savePromptUseCase = SavePromptUseCase(FakeSavedPromptRepo()),
+            observeNsfwFilterUseCase = ObserveNsfwFilterUseCase(fakePrefsRepo()),
+        )
+        assertEquals("API error", vm.uiState.value.error)
+        assertFalse(vm.uiState.value.isLoading)
+    }
+
+    @Test
+    fun onSortSelected_reloads() {
+        val page1 = PaginatedResult(
+            listOf(testImage(1L)),
+            PageMetadata(null, null),
+        )
+        val page2 = PaginatedResult(
+            listOf(testImage(10L), testImage(11L)),
+            PageMetadata(null, null),
+        )
+        val repo = FakeImageRepo(listOf(page1, page2))
+        val vm = createVm(repo)
+        assertEquals(1, vm.uiState.value.allImages.size)
+
+        vm.onSortSelected(SortOrder.Newest)
+        assertEquals(SortOrder.Newest, vm.uiState.value.selectedSort)
+        assertEquals(2, vm.uiState.value.allImages.size)
+        assertEquals(10L, vm.uiState.value.allImages[0].id)
+    }
+
+    @Test
+    fun onPeriodSelected_reloads() {
+        val page1 = PaginatedResult(listOf(testImage(1L)), PageMetadata(null, null))
+        val page2 = PaginatedResult(listOf(testImage(20L)), PageMetadata(null, null))
+        val repo = FakeImageRepo(listOf(page1, page2))
+        val vm = createVm(repo)
+
+        vm.onPeriodSelected(TimePeriod.Month)
+        assertEquals(TimePeriod.Month, vm.uiState.value.selectedPeriod)
+        assertEquals(20L, vm.uiState.value.allImages[0].id)
+    }
+
+    @Test
+    fun onAspectRatioSelected_filters_images() {
+        // portrait: 512x768, landscape: 768x512, square: 512x512
+        val images = listOf(
+            testImage(1L, width = 512, height = 768),
+            testImage(2L, width = 768, height = 512),
+            testImage(3L, width = 512, height = 512),
+        )
+        val repo = FakeImageRepo(
+            listOf(PaginatedResult(images, PageMetadata(null, null))),
+        )
+        val vm = createVm(repo)
+        assertEquals(3, vm.uiState.value.images.size)
+
+        vm.onAspectRatioSelected(com.riox432.civitdeck.domain.model.AspectRatioFilter.Portrait)
+        assertEquals(1, vm.uiState.value.images.size)
+        assertEquals(1L, vm.uiState.value.images[0].id)
+
+        vm.onAspectRatioSelected(null)
+        assertEquals(3, vm.uiState.value.images.size)
+    }
+
+    @Test
+    fun onImageSelected_and_dismiss() {
+        val repo = FakeImageRepo(
+            listOf(PaginatedResult(listOf(testImage(1L)), PageMetadata(null, null))),
+        )
+        val vm = createVm(repo)
+        assertNull(vm.uiState.value.selectedImageIndex)
+
+        vm.onImageSelected(0)
+        assertEquals(0, vm.uiState.value.selectedImageIndex)
+
+        vm.onDismissViewer()
+        assertNull(vm.uiState.value.selectedImageIndex)
+    }
+
+    @Test
+    fun loadMore_noop_when_no_more_pages() {
+        val repo = FakeImageRepo(
+            listOf(PaginatedResult(listOf(testImage(1L)), PageMetadata(null, null))),
+        )
+        val vm = createVm(repo)
+        assertFalse(vm.uiState.value.hasMore)
+        vm.loadMore()
+        assertEquals(1, repo.callCount) // only initial load
+    }
+}

--- a/androidApp/src/test/kotlin/com/riox432/civitdeck/ui/prompts/SavedPromptsViewModelTest.kt
+++ b/androidApp/src/test/kotlin/com/riox432/civitdeck/ui/prompts/SavedPromptsViewModelTest.kt
@@ -1,0 +1,80 @@
+package com.riox432.civitdeck.ui.prompts
+
+import com.riox432.civitdeck.domain.model.ImageGenerationMeta
+import com.riox432.civitdeck.domain.model.SavedPrompt
+import com.riox432.civitdeck.domain.repository.SavedPromptRepository
+import com.riox432.civitdeck.domain.usecase.DeleteSavedPromptUseCase
+import com.riox432.civitdeck.domain.usecase.ObserveSavedPromptsUseCase
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class SavedPromptsViewModelTest {
+
+    private val testDispatcher = UnconfinedTestDispatcher()
+
+    @BeforeTest
+    fun setup() {
+        Dispatchers.setMain(testDispatcher)
+    }
+
+    @AfterTest
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    private val testPrompts = listOf(
+        SavedPrompt(
+            id = 1L, prompt = "1girl", negativePrompt = null, sampler = null,
+            steps = null, cfgScale = null, seed = null, modelName = null,
+            size = null, sourceImageUrl = null, savedAt = 1000L,
+        ),
+    )
+
+    private class FakeRepo(
+        private val prompts: List<SavedPrompt>,
+    ) : SavedPromptRepository {
+        var deletedId: Long? = null
+
+        override fun observeAll(): Flow<List<SavedPrompt>> = flowOf(prompts)
+        override suspend fun save(meta: ImageGenerationMeta, sourceImageUrl: String?) =
+            error("not used")
+        override suspend fun delete(id: Long) { deletedId = id }
+    }
+
+    @Test
+    fun prompts_flow_emits_list() = runTest(testDispatcher) {
+        val repo = FakeRepo(testPrompts)
+        val vm = SavedPromptsViewModel(
+            observeSavedPromptsUseCase = ObserveSavedPromptsUseCase(repo),
+            deleteSavedPromptUseCase = DeleteSavedPromptUseCase(repo),
+        )
+        val job = backgroundScope.launch(testDispatcher) { vm.prompts.collect {} }
+        assertEquals(1, vm.prompts.value.size)
+        assertEquals("1girl", vm.prompts.value[0].prompt)
+        job.cancel()
+    }
+
+    @Test
+    fun delete_calls_use_case() {
+        val repo = FakeRepo(testPrompts)
+        val vm = SavedPromptsViewModel(
+            observeSavedPromptsUseCase = ObserveSavedPromptsUseCase(repo),
+            deleteSavedPromptUseCase = DeleteSavedPromptUseCase(repo),
+        )
+        vm.delete(1L)
+        assertTrue(repo.deletedId == 1L)
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -65,6 +65,7 @@ detekt-formatting = { module = "io.gitlab.arturbosch.detekt:detekt-formatting", 
 # Test
 kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotlin" }
 kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version = "1.10.2" }
+turbine = { module = "app.cash.turbine:turbine", version = "1.2.0" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }

--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -51,6 +51,7 @@ kotlin {
         commonTest.dependencies {
             implementation(libs.kotlin.test)
             implementation(libs.kotlinx.coroutines.test)
+            implementation(libs.turbine)
         }
     }
 }

--- a/shared/src/commonTest/kotlin/com/riox432/civitdeck/TestFixtures.kt
+++ b/shared/src/commonTest/kotlin/com/riox432/civitdeck/TestFixtures.kt
@@ -1,0 +1,135 @@
+package com.riox432.civitdeck
+
+import com.riox432.civitdeck.domain.model.Creator
+import com.riox432.civitdeck.domain.model.FavoriteModelSummary
+import com.riox432.civitdeck.domain.model.Image
+import com.riox432.civitdeck.domain.model.ImageStats
+import com.riox432.civitdeck.domain.model.Model
+import com.riox432.civitdeck.domain.model.ModelStats
+import com.riox432.civitdeck.domain.model.ModelType
+import com.riox432.civitdeck.domain.model.ModelVersion
+import com.riox432.civitdeck.domain.model.NsfwLevel
+import com.riox432.civitdeck.domain.model.PageMetadata
+import com.riox432.civitdeck.domain.model.PaginatedResult
+import com.riox432.civitdeck.domain.model.SavedPrompt
+
+fun testModel(
+    id: Long = 1L,
+    name: String = "Test Model",
+    type: ModelType = ModelType.Checkpoint,
+    nsfw: Boolean = false,
+    tags: List<String> = emptyList(),
+    creatorName: String = "testuser",
+) = Model(
+    id = id,
+    name = name,
+    description = null,
+    type = type,
+    nsfw = nsfw,
+    tags = tags,
+    mode = null,
+    creator = Creator(username = creatorName, image = null, modelCount = null, link = null),
+    stats = ModelStats(
+        downloadCount = 100,
+        favoriteCount = 50,
+        commentCount = 10,
+        ratingCount = 20,
+        rating = 4.5,
+    ),
+    modelVersions = listOf(testModelVersion(modelId = id)),
+)
+
+fun testModelVersion(
+    id: Long = 1L,
+    modelId: Long = 1L,
+    nsfwLevel: NsfwLevel = NsfwLevel.None,
+) = ModelVersion(
+    id = id,
+    modelId = modelId,
+    name = "v1.0",
+    description = null,
+    createdAt = "2024-01-01",
+    baseModel = "SD 1.5",
+    trainedWords = emptyList(),
+    downloadUrl = "https://example.com/download",
+    files = emptyList(),
+    images = listOf(testModelImage(nsfwLevel = nsfwLevel)),
+    stats = null,
+)
+
+fun testModelImage(nsfwLevel: NsfwLevel = NsfwLevel.None) =
+    com.riox432.civitdeck.domain.model.ModelImage(
+        url = "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/test-uuid/original=true/photo.jpeg",
+        nsfw = nsfwLevel != NsfwLevel.None,
+        nsfwLevel = nsfwLevel,
+        width = 512,
+        height = 512,
+        hash = null,
+        meta = null,
+    )
+
+fun <T> testPaginatedResult(
+    items: List<T> = emptyList(),
+    nextCursor: String? = null,
+) = PaginatedResult(
+    items = items,
+    metadata = PageMetadata(nextCursor = nextCursor, nextPage = null),
+)
+
+fun testImage(
+    id: Long = 1L,
+    nsfwLevel: NsfwLevel = NsfwLevel.None,
+) = Image(
+    id = id,
+    url = "https://image.civitai.com/test/$id.jpg",
+    hash = null,
+    width = 512,
+    height = 512,
+    nsfw = nsfwLevel != NsfwLevel.None,
+    nsfwLevel = nsfwLevel,
+    createdAt = "2024-01-01",
+    postId = null,
+    username = "testuser",
+    stats = ImageStats(
+        cryCount = 0,
+        laughCount = 0,
+        likeCount = 10,
+        heartCount = 5,
+        commentCount = 2,
+    ),
+    meta = null,
+)
+
+fun testFavoriteModelSummary(
+    id: Long = 1L,
+    name: String = "Fav Model",
+    type: ModelType = ModelType.Checkpoint,
+) = FavoriteModelSummary(
+    id = id,
+    name = name,
+    type = type,
+    nsfw = false,
+    thumbnailUrl = null,
+    creatorName = "testuser",
+    downloadCount = 100,
+    favoriteCount = 50,
+    rating = 4.5,
+    favoritedAt = 1000L,
+)
+
+fun testSavedPrompt(
+    id: Long = 1L,
+    prompt: String = "1girl, white hair",
+) = SavedPrompt(
+    id = id,
+    prompt = prompt,
+    negativePrompt = null,
+    sampler = "Euler a",
+    steps = 20,
+    cfgScale = 7.0,
+    seed = 12345L,
+    modelName = "TestModel",
+    size = "512x512",
+    sourceImageUrl = null,
+    savedAt = 1000L,
+)

--- a/shared/src/commonTest/kotlin/com/riox432/civitdeck/data/repository/BrowsingHistoryRepositoryImplTest.kt
+++ b/shared/src/commonTest/kotlin/com/riox432/civitdeck/data/repository/BrowsingHistoryRepositoryImplTest.kt
@@ -1,0 +1,128 @@
+package com.riox432.civitdeck.data.repository
+
+import com.riox432.civitdeck.data.local.dao.BrowsingHistoryDao
+import com.riox432.civitdeck.data.local.entity.BrowsingHistoryEntity
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class BrowsingHistoryRepositoryImplTest {
+
+    private class FakeDao : BrowsingHistoryDao {
+        val entities = mutableListOf<BrowsingHistoryEntity>()
+        private var idCounter = 1L
+
+        override suspend fun insert(entity: BrowsingHistoryEntity) {
+            entities.add(entity.copy(id = idCounter++))
+        }
+
+        override suspend fun getRecent(limit: Int): List<BrowsingHistoryEntity> =
+            entities.sortedByDescending { it.viewedAt }.take(limit)
+
+        override suspend fun getRecentModelIds(limit: Int): List<Long> =
+            entities.sortedByDescending { it.viewedAt }
+                .map { it.modelId }
+                .distinct()
+                .take(limit)
+
+        override suspend fun getAllModelIds(): List<Long> =
+            entities.map { it.modelId }.distinct()
+
+        override suspend fun count(): Int = entities.size
+
+        override suspend fun deleteAll() { entities.clear() }
+    }
+
+    @Test
+    fun trackView_inserts_entity() = runTest {
+        val dao = FakeDao()
+        val repo = BrowsingHistoryRepositoryImpl(dao)
+        repo.trackView(1L, "Checkpoint", "artist", listOf("anime"))
+        assertEquals(1, dao.entities.size)
+        assertEquals(1L, dao.entities[0].modelId)
+        assertEquals("Checkpoint", dao.entities[0].modelType)
+        assertEquals("artist", dao.entities[0].creatorName)
+        assertEquals("anime", dao.entities[0].tags)
+    }
+
+    @Test
+    fun trackView_joins_tags_with_comma() = runTest {
+        val dao = FakeDao()
+        val repo = BrowsingHistoryRepositoryImpl(dao)
+        repo.trackView(1L, "LORA", null, listOf("anime", "portrait", "girl"))
+        assertEquals("anime,portrait,girl", dao.entities[0].tags)
+    }
+
+    @Test
+    fun getRecentTypes_counts_by_type() = runTest {
+        val dao = FakeDao()
+        val repo = BrowsingHistoryRepositoryImpl(dao)
+        repo.trackView(1L, "Checkpoint", null, emptyList())
+        repo.trackView(2L, "Checkpoint", null, emptyList())
+        repo.trackView(3L, "LORA", null, emptyList())
+
+        val types = repo.getRecentTypes()
+        assertEquals(2, types["Checkpoint"])
+        assertEquals(1, types["LORA"])
+    }
+
+    @Test
+    fun getRecentCreators_counts_by_creator() = runTest {
+        val dao = FakeDao()
+        val repo = BrowsingHistoryRepositoryImpl(dao)
+        repo.trackView(1L, "Checkpoint", "artist1", emptyList())
+        repo.trackView(2L, "LORA", "artist1", emptyList())
+        repo.trackView(3L, "LORA", "artist2", emptyList())
+        repo.trackView(4L, "LORA", null, emptyList())
+
+        val creators = repo.getRecentCreators()
+        assertEquals(2, creators["artist1"])
+        assertEquals(1, creators["artist2"])
+        assertEquals(2, creators.size) // null creator excluded
+    }
+
+    @Test
+    fun getRecentTags_counts_split_tags() = runTest {
+        val dao = FakeDao()
+        val repo = BrowsingHistoryRepositoryImpl(dao)
+        repo.trackView(1L, "Checkpoint", null, listOf("anime", "girl"))
+        repo.trackView(2L, "LORA", null, listOf("anime", "landscape"))
+
+        val tags = repo.getRecentTags()
+        assertEquals(2, tags["anime"])
+        assertEquals(1, tags["girl"])
+        assertEquals(1, tags["landscape"])
+    }
+
+    @Test
+    fun getRecentTags_ignores_blank_tags() = runTest {
+        val dao = FakeDao()
+        val repo = BrowsingHistoryRepositoryImpl(dao)
+        repo.trackView(1L, "Checkpoint", null, emptyList())
+
+        val tags = repo.getRecentTags()
+        assertTrue(tags.isEmpty())
+    }
+
+    @Test
+    fun getAllViewedModelIds_returns_distinct_ids() = runTest {
+        val dao = FakeDao()
+        val repo = BrowsingHistoryRepositoryImpl(dao)
+        repo.trackView(1L, "Checkpoint", null, emptyList())
+        repo.trackView(1L, "Checkpoint", null, emptyList()) // duplicate
+        repo.trackView(2L, "LORA", null, emptyList())
+
+        val ids = repo.getAllViewedModelIds()
+        assertEquals(setOf(1L, 2L), ids)
+    }
+
+    @Test
+    fun clearAll_removes_everything() = runTest {
+        val dao = FakeDao()
+        val repo = BrowsingHistoryRepositoryImpl(dao)
+        repo.trackView(1L, "Checkpoint", null, emptyList())
+        repo.clearAll()
+        assertTrue(dao.entities.isEmpty())
+    }
+}

--- a/shared/src/commonTest/kotlin/com/riox432/civitdeck/data/repository/FavoriteRepositoryImplTest.kt
+++ b/shared/src/commonTest/kotlin/com/riox432/civitdeck/data/repository/FavoriteRepositoryImplTest.kt
@@ -1,0 +1,156 @@
+package com.riox432.civitdeck.data.repository
+
+import com.riox432.civitdeck.data.local.dao.FavoriteModelDao
+import com.riox432.civitdeck.data.local.dao.TypeCount
+import com.riox432.civitdeck.data.local.entity.FavoriteModelEntity
+import com.riox432.civitdeck.testModel
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class FavoriteRepositoryImplTest {
+
+    private class FakeDao : FavoriteModelDao {
+        val entities = mutableListOf<FavoriteModelEntity>()
+        private val flow = MutableStateFlow(0) // change counter
+
+        override fun getAllAsFlow(): Flow<List<FavoriteModelEntity>> =
+            flow.map { entities.sortedByDescending { it.favoritedAt } }
+
+        override suspend fun getById(id: Long): FavoriteModelEntity? =
+            entities.find { it.id == id }
+
+        override fun isFavorite(id: Long): Flow<Boolean> =
+            flow.map { entities.any { it.id == id } }
+
+        override suspend fun insert(entity: FavoriteModelEntity) {
+            entities.removeAll { it.id == entity.id }
+            entities.add(entity)
+            flow.value++
+        }
+
+        override suspend fun deleteById(id: Long) {
+            entities.removeAll { it.id == id }
+            flow.value++
+        }
+
+        override suspend fun count(): Int = entities.size
+
+        override suspend fun getAllIds(): List<Long> = entities.map { it.id }
+
+        override suspend fun getTypeCounts(): List<TypeCount> =
+            entities.groupBy { it.type }.map { (type, list) -> TypeCount(type, list.size) }
+    }
+
+    @Test
+    fun toggleFavorite_adds_when_not_exists() = runTest {
+        val dao = FakeDao()
+        val repo = FavoriteRepositoryImpl(dao)
+        val model = testModel(id = 1L)
+        repo.toggleFavorite(model)
+        assertEquals(1, dao.entities.size)
+        assertEquals(1L, dao.entities[0].id)
+    }
+
+    @Test
+    fun toggleFavorite_removes_when_exists() = runTest {
+        val dao = FakeDao()
+        dao.entities.add(
+            FavoriteModelEntity(
+                id = 1L, name = "Test", type = "Checkpoint", nsfw = false,
+                thumbnailUrl = null, creatorName = null, downloadCount = 0,
+                favoriteCount = 0, rating = 0.0, favoritedAt = 1000L,
+            ),
+        )
+        val repo = FavoriteRepositoryImpl(dao)
+        repo.toggleFavorite(testModel(id = 1L))
+        assertTrue(dao.entities.isEmpty())
+    }
+
+    @Test
+    fun observeFavorites_maps_entities_to_domain() = runTest {
+        val dao = FakeDao()
+        dao.entities.add(
+            FavoriteModelEntity(
+                id = 1L, name = "Model A", type = "LORA", nsfw = false,
+                thumbnailUrl = null, creatorName = "artist", downloadCount = 50,
+                favoriteCount = 10, rating = 4.0, favoritedAt = 1000L,
+            ),
+        )
+        val repo = FavoriteRepositoryImpl(dao)
+        val result = repo.observeFavorites().first()
+        assertEquals(1, result.size)
+        assertEquals("Model A", result[0].name)
+        assertEquals("artist", result[0].creatorName)
+    }
+
+    @Test
+    fun observeIsFavorite_returns_true_when_exists() = runTest {
+        val dao = FakeDao()
+        dao.entities.add(
+            FavoriteModelEntity(
+                id = 5L, name = "Test", type = "Checkpoint", nsfw = false,
+                thumbnailUrl = null, creatorName = null, downloadCount = 0,
+                favoriteCount = 0, rating = 0.0, favoritedAt = 1000L,
+            ),
+        )
+        val repo = FavoriteRepositoryImpl(dao)
+        assertTrue(repo.observeIsFavorite(5L).first())
+        assertFalse(repo.observeIsFavorite(99L).first())
+    }
+
+    @Test
+    fun getAllFavoriteIds_returns_ids() = runTest {
+        val dao = FakeDao()
+        dao.entities.addAll(
+            listOf(
+                FavoriteModelEntity(
+                    id = 1L, name = "A", type = "Checkpoint", nsfw = false,
+                    thumbnailUrl = null, creatorName = null, downloadCount = 0,
+                    favoriteCount = 0, rating = 0.0, favoritedAt = 1000L,
+                ),
+                FavoriteModelEntity(
+                    id = 2L, name = "B", type = "LORA", nsfw = false,
+                    thumbnailUrl = null, creatorName = null, downloadCount = 0,
+                    favoriteCount = 0, rating = 0.0, favoritedAt = 2000L,
+                ),
+            ),
+        )
+        val repo = FavoriteRepositoryImpl(dao)
+        assertEquals(setOf(1L, 2L), repo.getAllFavoriteIds())
+    }
+
+    @Test
+    fun getFavoriteTypeCounts_aggregates() = runTest {
+        val dao = FakeDao()
+        dao.entities.addAll(
+            listOf(
+                FavoriteModelEntity(
+                    id = 1L, name = "A", type = "Checkpoint", nsfw = false,
+                    thumbnailUrl = null, creatorName = null, downloadCount = 0,
+                    favoriteCount = 0, rating = 0.0, favoritedAt = 1000L,
+                ),
+                FavoriteModelEntity(
+                    id = 2L, name = "B", type = "Checkpoint", nsfw = false,
+                    thumbnailUrl = null, creatorName = null, downloadCount = 0,
+                    favoriteCount = 0, rating = 0.0, favoritedAt = 2000L,
+                ),
+                FavoriteModelEntity(
+                    id = 3L, name = "C", type = "LORA", nsfw = false,
+                    thumbnailUrl = null, creatorName = null, downloadCount = 0,
+                    favoriteCount = 0, rating = 0.0, favoritedAt = 3000L,
+                ),
+            ),
+        )
+        val repo = FavoriteRepositoryImpl(dao)
+        val counts = repo.getFavoriteTypeCounts()
+        assertEquals(2, counts["Checkpoint"])
+        assertEquals(1, counts["LORA"])
+    }
+}

--- a/shared/src/commonTest/kotlin/com/riox432/civitdeck/data/repository/SearchHistoryRepositoryImplTest.kt
+++ b/shared/src/commonTest/kotlin/com/riox432/civitdeck/data/repository/SearchHistoryRepositoryImplTest.kt
@@ -1,0 +1,95 @@
+package com.riox432.civitdeck.data.repository
+
+import com.riox432.civitdeck.data.local.dao.SearchHistoryDao
+import com.riox432.civitdeck.data.local.entity.SearchHistoryEntity
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class SearchHistoryRepositoryImplTest {
+
+    private class FakeDao : SearchHistoryDao {
+        val entities = mutableListOf<SearchHistoryEntity>()
+        private var idCounter = 1L
+        private val updates = MutableStateFlow(0)
+
+        override fun observeRecent(limit: Int): Flow<List<SearchHistoryEntity>> =
+            updates.map { entities.sortedByDescending { it.searchedAt }.take(limit) }
+
+        override suspend fun deleteByQuery(query: String) {
+            entities.removeAll { it.query == query }
+            updates.value++
+        }
+
+        override suspend fun insert(entity: SearchHistoryEntity) {
+            entities.add(entity.copy(id = idCounter++))
+            updates.value++
+        }
+
+        override suspend fun clearAll() {
+            entities.clear()
+            updates.value++
+        }
+
+        override suspend fun deleteById(id: Long) {
+            entities.removeAll { it.id == id }
+            updates.value++
+        }
+    }
+
+    @Test
+    fun observeRecentSearches_maps_queries() = runTest {
+        val dao = FakeDao()
+        dao.entities.add(SearchHistoryEntity(id = 1, query = "anime", searchedAt = 1000L))
+        dao.entities.add(SearchHistoryEntity(id = 2, query = "lora", searchedAt = 2000L))
+        val repo = SearchHistoryRepositoryImpl(dao)
+        val result = repo.observeRecentSearches().first()
+        assertEquals(listOf("lora", "anime"), result) // ordered by searchedAt DESC
+    }
+
+    @Test
+    fun addSearch_removes_duplicate_then_inserts() = runTest {
+        val dao = FakeDao()
+        dao.entities.add(SearchHistoryEntity(id = 1, query = "anime", searchedAt = 1000L))
+        val repo = SearchHistoryRepositoryImpl(dao)
+        repo.addSearch("anime")
+        // old "anime" should be removed, new one inserted
+        assertEquals(1, dao.entities.size)
+        assertTrue(dao.entities[0].searchedAt > 1000L) // new timestamp
+    }
+
+    @Test
+    fun addSearch_new_query_adds_to_list() = runTest {
+        val dao = FakeDao()
+        val repo = SearchHistoryRepositoryImpl(dao)
+        repo.addSearch("checkpoint")
+        assertEquals(1, dao.entities.size)
+        assertEquals("checkpoint", dao.entities[0].query)
+    }
+
+    @Test
+    fun clearAll_empties_history() = runTest {
+        val dao = FakeDao()
+        dao.entities.add(SearchHistoryEntity(id = 1, query = "a", searchedAt = 1000L))
+        dao.entities.add(SearchHistoryEntity(id = 2, query = "b", searchedAt = 2000L))
+        val repo = SearchHistoryRepositoryImpl(dao)
+        repo.clearAll()
+        assertTrue(dao.entities.isEmpty())
+    }
+
+    @Test
+    fun deleteSearch_removes_by_query() = runTest {
+        val dao = FakeDao()
+        dao.entities.add(SearchHistoryEntity(id = 1, query = "anime", searchedAt = 1000L))
+        dao.entities.add(SearchHistoryEntity(id = 2, query = "lora", searchedAt = 2000L))
+        val repo = SearchHistoryRepositoryImpl(dao)
+        repo.deleteSearch("anime")
+        assertEquals(1, dao.entities.size)
+        assertEquals("lora", dao.entities[0].query)
+    }
+}

--- a/shared/src/commonTest/kotlin/com/riox432/civitdeck/data/repository/SimpleRepositoriesImplTest.kt
+++ b/shared/src/commonTest/kotlin/com/riox432/civitdeck/data/repository/SimpleRepositoriesImplTest.kt
@@ -1,0 +1,183 @@
+package com.riox432.civitdeck.data.repository
+
+import com.riox432.civitdeck.data.local.dao.ExcludedTagDao
+import com.riox432.civitdeck.data.local.dao.HiddenModelDao
+import com.riox432.civitdeck.data.local.dao.SavedPromptDao
+import com.riox432.civitdeck.data.local.entity.ExcludedTagEntity
+import com.riox432.civitdeck.data.local.entity.HiddenModelEntity
+import com.riox432.civitdeck.data.local.entity.SavedPromptEntity
+import com.riox432.civitdeck.domain.model.ImageGenerationMeta
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class SimpleRepositoriesImplTest {
+
+    // --- ExcludedTagRepositoryImpl ---
+
+    private class FakeExcludedTagDao : ExcludedTagDao {
+        val entities = mutableListOf<ExcludedTagEntity>()
+
+        override suspend fun getAll(): List<ExcludedTagEntity> = entities.toList()
+
+        override suspend fun insert(entity: ExcludedTagEntity) {
+            if (entities.none { it.tag == entity.tag }) entities.add(entity)
+        }
+
+        override suspend fun delete(tag: String) {
+            entities.removeAll { it.tag == tag }
+        }
+    }
+
+    @Test
+    fun excludedTag_getAll_maps_to_strings() = runTest {
+        val dao = FakeExcludedTagDao()
+        dao.entities.add(ExcludedTagEntity(tag = "nsfw", addedAt = 1000L))
+        dao.entities.add(ExcludedTagEntity(tag = "gore", addedAt = 2000L))
+        val repo = ExcludedTagRepositoryImpl(dao)
+        assertEquals(listOf("nsfw", "gore"), repo.getExcludedTags())
+    }
+
+    @Test
+    fun excludedTag_add_inserts() = runTest {
+        val dao = FakeExcludedTagDao()
+        val repo = ExcludedTagRepositoryImpl(dao)
+        repo.addExcludedTag("violence")
+        assertEquals(1, dao.entities.size)
+        assertEquals("violence", dao.entities[0].tag)
+    }
+
+    @Test
+    fun excludedTag_remove_deletes() = runTest {
+        val dao = FakeExcludedTagDao()
+        dao.entities.add(ExcludedTagEntity(tag = "nsfw", addedAt = 1000L))
+        val repo = ExcludedTagRepositoryImpl(dao)
+        repo.removeExcludedTag("nsfw")
+        assertTrue(dao.entities.isEmpty())
+    }
+
+    // --- HiddenModelRepositoryImpl ---
+
+    private class FakeHiddenModelDao : HiddenModelDao {
+        val entities = mutableListOf<HiddenModelEntity>()
+
+        override suspend fun getAllIds(): List<Long> = entities.map { it.modelId }
+        override suspend fun getAll(): List<HiddenModelEntity> =
+            entities.sortedByDescending { it.hiddenAt }
+
+        override suspend fun insert(entity: HiddenModelEntity) {
+            if (entities.none { it.modelId == entity.modelId }) entities.add(entity)
+        }
+
+        override suspend fun delete(modelId: Long) {
+            entities.removeAll { it.modelId == modelId }
+        }
+    }
+
+    @Test
+    fun hiddenModel_getIds_returns_set() = runTest {
+        val dao = FakeHiddenModelDao()
+        dao.entities.add(HiddenModelEntity(modelId = 1L, modelName = "A", hiddenAt = 1000L))
+        dao.entities.add(HiddenModelEntity(modelId = 2L, modelName = "B", hiddenAt = 2000L))
+        val repo = HiddenModelRepositoryImpl(dao)
+        assertEquals(setOf(1L, 2L), repo.getHiddenModelIds())
+    }
+
+    @Test
+    fun hiddenModel_hide_inserts() = runTest {
+        val dao = FakeHiddenModelDao()
+        val repo = HiddenModelRepositoryImpl(dao)
+        repo.hideModel(42L, "Hidden Model")
+        assertEquals(1, dao.entities.size)
+        assertEquals(42L, dao.entities[0].modelId)
+        assertEquals("Hidden Model", dao.entities[0].modelName)
+    }
+
+    @Test
+    fun hiddenModel_unhide_deletes() = runTest {
+        val dao = FakeHiddenModelDao()
+        dao.entities.add(HiddenModelEntity(modelId = 1L, modelName = "A", hiddenAt = 1000L))
+        val repo = HiddenModelRepositoryImpl(dao)
+        repo.unhideModel(1L)
+        assertTrue(dao.entities.isEmpty())
+    }
+
+    // --- SavedPromptRepositoryImpl ---
+
+    private class FakeSavedPromptDao : SavedPromptDao {
+        val entities = mutableListOf<SavedPromptEntity>()
+        private var idCounter = 1L
+        private val updates = MutableStateFlow(0)
+
+        override fun observeAll(): Flow<List<SavedPromptEntity>> =
+            updates.map { entities.sortedByDescending { it.savedAt } }
+
+        override suspend fun insert(entity: SavedPromptEntity) {
+            entities.add(entity.copy(id = idCounter++))
+            updates.value++
+        }
+
+        override suspend fun deleteById(id: Long) {
+            entities.removeAll { it.id == id }
+            updates.value++
+        }
+    }
+
+    @Test
+    fun savedPrompt_observeAll_maps_to_domain() = runTest {
+        val dao = FakeSavedPromptDao()
+        dao.entities.add(
+            SavedPromptEntity(
+                id = 1L, prompt = "1girl", negativePrompt = null, sampler = null,
+                steps = null, cfgScale = null, seed = null, modelName = null,
+                size = null, sourceImageUrl = null, savedAt = 1000L,
+            ),
+        )
+        val repo = SavedPromptRepositoryImpl(dao)
+        val result = repo.observeAll().first()
+        assertEquals(1, result.size)
+        assertEquals("1girl", result[0].prompt)
+    }
+
+    @Test
+    fun savedPrompt_save_maps_meta_to_entity() = runTest {
+        val dao = FakeSavedPromptDao()
+        val repo = SavedPromptRepositoryImpl(dao)
+        val meta = ImageGenerationMeta(
+            prompt = "test prompt",
+            negativePrompt = "bad",
+            sampler = "Euler",
+            cfgScale = 7.0,
+            steps = 20,
+            seed = 123L,
+            model = "ModelName",
+            size = "512x512",
+        )
+        repo.save(meta, "https://example.com/img.jpg")
+        assertEquals(1, dao.entities.size)
+        assertEquals("test prompt", dao.entities[0].prompt)
+        assertEquals("bad", dao.entities[0].negativePrompt)
+        assertEquals("ModelName", dao.entities[0].modelName)
+        assertEquals("https://example.com/img.jpg", dao.entities[0].sourceImageUrl)
+    }
+
+    @Test
+    fun savedPrompt_delete_removes() = runTest {
+        val dao = FakeSavedPromptDao()
+        dao.entities.add(
+            SavedPromptEntity(
+                id = 1L, prompt = "test", negativePrompt = null, sampler = null,
+                steps = null, cfgScale = null, seed = null, modelName = null,
+                size = null, sourceImageUrl = null, savedAt = 1000L,
+            ),
+        )
+        val repo = SavedPromptRepositoryImpl(dao)
+        repo.delete(1L)
+        assertTrue(dao.entities.isEmpty())
+    }
+}

--- a/shared/src/commonTest/kotlin/com/riox432/civitdeck/data/repository/UserPreferencesRepositoryImplTest.kt
+++ b/shared/src/commonTest/kotlin/com/riox432/civitdeck/data/repository/UserPreferencesRepositoryImplTest.kt
@@ -1,0 +1,134 @@
+package com.riox432.civitdeck.data.repository
+
+import com.riox432.civitdeck.data.api.ApiKeyProvider
+import com.riox432.civitdeck.data.local.dao.UserPreferencesDao
+import com.riox432.civitdeck.data.local.entity.UserPreferencesEntity
+import com.riox432.civitdeck.domain.model.NsfwFilterLevel
+import com.riox432.civitdeck.domain.model.SortOrder
+import com.riox432.civitdeck.domain.model.TimePeriod
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class UserPreferencesRepositoryImplTest {
+
+    private class FakeDao : UserPreferencesDao {
+        val store = MutableStateFlow<UserPreferencesEntity?>(null)
+
+        override fun observePreferences(): Flow<UserPreferencesEntity?> = store
+
+        override suspend fun getPreferences(): UserPreferencesEntity? = store.value
+
+        override suspend fun upsert(entity: UserPreferencesEntity) {
+            store.value = entity
+        }
+    }
+
+    private fun createRepo(
+        dao: FakeDao = FakeDao(),
+        apiKeyProvider: ApiKeyProvider = ApiKeyProvider(),
+    ) = Triple(dao, apiKeyProvider, UserPreferencesRepositoryImpl(dao, apiKeyProvider))
+
+    // --- NSFW Filter Level ---
+
+    @Test
+    fun observeNsfwFilterLevel_defaults_to_Off() = runTest {
+        val (_, _, repo) = createRepo()
+        assertEquals(NsfwFilterLevel.Off, repo.observeNsfwFilterLevel().first())
+    }
+
+    @Test
+    fun setNsfwFilterLevel_persists_and_emits() = runTest {
+        val (dao, _, repo) = createRepo()
+        repo.setNsfwFilterLevel(NsfwFilterLevel.All)
+        assertEquals("All", dao.store.value?.nsfwFilterLevel)
+        assertEquals(NsfwFilterLevel.All, repo.observeNsfwFilterLevel().first())
+    }
+
+    // --- Sort Order ---
+
+    @Test
+    fun observeDefaultSortOrder_defaults_to_MostDownloaded() = runTest {
+        val (_, _, repo) = createRepo()
+        assertEquals(SortOrder.MostDownloaded, repo.observeDefaultSortOrder().first())
+    }
+
+    @Test
+    fun setDefaultSortOrder_persists() = runTest {
+        val (_, _, repo) = createRepo()
+        repo.setDefaultSortOrder(SortOrder.Newest)
+        assertEquals(SortOrder.Newest, repo.observeDefaultSortOrder().first())
+    }
+
+    // --- Time Period ---
+
+    @Test
+    fun observeDefaultTimePeriod_defaults_to_AllTime() = runTest {
+        val (_, _, repo) = createRepo()
+        assertEquals(TimePeriod.AllTime, repo.observeDefaultTimePeriod().first())
+    }
+
+    @Test
+    fun setDefaultTimePeriod_persists() = runTest {
+        val (_, _, repo) = createRepo()
+        repo.setDefaultTimePeriod(TimePeriod.Month)
+        assertEquals(TimePeriod.Month, repo.observeDefaultTimePeriod().first())
+    }
+
+    // --- Grid Columns ---
+
+    @Test
+    fun observeGridColumns_defaults_to_2() = runTest {
+        val (_, _, repo) = createRepo()
+        assertEquals(2, repo.observeGridColumns().first())
+    }
+
+    @Test
+    fun setGridColumns_persists() = runTest {
+        val (_, _, repo) = createRepo()
+        repo.setGridColumns(3)
+        assertEquals(3, repo.observeGridColumns().first())
+    }
+
+    // --- API Key ---
+
+    @Test
+    fun observeApiKey_defaults_to_null() = runTest {
+        val (_, _, repo) = createRepo()
+        assertNull(repo.observeApiKey().first())
+    }
+
+    @Test
+    fun setApiKey_persists_and_syncs_to_provider() = runTest {
+        val (_, apiKeyProvider, repo) = createRepo()
+        repo.setApiKey("test-key")
+        assertEquals("test-key", repo.observeApiKey().first())
+        assertEquals("test-key", repo.getApiKey())
+        assertEquals("test-key", apiKeyProvider.apiKey)
+    }
+
+    @Test
+    fun setApiKey_null_clears_both_dao_and_provider() = runTest {
+        val (_, apiKeyProvider, repo) = createRepo()
+        repo.setApiKey("test-key")
+        repo.setApiKey(null)
+        assertNull(repo.observeApiKey().first())
+        assertNull(apiKeyProvider.apiKey)
+    }
+
+    // --- Multiple preferences preserved ---
+
+    @Test
+    fun setting_one_preference_preserves_others() = runTest {
+        val (_, _, repo) = createRepo()
+        repo.setNsfwFilterLevel(NsfwFilterLevel.All)
+        repo.setGridColumns(3)
+        // nsfw should still be All after setting gridColumns
+        assertEquals(NsfwFilterLevel.All, repo.observeNsfwFilterLevel().first())
+        assertEquals(3, repo.observeGridColumns().first())
+    }
+}

--- a/shared/src/commonTest/kotlin/com/riox432/civitdeck/domain/usecase/BrowsingHistoryUseCasesTest.kt
+++ b/shared/src/commonTest/kotlin/com/riox432/civitdeck/domain/usecase/BrowsingHistoryUseCasesTest.kt
@@ -1,0 +1,78 @@
+package com.riox432.civitdeck.domain.usecase
+
+import com.riox432.civitdeck.domain.repository.BrowsingHistoryRepository
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class BrowsingHistoryUseCasesTest {
+
+    private class FakeBrowsingHistoryRepository : BrowsingHistoryRepository {
+        var trackCalled = false
+        var lastTrackModelId: Long? = null
+        var lastTrackType: String? = null
+        var lastTrackCreator: String? = null
+        var lastTrackTags: List<String>? = null
+        val viewedIds = setOf(10L, 20L, 30L)
+        var clearCalled = false
+
+        override suspend fun trackView(
+            modelId: Long,
+            modelType: String,
+            creatorName: String?,
+            tags: List<String>,
+        ) {
+            trackCalled = true
+            lastTrackModelId = modelId
+            lastTrackType = modelType
+            lastTrackCreator = creatorName
+            lastTrackTags = tags
+        }
+
+        override suspend fun getRecentTypes(limit: Int): Map<String, Int> = error("not used")
+        override suspend fun getRecentCreators(limit: Int): Map<String, Int> = error("not used")
+        override suspend fun getRecentTags(limit: Int): Map<String, Int> = error("not used")
+        override suspend fun getRecentModelIds(limit: Int): List<Long> = error("not used")
+        override suspend fun getAllViewedModelIds(): Set<Long> = viewedIds
+        override suspend fun clearAll() { clearCalled = true }
+    }
+
+    private val repo = FakeBrowsingHistoryRepository()
+
+    @Test
+    fun trackModelView_passes_all_parameters() = runTest {
+        val useCase = TrackModelViewUseCase(repo)
+        useCase(
+            modelId = 42L,
+            modelType = "Checkpoint",
+            creatorName = "artist1",
+            tags = listOf("anime", "portrait"),
+        )
+        assertTrue(repo.trackCalled)
+        assertEquals(42L, repo.lastTrackModelId)
+        assertEquals("Checkpoint", repo.lastTrackType)
+        assertEquals("artist1", repo.lastTrackCreator)
+        assertEquals(listOf("anime", "portrait"), repo.lastTrackTags)
+    }
+
+    @Test
+    fun trackModelView_handles_null_creator() = runTest {
+        val useCase = TrackModelViewUseCase(repo)
+        useCase(modelId = 1L, modelType = "LORA", creatorName = null, tags = emptyList())
+        assertEquals(null, repo.lastTrackCreator)
+    }
+
+    @Test
+    fun getViewedModelIds_returns_set() = runTest {
+        val useCase = GetViewedModelIdsUseCase(repo)
+        assertEquals(setOf(10L, 20L, 30L), useCase())
+    }
+
+    @Test
+    fun clearBrowsingHistory_delegates() = runTest {
+        val useCase = ClearBrowsingHistoryUseCase(repo)
+        useCase()
+        assertTrue(repo.clearCalled)
+    }
+}

--- a/shared/src/commonTest/kotlin/com/riox432/civitdeck/domain/usecase/ExcludedTagUseCasesTest.kt
+++ b/shared/src/commonTest/kotlin/com/riox432/civitdeck/domain/usecase/ExcludedTagUseCasesTest.kt
@@ -1,0 +1,43 @@
+package com.riox432.civitdeck.domain.usecase
+
+import com.riox432.civitdeck.domain.repository.ExcludedTagRepository
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class ExcludedTagUseCasesTest {
+
+    private class FakeExcludedTagRepository : ExcludedTagRepository {
+        val tags = mutableListOf("nsfw", "gore")
+        var addedTag: String? = null
+        var removedTag: String? = null
+
+        override suspend fun getExcludedTags(): List<String> = tags.toList()
+        override suspend fun addExcludedTag(tag: String) { addedTag = tag }
+        override suspend fun removeExcludedTag(tag: String) { removedTag = tag }
+    }
+
+    private val repo = FakeExcludedTagRepository()
+
+    @Test
+    fun getExcludedTags_returns_list() = runTest {
+        val useCase = GetExcludedTagsUseCase(repo)
+        val result = useCase()
+        assertEquals(listOf("nsfw", "gore"), result)
+    }
+
+    @Test
+    fun addExcludedTag_delegates() = runTest {
+        val useCase = AddExcludedTagUseCase(repo)
+        useCase("violence")
+        assertEquals("violence", repo.addedTag)
+    }
+
+    @Test
+    fun removeExcludedTag_delegates() = runTest {
+        val useCase = RemoveExcludedTagUseCase(repo)
+        useCase("gore")
+        assertEquals("gore", repo.removedTag)
+    }
+}

--- a/shared/src/commonTest/kotlin/com/riox432/civitdeck/domain/usecase/FavoriteUseCasesTest.kt
+++ b/shared/src/commonTest/kotlin/com/riox432/civitdeck/domain/usecase/FavoriteUseCasesTest.kt
@@ -1,0 +1,81 @@
+package com.riox432.civitdeck.domain.usecase
+
+import com.riox432.civitdeck.domain.model.FavoriteModelSummary
+import com.riox432.civitdeck.domain.model.Model
+import com.riox432.civitdeck.domain.repository.FavoriteRepository
+import com.riox432.civitdeck.testFavoriteModelSummary
+import com.riox432.civitdeck.testModel
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class FavoriteUseCasesTest {
+
+    private val favorites = listOf(
+        testFavoriteModelSummary(id = 1L, name = "Fav1"),
+        testFavoriteModelSummary(id = 2L, name = "Fav2"),
+    )
+
+    private fun fakeRepository(
+        isFavorite: Boolean = true,
+        toggledModel: Model? = null,
+    ) = object : FavoriteRepository {
+        var toggleCalled = false
+        var toggledWith: Model? = null
+
+        override fun observeFavorites(): Flow<List<FavoriteModelSummary>> =
+            flowOf(favorites)
+
+        override fun observeIsFavorite(modelId: Long): Flow<Boolean> =
+            flowOf(isFavorite)
+
+        override suspend fun toggleFavorite(model: Model) {
+            toggleCalled = true
+            toggledWith = model
+        }
+
+        override suspend fun addFavorite(model: Model) = error("not used")
+        override suspend fun removeFavorite(modelId: Long) = error("not used")
+        override suspend fun getAllFavoriteIds(): Set<Long> = error("not used")
+        override suspend fun getFavoriteTypeCounts(): Map<String, Int> = error("not used")
+    }
+
+    @Test
+    fun observeFavorites_emits_list() = runTest {
+        val repo = fakeRepository()
+        val useCase = ObserveFavoritesUseCase(repo)
+        val result = useCase().first()
+        assertEquals(2, result.size)
+        assertEquals("Fav1", result[0].name)
+    }
+
+    @Test
+    fun observeIsFavorite_emits_true() = runTest {
+        val repo = fakeRepository(isFavorite = true)
+        val useCase = ObserveIsFavoriteUseCase(repo)
+        val result = useCase(1L).first()
+        assertTrue(result)
+    }
+
+    @Test
+    fun observeIsFavorite_emits_false() = runTest {
+        val repo = fakeRepository(isFavorite = false)
+        val useCase = ObserveIsFavoriteUseCase(repo)
+        val result = useCase(1L).first()
+        assertEquals(false, result)
+    }
+
+    @Test
+    fun toggleFavorite_delegates_to_repository() = runTest {
+        val repo = fakeRepository()
+        val useCase = ToggleFavoriteUseCase(repo)
+        val model = testModel(id = 99L)
+        useCase(model)
+        assertTrue(repo.toggleCalled)
+        assertEquals(99L, repo.toggledWith?.id)
+    }
+}

--- a/shared/src/commonTest/kotlin/com/riox432/civitdeck/domain/usecase/GetRecommendationsUseCaseTest.kt
+++ b/shared/src/commonTest/kotlin/com/riox432/civitdeck/domain/usecase/GetRecommendationsUseCaseTest.kt
@@ -1,0 +1,231 @@
+package com.riox432.civitdeck.domain.usecase
+
+import com.riox432.civitdeck.domain.model.BaseModel
+import com.riox432.civitdeck.domain.model.FavoriteModelSummary
+import com.riox432.civitdeck.domain.model.Model
+import com.riox432.civitdeck.domain.model.ModelType
+import com.riox432.civitdeck.domain.model.ModelVersion
+import com.riox432.civitdeck.domain.model.NsfwFilterLevel
+import com.riox432.civitdeck.domain.model.PaginatedResult
+import com.riox432.civitdeck.domain.model.SortOrder
+import com.riox432.civitdeck.domain.model.TimePeriod
+import com.riox432.civitdeck.domain.repository.BrowsingHistoryRepository
+import com.riox432.civitdeck.domain.repository.FavoriteRepository
+import com.riox432.civitdeck.domain.repository.ModelRepository
+import com.riox432.civitdeck.domain.repository.UserPreferencesRepository
+import com.riox432.civitdeck.testModel
+import com.riox432.civitdeck.testPaginatedResult
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class GetRecommendationsUseCaseTest {
+
+    private class FakeModelRepository : ModelRepository {
+        var modelsResult: PaginatedResult<Model> = testPaginatedResult()
+        var lastType: ModelType? = null
+        var lastTag: String? = null
+        var lastSort: SortOrder? = null
+
+        override suspend fun getModels(
+            query: String?,
+            tag: String?,
+            type: ModelType?,
+            sort: SortOrder?,
+            period: TimePeriod?,
+            baseModels: List<BaseModel>?,
+            cursor: String?,
+            limit: Int?,
+            username: String?,
+            nsfw: Boolean?,
+        ): PaginatedResult<Model> {
+            lastType = type
+            lastTag = tag
+            lastSort = sort
+            return modelsResult
+        }
+
+        override suspend fun getModel(id: Long): Model = error("not used")
+        override suspend fun getModelVersion(id: Long): ModelVersion = error("not used")
+        override suspend fun getModelVersionByHash(hash: String): ModelVersion = error("not used")
+    }
+
+    private class FakeFavoriteRepository(
+        private val favoriteIds: Set<Long> = emptySet(),
+        private val typeCounts: Map<String, Int> = emptyMap(),
+    ) : FavoriteRepository {
+        override fun observeFavorites(): Flow<List<FavoriteModelSummary>> = error("not used")
+        override fun observeIsFavorite(modelId: Long): Flow<Boolean> = error("not used")
+        override suspend fun toggleFavorite(model: Model) = error("not used")
+        override suspend fun addFavorite(model: Model) = error("not used")
+        override suspend fun removeFavorite(modelId: Long) = error("not used")
+        override suspend fun getAllFavoriteIds(): Set<Long> = favoriteIds
+        override suspend fun getFavoriteTypeCounts(): Map<String, Int> = typeCounts
+    }
+
+    private class FakeBrowsingHistoryRepository(
+        private val recentTypes: Map<String, Int> = emptyMap(),
+        private val recentTags: Map<String, Int> = emptyMap(),
+        private val recentModelIds: List<Long> = emptyList(),
+    ) : BrowsingHistoryRepository {
+        override suspend fun trackView(
+            modelId: Long,
+            modelType: String,
+            creatorName: String?,
+            tags: List<String>,
+        ) = error("not used")
+
+        override suspend fun getRecentTypes(limit: Int): Map<String, Int> = recentTypes
+        override suspend fun getRecentCreators(limit: Int): Map<String, Int> = emptyMap()
+        override suspend fun getRecentTags(limit: Int): Map<String, Int> = recentTags
+        override suspend fun getRecentModelIds(limit: Int): List<Long> = recentModelIds
+        override suspend fun getAllViewedModelIds(): Set<Long> = error("not used")
+        override suspend fun clearAll() = error("not used")
+    }
+
+    @Suppress("TooManyFunctions")
+    private class FakeUserPreferencesRepository(
+        private val nsfwLevel: NsfwFilterLevel = NsfwFilterLevel.All,
+    ) : UserPreferencesRepository {
+        override fun observeNsfwFilterLevel(): Flow<NsfwFilterLevel> = flowOf(nsfwLevel)
+        override suspend fun setNsfwFilterLevel(level: NsfwFilterLevel) = error("not used")
+        override fun observeDefaultSortOrder(): Flow<SortOrder> = error("not used")
+        override suspend fun setDefaultSortOrder(sort: SortOrder) = error("not used")
+        override fun observeDefaultTimePeriod(): Flow<TimePeriod> = error("not used")
+        override suspend fun setDefaultTimePeriod(period: TimePeriod) = error("not used")
+        override fun observeGridColumns(): Flow<Int> = error("not used")
+        override suspend fun setGridColumns(columns: Int) = error("not used")
+        override fun observeApiKey(): Flow<String?> = error("not used")
+        override suspend fun setApiKey(apiKey: String?) = error("not used")
+        override suspend fun getApiKey(): String? = error("not used")
+    }
+
+    @Test
+    fun returns_type_section_when_favorites_have_types() = runTest {
+        val models = (1L..10L).map { testModel(id = it, type = ModelType.LORA) }
+        val modelRepo = FakeModelRepository().apply {
+            modelsResult = testPaginatedResult(items = models)
+        }
+        val favRepo = FakeFavoriteRepository(typeCounts = mapOf("LORA" to 5))
+        val browsingRepo = FakeBrowsingHistoryRepository()
+        val prefsRepo = FakeUserPreferencesRepository()
+
+        val useCase = GetRecommendationsUseCase(modelRepo, favRepo, browsingRepo, prefsRepo)
+        val sections = useCase()
+
+        assertTrue(sections.isNotEmpty())
+        assertEquals("Trending LORA", sections[0].title)
+        assertEquals("Based on your preferences", sections[0].reason)
+    }
+
+    @Test
+    fun returns_tag_section_when_browsing_has_tags() = runTest {
+        val models = (1L..10L).map { testModel(id = it) }
+        val modelRepo = FakeModelRepository().apply {
+            modelsResult = testPaginatedResult(items = models)
+        }
+        val favRepo = FakeFavoriteRepository()
+        val browsingRepo = FakeBrowsingHistoryRepository(recentTags = mapOf("anime" to 10))
+        val prefsRepo = FakeUserPreferencesRepository()
+
+        val useCase = GetRecommendationsUseCase(modelRepo, favRepo, browsingRepo, prefsRepo)
+        val sections = useCase()
+
+        assertTrue(sections.any { it.title.contains("anime") })
+    }
+
+    @Test
+    fun returns_trending_fallback_when_no_type_or_tag() = runTest {
+        val models = (1L..10L).map { testModel(id = it) }
+        val modelRepo = FakeModelRepository().apply {
+            modelsResult = testPaginatedResult(items = models)
+        }
+        val favRepo = FakeFavoriteRepository()
+        val browsingRepo = FakeBrowsingHistoryRepository()
+        val prefsRepo = FakeUserPreferencesRepository()
+
+        val useCase = GetRecommendationsUseCase(modelRepo, favRepo, browsingRepo, prefsRepo)
+        val sections = useCase()
+
+        assertEquals(1, sections.size)
+        assertEquals("Trending This Week", sections[0].title)
+        assertEquals("Popular models", sections[0].reason)
+    }
+
+    @Test
+    fun excludes_favorite_and_viewed_models() = runTest {
+        val models = (1L..12L).map { testModel(id = it) }
+        val modelRepo = FakeModelRepository().apply {
+            modelsResult = testPaginatedResult(items = models)
+        }
+        val favRepo = FakeFavoriteRepository(favoriteIds = setOf(1L, 2L))
+        val browsingRepo = FakeBrowsingHistoryRepository(recentModelIds = listOf(3L, 4L))
+        val prefsRepo = FakeUserPreferencesRepository()
+
+        val useCase = GetRecommendationsUseCase(modelRepo, favRepo, browsingRepo, prefsRepo)
+        val sections = useCase()
+
+        assertTrue(sections.isNotEmpty())
+        val allModelIds = sections.flatMap { it.models.map { m -> m.id } }
+        assertTrue(1L !in allModelIds)
+        assertTrue(2L !in allModelIds)
+        assertTrue(3L !in allModelIds)
+        assertTrue(4L !in allModelIds)
+    }
+
+    @Test
+    fun returns_empty_when_all_models_filtered() = runTest {
+        val modelRepo = FakeModelRepository().apply {
+            modelsResult = testPaginatedResult(items = emptyList())
+        }
+        val favRepo = FakeFavoriteRepository()
+        val browsingRepo = FakeBrowsingHistoryRepository()
+        val prefsRepo = FakeUserPreferencesRepository()
+
+        val useCase = GetRecommendationsUseCase(modelRepo, favRepo, browsingRepo, prefsRepo)
+        val sections = useCase()
+
+        assertTrue(sections.isEmpty())
+    }
+
+    @Test
+    fun favorite_types_weighted_higher_than_browsing_types() = runTest {
+        val loraModels = (1L..10L).map { testModel(id = it, type = ModelType.LORA) }
+        val modelRepo = FakeModelRepository().apply {
+            modelsResult = testPaginatedResult(items = loraModels)
+        }
+        // LORA: 2*3=6 from favorites, Checkpoint: 5 from browsing
+        // LORA should win because favorite weight is 3x
+        val favRepo = FakeFavoriteRepository(typeCounts = mapOf("LORA" to 2))
+        val browsingRepo = FakeBrowsingHistoryRepository(
+            recentTypes = mapOf("Checkpoint" to 5),
+        )
+        val prefsRepo = FakeUserPreferencesRepository()
+
+        val useCase = GetRecommendationsUseCase(modelRepo, favRepo, browsingRepo, prefsRepo)
+        val sections = useCase()
+
+        assertTrue(sections.isNotEmpty())
+        assertEquals(ModelType.LORA, modelRepo.lastType)
+    }
+
+    @Test
+    fun section_limited_to_ten_models() = runTest {
+        val models = (1L..20L).map { testModel(id = it) }
+        val modelRepo = FakeModelRepository().apply {
+            modelsResult = testPaginatedResult(items = models)
+        }
+        val favRepo = FakeFavoriteRepository()
+        val browsingRepo = FakeBrowsingHistoryRepository()
+        val prefsRepo = FakeUserPreferencesRepository()
+
+        val useCase = GetRecommendationsUseCase(modelRepo, favRepo, browsingRepo, prefsRepo)
+        val sections = useCase()
+
+        assertTrue(sections.isNotEmpty())
+        assertTrue(sections[0].models.size <= 10)
+    }
+}

--- a/shared/src/commonTest/kotlin/com/riox432/civitdeck/domain/usecase/HiddenModelUseCasesTest.kt
+++ b/shared/src/commonTest/kotlin/com/riox432/civitdeck/domain/usecase/HiddenModelUseCasesTest.kt
@@ -1,0 +1,66 @@
+package com.riox432.civitdeck.domain.usecase
+
+import com.riox432.civitdeck.data.local.entity.HiddenModelEntity
+import com.riox432.civitdeck.domain.repository.HiddenModelRepository
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class HiddenModelUseCasesTest {
+
+    private class FakeHiddenModelRepository : HiddenModelRepository {
+        val hiddenIds = mutableSetOf(1L, 2L)
+        val hiddenEntities = mutableListOf(
+            HiddenModelEntity(modelId = 1L, modelName = "Model A", hiddenAt = 1000L),
+            HiddenModelEntity(modelId = 2L, modelName = "Model B", hiddenAt = 2000L),
+        )
+        var hideCalled = false
+        var unhideCalled = false
+        var lastHideId: Long? = null
+        var lastUnhideId: Long? = null
+
+        override suspend fun getHiddenModelIds(): Set<Long> = hiddenIds.toSet()
+        override suspend fun getHiddenModels(): List<HiddenModelEntity> = hiddenEntities.toList()
+        override suspend fun hideModel(modelId: Long, modelName: String) {
+            hideCalled = true
+            lastHideId = modelId
+        }
+        override suspend fun unhideModel(modelId: Long) {
+            unhideCalled = true
+            lastUnhideId = modelId
+        }
+    }
+
+    private val repo = FakeHiddenModelRepository()
+
+    @Test
+    fun getHiddenModelIds_returns_set() = runTest {
+        val useCase = GetHiddenModelIdsUseCase(repo)
+        assertEquals(setOf(1L, 2L), useCase())
+    }
+
+    @Test
+    fun getHiddenModels_returns_entities() = runTest {
+        val useCase = GetHiddenModelsUseCase(repo)
+        val result = useCase()
+        assertEquals(2, result.size)
+        assertEquals("Model A", result[0].modelName)
+    }
+
+    @Test
+    fun hideModel_delegates() = runTest {
+        val useCase = HideModelUseCase(repo)
+        useCase(42L, "Hidden Model")
+        assertTrue(repo.hideCalled)
+        assertEquals(42L, repo.lastHideId)
+    }
+
+    @Test
+    fun unhideModel_delegates() = runTest {
+        val useCase = UnhideModelUseCase(repo)
+        useCase(1L)
+        assertTrue(repo.unhideCalled)
+        assertEquals(1L, repo.lastUnhideId)
+    }
+}

--- a/shared/src/commonTest/kotlin/com/riox432/civitdeck/domain/usecase/ImageUseCasesTest.kt
+++ b/shared/src/commonTest/kotlin/com/riox432/civitdeck/domain/usecase/ImageUseCasesTest.kt
@@ -1,0 +1,74 @@
+package com.riox432.civitdeck.domain.usecase
+
+import com.riox432.civitdeck.domain.model.Image
+import com.riox432.civitdeck.domain.model.NsfwLevel
+import com.riox432.civitdeck.domain.model.PaginatedResult
+import com.riox432.civitdeck.domain.model.SortOrder
+import com.riox432.civitdeck.domain.model.TimePeriod
+import com.riox432.civitdeck.domain.repository.ImageRepository
+import com.riox432.civitdeck.testImage
+import com.riox432.civitdeck.testPaginatedResult
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class ImageUseCasesTest {
+
+    private val images = listOf(testImage(id = 1L), testImage(id = 2L))
+    private val result = testPaginatedResult(items = images, nextCursor = "next")
+
+    private fun fakeRepository() = object : ImageRepository {
+        var lastArgs: Map<String, Any?> = emptyMap()
+
+        override suspend fun getImages(
+            modelId: Long?,
+            modelVersionId: Long?,
+            username: String?,
+            sort: SortOrder?,
+            period: TimePeriod?,
+            nsfwLevel: NsfwLevel?,
+            limit: Int?,
+            cursor: String?,
+        ): PaginatedResult<Image> {
+            lastArgs = mapOf(
+                "modelId" to modelId, "modelVersionId" to modelVersionId,
+                "username" to username, "sort" to sort, "period" to period,
+                "nsfwLevel" to nsfwLevel, "limit" to limit, "cursor" to cursor,
+            )
+            return result
+        }
+    }
+
+    @Test
+    fun getImages_returns_result() = runTest {
+        val repo = fakeRepository()
+        val useCase = GetImagesUseCase(repo)
+        val actual = useCase()
+        assertEquals(2, actual.items.size)
+        assertEquals("next", actual.metadata.nextCursor)
+    }
+
+    @Test
+    fun getImages_passes_all_parameters() = runTest {
+        val repo = fakeRepository()
+        val useCase = GetImagesUseCase(repo)
+        useCase(
+            modelId = 10L,
+            modelVersionId = 20L,
+            username = "user1",
+            sort = SortOrder.Newest,
+            period = TimePeriod.Day,
+            nsfwLevel = NsfwLevel.Soft,
+            limit = 5,
+            cursor = "cur",
+        )
+        assertEquals(10L, repo.lastArgs["modelId"])
+        assertEquals(20L, repo.lastArgs["modelVersionId"])
+        assertEquals("user1", repo.lastArgs["username"])
+        assertEquals(SortOrder.Newest, repo.lastArgs["sort"])
+        assertEquals(TimePeriod.Day, repo.lastArgs["period"])
+        assertEquals(NsfwLevel.Soft, repo.lastArgs["nsfwLevel"])
+        assertEquals(5, repo.lastArgs["limit"])
+        assertEquals("cur", repo.lastArgs["cursor"])
+    }
+}

--- a/shared/src/commonTest/kotlin/com/riox432/civitdeck/domain/usecase/ModelUseCasesTest.kt
+++ b/shared/src/commonTest/kotlin/com/riox432/civitdeck/domain/usecase/ModelUseCasesTest.kt
@@ -1,0 +1,111 @@
+package com.riox432.civitdeck.domain.usecase
+
+import com.riox432.civitdeck.domain.model.BaseModel
+import com.riox432.civitdeck.domain.model.Model
+import com.riox432.civitdeck.domain.model.ModelType
+import com.riox432.civitdeck.domain.model.ModelVersion
+import com.riox432.civitdeck.domain.model.PaginatedResult
+import com.riox432.civitdeck.domain.model.SortOrder
+import com.riox432.civitdeck.domain.model.TimePeriod
+import com.riox432.civitdeck.domain.repository.ModelRepository
+import com.riox432.civitdeck.testModel
+import com.riox432.civitdeck.testPaginatedResult
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class ModelUseCasesTest {
+
+    private val sampleModel = testModel()
+    private val sampleResult = testPaginatedResult(items = listOf(sampleModel), nextCursor = "abc")
+
+    private fun fakeRepository(
+        modelsResult: PaginatedResult<Model> = sampleResult,
+        modelDetail: Model = sampleModel,
+    ) = object : ModelRepository {
+        var lastGetModelsArgs: Map<String, Any?> = emptyMap()
+
+        override suspend fun getModels(
+            query: String?,
+            tag: String?,
+            type: ModelType?,
+            sort: SortOrder?,
+            period: TimePeriod?,
+            baseModels: List<BaseModel>?,
+            cursor: String?,
+            limit: Int?,
+            username: String?,
+            nsfw: Boolean?,
+        ): PaginatedResult<Model> {
+            lastGetModelsArgs = mapOf(
+                "query" to query, "tag" to tag, "type" to type,
+                "sort" to sort, "period" to period, "baseModels" to baseModels,
+                "cursor" to cursor, "limit" to limit, "username" to username,
+                "nsfw" to nsfw,
+            )
+            return modelsResult
+        }
+
+        override suspend fun getModel(id: Long): Model = modelDetail
+        override suspend fun getModelVersion(id: Long): ModelVersion = error("not used")
+        override suspend fun getModelVersionByHash(hash: String): ModelVersion = error("not used")
+    }
+
+    // --- GetModelsUseCase ---
+
+    @Test
+    fun getModels_returns_repository_result() = runTest {
+        val repo = fakeRepository()
+        val useCase = GetModelsUseCase(repo)
+        val result = useCase()
+        assertEquals(sampleResult, result)
+    }
+
+    @Test
+    fun getModels_passes_all_parameters() = runTest {
+        val repo = fakeRepository()
+        val useCase = GetModelsUseCase(repo)
+        useCase(
+            query = "test",
+            tag = "anime",
+            type = ModelType.LORA,
+            sort = SortOrder.Newest,
+            period = TimePeriod.Week,
+            cursor = "cursor123",
+            limit = 20,
+            nsfw = false,
+        )
+        assertEquals("test", repo.lastGetModelsArgs["query"])
+        assertEquals("anime", repo.lastGetModelsArgs["tag"])
+        assertEquals(ModelType.LORA, repo.lastGetModelsArgs["type"])
+        assertEquals(SortOrder.Newest, repo.lastGetModelsArgs["sort"])
+        assertEquals(TimePeriod.Week, repo.lastGetModelsArgs["period"])
+        assertEquals("cursor123", repo.lastGetModelsArgs["cursor"])
+        assertEquals(20, repo.lastGetModelsArgs["limit"])
+        assertEquals(false, repo.lastGetModelsArgs["nsfw"])
+    }
+
+    // --- GetModelDetailUseCase ---
+
+    @Test
+    fun getModelDetail_returns_model() = runTest {
+        val model = testModel(id = 42L, name = "Detail Model")
+        val repo = fakeRepository(modelDetail = model)
+        val useCase = GetModelDetailUseCase(repo)
+        val result = useCase(42L)
+        assertEquals(42L, result.id)
+        assertEquals("Detail Model", result.name)
+    }
+
+    // --- GetCreatorModelsUseCase ---
+
+    @Test
+    fun getCreatorModels_passes_username() = runTest {
+        val repo = fakeRepository()
+        val useCase = GetCreatorModelsUseCase(repo)
+        useCase(username = "creator1", cursor = "cur", limit = 10)
+        assertEquals("creator1", repo.lastGetModelsArgs["username"])
+        assertEquals("cur", repo.lastGetModelsArgs["cursor"])
+        assertEquals(10, repo.lastGetModelsArgs["limit"])
+    }
+}

--- a/shared/src/commonTest/kotlin/com/riox432/civitdeck/domain/usecase/SavedPromptUseCasesTest.kt
+++ b/shared/src/commonTest/kotlin/com/riox432/civitdeck/domain/usecase/SavedPromptUseCasesTest.kt
@@ -1,0 +1,79 @@
+package com.riox432.civitdeck.domain.usecase
+
+import com.riox432.civitdeck.domain.model.ImageGenerationMeta
+import com.riox432.civitdeck.domain.model.SavedPrompt
+import com.riox432.civitdeck.domain.repository.SavedPromptRepository
+import com.riox432.civitdeck.testSavedPrompt
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class SavedPromptUseCasesTest {
+
+    private val prompts = listOf(
+        testSavedPrompt(id = 1L, prompt = "prompt1"),
+        testSavedPrompt(id = 2L, prompt = "prompt2"),
+    )
+
+    private class FakeSavedPromptRepository(
+        private val prompts: List<SavedPrompt>,
+    ) : SavedPromptRepository {
+        var saveCalled = false
+        var lastSavedMeta: ImageGenerationMeta? = null
+        var lastSavedUrl: String? = null
+        var deleteCalled = false
+        var lastDeletedId: Long? = null
+
+        override fun observeAll(): Flow<List<SavedPrompt>> = flowOf(prompts)
+        override suspend fun save(meta: ImageGenerationMeta, sourceImageUrl: String?) {
+            saveCalled = true
+            lastSavedMeta = meta
+            lastSavedUrl = sourceImageUrl
+        }
+        override suspend fun delete(id: Long) {
+            deleteCalled = true
+            lastDeletedId = id
+        }
+    }
+
+    private val repo = FakeSavedPromptRepository(prompts)
+
+    @Test
+    fun observeSavedPrompts_emits_list() = runTest {
+        val useCase = ObserveSavedPromptsUseCase(repo)
+        val result = useCase().first()
+        assertEquals(2, result.size)
+        assertEquals("prompt1", result[0].prompt)
+    }
+
+    @Test
+    fun savePrompt_delegates() = runTest {
+        val meta = ImageGenerationMeta(
+            prompt = "1girl",
+            negativePrompt = "bad",
+            sampler = "Euler",
+            cfgScale = 7.0,
+            steps = 20,
+            seed = 123L,
+            model = "Model",
+            size = "512x512",
+        )
+        val useCase = SavePromptUseCase(repo)
+        useCase(meta, "https://example.com/img.jpg")
+        assertTrue(repo.saveCalled)
+        assertEquals("1girl", repo.lastSavedMeta?.prompt)
+        assertEquals("https://example.com/img.jpg", repo.lastSavedUrl)
+    }
+
+    @Test
+    fun deletePrompt_delegates() = runTest {
+        val useCase = DeleteSavedPromptUseCase(repo)
+        useCase(42L)
+        assertTrue(repo.deleteCalled)
+        assertEquals(42L, repo.lastDeletedId)
+    }
+}

--- a/shared/src/commonTest/kotlin/com/riox432/civitdeck/domain/usecase/SearchHistoryUseCasesTest.kt
+++ b/shared/src/commonTest/kotlin/com/riox432/civitdeck/domain/usecase/SearchHistoryUseCasesTest.kt
@@ -1,0 +1,47 @@
+package com.riox432.civitdeck.domain.usecase
+
+import com.riox432.civitdeck.domain.repository.SearchHistoryRepository
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class SearchHistoryUseCasesTest {
+
+    private class FakeSearchHistoryRepository : SearchHistoryRepository {
+        val searches = MutableStateFlow(listOf("kotlin", "anime"))
+        var addedQuery: String? = null
+        var clearCalled = false
+
+        override fun observeRecentSearches(): Flow<List<String>> = searches
+        override suspend fun addSearch(query: String) { addedQuery = query }
+        override suspend fun deleteSearch(query: String) = error("not used")
+        override suspend fun clearAll() { clearCalled = true }
+    }
+
+    private val repo = FakeSearchHistoryRepository()
+
+    @Test
+    fun observeSearchHistory_emits_list() = runTest {
+        val useCase = ObserveSearchHistoryUseCase(repo)
+        val result = useCase().first()
+        assertEquals(listOf("kotlin", "anime"), result)
+    }
+
+    @Test
+    fun addSearchHistory_delegates() = runTest {
+        val useCase = AddSearchHistoryUseCase(repo)
+        useCase("lora")
+        assertEquals("lora", repo.addedQuery)
+    }
+
+    @Test
+    fun clearSearchHistory_delegates() = runTest {
+        val useCase = ClearSearchHistoryUseCase(repo)
+        useCase()
+        assertTrue(repo.clearCalled)
+    }
+}

--- a/shared/src/commonTest/kotlin/com/riox432/civitdeck/domain/usecase/UserPreferencesUseCasesTest.kt
+++ b/shared/src/commonTest/kotlin/com/riox432/civitdeck/domain/usecase/UserPreferencesUseCasesTest.kt
@@ -1,0 +1,128 @@
+package com.riox432.civitdeck.domain.usecase
+
+import com.riox432.civitdeck.domain.model.NsfwFilterLevel
+import com.riox432.civitdeck.domain.model.SortOrder
+import com.riox432.civitdeck.domain.model.TimePeriod
+import com.riox432.civitdeck.domain.repository.UserPreferencesRepository
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+@Suppress("TooManyFunctions")
+class UserPreferencesUseCasesTest {
+
+    private class FakeUserPreferencesRepository : UserPreferencesRepository {
+        val nsfwLevel = MutableStateFlow(NsfwFilterLevel.Off)
+        val sortOrder = MutableStateFlow(SortOrder.HighestRated)
+        val timePeriod = MutableStateFlow(TimePeriod.AllTime)
+        val gridColumns = MutableStateFlow(2)
+        val apiKeyFlow = MutableStateFlow<String?>(null)
+        var storedApiKey: String? = null
+
+        override fun observeNsfwFilterLevel(): Flow<NsfwFilterLevel> = nsfwLevel
+        override suspend fun setNsfwFilterLevel(level: NsfwFilterLevel) { nsfwLevel.value = level }
+        override fun observeDefaultSortOrder(): Flow<SortOrder> = sortOrder
+        override suspend fun setDefaultSortOrder(sort: SortOrder) { sortOrder.value = sort }
+        override fun observeDefaultTimePeriod(): Flow<TimePeriod> = timePeriod
+        override suspend fun setDefaultTimePeriod(period: TimePeriod) { timePeriod.value = period }
+        override fun observeGridColumns(): Flow<Int> = gridColumns
+        override suspend fun setGridColumns(columns: Int) { gridColumns.value = columns }
+        override fun observeApiKey(): Flow<String?> = apiKeyFlow
+        override suspend fun setApiKey(apiKey: String?) {
+            storedApiKey = apiKey
+            apiKeyFlow.value = apiKey
+        }
+        override suspend fun getApiKey(): String? = storedApiKey
+    }
+
+    private val repo = FakeUserPreferencesRepository()
+
+    // --- NSFW Filter ---
+
+    @Test
+    fun observeNsfwFilter_emits_current_level() = runTest {
+        val useCase = ObserveNsfwFilterUseCase(repo)
+        assertEquals(NsfwFilterLevel.Off, useCase().first())
+    }
+
+    @Test
+    fun setNsfwFilter_updates_level() = runTest {
+        val useCase = SetNsfwFilterUseCase(repo)
+        useCase(NsfwFilterLevel.All)
+        assertEquals(NsfwFilterLevel.All, repo.nsfwLevel.value)
+    }
+
+    // --- Sort Order ---
+
+    @Test
+    fun observeDefaultSortOrder_emits_current() = runTest {
+        val useCase = ObserveDefaultSortOrderUseCase(repo)
+        assertEquals(SortOrder.HighestRated, useCase().first())
+    }
+
+    @Test
+    fun setDefaultSortOrder_updates() = runTest {
+        val useCase = SetDefaultSortOrderUseCase(repo)
+        useCase(SortOrder.MostDownloaded)
+        assertEquals(SortOrder.MostDownloaded, repo.sortOrder.value)
+    }
+
+    // --- Time Period ---
+
+    @Test
+    fun observeDefaultTimePeriod_emits_current() = runTest {
+        val useCase = ObserveDefaultTimePeriodUseCase(repo)
+        assertEquals(TimePeriod.AllTime, useCase().first())
+    }
+
+    @Test
+    fun setDefaultTimePeriod_updates() = runTest {
+        val useCase = SetDefaultTimePeriodUseCase(repo)
+        useCase(TimePeriod.Week)
+        assertEquals(TimePeriod.Week, repo.timePeriod.value)
+    }
+
+    // --- Grid Columns ---
+
+    @Test
+    fun observeGridColumns_emits_current() = runTest {
+        val useCase = ObserveGridColumnsUseCase(repo)
+        assertEquals(2, useCase().first())
+    }
+
+    @Test
+    fun setGridColumns_updates() = runTest {
+        val useCase = SetGridColumnsUseCase(repo)
+        useCase(3)
+        assertEquals(3, repo.gridColumns.value)
+    }
+
+    // --- API Key ---
+
+    @Test
+    fun observeApiKey_emits_null_initially() = runTest {
+        val useCase = ObserveApiKeyUseCase(repo)
+        assertNull(useCase().first())
+    }
+
+    @Test
+    fun setApiKey_stores_and_emits() = runTest {
+        val setUseCase = SetApiKeyUseCase(repo)
+        val observeUseCase = ObserveApiKeyUseCase(repo)
+        setUseCase("my-key")
+        assertEquals("my-key", observeUseCase().first())
+        assertEquals("my-key", repo.storedApiKey)
+    }
+
+    @Test
+    fun setApiKey_null_clears_key() = runTest {
+        val setUseCase = SetApiKeyUseCase(repo)
+        setUseCase("my-key")
+        setUseCase(null)
+        assertNull(repo.storedApiKey)
+    }
+}


### PR DESCRIPTION
## Description

Add comprehensive unit test coverage across the shared KMP module and Android app.

**120 tests total (109 new):**
- 10 use case test files (45 tests) — all 21 use cases covered except ValidateApiKey and ClearCache (concrete class dependencies)
- 5 repository test files (40 tests) — FavoriteRepository, BrowsingHistory, UserPreferences, SearchHistory, ExcludedTag/HiddenModel/SavedPrompt
- 5 ViewModel test files (24 tests) — Favorites, SavedPrompts, ModelDetail, CreatorProfile, ImageGallery
- Shared TestFixtures for reusable test data factories
- Added turbine, kotlin-test, kotlinx-coroutines-test dependencies

## Related Issues

Closes #113, Closes #114, Closes #115

## Screenshots / Video

<!-- If applicable, add screenshots or screen recordings -->

## Test Plan

- [x] `./gradlew :shared:testDebugUnitTest` — 96 tests pass
- [x] `./gradlew :androidApp:testDebugUnitTest` — 24 tests pass
- [x] `./gradlew detekt` — clean

## Review Checklist

- [x] Code follows project architecture (Clean Architecture + MVVM)
- [x] Shared logic is in `commonMain`, platform-specific code only when necessary
- [x] No unnecessary dependencies added
- [x] Tests added/updated as needed

## Breaking Changes

None