### PR TITLE
Fix Phase 2 quality issues: bugs, dead code, and feature gaps

### DIFF
--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/CivitDeckApplication.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/CivitDeckApplication.kt
@@ -99,7 +99,7 @@ val androidModule = module {
     }
     viewModel { params -> CreatorProfileViewModel(params.get(), get()) }
     viewModel { params -> ImageGalleryViewModel(params.get(), get(), get(), get(), get()) }
-    viewModel { SavedPromptsViewModel(get(), get(), get(), get(), get(), get()) }
+    viewModel { SavedPromptsViewModel(get(), get(), get(), get(), get()) }
     viewModel {
         SettingsViewModel(
             get(), get(), get(), get(), get(), get(),

--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/adaptive/AdaptiveUtils.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/adaptive/AdaptiveUtils.kt
@@ -28,9 +28,3 @@ fun isExpandedWidth(): Boolean {
     val windowSizeClass = currentWindowAdaptiveInfo().windowSizeClass
     return windowSizeClass.isWidthAtLeastBreakpoint(WIDTH_DP_MEDIUM_LOWER_BOUND)
 }
-
-@Composable
-fun isTableTopPosture(): Boolean {
-    val posture = currentWindowAdaptiveInfo().windowPosture
-    return posture.isTabletop
-}

--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/compare/ModelCompareScreen.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/compare/ModelCompareScreen.kt
@@ -142,7 +142,14 @@ private fun CompareBody(
             )
         }
         item { HorizontalDivider(modifier = Modifier.padding(vertical = Spacing.sm)) }
-        item { CompareSpecsTable(leftModel = leftModel, rightModel = rightModel) }
+        item {
+            CompareSpecsTable(
+                leftModel = leftModel,
+                rightModel = rightModel,
+                leftVersionIndex = leftState.selectedVersionIndex,
+                rightVersionIndex = rightState.selectedVersionIndex,
+            )
+        }
     }
 }
 
@@ -315,6 +322,8 @@ private fun VersionChipRow(
 private fun CompareSpecsTable(
     leftModel: Model,
     rightModel: Model,
+    leftVersionIndex: Int,
+    rightVersionIndex: Int,
 ) {
     Column(modifier = Modifier.padding(horizontal = Spacing.md)) {
         Text(
@@ -323,7 +332,11 @@ private fun CompareSpecsTable(
             modifier = Modifier.padding(bottom = Spacing.sm),
         )
         SpecRow("Type", leftModel.type.name, rightModel.type.name)
-        SpecRow("Base Model", leftBaseModel(leftModel), leftBaseModel(rightModel))
+        SpecRow(
+            "Base Model",
+            baseModelForVersion(leftModel, leftVersionIndex),
+            baseModelForVersion(rightModel, rightVersionIndex),
+        )
         SpecRow(
             "Downloads",
             FormatUtils.formatCount(leftModel.stats.downloadCount),
@@ -341,18 +354,18 @@ private fun CompareSpecsTable(
         )
         SpecRow(
             "File Size",
-            primaryFileSize(leftModel),
-            primaryFileSize(rightModel),
+            primaryFileSize(leftModel, leftVersionIndex),
+            primaryFileSize(rightModel, rightVersionIndex),
         )
     }
 }
 
-private fun leftBaseModel(model: Model): String =
-    model.modelVersions.firstOrNull()?.baseModel ?: "-"
+private fun baseModelForVersion(model: Model, versionIndex: Int): String =
+    model.modelVersions.getOrNull(versionIndex)?.baseModel ?: "-"
 
-private fun primaryFileSize(model: Model): String {
-    val file = model.modelVersions.firstOrNull()?.files
-        ?.firstOrNull { it.primary } ?: model.modelVersions.firstOrNull()?.files?.firstOrNull()
+private fun primaryFileSize(model: Model, versionIndex: Int): String {
+    val version = model.modelVersions.getOrNull(versionIndex) ?: return "-"
+    val file = version.files.firstOrNull { it.primary } ?: version.files.firstOrNull()
     return if (file != null) FormatUtils.formatFileSize(file.sizeKB) else "-"
 }
 

--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/navigation/CivitDeckNavGraph.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/navigation/CivitDeckNavGraph.kt
@@ -21,7 +21,10 @@ import androidx.compose.material.icons.outlined.Settings
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
+import androidx.compose.material3.adaptive.currentWindowAdaptiveInfo
 import androidx.compose.material3.adaptive.navigationsuite.NavigationSuiteScaffold
+import androidx.compose.material3.adaptive.navigationsuite.NavigationSuiteScaffoldDefaults
+import androidx.compose.material3.adaptive.navigationsuite.NavigationSuiteType
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.getValue
@@ -40,6 +43,7 @@ import androidx.navigation3.runtime.EntryProviderScope
 import androidx.navigation3.runtime.entryProvider
 import androidx.navigation3.runtime.rememberSaveableStateHolderNavEntryDecorator
 import androidx.navigation3.ui.NavDisplay
+import androidx.window.core.layout.WindowSizeClass.Companion.WIDTH_DP_EXPANDED_LOWER_BOUND
 import com.riox432.civitdeck.ui.collections.CollectionDetailScreen
 import com.riox432.civitdeck.ui.collections.CollectionDetailViewModel
 import com.riox432.civitdeck.ui.collections.CollectionsScreen
@@ -142,7 +146,17 @@ fun CivitDeckNavGraph() {
     var compareModelId by rememberSaveable { mutableStateOf<Long?>(null) }
     var compareModelName by rememberSaveable { mutableStateOf<String?>(null) }
 
+    val adaptiveInfo = currentWindowAdaptiveInfo()
+    val navLayoutType = if (
+        adaptiveInfo.windowSizeClass.isWidthAtLeastBreakpoint(WIDTH_DP_EXPANDED_LOWER_BOUND)
+    ) {
+        NavigationSuiteType.NavigationDrawer
+    } else {
+        NavigationSuiteScaffoldDefaults.calculateFromAdaptiveInfo(adaptiveInfo)
+    }
+
     NavigationSuiteScaffold(
+        layoutType = navLayoutType,
         navigationSuiteItems = {
             Tab.entries.forEach { tab ->
                 val selected = tab == selectedTab

--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/prompts/SavedPromptsScreen.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/prompts/SavedPromptsScreen.kt
@@ -25,6 +25,7 @@ import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.Star
 import androidx.compose.material.icons.outlined.BookmarkBorder
 import androidx.compose.material.icons.outlined.StarBorder
+import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Card
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -34,10 +35,13 @@ import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.ScrollableTabRow
 import androidx.compose.material3.Tab
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
@@ -47,6 +51,7 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.riox432.civitdeck.domain.export.PromptTemplateEngine
 import com.riox432.civitdeck.domain.export.WorkflowExportService
 import com.riox432.civitdeck.domain.model.ImageGenerationMeta
 import com.riox432.civitdeck.domain.model.SavedPrompt
@@ -171,6 +176,62 @@ private fun PromptList(
     listState: LazyListState = rememberLazyListState(),
 ) {
     val context = LocalContext.current
+    var templateDialogPromptId by remember { mutableStateOf<Long?>(null) }
+    var templateNameInput by remember { mutableStateOf("") }
+    var applyTemplatePrompt by remember { mutableStateOf<SavedPrompt?>(null) }
+
+    PromptLazyColumn(
+        prompts = prompts,
+        modifier = modifier,
+        listState = listState,
+        context = context,
+        onDelete = onDelete,
+        onToggleTemplate = { id, isTemplate ->
+            if (isTemplate) {
+                onToggleTemplate(id, false, null)
+            } else {
+                templateNameInput = ""
+                templateDialogPromptId = id
+            }
+        },
+        onRequestApply = { applyTemplatePrompt = it },
+    )
+
+    templateDialogPromptId?.let { promptId ->
+        TemplateNameDialog(
+            name = templateNameInput,
+            onNameChange = { templateNameInput = it },
+            onConfirm = {
+                val name = templateNameInput.trim().ifEmpty { null }
+                onToggleTemplate(promptId, true, name)
+                templateDialogPromptId = null
+            },
+            onDismiss = { templateDialogPromptId = null },
+        )
+    }
+
+    applyTemplatePrompt?.let { prompt ->
+        ApplyTemplateDialog(
+            prompt = prompt,
+            onGenerate = { result ->
+                copyToClipboard(context, result)
+                applyTemplatePrompt = null
+            },
+            onDismiss = { applyTemplatePrompt = null },
+        )
+    }
+}
+
+@Composable
+private fun PromptLazyColumn(
+    prompts: List<SavedPrompt>,
+    context: Context,
+    onDelete: (Long) -> Unit,
+    onToggleTemplate: (Long, Boolean) -> Unit,
+    onRequestApply: (SavedPrompt) -> Unit,
+    modifier: Modifier = Modifier,
+    listState: LazyListState = rememberLazyListState(),
+) {
     LazyColumn(
         modifier = modifier.fillMaxSize(),
         state = listState,
@@ -182,14 +243,52 @@ private fun PromptList(
                 prompt = prompt,
                 onCopy = { copyToClipboard(context, prompt.prompt) },
                 onDelete = { onDelete(prompt.id) },
-                onToggleTemplate = {
-                    onToggleTemplate(prompt.id, !prompt.isTemplate, prompt.templateName)
-                },
+                onToggleTemplate = { onToggleTemplate(prompt.id, prompt.isTemplate) },
                 onExport = { exportPrompt(context, prompt) },
+                onApply = if (prompt.isTemplate) {
+                    {
+                        val variables = PromptTemplateEngine.extractVariables(prompt.prompt)
+                        if (variables.isEmpty()) {
+                            copyToClipboard(context, prompt.prompt)
+                        } else {
+                            onRequestApply(prompt)
+                        }
+                    }
+                } else {
+                    null
+                },
                 modifier = Modifier.animateItem(),
             )
         }
     }
+}
+
+@Composable
+private fun TemplateNameDialog(
+    name: String,
+    onNameChange: (String) -> Unit,
+    onConfirm: () -> Unit,
+    onDismiss: () -> Unit,
+) {
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text("Save as Template") },
+        text = {
+            OutlinedTextField(
+                value = name,
+                onValueChange = onNameChange,
+                label = { Text("Template name (optional)") },
+                singleLine = true,
+                modifier = Modifier.fillMaxWidth(),
+            )
+        },
+        confirmButton = {
+            TextButton(onClick = onConfirm) { Text("Save") }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) { Text("Cancel") }
+        },
+    )
 }
 
 @Composable
@@ -199,6 +298,7 @@ private fun PromptCard(
     onDelete: () -> Unit,
     onToggleTemplate: () -> Unit,
     onExport: () -> Unit,
+    onApply: (() -> Unit)? = null,
     modifier: Modifier = Modifier,
 ) {
     Card(
@@ -220,7 +320,12 @@ private fun PromptCard(
             Spacer(modifier = Modifier.height(Spacing.sm))
             PromptParams(prompt)
             Spacer(modifier = Modifier.height(Spacing.sm))
-            PromptActions(onCopy = onCopy, onExport = onExport, onDelete = onDelete)
+            PromptActions(
+                onCopy = onCopy,
+                onExport = onExport,
+                onDelete = onDelete,
+                onApply = onApply,
+            )
         }
     }
 }
@@ -276,11 +381,21 @@ private fun NegativePromptText(text: String) {
 }
 
 @Composable
-private fun PromptActions(onCopy: () -> Unit, onExport: () -> Unit, onDelete: () -> Unit) {
+private fun PromptActions(
+    onCopy: () -> Unit,
+    onExport: () -> Unit,
+    onDelete: () -> Unit,
+    onApply: (() -> Unit)? = null,
+) {
     Row(
         horizontalArrangement = Arrangement.spacedBy(Spacing.sm),
         verticalAlignment = Alignment.CenterVertically,
     ) {
+        if (onApply != null) {
+            OutlinedButton(onClick = onApply) {
+                Text("Apply")
+            }
+        }
         OutlinedButton(onClick = onCopy) {
             Text("Copy")
         }
@@ -314,6 +429,51 @@ private fun PromptParams(prompt: SavedPrompt) {
             color = MaterialTheme.colorScheme.onSurfaceVariant,
         )
     }
+}
+
+@Composable
+private fun ApplyTemplateDialog(
+    prompt: SavedPrompt,
+    onGenerate: (String) -> Unit,
+    onDismiss: () -> Unit,
+) {
+    val variables = remember(prompt.id) {
+        PromptTemplateEngine.extractVariables(prompt.prompt)
+    }
+    val values = remember(prompt.id) {
+        mutableStateOf(variables.associateWith { "" })
+    }
+
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text(prompt.templateName ?: "Apply Template") },
+        text = {
+            Column(verticalArrangement = Arrangement.spacedBy(Spacing.sm)) {
+                variables.forEach { variable ->
+                    OutlinedTextField(
+                        value = values.value[variable] ?: "",
+                        onValueChange = { newValue ->
+                            values.value = values.value.toMutableMap().apply {
+                                put(variable, newValue)
+                            }
+                        },
+                        label = { Text(variable) },
+                        singleLine = true,
+                        modifier = Modifier.fillMaxWidth(),
+                    )
+                }
+            }
+        },
+        confirmButton = {
+            TextButton(onClick = {
+                val result = PromptTemplateEngine.substitute(prompt.prompt, values.value)
+                onGenerate(result)
+            }) { Text("Generate") }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) { Text("Cancel") }
+        },
+    )
 }
 
 private fun exportPrompt(context: Context, prompt: SavedPrompt) {

--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/prompts/SavedPromptsViewModel.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/prompts/SavedPromptsViewModel.kt
@@ -8,7 +8,6 @@ import com.riox432.civitdeck.domain.usecase.ObserveSavedPromptsUseCase
 import com.riox432.civitdeck.domain.usecase.ObserveTemplatesUseCase
 import com.riox432.civitdeck.domain.usecase.SearchSavedPromptsUseCase
 import com.riox432.civitdeck.domain.usecase.ToggleTemplateUseCase
-import com.riox432.civitdeck.domain.usecase.UpdatePromptCategoryUseCase
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
@@ -27,7 +26,6 @@ class SavedPromptsViewModel(
     private val searchSavedPromptsUseCase: SearchSavedPromptsUseCase,
     private val observeTemplatesUseCase: ObserveTemplatesUseCase,
     private val toggleTemplateUseCase: ToggleTemplateUseCase,
-    private val updatePromptCategoryUseCase: UpdatePromptCategoryUseCase,
 ) : ViewModel() {
 
     private val _selectedTab = MutableStateFlow(PromptTab.All)
@@ -66,12 +64,6 @@ class SavedPromptsViewModel(
     fun toggleTemplate(id: Long, isTemplate: Boolean, templateName: String? = null) {
         viewModelScope.launch {
             toggleTemplateUseCase(id, isTemplate, templateName)
-        }
-    }
-
-    fun updateCategory(id: Long, category: String?) {
-        viewModelScope.launch {
-            updatePromptCategoryUseCase(id, category)
         }
     }
 }

--- a/androidApp/src/test/kotlin/com/riox432/civitdeck/ui/gallery/ImageGalleryViewModelTest.kt
+++ b/androidApp/src/test/kotlin/com/riox432/civitdeck/ui/gallery/ImageGalleryViewModelTest.kt
@@ -89,7 +89,6 @@ class ImageGalleryViewModelTest {
         override fun observeHistory() = flowOf(emptyList<com.riox432.civitdeck.domain.model.SavedPrompt>())
         override fun search(query: String) = flowOf(emptyList<com.riox432.civitdeck.domain.model.SavedPrompt>())
         override suspend fun toggleTemplate(id: Long, isTemplate: Boolean, templateName: String?) = Unit
-        override suspend fun updateCategory(id: Long, category: String?) = Unit
         override suspend fun delete(id: Long) = Unit
     }
 

--- a/androidApp/src/test/kotlin/com/riox432/civitdeck/ui/prompts/SavedPromptsViewModelTest.kt
+++ b/androidApp/src/test/kotlin/com/riox432/civitdeck/ui/prompts/SavedPromptsViewModelTest.kt
@@ -5,6 +5,9 @@ import com.riox432.civitdeck.domain.model.SavedPrompt
 import com.riox432.civitdeck.domain.repository.SavedPromptRepository
 import com.riox432.civitdeck.domain.usecase.DeleteSavedPromptUseCase
 import com.riox432.civitdeck.domain.usecase.ObserveSavedPromptsUseCase
+import com.riox432.civitdeck.domain.usecase.ObserveTemplatesUseCase
+import com.riox432.civitdeck.domain.usecase.SearchSavedPromptsUseCase
+import com.riox432.civitdeck.domain.usecase.ToggleTemplateUseCase
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
@@ -49,18 +52,30 @@ class SavedPromptsViewModelTest {
         var deletedId: Long? = null
 
         override fun observeAll(): Flow<List<SavedPrompt>> = flowOf(prompts)
+        override fun observeTemplates(): Flow<List<SavedPrompt>> = flowOf(emptyList())
+        override fun observeHistory(): Flow<List<SavedPrompt>> = flowOf(emptyList())
+        override fun search(query: String): Flow<List<SavedPrompt>> = flowOf(emptyList())
         override suspend fun save(meta: ImageGenerationMeta, sourceImageUrl: String?) =
+            error("not used")
+        override suspend fun autoSave(meta: ImageGenerationMeta, sourceImageUrl: String?) =
+            error("not used")
+        override suspend fun toggleTemplate(id: Long, isTemplate: Boolean, templateName: String?) =
             error("not used")
         override suspend fun delete(id: Long) { deletedId = id }
     }
 
+    private fun createViewModel(repo: FakeRepo) = SavedPromptsViewModel(
+        observeSavedPromptsUseCase = ObserveSavedPromptsUseCase(repo),
+        deleteSavedPromptUseCase = DeleteSavedPromptUseCase(repo),
+        searchSavedPromptsUseCase = SearchSavedPromptsUseCase(repo),
+        observeTemplatesUseCase = ObserveTemplatesUseCase(repo),
+        toggleTemplateUseCase = ToggleTemplateUseCase(repo),
+    )
+
     @Test
     fun prompts_flow_emits_list() = runTest(testDispatcher) {
         val repo = FakeRepo(testPrompts)
-        val vm = SavedPromptsViewModel(
-            observeSavedPromptsUseCase = ObserveSavedPromptsUseCase(repo),
-            deleteSavedPromptUseCase = DeleteSavedPromptUseCase(repo),
-        )
+        val vm = createViewModel(repo)
         val job = backgroundScope.launch(testDispatcher) { vm.prompts.collect {} }
         assertEquals(1, vm.prompts.value.size)
         assertEquals("1girl", vm.prompts.value[0].prompt)
@@ -70,10 +85,7 @@ class SavedPromptsViewModelTest {
     @Test
     fun delete_calls_use_case() {
         val repo = FakeRepo(testPrompts)
-        val vm = SavedPromptsViewModel(
-            observeSavedPromptsUseCase = ObserveSavedPromptsUseCase(repo),
-            deleteSavedPromptUseCase = DeleteSavedPromptUseCase(repo),
-        )
+        val vm = createViewModel(repo)
         vm.delete(1L)
         assertTrue(repo.deletedId == 1L)
     }

--- a/iosApp/iosApp/DesignSystem/AdaptiveGrid.swift
+++ b/iosApp/iosApp/DesignSystem/AdaptiveGrid.swift
@@ -1,8 +1,9 @@
 import SwiftUI
 
 enum AdaptiveGrid {
-    private static let mediumBonus = 0
-    private static let regularBonus = 2
+    private static let mediumBonus = 1
+    private static let expandedBonus = 2
+    private static let expandedWidthThreshold: CGFloat = 840
 
     static func columns(
         userPreference: Int,
@@ -30,7 +31,8 @@ enum AdaptiveGrid {
     private static func bonus(for sizeClass: UserInterfaceSizeClass?) -> Int {
         switch sizeClass {
         case .regular:
-            return regularBonus
+            let width = UIScreen.main.bounds.width
+            return width >= expandedWidthThreshold ? expandedBonus : mediumBonus
         default:
             return 0
         }

--- a/iosApp/iosApp/Features/Compare/ModelCompareScreen.swift
+++ b/iosApp/iosApp/Features/Compare/ModelCompareScreen.swift
@@ -192,8 +192,10 @@ struct ModelCompareScreen: View {
             specRow(label: "Type", leftValue: left.type.name, rightValue: right.type.name)
             specRow(
                 label: "Base Model",
-                leftValue: left.modelVersions.first?.baseModel ?? "-",
-                rightValue: right.modelVersions.first?.baseModel ?? "-"
+                leftValue: selectedVersion(model: left, index: viewModel.leftSelectedVersionIndex)?
+                    .baseModel ?? "-",
+                rightValue: selectedVersion(model: right, index: viewModel.rightSelectedVersionIndex)?
+                    .baseModel ?? "-"
             )
             specRow(
                 label: "Downloads",
@@ -212,8 +214,12 @@ struct ModelCompareScreen: View {
             )
             specRow(
                 label: "File Size",
-                leftValue: primaryFileSize(model: left),
-                rightValue: primaryFileSize(model: right)
+                leftValue: primaryFileSize(
+                    model: left, versionIndex: viewModel.leftSelectedVersionIndex
+                ),
+                rightValue: primaryFileSize(
+                    model: right, versionIndex: viewModel.rightSelectedVersionIndex
+                )
             )
         }
         .padding(.bottom, Spacing.lg)
@@ -244,8 +250,12 @@ struct ModelCompareScreen: View {
         return version.images.filter { $0.isAllowedByFilter(viewModel.nsfwFilterLevel) }
     }
 
-    private func primaryFileSize(model: Model) -> String {
-        guard let version = model.modelVersions.first else { return "-" }
+    private func selectedVersion(model: Model, index: Int) -> ModelVersion? {
+        index < model.modelVersions.count ? model.modelVersions[index] : nil
+    }
+
+    private func primaryFileSize(model: Model, versionIndex: Int) -> String {
+        guard let version = selectedVersion(model: model, index: versionIndex) else { return "-" }
         let file = version.files.first { $0.primary } ?? version.files.first
         guard let file else { return "-" }
         return FormatUtils.shared.formatFileSize(sizeKB: file.sizeKB)

--- a/iosApp/iosApp/Features/Prompts/SavedPromptsScreen.swift
+++ b/iosApp/iosApp/Features/Prompts/SavedPromptsScreen.swift
@@ -3,6 +3,9 @@ import Shared
 
 struct SavedPromptsScreen: View {
     @StateObject private var viewModel = SavedPromptsViewModel()
+    @State private var templateDialogPromptId: Int64?
+    @State private var templateNameInput = ""
+    @State private var applyTemplatePrompt: SavedPrompt?
 
     var body: some View {
         VStack(spacing: 0) {
@@ -14,6 +17,33 @@ struct SavedPromptsScreen: View {
                 promptList
             }
         }
+        .alert("Save as Template", isPresented: showTemplateAlert) {
+            TextField("Template name (optional)", text: $templateNameInput)
+            Button("Save") {
+                let name = templateNameInput.trimmingCharacters(in: .whitespaces)
+                if let promptId = templateDialogPromptId {
+                    viewModel.toggleTemplate(
+                        id: promptId,
+                        isTemplate: true,
+                        templateName: name.isEmpty ? nil : name
+                    )
+                }
+                templateDialogPromptId = nil
+            }
+            Button("Cancel", role: .cancel) {
+                templateDialogPromptId = nil
+            }
+        }
+        .sheet(item: $applyTemplatePrompt) { prompt in
+            ApplyTemplateSheet(prompt: prompt)
+        }
+    }
+
+    private var showTemplateAlert: Binding<Bool> {
+        Binding(
+            get: { templateDialogPromptId != nil },
+            set: { if !$0 { templateDialogPromptId = nil } }
+        )
     }
 
     private var searchBar: some View {
@@ -58,15 +88,28 @@ struct SavedPromptsScreen: View {
                 PromptCardView(
                     prompt: prompt,
                     onToggleTemplate: {
-                        viewModel.toggleTemplate(
-                            id: prompt.id,
-                            isTemplate: !prompt.isTemplate,
-                            templateName: prompt.templateName
-                        )
+                        if prompt.isTemplate {
+                            viewModel.toggleTemplate(
+                                id: prompt.id, isTemplate: false, templateName: nil
+                            )
+                        } else {
+                            templateNameInput = ""
+                            templateDialogPromptId = prompt.id
+                        }
                     },
                     onDelete: {
                         viewModel.delete(id: prompt.id)
-                    }
+                    },
+                    onApply: prompt.isTemplate ? {
+                        let variables = PromptTemplateEngine.shared.extractVariables(
+                            template: prompt.prompt
+                        )
+                        if variables.isEmpty {
+                            UIPasteboard.general.string = prompt.prompt
+                        } else {
+                            applyTemplatePrompt = prompt
+                        }
+                    } : nil
                 )
             }
         }
@@ -80,6 +123,7 @@ private struct PromptCardView: View {
     let prompt: SavedPrompt
     let onToggleTemplate: () -> Void
     let onDelete: () -> Void
+    var onApply: (() -> Void)?
 
     var body: some View {
         VStack(alignment: .leading, spacing: 8) {
@@ -143,6 +187,12 @@ private struct PromptCardView: View {
 
     private var actionsRow: some View {
         HStack {
+            if let onApply {
+                Button("Apply") { onApply() }
+                    .buttonStyle(.bordered)
+                    .controlSize(.small)
+            }
+
             Button("Copy") {
                 UIPasteboard.general.string = prompt.prompt
             }
@@ -189,3 +239,54 @@ private struct PromptCardView: View {
         topVC.present(activityVC, animated: true)
     }
 }
+
+// MARK: - Apply Template Sheet
+
+private struct ApplyTemplateSheet: View {
+    let prompt: SavedPrompt
+    @Environment(\.dismiss) private var dismiss
+    @State private var values: [String: String] = [:]
+
+    private var variables: [String] {
+        let list = PromptTemplateEngine.shared.extractVariables(template: prompt.prompt)
+        return list.compactMap { $0 as? String }
+    }
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                ForEach(variables, id: \.self) { variable in
+                    TextField(variable, text: binding(for: variable))
+                }
+            }
+            .navigationTitle(prompt.templateName ?? "Apply Template")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel") { dismiss() }
+                }
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Generate") {
+                        let result = PromptTemplateEngine.shared.substitute(
+                            template: prompt.prompt,
+                            values: values
+                        )
+                        UIPasteboard.general.string = result
+                        dismiss()
+                    }
+                }
+            }
+        }
+    }
+
+    private func binding(for key: String) -> Binding<String> {
+        Binding(
+            get: { values[key] ?? "" },
+            set: { values[key] = $0 }
+        )
+    }
+}
+
+// MARK: - SavedPrompt + Identifiable
+
+extension SavedPrompt: @retroactive Identifiable {}

--- a/iosApp/iosApp/Features/Prompts/SavedPromptsViewModel.swift
+++ b/iosApp/iosApp/Features/Prompts/SavedPromptsViewModel.swift
@@ -38,7 +38,6 @@ final class SavedPromptsViewModel: ObservableObject {
     private let deleteSavedPromptUseCase: DeleteSavedPromptUseCase
     private let observeTemplatesUseCase: ObserveTemplatesUseCase
     private let toggleTemplateUseCase: ToggleTemplateUseCase
-    private let updatePromptCategoryUseCase: UpdatePromptCategoryUseCase
 
     private var observeTask: Task<Void, Never>?
     private var observeTemplatesTask: Task<Void, Never>?
@@ -48,7 +47,6 @@ final class SavedPromptsViewModel: ObservableObject {
         self.deleteSavedPromptUseCase = KoinHelper.shared.getDeleteSavedPromptUseCase()
         self.observeTemplatesUseCase = KoinHelper.shared.getObserveTemplatesUseCase()
         self.toggleTemplateUseCase = KoinHelper.shared.getToggleTemplateUseCase()
-        self.updatePromptCategoryUseCase = KoinHelper.shared.getUpdatePromptCategoryUseCase()
         observeTask = Task { await observeAll() }
         observeTemplatesTask = Task { await observeTemplates() }
     }
@@ -81,12 +79,6 @@ final class SavedPromptsViewModel: ObservableObject {
     func toggleTemplate(id: Int64, isTemplate: Bool, templateName: String?) {
         Task {
             try await toggleTemplateUseCase.invoke(id: id, isTemplate: isTemplate, templateName: templateName)
-        }
-    }
-
-    func updateCategory(id: Int64, category: String?) {
-        Task {
-            try await updatePromptCategoryUseCase.invoke(id: id, category: category)
         }
     }
 }

--- a/shared/schemas/com.riox432.civitdeck.data.local.CivitDeckDatabase/12.json
+++ b/shared/schemas/com.riox432.civitdeck.data.local.CivitDeckDatabase/12.json
@@ -1,0 +1,697 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 12,
+    "identityHash": "f0de9d17e9a6de3bd3aaf15bb14d19d8",
+    "entities": [
+      {
+        "tableName": "collections",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL, `isDefault` INTEGER NOT NULL, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isDefault",
+            "columnName": "isDefault",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "collection_model_entries",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`collectionId` INTEGER NOT NULL, `modelId` INTEGER NOT NULL, `name` TEXT NOT NULL, `type` TEXT NOT NULL, `nsfw` INTEGER NOT NULL, `thumbnailUrl` TEXT, `creatorName` TEXT, `downloadCount` INTEGER NOT NULL, `favoriteCount` INTEGER NOT NULL, `rating` REAL NOT NULL, `addedAt` INTEGER NOT NULL, PRIMARY KEY(`collectionId`, `modelId`), FOREIGN KEY(`collectionId`) REFERENCES `collections`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "collectionId",
+            "columnName": "collectionId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "modelId",
+            "columnName": "modelId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "nsfw",
+            "columnName": "nsfw",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "thumbnailUrl",
+            "columnName": "thumbnailUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "creatorName",
+            "columnName": "creatorName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "downloadCount",
+            "columnName": "downloadCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "favoriteCount",
+            "columnName": "favoriteCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "rating",
+            "columnName": "rating",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "addedAt",
+            "columnName": "addedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "collectionId",
+            "modelId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_collection_model_entries_modelId",
+            "unique": false,
+            "columnNames": [
+              "modelId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_collection_model_entries_modelId` ON `${TABLE_NAME}` (`modelId`)"
+          },
+          {
+            "name": "index_collection_model_entries_collectionId",
+            "unique": false,
+            "columnNames": [
+              "collectionId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_collection_model_entries_collectionId` ON `${TABLE_NAME}` (`collectionId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "collections",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "collectionId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "cached_api_responses",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`cacheKey` TEXT NOT NULL, `responseJson` TEXT NOT NULL, `cachedAt` INTEGER NOT NULL, PRIMARY KEY(`cacheKey`))",
+        "fields": [
+          {
+            "fieldPath": "cacheKey",
+            "columnName": "cacheKey",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "responseJson",
+            "columnName": "responseJson",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cachedAt",
+            "columnName": "cachedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "cacheKey"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_cached_api_responses_cachedAt",
+            "unique": false,
+            "columnNames": [
+              "cachedAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_cached_api_responses_cachedAt` ON `${TABLE_NAME}` (`cachedAt`)"
+          }
+        ]
+      },
+      {
+        "tableName": "user_preferences",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `nsfwFilterLevel` TEXT NOT NULL, `defaultSortOrder` TEXT NOT NULL, `defaultTimePeriod` TEXT NOT NULL, `gridColumns` INTEGER NOT NULL, `apiKey` TEXT, `powerUserMode` INTEGER NOT NULL, `notificationsEnabled` INTEGER NOT NULL, `pollingIntervalMinutes` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "nsfwFilterLevel",
+            "columnName": "nsfwFilterLevel",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "defaultSortOrder",
+            "columnName": "defaultSortOrder",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "defaultTimePeriod",
+            "columnName": "defaultTimePeriod",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "gridColumns",
+            "columnName": "gridColumns",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "apiKey",
+            "columnName": "apiKey",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "powerUserMode",
+            "columnName": "powerUserMode",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "notificationsEnabled",
+            "columnName": "notificationsEnabled",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "pollingIntervalMinutes",
+            "columnName": "pollingIntervalMinutes",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "saved_prompts",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `prompt` TEXT NOT NULL, `negativePrompt` TEXT, `sampler` TEXT, `steps` INTEGER, `cfgScale` REAL, `seed` INTEGER, `modelName` TEXT, `size` TEXT, `sourceImageUrl` TEXT, `savedAt` INTEGER NOT NULL, `isTemplate` INTEGER NOT NULL, `templateName` TEXT, `autoSaved` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "prompt",
+            "columnName": "prompt",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "negativePrompt",
+            "columnName": "negativePrompt",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "sampler",
+            "columnName": "sampler",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "steps",
+            "columnName": "steps",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "cfgScale",
+            "columnName": "cfgScale",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "seed",
+            "columnName": "seed",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "modelName",
+            "columnName": "modelName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "size",
+            "columnName": "size",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "sourceImageUrl",
+            "columnName": "sourceImageUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "savedAt",
+            "columnName": "savedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isTemplate",
+            "columnName": "isTemplate",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "templateName",
+            "columnName": "templateName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "autoSaved",
+            "columnName": "autoSaved",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "search_history",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `query` TEXT NOT NULL, `searchedAt` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "query",
+            "columnName": "query",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "searchedAt",
+            "columnName": "searchedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "browsing_history",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `modelId` INTEGER NOT NULL, `modelType` TEXT NOT NULL, `creatorName` TEXT, `tags` TEXT NOT NULL, `viewedAt` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "modelId",
+            "columnName": "modelId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "modelType",
+            "columnName": "modelType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "creatorName",
+            "columnName": "creatorName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "tags",
+            "columnName": "tags",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "viewedAt",
+            "columnName": "viewedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_browsing_history_modelId",
+            "unique": false,
+            "columnNames": [
+              "modelId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_browsing_history_modelId` ON `${TABLE_NAME}` (`modelId`)"
+          },
+          {
+            "name": "index_browsing_history_viewedAt",
+            "unique": false,
+            "columnNames": [
+              "viewedAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_browsing_history_viewedAt` ON `${TABLE_NAME}` (`viewedAt`)"
+          }
+        ]
+      },
+      {
+        "tableName": "excluded_tags",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`tag` TEXT NOT NULL, `addedAt` INTEGER NOT NULL, PRIMARY KEY(`tag`))",
+        "fields": [
+          {
+            "fieldPath": "tag",
+            "columnName": "tag",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "addedAt",
+            "columnName": "addedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "tag"
+          ]
+        }
+      },
+      {
+        "tableName": "hidden_models",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`modelId` INTEGER NOT NULL, `modelName` TEXT NOT NULL, `hiddenAt` INTEGER NOT NULL, PRIMARY KEY(`modelId`))",
+        "fields": [
+          {
+            "fieldPath": "modelId",
+            "columnName": "modelId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "modelName",
+            "columnName": "modelName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "hiddenAt",
+            "columnName": "hiddenAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "modelId"
+          ]
+        }
+      },
+      {
+        "tableName": "model_directories",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `path` TEXT NOT NULL, `label` TEXT, `lastScannedAt` INTEGER, `isEnabled` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "path",
+            "columnName": "path",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "label",
+            "columnName": "label",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "lastScannedAt",
+            "columnName": "lastScannedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "isEnabled",
+            "columnName": "isEnabled",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "local_model_files",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `directoryId` INTEGER NOT NULL, `filePath` TEXT NOT NULL, `fileName` TEXT NOT NULL, `sha256Hash` TEXT NOT NULL, `sizeBytes` INTEGER NOT NULL, `scannedAt` INTEGER NOT NULL, `matchedModelId` INTEGER, `matchedModelName` TEXT, `matchedVersionId` INTEGER, `matchedVersionName` TEXT, `latestVersionId` INTEGER, `hasUpdate` INTEGER NOT NULL, FOREIGN KEY(`directoryId`) REFERENCES `model_directories`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "directoryId",
+            "columnName": "directoryId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "filePath",
+            "columnName": "filePath",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fileName",
+            "columnName": "fileName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sha256Hash",
+            "columnName": "sha256Hash",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sizeBytes",
+            "columnName": "sizeBytes",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "scannedAt",
+            "columnName": "scannedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "matchedModelId",
+            "columnName": "matchedModelId",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "matchedModelName",
+            "columnName": "matchedModelName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "matchedVersionId",
+            "columnName": "matchedVersionId",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "matchedVersionName",
+            "columnName": "matchedVersionName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "latestVersionId",
+            "columnName": "latestVersionId",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "hasUpdate",
+            "columnName": "hasUpdate",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_local_model_files_directoryId",
+            "unique": false,
+            "columnNames": [
+              "directoryId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_local_model_files_directoryId` ON `${TABLE_NAME}` (`directoryId`)"
+          },
+          {
+            "name": "index_local_model_files_sha256Hash",
+            "unique": false,
+            "columnNames": [
+              "sha256Hash"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_local_model_files_sha256Hash` ON `${TABLE_NAME}` (`sha256Hash`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "model_directories",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "directoryId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "model_version_checkpoints",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`modelId` INTEGER NOT NULL, `lastKnownVersionId` INTEGER NOT NULL, `lastCheckedAt` INTEGER NOT NULL, PRIMARY KEY(`modelId`))",
+        "fields": [
+          {
+            "fieldPath": "modelId",
+            "columnName": "modelId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastKnownVersionId",
+            "columnName": "lastKnownVersionId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastCheckedAt",
+            "columnName": "lastCheckedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "modelId"
+          ]
+        }
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'f0de9d17e9a6de3bd3aaf15bb14d19d8')"
+    ]
+  }
+}

--- a/shared/src/commonMain/kotlin/com/riox432/civitdeck/data/local/CivitDeckDatabase.kt
+++ b/shared/src/commonMain/kotlin/com/riox432/civitdeck/data/local/CivitDeckDatabase.kt
@@ -48,7 +48,7 @@ import kotlinx.coroutines.IO
         LocalModelFileEntity::class,
         ModelVersionCheckpointEntity::class,
     ],
-    version = 11,
+    version = 12,
 )
 @ConstructedBy(CivitDeckDatabaseConstructor::class)
 abstract class CivitDeckDatabase : RoomDatabase() {
@@ -300,6 +300,13 @@ val MIGRATION_10_11 = object : Migration(10, 11) {
     }
 }
 
+// No-op migration: category column remains in DB but is no longer mapped to entity
+val MIGRATION_11_12 = object : Migration(11, 12) {
+    override fun migrate(connection: SQLiteConnection) {
+        // category column stays in the table; Room ignores unmapped columns
+    }
+}
+
 fun getRoomDatabase(builder: RoomDatabase.Builder<CivitDeckDatabase>): CivitDeckDatabase {
     return builder
         .addMigrations(
@@ -313,6 +320,7 @@ fun getRoomDatabase(builder: RoomDatabase.Builder<CivitDeckDatabase>): CivitDeck
             MIGRATION_8_9,
             MIGRATION_9_10,
             MIGRATION_10_11,
+            MIGRATION_11_12,
         )
         .setDriver(BundledSQLiteDriver())
         .setQueryCoroutineContext(Dispatchers.IO)

--- a/shared/src/commonMain/kotlin/com/riox432/civitdeck/data/local/dao/SavedPromptDao.kt
+++ b/shared/src/commonMain/kotlin/com/riox432/civitdeck/data/local/dao/SavedPromptDao.kt
@@ -36,9 +36,6 @@ interface SavedPromptDao {
     @Query("UPDATE saved_prompts SET isTemplate = :isTemplate, templateName = :templateName WHERE id = :id")
     suspend fun updateTemplate(id: Long, isTemplate: Boolean, templateName: String?)
 
-    @Query("UPDATE saved_prompts SET category = :category WHERE id = :id")
-    suspend fun updateCategory(id: Long, category: String?)
-
     @Insert
     suspend fun insert(entity: SavedPromptEntity)
 

--- a/shared/src/commonMain/kotlin/com/riox432/civitdeck/data/local/entity/SavedPromptEntity.kt
+++ b/shared/src/commonMain/kotlin/com/riox432/civitdeck/data/local/entity/SavedPromptEntity.kt
@@ -18,6 +18,5 @@ data class SavedPromptEntity(
     val savedAt: Long,
     val isTemplate: Boolean = false,
     val templateName: String? = null,
-    val category: String? = null,
     val autoSaved: Boolean = false,
 )

--- a/shared/src/commonMain/kotlin/com/riox432/civitdeck/data/repository/SavedPromptRepositoryImpl.kt
+++ b/shared/src/commonMain/kotlin/com/riox432/civitdeck/data/repository/SavedPromptRepositoryImpl.kt
@@ -41,10 +41,6 @@ class SavedPromptRepositoryImpl(
         dao.updateTemplate(id, isTemplate, templateName)
     }
 
-    override suspend fun updateCategory(id: Long, category: String?) {
-        dao.updateCategory(id, category)
-    }
-
     override suspend fun delete(id: Long) = dao.deleteById(id)
 
     private fun ImageGenerationMeta.toEntity(

--- a/shared/src/commonMain/kotlin/com/riox432/civitdeck/di/DomainModule.kt
+++ b/shared/src/commonMain/kotlin/com/riox432/civitdeck/di/DomainModule.kt
@@ -63,7 +63,6 @@ import com.riox432.civitdeck.domain.usecase.ToggleFavoriteUseCase
 import com.riox432.civitdeck.domain.usecase.ToggleTemplateUseCase
 import com.riox432.civitdeck.domain.usecase.TrackModelViewUseCase
 import com.riox432.civitdeck.domain.usecase.UnhideModelUseCase
-import com.riox432.civitdeck.domain.usecase.UpdatePromptCategoryUseCase
 import com.riox432.civitdeck.domain.usecase.ValidateApiKeyUseCase
 import com.riox432.civitdeck.domain.usecase.VerifyModelHashUseCase
 import org.koin.dsl.module
@@ -86,7 +85,6 @@ val domainModule = module {
     factory { ToggleTemplateUseCase(get()) }
     factory { SearchSavedPromptsUseCase(get()) }
     factory { ObserveTemplatesUseCase(get()) }
-    factory { UpdatePromptCategoryUseCase(get()) }
     factory { ObserveSearchHistoryUseCase(get()) }
     factory { AddSearchHistoryUseCase(get()) }
     factory { ClearSearchHistoryUseCase(get()) }

--- a/shared/src/commonMain/kotlin/com/riox432/civitdeck/domain/model/SavedPrompt.kt
+++ b/shared/src/commonMain/kotlin/com/riox432/civitdeck/domain/model/SavedPrompt.kt
@@ -16,7 +16,6 @@ data class SavedPrompt(
     val savedAt: Long,
     val isTemplate: Boolean = false,
     val templateName: String? = null,
-    val category: String? = null,
     val autoSaved: Boolean = false,
 )
 
@@ -34,6 +33,5 @@ fun SavedPromptEntity.toDomain(): SavedPrompt = SavedPrompt(
     savedAt = savedAt,
     isTemplate = isTemplate,
     templateName = templateName,
-    category = category,
     autoSaved = autoSaved,
 )

--- a/shared/src/commonMain/kotlin/com/riox432/civitdeck/domain/repository/SavedPromptRepository.kt
+++ b/shared/src/commonMain/kotlin/com/riox432/civitdeck/domain/repository/SavedPromptRepository.kt
@@ -12,6 +12,5 @@ interface SavedPromptRepository {
     suspend fun save(meta: ImageGenerationMeta, sourceImageUrl: String?)
     suspend fun autoSave(meta: ImageGenerationMeta, sourceImageUrl: String?)
     suspend fun toggleTemplate(id: Long, isTemplate: Boolean, templateName: String?)
-    suspend fun updateCategory(id: Long, category: String?)
     suspend fun delete(id: Long)
 }

--- a/shared/src/commonMain/kotlin/com/riox432/civitdeck/domain/usecase/UpdatePromptCategoryUseCase.kt
+++ b/shared/src/commonMain/kotlin/com/riox432/civitdeck/domain/usecase/UpdatePromptCategoryUseCase.kt
@@ -1,8 +1,0 @@
-package com.riox432.civitdeck.domain.usecase
-
-import com.riox432.civitdeck.domain.repository.SavedPromptRepository
-
-class UpdatePromptCategoryUseCase(private val repository: SavedPromptRepository) {
-    suspend operator fun invoke(id: Long, category: String?) =
-        repository.updateCategory(id, category)
-}

--- a/shared/src/commonTest/kotlin/com/riox432/civitdeck/data/repository/SimpleRepositoriesImplTest.kt
+++ b/shared/src/commonTest/kotlin/com/riox432/civitdeck/data/repository/SimpleRepositoriesImplTest.kt
@@ -135,11 +135,6 @@ class SimpleRepositoriesImplTest {
             updates.value++
         }
 
-        override suspend fun updateCategory(id: Long, category: String?) {
-            val idx = entities.indexOfFirst { it.id == id }
-            if (idx >= 0) entities[idx] = entities[idx].copy(category = category)
-            updates.value++
-        }
 
         override suspend fun insert(entity: SavedPromptEntity) {
             entities.add(entity.copy(id = idCounter++))

--- a/shared/src/commonTest/kotlin/com/riox432/civitdeck/domain/usecase/SavedPromptUseCasesTest.kt
+++ b/shared/src/commonTest/kotlin/com/riox432/civitdeck/domain/usecase/SavedPromptUseCasesTest.kt
@@ -45,7 +45,6 @@ class SavedPromptUseCasesTest {
             lastSavedMeta = meta
         }
         override suspend fun toggleTemplate(id: Long, isTemplate: Boolean, templateName: String?) = Unit
-        override suspend fun updateCategory(id: Long, category: String?) = Unit
         override suspend fun delete(id: Long) {
             deleteCalled = true
             lastDeletedId = id

--- a/shared/src/iosMain/kotlin/com/riox432/civitdeck/di/KoinHelper.kt
+++ b/shared/src/iosMain/kotlin/com/riox432/civitdeck/di/KoinHelper.kt
@@ -64,7 +64,6 @@ import com.riox432.civitdeck.domain.usecase.ToggleFavoriteUseCase
 import com.riox432.civitdeck.domain.usecase.ToggleTemplateUseCase
 import com.riox432.civitdeck.domain.usecase.TrackModelViewUseCase
 import com.riox432.civitdeck.domain.usecase.UnhideModelUseCase
-import com.riox432.civitdeck.domain.usecase.UpdatePromptCategoryUseCase
 import com.riox432.civitdeck.domain.usecase.ValidateApiKeyUseCase
 import com.riox432.civitdeck.domain.usecase.VerifyModelHashUseCase
 import org.koin.mp.KoinPlatform.getKoin
@@ -138,7 +137,6 @@ object KoinHelper {
     fun getToggleTemplateUseCase(): ToggleTemplateUseCase = getKoin().get()
     fun getSearchSavedPromptsUseCase(): SearchSavedPromptsUseCase = getKoin().get()
     fun getObserveTemplatesUseCase(): ObserveTemplatesUseCase = getKoin().get()
-    fun getUpdatePromptCategoryUseCase(): UpdatePromptCategoryUseCase = getKoin().get()
 
     // Notification use cases
     fun getCheckModelUpdatesUseCase(): CheckModelUpdatesUseCase = getKoin().get()


### PR DESCRIPTION
## Description

Post-Phase 2 quality sweep fixing 7 items:

1. **Model Comparison bug fix** — Base Model and File Size now reflect the selected version instead of always showing the first version (Android + iOS)
2. **Category dead code removal** — Deleted `UpdatePromptCategoryUseCase`, `category` field from entity/model, and all references across shared/Android/iOS. Added Room migration 11→12 (no-op, column remains in DB but unmapped)
3. **Template name input UI** — AlertDialog prompts for template name when toggling a prompt to template (Android + iOS). Unsetting a template requires no dialog
4. **PromptTemplateEngine UI integration** — "Apply" button on template cards extracts variables, shows input dialog for substitution, copies result to clipboard (Android + iOS)
5. **iOS grid column parity** — Added intermediate 3-column breakpoint (600–840pt) to match Android's 2→3→4 progression
6. **Android tablet navigation** — `NavigationSuiteScaffold` now uses `NavigationDrawer` layout on expanded width, showing labeled sidebar on large tablets
7. **Foldable dead code removal** — Removed unused `isTableTopPosture()` from `AdaptiveUtils.kt`

## Related Issues

<!-- Link related GitHub issues: Closes #123, Fixes #456 -->

## Screenshots / Video

<!-- If applicable, add screenshots or screen recordings -->

## Test Plan

- [x] `./gradlew :shared:testDebugUnitTest` — all pass
- [x] `./gradlew detekt` — clean
- [x] `swiftlint --strict` — clean
- [x] Grep verified no `category`/`UpdatePromptCategory` references remain
- [ ] Manual: Model Compare version switching shows correct specs
- [ ] Manual: Template toggle shows name input dialog
- [ ] Manual: Apply button on templates extracts variables and copies result

## Review Checklist

- [x] Code follows project architecture (Clean Architecture + MVVM)
- [x] Shared logic is in `commonMain`, platform-specific code only when necessary
- [x] No unnecessary dependencies added
- [x] Tests added/updated as needed

## Breaking Changes

Room schema bumped from v11 to v12 (no-op migration — category column remains in DB but is no longer mapped to entity)