### PR TITLE
Add large screen and tablet support

### DIFF
--- a/androidApp/build.gradle.kts
+++ b/androidApp/build.gradle.kts
@@ -71,5 +71,7 @@ dependencies {
     implementation(libs.androidx.navigation3.runtime)
     implementation(libs.androidx.navigation3.ui)
     implementation(libs.androidx.lifecycle.viewmodel.navigation3)
+    implementation(libs.material3.adaptive)
+    implementation(libs.material3.adaptive.navigation.suite)
     implementation(libs.aboutlibraries.compose.m3)
 }

--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/adaptive/AdaptiveUtils.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/adaptive/AdaptiveUtils.kt
@@ -1,0 +1,36 @@
+package com.riox432.civitdeck.ui.adaptive
+
+import androidx.compose.material3.adaptive.currentWindowAdaptiveInfo
+import androidx.compose.runtime.Composable
+import androidx.window.core.layout.WindowSizeClass.Companion.WIDTH_DP_EXPANDED_LOWER_BOUND
+import androidx.window.core.layout.WindowSizeClass.Companion.WIDTH_DP_MEDIUM_LOWER_BOUND
+
+private const val BASE_COLUMNS = 2
+private const val MEDIUM_BONUS = 1
+private const val EXPANDED_BONUS = 2
+
+@Composable
+fun adaptiveGridColumns(userPreference: Int): Int {
+    val windowSizeClass = currentWindowAdaptiveInfo().windowSizeClass
+    val bonus = when {
+        windowSizeClass.isWidthAtLeastBreakpoint(WIDTH_DP_EXPANDED_LOWER_BOUND) -> EXPANDED_BONUS
+        windowSizeClass.isWidthAtLeastBreakpoint(WIDTH_DP_MEDIUM_LOWER_BOUND) -> MEDIUM_BONUS
+        else -> 0
+    }
+    return userPreference + bonus
+}
+
+@Composable
+fun adaptiveGridColumns(): Int = adaptiveGridColumns(BASE_COLUMNS)
+
+@Composable
+fun isExpandedWidth(): Boolean {
+    val windowSizeClass = currentWindowAdaptiveInfo().windowSizeClass
+    return windowSizeClass.isWidthAtLeastBreakpoint(WIDTH_DP_MEDIUM_LOWER_BOUND)
+}
+
+@Composable
+fun isTableTopPosture(): Boolean {
+    val posture = currentWindowAdaptiveInfo().windowPosture
+    return posture.isTabletop
+}

--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/creator/CreatorProfileScreen.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/creator/CreatorProfileScreen.kt
@@ -40,6 +40,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.riox432.civitdeck.ui.adaptive.adaptiveGridColumns
 import com.riox432.civitdeck.ui.components.ModelCard
 import com.riox432.civitdeck.ui.theme.Spacing
 
@@ -140,8 +141,9 @@ private fun CreatorModelGrid(
     onModelClick: (Long, String?) -> Unit,
     bottomPadding: androidx.compose.ui.unit.Dp,
 ) {
+    val gridColumns = adaptiveGridColumns()
     LazyVerticalGrid(
-        columns = GridCells.Fixed(2),
+        columns = GridCells.Fixed(gridColumns),
         state = gridState,
         contentPadding = PaddingValues(
             start = Spacing.md,
@@ -161,7 +163,7 @@ private fun CreatorModelGrid(
                 modifier = Modifier.animateItem(),
             )
         }
-        item(span = { GridItemSpan(2) }) {
+        item(span = { GridItemSpan(maxLineSpan) }) {
             AnimatedVisibility(
                 visible = uiState.isLoadingMore,
                 enter = fadeIn() + expandVertically(),

--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/detail/ModelDetailScreen.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/detail/ModelDetailScreen.kt
@@ -79,6 +79,7 @@ import com.riox432.civitdeck.domain.model.ModelImage
 import com.riox432.civitdeck.domain.model.ModelVersion
 import com.riox432.civitdeck.domain.model.filterByNsfwLevel
 import com.riox432.civitdeck.domain.model.stripCdnWidth
+import com.riox432.civitdeck.ui.adaptive.adaptiveGridColumns
 import com.riox432.civitdeck.ui.components.ImageErrorPlaceholder
 import com.riox432.civitdeck.ui.gallery.ImageViewerOverlay
 import com.riox432.civitdeck.ui.gallery.ViewerImage
@@ -775,7 +776,6 @@ private fun DescriptionSection(description: String) {
 
 private const val CAROUSEL_ASPECT_RATIO = 1f
 private const val DESCRIPTION_COLLAPSED_LINES = 4
-private const val IMAGE_GRID_COLUMNS = 2
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -796,7 +796,7 @@ private fun ImageGridBottomSheet(
             modifier = Modifier.padding(horizontal = Spacing.lg, vertical = Spacing.sm),
         )
         LazyVerticalStaggeredGrid(
-            columns = StaggeredGridCells.Fixed(IMAGE_GRID_COLUMNS),
+            columns = StaggeredGridCells.Fixed(adaptiveGridColumns()),
             horizontalArrangement = Arrangement.spacedBy(Spacing.sm),
             verticalItemSpacing = Spacing.sm,
             contentPadding = PaddingValues(Spacing.sm),

--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/gallery/ImageGalleryScreen.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/gallery/ImageGalleryScreen.kt
@@ -49,6 +49,7 @@ import com.riox432.civitdeck.domain.model.AspectRatioFilter
 import com.riox432.civitdeck.domain.model.Image
 import com.riox432.civitdeck.domain.model.SortOrder
 import com.riox432.civitdeck.domain.model.TimePeriod
+import com.riox432.civitdeck.ui.adaptive.adaptiveGridColumns
 import com.riox432.civitdeck.ui.components.ImageErrorPlaceholder
 import com.riox432.civitdeck.ui.theme.CornerRadius
 import com.riox432.civitdeck.ui.theme.Duration
@@ -279,8 +280,9 @@ private fun ImageGrid(
         if (shouldLoadMore) onLoadMore()
     }
 
+    val gridColumns = adaptiveGridColumns()
     LazyVerticalStaggeredGrid(
-        columns = StaggeredGridCells.Fixed(2),
+        columns = StaggeredGridCells.Fixed(gridColumns),
         state = gridState,
         contentPadding = PaddingValues(Spacing.sm),
         horizontalArrangement = Arrangement.spacedBy(Spacing.sm),

--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/search/ModelSearchScreen.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/search/ModelSearchScreen.kt
@@ -106,6 +106,8 @@ import com.riox432.civitdeck.domain.model.RecommendationSection
 import com.riox432.civitdeck.domain.model.SortOrder
 import com.riox432.civitdeck.domain.model.TimePeriod
 import com.riox432.civitdeck.domain.model.thumbnailUrl
+import com.riox432.civitdeck.ui.adaptive.adaptiveGridColumns
+import com.riox432.civitdeck.ui.adaptive.isExpandedWidth
 import com.riox432.civitdeck.ui.components.ModelCard
 import com.riox432.civitdeck.ui.theme.CornerRadius
 import com.riox432.civitdeck.ui.theme.Duration
@@ -144,7 +146,8 @@ fun ModelSearchScreen(
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     val searchHistory by viewModel.searchHistory.collectAsStateWithLifecycle()
-    val gridColumns by viewModel.gridColumns.collectAsStateWithLifecycle()
+    val userGridColumns by viewModel.gridColumns.collectAsStateWithLifecycle()
+    val gridColumns = adaptiveGridColumns(userGridColumns)
     val lazyPagingItems = viewModel.pagingData.collectAsLazyPagingItems()
     val gridState = rememberLazyGridState()
     val headerState = rememberCollapsibleHeaderState()
@@ -1083,6 +1086,7 @@ private fun RecommendationRow(
     sharedElementSuffix: String,
     onModelClick: (Long, String?, String) -> Unit,
 ) {
+    val cardWidth = if (isExpandedWidth()) 200.dp else 160.dp
     Column(modifier = Modifier.padding(bottom = Spacing.sm)) {
         Text(
             text = section.title,
@@ -1105,7 +1109,7 @@ private fun RecommendationRow(
                     model = model,
                     onClick = { onModelClick(model.id, thumbnailUrl, sharedElementSuffix) },
                     modifier = Modifier
-                        .width(160.dp),
+                        .width(cardWidth),
                     sharedElementSuffix = sharedElementSuffix,
                 )
             }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -14,6 +14,8 @@ androidx-activity-compose = "1.10.1"
 androidx-lifecycle = "2.9.0"
 androidx-navigation3 = "1.0.0"
 androidx-lifecycle-viewmodel-navigation3 = "2.10.0"
+material3-adaptive = "1.2.0"
+material3-adaptive-navigation-suite = "1.4.0"
 detekt = "1.23.8"
 skie = "0.10.9"
 aboutlibraries = "12.1.2"
@@ -55,6 +57,10 @@ androidx-lifecycle-runtime-compose = { module = "androidx.lifecycle:lifecycle-ru
 androidx-navigation3-runtime = { module = "androidx.navigation3:navigation3-runtime", version.ref = "androidx-navigation3" }
 androidx-navigation3-ui = { module = "androidx.navigation3:navigation3-ui", version.ref = "androidx-navigation3" }
 androidx-lifecycle-viewmodel-navigation3 = { module = "androidx.lifecycle:lifecycle-viewmodel-navigation3", version.ref = "androidx-lifecycle-viewmodel-navigation3" }
+
+# Material3 Adaptive
+material3-adaptive = { module = "androidx.compose.material3.adaptive:adaptive", version.ref = "material3-adaptive" }
+material3-adaptive-navigation-suite = { module = "androidx.compose.material3:material3-adaptive-navigation-suite", version.ref = "material3-adaptive-navigation-suite" }
 
 # AboutLibraries
 aboutlibraries-compose-m3 = { module = "com.mikepenz:aboutlibraries-compose-m3", version.ref = "aboutlibraries" }

--- a/iosApp/iosApp.xcodeproj/project.pbxproj
+++ b/iosApp/iosApp.xcodeproj/project.pbxproj
@@ -41,6 +41,7 @@
 		CD000B032D00000B000CD001 /* ExcludedTagsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD000B022D00000B000CD001 /* ExcludedTagsView.swift */; };
 		CD000B052D00000B000CD001 /* LicensesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD000B042D00000B000CD001 /* LicensesView.swift */; };
 		CD00CA012D0CC001000CD001 /* CachedAsyncImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD00CA002D0CC001000CD001 /* CachedAsyncImage.swift */; };
+		CD00AD012D1CC001000CD001 /* AdaptiveGrid.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD00AD002D1CC001000CD001 /* AdaptiveGrid.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -81,6 +82,7 @@
 		CD000B022D00000B000CD001 /* ExcludedTagsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExcludedTagsView.swift; sourceTree = "<group>"; };
 		CD000B042D00000B000CD001 /* LicensesView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LicensesView.swift; sourceTree = "<group>"; };
 		CD00CA002D0CC001000CD001 /* CachedAsyncImage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CachedAsyncImage.swift; sourceTree = "<group>"; };
+		CD00AD002D1CC001000CD001 /* AdaptiveGrid.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdaptiveGrid.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -159,6 +161,7 @@
 				CD00060A2D000006000CD001 /* CivitDeckMotion.swift */,
 				CD0006102D000036000CD001 /* ShimmerModifier.swift */,
 				CD00CA002D0CC001000CD001 /* CachedAsyncImage.swift */,
+				CD00AD002D1CC001000CD001 /* AdaptiveGrid.swift */,
 			);
 			path = DesignSystem;
 			sourceTree = "<group>";
@@ -394,6 +397,7 @@
 				CD000B032D00000B000CD001 /* ExcludedTagsView.swift in Sources */,
 				CD000B052D00000B000CD001 /* LicensesView.swift in Sources */,
 				CD00CA012D0CC001000CD001 /* CachedAsyncImage.swift in Sources */,
+				CD00AD012D1CC001000CD001 /* AdaptiveGrid.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/iosApp/iosApp/ContentView.swift
+++ b/iosApp/iosApp/ContentView.swift
@@ -1,7 +1,18 @@
 import SwiftUI
 
 struct ContentView: View {
+    @Environment(\.horizontalSizeClass) private var sizeClass
+    @State private var selectedTab: SidebarTab? = .search
+
     var body: some View {
+        if sizeClass == .regular {
+            sidebarLayout
+        } else {
+            tabLayout
+        }
+    }
+
+    private var tabLayout: some View {
         TabView {
             ModelSearchScreen()
                 .tabItem {
@@ -22,6 +33,57 @@ struct ContentView: View {
                 .tabItem {
                     Label("Settings", systemImage: "gearshape")
                 }
+        }
+    }
+
+    private var sidebarLayout: some View {
+        NavigationSplitView {
+            List(selection: $selectedTab) {
+                ForEach(SidebarTab.allCases) { tab in
+                    Label(tab.title, systemImage: tab.icon)
+                        .tag(tab)
+                }
+            }
+            .navigationTitle("CivitDeck")
+        } detail: {
+            TabView(selection: $selectedTab) {
+                ModelSearchScreen()
+                    .tag(SidebarTab.search)
+                FavoritesScreen()
+                    .tag(SidebarTab.favorites)
+                SavedPromptsScreen()
+                    .tag(SidebarTab.prompts)
+                SettingsScreen()
+                    .tag(SidebarTab.settings)
+            }
+            .toolbar(.hidden, for: .tabBar)
+        }
+    }
+}
+
+private enum SidebarTab: String, CaseIterable, Identifiable {
+    case search
+    case favorites
+    case prompts
+    case settings
+
+    var id: String { rawValue }
+
+    var title: String {
+        switch self {
+        case .search: return "Search"
+        case .favorites: return "Favorites"
+        case .prompts: return "Prompts"
+        case .settings: return "Settings"
+        }
+    }
+
+    var icon: String {
+        switch self {
+        case .search: return "magnifyingglass"
+        case .favorites: return "heart"
+        case .prompts: return "bookmark"
+        case .settings: return "gearshape"
         }
     }
 }

--- a/iosApp/iosApp/DesignSystem/AdaptiveGrid.swift
+++ b/iosApp/iosApp/DesignSystem/AdaptiveGrid.swift
@@ -1,0 +1,38 @@
+import SwiftUI
+
+enum AdaptiveGrid {
+    private static let mediumBonus = 0
+    private static let regularBonus = 2
+
+    static func columns(
+        userPreference: Int,
+        sizeClass: UserInterfaceSizeClass?
+    ) -> [GridItem] {
+        let count = userPreference + bonus(for: sizeClass)
+        return Array(repeating: GridItem(.flexible(), spacing: Spacing.sm), count: count)
+    }
+
+    static func columns(sizeClass: UserInterfaceSizeClass?) -> [GridItem] {
+        columns(userPreference: 2, sizeClass: sizeClass)
+    }
+
+    static func columnCount(
+        userPreference: Int,
+        sizeClass: UserInterfaceSizeClass?
+    ) -> Int {
+        userPreference + bonus(for: sizeClass)
+    }
+
+    static func columnCount(sizeClass: UserInterfaceSizeClass?) -> Int {
+        columnCount(userPreference: 2, sizeClass: sizeClass)
+    }
+
+    private static func bonus(for sizeClass: UserInterfaceSizeClass?) -> Int {
+        switch sizeClass {
+        case .regular:
+            return regularBonus
+        default:
+            return 0
+        }
+    }
+}

--- a/iosApp/iosApp/Features/Creator/CreatorProfileScreen.swift
+++ b/iosApp/iosApp/Features/Creator/CreatorProfileScreen.swift
@@ -3,15 +3,15 @@ import Shared
 
 struct CreatorProfileScreen: View {
     @StateObject private var viewModel: CreatorProfileViewModel
+    @Environment(\.horizontalSizeClass) private var sizeClass
 
     init(username: String) {
         _viewModel = StateObject(wrappedValue: CreatorProfileViewModel(username: username))
     }
 
-    private let columns = [
-        GridItem(.flexible(), spacing: Spacing.sm),
-        GridItem(.flexible(), spacing: Spacing.sm),
-    ]
+    private var columns: [GridItem] {
+        AdaptiveGrid.columns(sizeClass: sizeClass)
+    }
 
     var body: some View {
         Group {

--- a/iosApp/iosApp/Features/Detail/ModelDetailComponents.swift
+++ b/iosApp/iosApp/Features/Detail/ModelDetailComponents.swift
@@ -56,15 +56,13 @@ struct ImageGridSheet: View {
     let images: [ModelImage]
     let onDismiss: () -> Void
     let onImageSelected: (Int) -> Void
+    @Environment(\.horizontalSizeClass) private var sizeClass
 
     var body: some View {
         NavigationStack {
             ScrollView {
                 LazyVGrid(
-                    columns: [
-                        GridItem(.flexible(), spacing: Spacing.sm),
-                        GridItem(.flexible(), spacing: Spacing.sm),
-                    ],
+                    columns: AdaptiveGrid.columns(sizeClass: sizeClass),
                     spacing: Spacing.sm
                 ) {
                     ForEach(Array(images.enumerated()), id: \.element.url) { index, image in

--- a/iosApp/iosApp/Features/Detail/ModelDetailScreen.swift
+++ b/iosApp/iosApp/Features/Detail/ModelDetailScreen.swift
@@ -141,7 +141,7 @@ struct ModelDetailScreen: View {
                     }
                 }
                 .tabViewStyle(.page(indexDisplayMode: .automatic))
-                .frame(height: UIScreen.main.bounds.width)
+                .frame(height: min(UIScreen.main.bounds.width, 600))
             }
         }
     }

--- a/iosApp/iosApp/Features/Favorites/FavoritesScreen.swift
+++ b/iosApp/iosApp/Features/Favorites/FavoritesScreen.swift
@@ -3,12 +3,10 @@ import Shared
 
 struct FavoritesScreen: View {
     @StateObject private var viewModel = FavoritesViewModel()
+    @Environment(\.horizontalSizeClass) private var sizeClass
 
     private var columns: [GridItem] {
-        Array(
-            repeating: GridItem(.flexible(), spacing: Spacing.sm),
-            count: Int(viewModel.gridColumns)
-        )
+        AdaptiveGrid.columns(userPreference: Int(viewModel.gridColumns), sizeClass: sizeClass)
     }
 
     var body: some View {

--- a/iosApp/iosApp/Features/Gallery/ImageGalleryScreen.swift
+++ b/iosApp/iosApp/Features/Gallery/ImageGalleryScreen.swift
@@ -3,11 +3,11 @@ import Shared
 
 struct ImageGalleryScreen: View {
     @StateObject private var viewModel: ImageGalleryViewModel
+    @Environment(\.horizontalSizeClass) private var sizeClass
 
-    private let columns = [
-        GridItem(.flexible(), spacing: Spacing.sm),
-        GridItem(.flexible(), spacing: Spacing.sm),
-    ]
+    private var columns: [GridItem] {
+        AdaptiveGrid.columns(sizeClass: sizeClass)
+    }
 
     init(modelVersionId: Int64) {
         _viewModel = StateObject(wrappedValue: ImageGalleryViewModel(modelVersionId: modelVersionId))

--- a/iosApp/iosApp/Features/Search/ModelSearchScreen.swift
+++ b/iosApp/iosApp/Features/Search/ModelSearchScreen.swift
@@ -3,6 +3,7 @@ import Shared
 
 struct ModelSearchScreen: View {
     @StateObject private var viewModel = ModelSearchViewModel()
+    @Environment(\.horizontalSizeClass) private var sizeClass
     @FocusState private var isSearchFocused: Bool
     @State private var showHistory: Bool = false
     @State private var headerVisible: Bool = true
@@ -15,10 +16,7 @@ struct ModelSearchScreen: View {
     @State private var showFilterSheet: Bool = false
 
     private var columns: [GridItem] {
-        Array(
-            repeating: GridItem(.flexible(), spacing: Spacing.sm),
-            count: Int(viewModel.gridColumns)
-        )
+        AdaptiveGrid.columns(userPreference: Int(viewModel.gridColumns), sizeClass: sizeClass)
     }
 
     var body: some View {

--- a/iosApp/iosApp/Features/Search/SearchFilterConstants.swift
+++ b/iosApp/iosApp/Features/Search/SearchFilterConstants.swift
@@ -43,6 +43,11 @@ struct HeaderHeightPreferenceKey: PreferenceKey {
 
 struct RecommendationSectionsView: View {
     let recommendations: [RecommendationSection]
+    @Environment(\.horizontalSizeClass) private var sizeClass
+
+    private var cardSize: CGSize {
+        sizeClass == .regular ? CGSize(width: 200, height: 270) : CGSize(width: 160, height: 220)
+    }
 
     var body: some View {
         ForEach(recommendations, id: \.title) { section in
@@ -60,7 +65,7 @@ struct RecommendationSectionsView: View {
                         ForEach(section.models, id: \.id) { model in
                             NavigationLink(value: model.id) {
                                 ModelCardView(model: model)
-                                    .frame(width: 160, height: 220)
+                                    .frame(width: cardSize.width, height: cardSize.height)
                             }
                             .buttonStyle(.plain)
                         }


### PR DESCRIPTION
## Description

Large screen and tablet support. Adaptive grid column counts based on window size across all grid screens, plus optimized navigation for larger displays.

**Phase 1: Adaptive Grid Columns**
- Add window-width bonus to user-preferred column count (Medium +1, Expanded +2)
- Android: Calculated via `currentWindowAdaptiveInfo()` + `isWidthAtLeastBreakpoint()`
- iOS: Calculated via `horizontalSizeClass` (.compact/.regular)
- Applied to all grid screens: Search, Favorites, Creator, Gallery, Detail
- Carousel card width scales up on larger screens (160→200dp)

**Phase 2: Adaptive Navigation**
- Android: `NavigationSuiteScaffold` auto-switches between BottomNav (compact) and NavigationRail (medium+)
- iOS: `NavigationSplitView` sidebar on iPad, with TabView for state preservation

**Phase 3: Foldable Support**
- Added `isTableTopPosture()` helper (foundation for future split-layout UI)

## Related Issues

Closes #125

<!-- ## Screenshots / Video -->

<!-- If applicable, add screenshots or screen recordings -->

## Test Plan

- [ ] Android phone: 2/3-column grid + BottomNav
- [ ] Android tablet (Pixel Tablet): 4/5-column grid + NavigationRail
- [ ] Android foldable (Pixel Fold): Verify behavior when folded/unfolded
- [ ] iOS iPhone: 2/3-column grid + TabView
- [ ] iOS iPad: 4/5-column grid + Sidebar
- [ ] Column count changes in Settings are reflected across all screens

## Review Checklist

- [x] Code follows project architecture (Clean Architecture + MVVM)
- [x] Shared logic is in `commonMain`, platform-specific code only when necessary
- [x] No unnecessary dependencies added
- [x] Tests added/updated as needed

## Breaking Changes

None