### PR TITLE
Add image slider comparison overlay

### DIFF
--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/compare/ImageComparisonOverlay.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/compare/ImageComparisonOverlay.kt
@@ -1,0 +1,167 @@
+package com.riox432.civitdeck.ui.compare
+
+import androidx.activity.compose.BackHandler
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.IconButtonDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Dialog
+import androidx.compose.ui.window.DialogProperties
+import com.riox432.civitdeck.R
+
+/**
+ * Full-screen overlay for comparing two images with a slider.
+ *
+ * Shows a close button, orientation toggle, and before/after labels.
+ */
+@Composable
+fun ImageComparisonOverlay(
+    beforeImageUrl: String,
+    afterImageUrl: String,
+    beforeLabel: String = "Before",
+    afterLabel: String = "After",
+    onDismiss: () -> Unit,
+) {
+    Dialog(
+        onDismissRequest = onDismiss,
+        properties = DialogProperties(
+            usePlatformDefaultWidth = false,
+            decorFitsSystemWindows = false,
+        ),
+    ) {
+        BackHandler(onBack = onDismiss)
+        OverlayContent(beforeImageUrl, afterImageUrl, beforeLabel, afterLabel, onDismiss)
+    }
+}
+
+@Composable
+private fun OverlayContent(
+    beforeImageUrl: String,
+    afterImageUrl: String,
+    beforeLabel: String,
+    afterLabel: String,
+    onDismiss: () -> Unit,
+) {
+    var orientation by remember { mutableStateOf(SliderOrientation.Horizontal) }
+    var controlsVisible by remember { mutableStateOf(true) }
+
+    Box(modifier = Modifier.fillMaxSize().background(Color.Black)) {
+        ImageComparisonSlider(
+            beforeImageUrl = beforeImageUrl,
+            afterImageUrl = afterImageUrl,
+            orientation = orientation,
+            modifier = Modifier.fillMaxSize(),
+        )
+
+        AnimatedVisibility(visible = controlsVisible, enter = fadeIn(), exit = fadeOut()) {
+            OverlayControls(
+                orientation = orientation,
+                beforeLabel = beforeLabel,
+                afterLabel = afterLabel,
+                onToggleOrientation = {
+                    orientation = when (orientation) {
+                        SliderOrientation.Horizontal -> SliderOrientation.Vertical
+                        SliderOrientation.Vertical -> SliderOrientation.Horizontal
+                    }
+                },
+                onDismiss = onDismiss,
+            )
+        }
+    }
+}
+
+@Composable
+private fun OverlayControls(
+    orientation: SliderOrientation,
+    beforeLabel: String,
+    afterLabel: String,
+    onToggleOrientation: () -> Unit,
+    onDismiss: () -> Unit,
+) {
+    Box(modifier = Modifier.fillMaxSize()) {
+        // Top bar: close + orientation toggle
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .align(Alignment.TopCenter)
+                .padding(CONTROL_PADDING.dp),
+            horizontalArrangement = Arrangement.SpaceBetween,
+        ) {
+            OverlayIconButton(onClick = onDismiss) {
+                Icon(Icons.Default.Close, contentDescription = "Close")
+            }
+            OverlayIconButton(onClick = onToggleOrientation) {
+                val iconRes = when (orientation) {
+                    SliderOrientation.Horizontal -> R.drawable.ic_slider_vertical
+                    SliderOrientation.Vertical -> R.drawable.ic_slider_horizontal
+                }
+                Icon(painterResource(id = iconRes), contentDescription = "Toggle orientation")
+            }
+        }
+
+        // Bottom labels
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .align(Alignment.BottomCenter)
+                .padding(CONTROL_PADDING.dp),
+            horizontalArrangement = Arrangement.SpaceBetween,
+        ) {
+            LabelChip(text = beforeLabel)
+            LabelChip(text = afterLabel)
+        }
+    }
+}
+
+@Composable
+private fun OverlayIconButton(onClick: () -> Unit, content: @Composable () -> Unit) {
+    IconButton(
+        onClick = onClick,
+        colors = IconButtonDefaults.iconButtonColors(
+            containerColor = MaterialTheme.colorScheme.surface.copy(alpha = CHIP_ALPHA),
+            contentColor = MaterialTheme.colorScheme.onSurface,
+        ),
+    ) {
+        content()
+    }
+}
+
+@Composable
+private fun LabelChip(text: String) {
+    Text(
+        text = text,
+        style = MaterialTheme.typography.labelMedium,
+        color = Color.White,
+        modifier = Modifier
+            .background(Color.Black.copy(alpha = CHIP_ALPHA), MaterialTheme.shapes.small)
+            .padding(horizontal = CHIP_H_PADDING.dp, vertical = CHIP_V_PADDING.dp),
+    )
+}
+
+private const val CONTROL_PADDING = 16
+private const val CHIP_ALPHA = 0.7f
+private const val CHIP_H_PADDING = 12
+private const val CHIP_V_PADDING = 6

--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/compare/ImageComparisonSlider.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/compare/ImageComparisonSlider.kt
@@ -1,0 +1,196 @@
+package com.riox432.civitdeck.ui.compare
+
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.background
+import androidx.compose.foundation.gestures.detectDragGestures
+import androidx.compose.foundation.gestures.rememberTransformableState
+import androidx.compose.foundation.gestures.transformable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.clipToBounds
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.layout.onSizeChanged
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.unit.IntOffset
+import androidx.compose.ui.unit.IntSize
+import androidx.compose.ui.unit.dp
+import coil3.compose.AsyncImage
+import coil3.request.ImageRequest
+import coil3.request.crossfade
+import com.riox432.civitdeck.R
+import com.riox432.civitdeck.ui.theme.Duration
+import kotlin.math.roundToInt
+
+/** Slider orientation for image comparison. */
+enum class SliderOrientation { Horizontal, Vertical }
+
+/**
+ * A before/after image comparison slider with drag-to-reveal and pinch-to-zoom.
+ *
+ * The before image is clipped by the slider position, revealing the after
+ * image underneath. Users can drag the divider to compare and pinch to zoom.
+ */
+@Composable
+fun ImageComparisonSlider(
+    beforeImageUrl: String,
+    afterImageUrl: String,
+    modifier: Modifier = Modifier,
+    orientation: SliderOrientation = SliderOrientation.Horizontal,
+) {
+    var containerSize by remember { mutableStateOf(IntSize.Zero) }
+    var sliderFraction by remember { mutableFloatStateOf(INITIAL_FRACTION) }
+    var scale by remember { mutableFloatStateOf(MIN_SCALE) }
+    var panOffset by remember { mutableStateOf(Offset.Zero) }
+
+    val transformState = rememberTransformableState { zoomChange, panChange, _ ->
+        val newScale = (scale * zoomChange).coerceIn(MIN_SCALE, MAX_SCALE)
+        scale = newScale
+        panOffset = if (newScale > MIN_SCALE) panOffset + panChange else Offset.Zero
+    }
+
+    Box(
+        modifier = modifier
+            .clipToBounds()
+            .onSizeChanged { containerSize = it }
+            .transformable(state = transformState),
+    ) {
+        val zoomModifier = Modifier.graphicsLayer {
+            scaleX = scale
+            scaleY = scale
+            translationX = panOffset.x
+            translationY = panOffset.y
+        }
+
+        // After image (bottom layer, fully visible)
+        ComparisonImage(afterImageUrl, Modifier.fillMaxSize().then(zoomModifier))
+
+        // Before image (top layer, clipped by slider)
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .graphicsLayer {
+                    clip = true
+                    shape = SliderClipShape(sliderFraction, orientation)
+                },
+        ) {
+            ComparisonImage(beforeImageUrl, Modifier.fillMaxSize().then(zoomModifier))
+        }
+
+        // Divider line
+        SliderDivider(sliderFraction, orientation, containerSize)
+
+        // Drag handle
+        SliderHandle(sliderFraction, orientation, containerSize) { delta ->
+            val max = when (orientation) {
+                SliderOrientation.Horizontal -> containerSize.width.toFloat()
+                SliderOrientation.Vertical -> containerSize.height.toFloat()
+            }
+            if (max > 0f) {
+                val primary = when (orientation) {
+                    SliderOrientation.Horizontal -> delta.x
+                    SliderOrientation.Vertical -> delta.y
+                }
+                sliderFraction = (sliderFraction + primary / max).coerceIn(0f, 1f)
+            }
+        }
+    }
+}
+
+// MARK: - Internal composables
+
+@Composable
+private fun ComparisonImage(imageUrl: String, modifier: Modifier = Modifier) {
+    AsyncImage(
+        model = ImageRequest.Builder(LocalContext.current)
+            .data(imageUrl).crossfade(Duration.normal).build(),
+        contentDescription = null,
+        contentScale = ContentScale.Fit,
+        modifier = modifier,
+    )
+}
+
+@Composable
+private fun SliderDivider(
+    fraction: Float,
+    orientation: SliderOrientation,
+    size: IntSize,
+) {
+    Canvas(modifier = Modifier.fillMaxSize()) {
+        when (orientation) {
+            SliderOrientation.Horizontal -> {
+                val x = size.width * fraction
+                drawLine(Color.White, Offset(x, 0f), Offset(x, size.height.toFloat()), DIVIDER_PX)
+            }
+            SliderOrientation.Vertical -> {
+                val y = size.height * fraction
+                drawLine(Color.White, Offset(0f, y), Offset(size.width.toFloat(), y), DIVIDER_PX)
+            }
+        }
+    }
+}
+
+@Composable
+private fun SliderHandle(
+    fraction: Float,
+    orientation: SliderOrientation,
+    containerSize: IntSize,
+    onDrag: (Offset) -> Unit,
+) {
+    val halfHandle = HANDLE_DP / 2f
+    val ox = when (orientation) {
+        SliderOrientation.Horizontal -> containerSize.width * fraction - halfHandle
+        SliderOrientation.Vertical -> containerSize.width / 2f - halfHandle
+    }.roundToInt()
+    val oy = when (orientation) {
+        SliderOrientation.Horizontal -> containerSize.height / 2f - halfHandle
+        SliderOrientation.Vertical -> containerSize.height * fraction - halfHandle
+    }.roundToInt()
+
+    Box(
+        modifier = Modifier
+            .offset { IntOffset(ox, oy) }
+            .size(HANDLE_DP.dp)
+            .clip(CircleShape)
+            .background(Color.White.copy(alpha = HANDLE_ALPHA))
+            .pointerInput(Unit) { detectDragGestures { _, d -> onDrag(d) } },
+        contentAlignment = Alignment.Center,
+    ) {
+        val iconRes = when (orientation) {
+            SliderOrientation.Horizontal -> R.drawable.ic_slider_horizontal
+            SliderOrientation.Vertical -> R.drawable.ic_slider_vertical
+        }
+        Icon(
+            painter = painterResource(id = iconRes),
+            contentDescription = "Slider handle",
+            tint = MaterialTheme.colorScheme.onSurface,
+            modifier = Modifier.size(ICON_DP.dp),
+        )
+    }
+}
+
+private const val INITIAL_FRACTION = 0.5f
+private const val MIN_SCALE = 1f
+private const val MAX_SCALE = 5f
+private const val DIVIDER_PX = 3f
+private const val HANDLE_DP = 40f
+private const val ICON_DP = 20f
+private const val HANDLE_ALPHA = 0.85f

--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/compare/ModelCompareScreen.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/compare/ModelCompareScreen.kt
@@ -20,6 +20,7 @@ import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.Button
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FilterChip
@@ -33,6 +34,9 @@ import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.VerticalDivider
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.ContentScale
@@ -96,32 +100,56 @@ private fun CompareBody(
     onRightVersionSelected: (Int) -> Unit,
     contentPadding: PaddingValues,
 ) {
-    val bothLoading = leftState.isLoading || rightState.isLoading
     val leftModel = leftState.model
     val rightModel = rightState.model
 
-    if (bothLoading && (leftModel == null || rightModel == null)) {
-        Box(
-            modifier = Modifier.fillMaxSize().padding(contentPadding),
-            contentAlignment = Alignment.Center,
-        ) {
-            CircularProgressIndicator()
-        }
+    val bothLoading = leftState.isLoading || rightState.isLoading
+    val bothMissing = leftModel == null || rightModel == null
+    if (bothLoading && bothMissing) {
+        CenteredBox(contentPadding) { CircularProgressIndicator() }
         return
     }
-
     if (leftModel == null || rightModel == null) {
-        Box(
-            modifier = Modifier.fillMaxSize().padding(contentPadding),
-            contentAlignment = Alignment.Center,
-        ) {
+        CenteredBox(contentPadding) {
             Text(
-                text = leftState.error ?: rightState.error ?: "Failed to load models",
-                color = MaterialTheme.colorScheme.error,
+                leftState.error ?: rightState.error ?: "Failed to load models",
+                color = MaterialTheme.colorScheme.error
             )
         }
         return
     }
+
+    CompareLoadedBody(
+        leftState,
+        rightState,
+        leftModel,
+        rightModel,
+        onLeftVersionSelected,
+        onRightVersionSelected,
+        contentPadding
+    )
+}
+
+@Composable
+private fun CenteredBox(padding: PaddingValues, content: @Composable () -> Unit) {
+    Box(Modifier.fillMaxSize().padding(padding), contentAlignment = Alignment.Center) { content() }
+}
+
+@Suppress("LongParameterList")
+@Composable
+private fun CompareLoadedBody(
+    leftState: ModelDetailUiState,
+    rightState: ModelDetailUiState,
+    leftModel: Model,
+    rightModel: Model,
+    onLeftVersionSelected: (Int) -> Unit,
+    onRightVersionSelected: (Int) -> Unit,
+    contentPadding: PaddingValues,
+) {
+    var showImageComparison by remember { mutableStateOf(false) }
+    val leftImages = leftModel.selectedImages(leftState)
+    val rightImages = rightModel.selectedImages(rightState)
+    val canCompareImages = leftImages.isNotEmpty() && rightImages.isNotEmpty()
 
     LazyColumn(
         modifier = Modifier.fillMaxSize(),
@@ -131,24 +159,50 @@ private fun CompareBody(
         ),
     ) {
         item { ComparePanelsRow(leftState, rightState) }
+        if (canCompareImages) {
+            item { CompareImagesButton(onClick = { showImageComparison = true }) }
+        }
         item {
             CompareVersionSelectors(
-                leftModel = leftModel,
-                rightModel = rightModel,
-                leftSelectedIndex = leftState.selectedVersionIndex,
-                rightSelectedIndex = rightState.selectedVersionIndex,
-                onLeftVersionSelected = onLeftVersionSelected,
-                onRightVersionSelected = onRightVersionSelected,
+                leftModel,
+                rightModel,
+                leftState.selectedVersionIndex,
+                rightState.selectedVersionIndex,
+                onLeftVersionSelected,
+                onRightVersionSelected
             )
         }
         item { HorizontalDivider(modifier = Modifier.padding(vertical = Spacing.sm)) }
         item {
             CompareSpecsTable(
-                leftModel = leftModel,
-                rightModel = rightModel,
-                leftVersionIndex = leftState.selectedVersionIndex,
-                rightVersionIndex = rightState.selectedVersionIndex,
+                leftModel,
+                rightModel,
+                leftState.selectedVersionIndex,
+                rightState.selectedVersionIndex
             )
+        }
+    }
+
+    if (showImageComparison && canCompareImages) {
+        ImageComparisonOverlay(leftImages.first().url, rightImages.first().url, leftModel.name, rightModel.name) {
+            showImageComparison = false
+        }
+    }
+}
+
+private fun Model.selectedImages(state: ModelDetailUiState): List<ModelImage> {
+    val version = modelVersions.getOrNull(state.selectedVersionIndex) ?: return emptyList()
+    return version.images.filterByNsfwLevel(state.nsfwFilterLevel)
+}
+
+@Composable
+private fun CompareImagesButton(onClick: () -> Unit) {
+    Box(
+        modifier = Modifier.fillMaxWidth().padding(horizontal = Spacing.md, vertical = Spacing.sm),
+        contentAlignment = Alignment.Center,
+    ) {
+        Button(onClick = onClick) {
+            Text("Compare Images")
         }
     }
 }

--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/compare/SliderClipShape.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/compare/SliderClipShape.kt
@@ -1,0 +1,36 @@
+package com.riox432.civitdeck.ui.compare
+
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.Outline
+import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.LayoutDirection
+
+/**
+ * A clip shape that reveals a fraction of the content based on slider position.
+ *
+ * For [SliderOrientation.Horizontal], clips from the left edge to [fraction] of the width.
+ * For [SliderOrientation.Vertical], clips from the top edge to [fraction] of the height.
+ */
+internal class SliderClipShape(
+    private val fraction: Float,
+    private val orientation: SliderOrientation,
+) : Shape {
+    override fun createOutline(size: Size, layoutDirection: LayoutDirection, density: Density): Outline {
+        val rect = when (orientation) {
+            SliderOrientation.Horizontal -> androidx.compose.ui.geometry.Rect(
+                left = 0f,
+                top = 0f,
+                right = size.width * fraction,
+                bottom = size.height,
+            )
+            SliderOrientation.Vertical -> androidx.compose.ui.geometry.Rect(
+                left = 0f,
+                top = 0f,
+                right = size.width,
+                bottom = size.height * fraction,
+            )
+        }
+        return Outline.Rectangle(rect)
+    }
+}

--- a/androidApp/src/main/res/drawable/ic_slider_horizontal.xml
+++ b/androidApp/src/main/res/drawable/ic_slider_horizontal.xml
@@ -1,0 +1,14 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <!-- Left arrow -->
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M9,12L5,8v3H2v2h3v3z" />
+    <!-- Right arrow -->
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M15,12l4,-4v3h3v2h-3v3z" />
+</vector>

--- a/androidApp/src/main/res/drawable/ic_slider_vertical.xml
+++ b/androidApp/src/main/res/drawable/ic_slider_vertical.xml
@@ -1,0 +1,14 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <!-- Up arrow -->
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M12,9L8,5h3V2h2v3h3z" />
+    <!-- Down arrow -->
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M12,15l-4,4h3v3h2v-3h3z" />
+</vector>

--- a/iosApp/iosApp.xcodeproj/project.pbxproj
+++ b/iosApp/iosApp.xcodeproj/project.pbxproj
@@ -48,6 +48,8 @@
 		CD00CE012D2CC001000CD001 /* ComparisonState.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD00CE002D2CC001000CD001 /* ComparisonState.swift */; };
 		CD00CE032D2CC001000CD001 /* ModelCompareScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD00CE022D2CC001000CD001 /* ModelCompareScreen.swift */; };
 		CD00CE052D2CC001000CD001 /* ModelCompareViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD00CE042D2CC001000CD001 /* ModelCompareViewModel.swift */; };
+		CD00IS012D6CC001000CD001 /* ImageComparisonSlider.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD00IS002D6CC001000CD001 /* ImageComparisonSlider.swift */; };
+		CD00IO012D6CC001000CD001 /* ImageComparisonOverlay.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD00IO002D6CC001000CD001 /* ImageComparisonOverlay.swift */; };
 		CD00VD012D4CC001000CD001 /* VersionDetailSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD00VD002D4CC001000CD001 /* VersionDetailSection.swift */; };
 		CD00FB012D5CC001000CD001 /* ModelFileBrowserViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD00FB002D5CC001000CD001 /* ModelFileBrowserViewModel.swift */; };
 		CD00FB032D5CC001000CD001 /* ModelFileBrowserScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD00FB022D5CC001000CD001 /* ModelFileBrowserScreen.swift */; };
@@ -98,6 +100,8 @@
 		CD00CE002D2CC001000CD001 /* ComparisonState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ComparisonState.swift; sourceTree = "<group>"; };
 		CD00CE022D2CC001000CD001 /* ModelCompareScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModelCompareScreen.swift; sourceTree = "<group>"; };
 		CD00CE042D2CC001000CD001 /* ModelCompareViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModelCompareViewModel.swift; sourceTree = "<group>"; };
+		CD00IS002D6CC001000CD001 /* ImageComparisonSlider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageComparisonSlider.swift; sourceTree = "<group>"; };
+		CD00IO002D6CC001000CD001 /* ImageComparisonOverlay.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageComparisonOverlay.swift; sourceTree = "<group>"; };
 		CD00VD002D4CC001000CD001 /* VersionDetailSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VersionDetailSection.swift; sourceTree = "<group>"; };
 		CD00FB002D5CC001000CD001 /* ModelFileBrowserViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModelFileBrowserViewModel.swift; sourceTree = "<group>"; };
 		CD00FB022D5CC001000CD001 /* ModelFileBrowserScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModelFileBrowserScreen.swift; sourceTree = "<group>"; };
@@ -216,6 +220,8 @@
 			isa = PBXGroup;
 			children = (
 				CD00CE002D2CC001000CD001 /* ComparisonState.swift */,
+				CD00IS002D6CC001000CD001 /* ImageComparisonSlider.swift */,
+				CD00IO002D6CC001000CD001 /* ImageComparisonOverlay.swift */,
 				CD00CE022D2CC001000CD001 /* ModelCompareScreen.swift */,
 				CD00CE042D2CC001000CD001 /* ModelCompareViewModel.swift */,
 			);
@@ -447,6 +453,8 @@
 				CD00CE012D2CC001000CD001 /* ComparisonState.swift in Sources */,
 				CD00CE032D2CC001000CD001 /* ModelCompareScreen.swift in Sources */,
 				CD00CE052D2CC001000CD001 /* ModelCompareViewModel.swift in Sources */,
+				CD00IS012D6CC001000CD001 /* ImageComparisonSlider.swift in Sources */,
+				CD00IO012D6CC001000CD001 /* ImageComparisonOverlay.swift in Sources */,
 				CD00VD012D4CC001000CD001 /* VersionDetailSection.swift in Sources */,
 				CD00FB012D5CC001000CD001 /* ModelFileBrowserViewModel.swift in Sources */,
 				CD00FB032D5CC001000CD001 /* ModelFileBrowserScreen.swift in Sources */,

--- a/iosApp/iosApp/DesignSystem/CachedAsyncImage.swift
+++ b/iosApp/iosApp/DesignSystem/CachedAsyncImage.swift
@@ -8,6 +8,7 @@ private let imageLogger = Logger(subsystem: "com.riox432.civitdeck", category: "
 /// with a larger URLCache for better image caching performance.
 struct CachedAsyncImage<Content: View>: View {
     let url: URL?
+    var maxPixelSize: CGFloat = defaultMaxPixelSize
     @ViewBuilder let content: (AsyncImagePhase) -> Content
 
     @State private var phase: AsyncImagePhase = .empty
@@ -35,7 +36,7 @@ struct CachedAsyncImage<Content: View>: View {
             // Use CGImageSource for memory-efficient downsampling.
             // Unlike UIImage(data:) + byPreparingThumbnail, this does NOT
             // decode the full-resolution image into memory first.
-            guard let image = Self.downsampledImage(data: data, maxPixelSize: 400) else {
+            guard let image = Self.downsampledImage(data: data, maxPixelSize: maxPixelSize) else {
                 phase = .failure(ImageLoadingError.invalidData)
                 return
             }
@@ -82,6 +83,8 @@ enum ImageURLSession {
         return URLSession(configuration: config)
     }()
 }
+
+private let defaultMaxPixelSize: CGFloat = 400
 
 private enum ImageLoadingError: Error {
     case invalidData

--- a/iosApp/iosApp/Features/Compare/ImageComparisonOverlay.swift
+++ b/iosApp/iosApp/Features/Compare/ImageComparisonOverlay.swift
@@ -1,0 +1,104 @@
+import SwiftUI
+
+/// Full-screen overlay for comparing two images with a slider.
+///
+/// Shows a close button, orientation toggle, and before/after labels.
+struct ImageComparisonOverlay: View {
+    let beforeImageUrl: String
+    let afterImageUrl: String
+    var beforeLabel: String = "Before"
+    var afterLabel: String = "After"
+    let onDismiss: () -> Void
+
+    @State private var orientation: SliderOrientation = .horizontal
+
+    var body: some View {
+        ZStack {
+            Color.black.ignoresSafeArea()
+
+            ImageComparisonSlider(
+                beforeImageUrl: beforeImageUrl,
+                afterImageUrl: afterImageUrl,
+                orientation: orientation
+            )
+
+            overlayControls
+        }
+    }
+
+    // MARK: - Controls
+
+    private var overlayControls: some View {
+        VStack {
+            topBar
+            Spacer()
+            bottomLabels
+        }
+        .padding(controlPadding)
+    }
+
+    private var topBar: some View {
+        HStack {
+            OverlayCircleButton(systemName: "xmark", action: onDismiss)
+            Spacer()
+            OverlayCircleButton(
+                systemName: orientation == .horizontal
+                    ? "arrow.up.and.down"
+                    : "arrow.left.and.right"
+            ) {
+                withAnimation(MotionAnimation.fast) {
+                    orientation = orientation == .horizontal ? .vertical : .horizontal
+                }
+            }
+        }
+    }
+
+    private var bottomLabels: some View {
+        HStack {
+            ComparisonLabelChip(text: beforeLabel)
+            Spacer()
+            ComparisonLabelChip(text: afterLabel)
+        }
+    }
+}
+
+// MARK: - Overlay Circle Button
+
+private struct OverlayCircleButton: View {
+    let systemName: String
+    let action: () -> Void
+
+    var body: some View {
+        Button(action: action) {
+            Image(systemName: systemName)
+                .font(.title3)
+                .fontWeight(.semibold)
+                .foregroundColor(.white)
+                .padding(buttonPadding)
+                .background(.ultraThinMaterial, in: Circle())
+        }
+    }
+}
+
+// MARK: - Label Chip
+
+private struct ComparisonLabelChip: View {
+    let text: String
+
+    var body: some View {
+        Text(text)
+            .font(.civitLabelMedium)
+            .foregroundColor(.white)
+            .padding(.horizontal, chipHPadding)
+            .padding(.vertical, chipVPadding)
+            .background(Color.black.opacity(chipAlpha), in: Capsule())
+    }
+}
+
+// MARK: - Constants
+
+private let controlPadding: CGFloat = 16
+private let buttonPadding: CGFloat = 10
+private let chipHPadding: CGFloat = 12
+private let chipVPadding: CGFloat = 6
+private let chipAlpha: Double = 0.7

--- a/iosApp/iosApp/Features/Compare/ImageComparisonSlider.swift
+++ b/iosApp/iosApp/Features/Compare/ImageComparisonSlider.swift
@@ -1,0 +1,186 @@
+import SwiftUI
+
+/// Slider orientation for image comparison.
+enum SliderOrientation {
+    case horizontal
+    case vertical
+}
+
+/// A before/after image comparison slider with drag-to-reveal and pinch-to-zoom.
+///
+/// The before image is clipped by the slider position, revealing the after
+/// image underneath. Users can drag the divider to compare and pinch to zoom.
+struct ImageComparisonSlider: View {
+    let beforeImageUrl: String
+    let afterImageUrl: String
+    var orientation: SliderOrientation = .horizontal
+
+    @State private var sliderFraction: CGFloat = initialFraction
+    @State private var scale: CGFloat = 1.0
+    @State private var offset: CGSize = .zero
+
+    var body: some View {
+        GeometryReader { geometry in
+            let size = geometry.size
+
+            ZStack {
+                // After image (bottom layer, fully visible)
+                comparisonImage(url: afterImageUrl, size: size)
+
+                // Before image (top layer, clipped by slider)
+                comparisonImage(url: beforeImageUrl, size: size)
+                    .clipShape(SliderClipShape(fraction: sliderFraction, orientation: orientation))
+
+                // Divider line
+                dividerLine(size: size)
+
+                // Drag handle
+                sliderHandle(size: size)
+            }
+            .clipped()
+            .gesture(magnificationGesture)
+        }
+    }
+
+    // MARK: - Image
+
+    private func comparisonImage(url: String, size: CGSize) -> some View {
+        CachedAsyncImage(url: URL(string: url), maxPixelSize: imageMaxPixelSize) { phase in
+            switch phase {
+            case .success(let image):
+                image
+                    .resizable()
+                    .scaledToFit()
+                    .scaleEffect(scale)
+                    .offset(offset)
+            case .failure:
+                Color.civitSurfaceVariant
+                    .overlay { Image(systemName: "photo").foregroundColor(.civitOnSurfaceVariant) }
+            case .empty:
+                Color.civitSurfaceVariant.shimmer()
+            @unknown default:
+                Color.civitSurfaceVariant
+            }
+        }
+        .frame(width: size.width, height: size.height)
+    }
+
+    // MARK: - Divider
+
+    private func dividerLine(size: CGSize) -> some View {
+        Canvas { context, canvasSize in
+            var path = Path()
+            switch orientation {
+            case .horizontal:
+                let posX = canvasSize.width * sliderFraction
+                path.move(to: CGPoint(x: posX, y: 0))
+                path.addLine(to: CGPoint(x: posX, y: canvasSize.height))
+            case .vertical:
+                let posY = canvasSize.height * sliderFraction
+                path.move(to: CGPoint(x: 0, y: posY))
+                path.addLine(to: CGPoint(x: canvasSize.width, y: posY))
+            }
+            context.stroke(path, with: .color(.white), lineWidth: dividerWidth)
+        }
+        .allowsHitTesting(false)
+    }
+
+    // MARK: - Handle
+
+    private func sliderHandle(size: CGSize) -> some View {
+        let posX: CGFloat
+        let posY: CGFloat
+
+        switch orientation {
+        case .horizontal:
+            posX = size.width * sliderFraction
+            posY = size.height / 2
+        case .vertical:
+            posX = size.width / 2
+            posY = size.height * sliderFraction
+        }
+
+        return Circle()
+            .fill(Color.white.opacity(handleAlpha))
+            .frame(width: handleSize, height: handleSize)
+            .overlay {
+                Image(systemName: orientation == .horizontal
+                      ? "arrow.left.and.right"
+                      : "arrow.up.and.down")
+                    .font(.system(size: iconSize, weight: .semibold))
+                    .foregroundColor(.civitOnSurface)
+            }
+            .position(x: posX, y: posY)
+            .gesture(dragGesture(size: size))
+    }
+
+    // MARK: - Gestures
+
+    private func dragGesture(size: CGSize) -> some Gesture {
+        DragGesture()
+            .onChanged { value in
+                switch orientation {
+                case .horizontal:
+                    sliderFraction = (value.location.x / size.width).clamped(to: 0...1)
+                case .vertical:
+                    sliderFraction = (value.location.y / size.height).clamped(to: 0...1)
+                }
+            }
+    }
+
+    private var magnificationGesture: some Gesture {
+        MagnificationGesture()
+            .onChanged { value in
+                scale = min(max(value, minScale), maxScale)
+            }
+            .onEnded { _ in
+                withAnimation(MotionAnimation.fast) {
+                    if scale < 1.2 {
+                        scale = 1.0
+                        offset = .zero
+                    }
+                }
+            }
+    }
+}
+
+// MARK: - Clip Shape
+
+private struct SliderClipShape: Shape {
+    let fraction: CGFloat
+    let orientation: SliderOrientation
+
+    func path(in rect: CGRect) -> Path {
+        switch orientation {
+        case .horizontal:
+            return Path(CGRect(
+                x: rect.minX, y: rect.minY,
+                width: rect.width * fraction, height: rect.height
+            ))
+        case .vertical:
+            return Path(CGRect(
+                x: rect.minX, y: rect.minY,
+                width: rect.width, height: rect.height * fraction
+            ))
+        }
+    }
+}
+
+// MARK: - Constants
+
+private let initialFraction: CGFloat = 0.5
+private let minScale: CGFloat = 1.0
+private let maxScale: CGFloat = 5.0
+private let dividerWidth: CGFloat = 3
+private let handleSize: CGFloat = 40
+private let iconSize: CGFloat = 16
+private let handleAlpha: Double = 0.85
+private let imageMaxPixelSize: CGFloat = 1200
+
+// MARK: - Comparable Clamping
+
+private extension Comparable {
+    func clamped(to range: ClosedRange<Self>) -> Self {
+        min(max(self, range.lowerBound), range.upperBound)
+    }
+}

--- a/iosApp/iosApp/Features/Compare/ModelCompareScreen.swift
+++ b/iosApp/iosApp/Features/Compare/ModelCompareScreen.swift
@@ -3,6 +3,7 @@ import Shared
 
 struct ModelCompareScreen: View {
     @StateObject private var viewModel: ModelCompareViewModel
+    @State private var showImageComparison = false
 
     init(leftModelId: Int64, rightModelId: Int64) {
         _viewModel = StateObject(wrappedValue: ModelCompareViewModel(
@@ -31,14 +32,47 @@ struct ModelCompareScreen: View {
     // MARK: - Content
 
     private func compareContent(left: Model, right: Model) -> some View {
-        ScrollView {
+        let leftVersion = selectedVersion(model: left, index: viewModel.leftSelectedVersionIndex)
+        let rightVersion = selectedVersion(model: right, index: viewModel.rightSelectedVersionIndex)
+        let leftImages = filteredImages(version: leftVersion)
+        let rightImages = filteredImages(version: rightVersion)
+        let canCompareImages = !leftImages.isEmpty && !rightImages.isEmpty
+
+        return ScrollView {
             VStack(spacing: 0) {
                 comparePanels(left: left, right: right)
+                if canCompareImages {
+                    compareImagesButton
+                }
                 compareVersionSelectors(left: left, right: right)
                 Divider().padding(.vertical, Spacing.sm)
                 specsTable(left: left, right: right)
             }
         }
+        .fullScreenCover(isPresented: $showImageComparison) {
+            if let leftUrl = leftImages.first?.url,
+               let rightUrl = rightImages.first?.url {
+                ImageComparisonOverlay(
+                    beforeImageUrl: leftUrl,
+                    afterImageUrl: rightUrl,
+                    beforeLabel: left.name,
+                    afterLabel: right.name,
+                    onDismiss: { showImageComparison = false }
+                )
+            }
+        }
+    }
+
+    private var compareImagesButton: some View {
+        Button {
+            showImageComparison = true
+        } label: {
+            Text("Compare Images")
+                .font(.civitLabelMedium)
+                .fontWeight(.semibold)
+        }
+        .buttonStyle(.borderedProminent)
+        .padding(.vertical, Spacing.sm)
     }
 
     // MARK: - Panels


### PR DESCRIPTION
## Description

Add an interactive before/after image comparison slider for model version comparison. Both platforms feature a draggable divider that reveals/hides two images, vertical/horizontal slider mode toggle, and pinch-to-zoom while comparing.

**Android:**
- `ImageComparisonSlider` composable with `SliderClipShape` for clip-based image reveal
- `ImageComparisonOverlay` full-screen dialog with orientation toggle and labels
- Pinch-to-zoom via Compose `transformable` modifier
- Custom vector drawable icons for horizontal/vertical slider handles

**iOS:**
- `ImageComparisonSlider` SwiftUI view with `GeometryReader` + custom `Shape` clipping
- `ImageComparisonOverlay` full-screen cover with orientation toggle and labels
- `MagnificationGesture` for pinch-to-zoom
- `CachedAsyncImage` updated to accept configurable `maxPixelSize` (defaults to 400, comparison uses 1200)

**Integration:**
- "Compare Images" button added to both Android and iOS `ModelCompareScreen`
- Button appears when both compared models have images for their selected versions

## Related Issues

Closes #170

## Screenshots / Video

<!-- If applicable, add screenshots or screen recordings -->

## Test Plan

- [ ] Open Compare screen with two models that have images
- [ ] Verify "Compare Images" button appears
- [ ] Tap button to open full-screen comparison overlay
- [ ] Drag the slider handle left/right to reveal before/after images
- [ ] Toggle orientation between horizontal and vertical
- [ ] Pinch to zoom while comparing
- [ ] Dismiss overlay with close button or back gesture
- [ ] Verify both Android and iOS work consistently

## Review Checklist

- [x] Code follows project architecture (Clean Architecture + MVVM)
- [x] Shared logic is in `commonMain`, platform-specific code only when necessary
- [x] No unnecessary dependencies added
- [ ] Tests added/updated as needed

## Breaking Changes

None