### PR TITLE
Add NSFW blur with adjustable strength

### DIFF
--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/CivitDeckApplication.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/CivitDeckApplication.kt
@@ -98,14 +98,15 @@ val androidModule = module {
         )
     }
     viewModel { params -> CreatorProfileViewModel(params.get(), get()) }
-    viewModel { params -> ImageGalleryViewModel(params.get(), get(), get(), get(), get()) }
+    viewModel { params -> ImageGalleryViewModel(params.get(), get(), get(), get(), get(), get()) }
     viewModel { SavedPromptsViewModel(get(), get(), get(), get(), get()) }
     viewModel {
         SettingsViewModel(
             get(), get(), get(), get(), get(), get(),
             get(), get(), get(), get(), get(), get(),
-            get(), get(), get(), get(), get(), get(), get(),
             get(), get(), get(), get(), get(), get(),
+            get(), get(), get(), get(), get(), get(),
+            get(), get(), get(),
         )
     }
     viewModel { ModelFileBrowserViewModel(get(), get(), get(), get(), get(), get()) }

--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/components/NsfwBlurOverlay.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/components/NsfwBlurOverlay.kt
@@ -1,0 +1,63 @@
+package com.riox432.civitdeck.ui.components
+
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.blur
+import androidx.compose.ui.unit.dp
+import com.riox432.civitdeck.domain.model.NsfwBlurSettings
+import com.riox432.civitdeck.domain.model.NsfwLevel
+
+/**
+ * Wraps [content] with a blur overlay based on the NSFW level and blur settings.
+ * Supports tap-to-reveal: tapping the blurred area temporarily removes the blur.
+ */
+@Composable
+fun NsfwBlurOverlay(
+    nsfwLevel: NsfwLevel,
+    blurSettings: NsfwBlurSettings,
+    modifier: Modifier = Modifier,
+    content: @Composable () -> Unit,
+) {
+    val blurRadius = blurSettings.blurRadiusFor(nsfwLevel)
+    var isRevealed by remember { mutableStateOf(false) }
+    val effectiveBlur = if (isRevealed) 0f else blurRadius
+
+    Box(modifier = modifier) {
+        Box(modifier = Modifier.blur(effectiveBlur.dp)) {
+            content()
+        }
+
+        // Tap-to-reveal overlay when blurred
+        AnimatedVisibility(
+            visible = effectiveBlur > 0f,
+            enter = fadeIn(),
+            exit = fadeOut(),
+        ) {
+            Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .clickable { isRevealed = true },
+                contentAlignment = Alignment.Center,
+            ) {
+                Text(
+                    text = "Tap to reveal",
+                    style = MaterialTheme.typography.labelMedium,
+                    color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.7f),
+                )
+            }
+        }
+    }
+}

--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/gallery/ImageGalleryScreen.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/gallery/ImageGalleryScreen.kt
@@ -47,10 +47,12 @@ import coil3.request.ImageRequest
 import coil3.request.crossfade
 import com.riox432.civitdeck.domain.model.AspectRatioFilter
 import com.riox432.civitdeck.domain.model.Image
+import com.riox432.civitdeck.domain.model.NsfwBlurSettings
 import com.riox432.civitdeck.domain.model.SortOrder
 import com.riox432.civitdeck.domain.model.TimePeriod
 import com.riox432.civitdeck.ui.adaptive.adaptiveGridColumns
 import com.riox432.civitdeck.ui.components.ImageErrorPlaceholder
+import com.riox432.civitdeck.ui.components.NsfwBlurOverlay
 import com.riox432.civitdeck.ui.theme.CornerRadius
 import com.riox432.civitdeck.ui.theme.Duration
 import com.riox432.civitdeck.ui.theme.Easing
@@ -147,6 +149,7 @@ private fun ImageGalleryBody(
                 "error" -> ErrorState(error = uiState.error ?: "", onRetry = onRetry)
                 else -> ImageGrid(
                     images = uiState.images,
+                    blurSettings = uiState.nsfwBlurSettings,
                     isLoadingMore = uiState.isLoadingMore,
                     onImageClick = onImageClick,
                     onLoadMore = onLoadMore,
@@ -263,6 +266,7 @@ private fun ErrorState(error: String, onRetry: () -> Unit) {
 @Composable
 private fun ImageGrid(
     images: List<Image>,
+    blurSettings: NsfwBlurSettings,
     isLoadingMore: Boolean,
     onImageClick: (Int) -> Unit,
     onLoadMore: () -> Unit,
@@ -292,6 +296,7 @@ private fun ImageGrid(
         itemsIndexed(images, key = { _, image -> image.id }) { index, image ->
             ImageGridItem(
                 image = image,
+                blurSettings = blurSettings,
                 onClick = { onImageClick(index) },
                 modifier = Modifier.animateItem(),
             )
@@ -312,6 +317,7 @@ private fun ImageGrid(
 @Composable
 private fun ImageGridItem(
     image: Image,
+    blurSettings: NsfwBlurSettings,
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
@@ -321,34 +327,41 @@ private fun ImageGridItem(
         1f
     }
 
-    SubcomposeAsyncImage(
-        model = ImageRequest.Builder(LocalContext.current)
-            .data(image.url)
-            .crossfade(Duration.normal)
-            .build(),
-        contentDescription = null,
-        contentScale = ContentScale.Crop,
+    NsfwBlurOverlay(
+        nsfwLevel = image.nsfwLevel,
+        blurSettings = blurSettings,
         modifier = modifier
             .fillMaxWidth()
-            .aspectRatio(aspectRatio)
             .clip(RoundedCornerShape(CornerRadius.image))
             .clickable(onClick = onClick),
-        loading = {
-            Box(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .aspectRatio(aspectRatio)
-                    .shimmer(),
-            )
-        },
-        error = {
-            ImageErrorPlaceholder(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .aspectRatio(aspectRatio),
-            )
-        },
-    )
+    ) {
+        SubcomposeAsyncImage(
+            model = ImageRequest.Builder(LocalContext.current)
+                .data(image.url)
+                .crossfade(Duration.normal)
+                .build(),
+            contentDescription = null,
+            contentScale = ContentScale.Crop,
+            modifier = Modifier
+                .fillMaxWidth()
+                .aspectRatio(aspectRatio),
+            loading = {
+                Box(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .aspectRatio(aspectRatio)
+                        .shimmer(),
+                )
+            },
+            error = {
+                ImageErrorPlaceholder(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .aspectRatio(aspectRatio),
+                )
+            },
+        )
+    }
 }
 
 private const val LOAD_MORE_THRESHOLD = 6

--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/gallery/ImageGalleryViewModel.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/gallery/ImageGalleryViewModel.kt
@@ -5,12 +5,14 @@ import androidx.lifecycle.viewModelScope
 import com.riox432.civitdeck.domain.model.AspectRatioFilter
 import com.riox432.civitdeck.domain.model.Image
 import com.riox432.civitdeck.domain.model.ImageGenerationMeta
+import com.riox432.civitdeck.domain.model.NsfwBlurSettings
 import com.riox432.civitdeck.domain.model.NsfwFilterLevel
 import com.riox432.civitdeck.domain.model.NsfwLevel
 import com.riox432.civitdeck.domain.model.SortOrder
 import com.riox432.civitdeck.domain.model.TimePeriod
 import com.riox432.civitdeck.domain.usecase.AutoSavePromptUseCase
 import com.riox432.civitdeck.domain.usecase.GetImagesUseCase
+import com.riox432.civitdeck.domain.usecase.ObserveNsfwBlurSettingsUseCase
 import com.riox432.civitdeck.domain.usecase.ObserveNsfwFilterUseCase
 import com.riox432.civitdeck.domain.usecase.SavePromptUseCase
 import kotlinx.coroutines.CancellationException
@@ -26,6 +28,7 @@ data class ImageGalleryUiState(
     val selectedSort: SortOrder = SortOrder.HighestRated,
     val selectedPeriod: TimePeriod = TimePeriod.AllTime,
     val nsfwFilterLevel: NsfwFilterLevel = NsfwFilterLevel.Off,
+    val nsfwBlurSettings: NsfwBlurSettings = NsfwBlurSettings(),
     val selectedAspectRatio: AspectRatioFilter? = null,
     val isLoading: Boolean = false,
     val isLoadingMore: Boolean = false,
@@ -44,6 +47,7 @@ class ImageGalleryViewModel(
     private val savePromptUseCase: SavePromptUseCase,
     private val observeNsfwFilterUseCase: ObserveNsfwFilterUseCase,
     private val autoSavePromptUseCase: AutoSavePromptUseCase,
+    private val observeNsfwBlurSettingsUseCase: ObserveNsfwBlurSettingsUseCase,
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow(ImageGalleryUiState())
@@ -53,7 +57,16 @@ class ImageGalleryViewModel(
 
     init {
         observeNsfwFilter()
+        observeBlurSettings()
         loadImages()
+    }
+
+    private fun observeBlurSettings() {
+        viewModelScope.launch {
+            observeNsfwBlurSettingsUseCase().collect { settings ->
+                _uiState.update { it.copy(nsfwBlurSettings = settings) }
+            }
+        }
     }
 
     private fun observeNsfwFilter() {

--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/settings/SettingsScreen.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/settings/SettingsScreen.kt
@@ -20,6 +20,7 @@ import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Slider
 import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
@@ -37,6 +38,7 @@ import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.riox432.civitdeck.BuildConfig
+import com.riox432.civitdeck.domain.model.NsfwBlurSettings
 import com.riox432.civitdeck.domain.model.NsfwFilterLevel
 import com.riox432.civitdeck.domain.model.PollingInterval
 import com.riox432.civitdeck.domain.model.SortOrder
@@ -61,6 +63,17 @@ fun SettingsScreen(
         }
     }
 
+    SettingsContent(state, viewModel, listState, onNavigateToLicenses, onNavigateToModelFiles)
+}
+
+@Composable
+private fun SettingsContent(
+    state: SettingsUiState,
+    viewModel: SettingsViewModel,
+    listState: androidx.compose.foundation.lazy.LazyListState,
+    onNavigateToLicenses: () -> Unit,
+    onNavigateToModelFiles: () -> Unit,
+) {
     LazyColumn(state = listState) {
         item { SectionHeader("Account") }
         item {
@@ -90,6 +103,14 @@ fun SettingsScreen(
         }
         item { SectionHeader("Content Filter") }
         item { NsfwToggleRow(state.nsfwFilterLevel, viewModel::onNsfwFilterChanged) }
+        if (state.nsfwFilterLevel != NsfwFilterLevel.Off) {
+            item {
+                NsfwBlurSection(
+                    settings = state.nsfwBlurSettings,
+                    onSettingsChanged = viewModel::onNsfwBlurSettingsChanged,
+                )
+            }
+        }
         item { SectionHeader("Display") }
         item { SortOrderRow(state.defaultSortOrder, viewModel::onSortOrderChanged) }
         item { TimePeriodRow(state.defaultTimePeriod, viewModel::onTimePeriodChanged) }
@@ -188,6 +209,59 @@ private fun NsfwToggleRow(level: NsfwFilterLevel, onToggle: (NsfwFilterLevel) ->
             onCheckedChange = {
                 onToggle(if (level == NsfwFilterLevel.Off) NsfwFilterLevel.All else NsfwFilterLevel.Off)
             },
+        )
+    }
+}
+
+@Composable
+private fun NsfwBlurSection(
+    settings: NsfwBlurSettings,
+    onSettingsChanged: (NsfwBlurSettings) -> Unit,
+) {
+    Column(
+        modifier = Modifier.padding(horizontal = Spacing.lg),
+        verticalArrangement = Arrangement.spacedBy(Spacing.xs),
+    ) {
+        Text(
+            "Blur Intensity",
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        BlurSliderRow("Soft", settings.softIntensity) {
+            onSettingsChanged(settings.copy(softIntensity = it))
+        }
+        BlurSliderRow("Mature", settings.matureIntensity) {
+            onSettingsChanged(settings.copy(matureIntensity = it))
+        }
+        BlurSliderRow("Explicit", settings.explicitIntensity) {
+            onSettingsChanged(settings.copy(explicitIntensity = it))
+        }
+    }
+}
+
+@Composable
+private fun BlurSliderRow(
+    label: String,
+    intensity: Int,
+    onChanged: (Int) -> Unit,
+) {
+    Column(modifier = Modifier.fillMaxWidth()) {
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceBetween,
+        ) {
+            Text(label, style = MaterialTheme.typography.bodyMedium)
+            Text(
+                text = if (intensity == 0) "Hidden" else "$intensity%",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+        Slider(
+            value = intensity.toFloat(),
+            onValueChange = { onChanged(it.toInt()) },
+            valueRange = 0f..100f,
+            steps = 3,
         )
     }
 }

--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/settings/SettingsViewModel.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/settings/SettingsViewModel.kt
@@ -3,6 +3,7 @@ package com.riox432.civitdeck.ui.settings
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.riox432.civitdeck.data.local.entity.HiddenModelEntity
+import com.riox432.civitdeck.domain.model.NsfwBlurSettings
 import com.riox432.civitdeck.domain.model.NsfwFilterLevel
 import com.riox432.civitdeck.domain.model.PollingInterval
 import com.riox432.civitdeck.domain.model.SortOrder
@@ -18,6 +19,7 @@ import com.riox432.civitdeck.domain.usecase.ObserveDefaultSortOrderUseCase
 import com.riox432.civitdeck.domain.usecase.ObserveDefaultTimePeriodUseCase
 import com.riox432.civitdeck.domain.usecase.ObserveGridColumnsUseCase
 import com.riox432.civitdeck.domain.usecase.ObserveNotificationsEnabledUseCase
+import com.riox432.civitdeck.domain.usecase.ObserveNsfwBlurSettingsUseCase
 import com.riox432.civitdeck.domain.usecase.ObserveNsfwFilterUseCase
 import com.riox432.civitdeck.domain.usecase.ObservePollingIntervalUseCase
 import com.riox432.civitdeck.domain.usecase.ObservePowerUserModeUseCase
@@ -27,6 +29,7 @@ import com.riox432.civitdeck.domain.usecase.SetDefaultSortOrderUseCase
 import com.riox432.civitdeck.domain.usecase.SetDefaultTimePeriodUseCase
 import com.riox432.civitdeck.domain.usecase.SetGridColumnsUseCase
 import com.riox432.civitdeck.domain.usecase.SetNotificationsEnabledUseCase
+import com.riox432.civitdeck.domain.usecase.SetNsfwBlurSettingsUseCase
 import com.riox432.civitdeck.domain.usecase.SetNsfwFilterUseCase
 import com.riox432.civitdeck.domain.usecase.SetPollingIntervalUseCase
 import com.riox432.civitdeck.domain.usecase.SetPowerUserModeUseCase
@@ -43,6 +46,7 @@ import kotlinx.coroutines.launch
 
 data class SettingsUiState(
     val nsfwFilterLevel: NsfwFilterLevel = NsfwFilterLevel.Off,
+    val nsfwBlurSettings: NsfwBlurSettings = NsfwBlurSettings(),
     val defaultSortOrder: SortOrder = SortOrder.MostDownloaded,
     val defaultTimePeriod: TimePeriod = TimePeriod.AllTime,
     val gridColumns: Int = 2,
@@ -61,6 +65,8 @@ data class SettingsUiState(
 class SettingsViewModel(
     observeNsfwFilterUseCase: ObserveNsfwFilterUseCase,
     private val setNsfwFilterUseCase: SetNsfwFilterUseCase,
+    observeNsfwBlurSettingsUseCase: ObserveNsfwBlurSettingsUseCase,
+    private val setNsfwBlurSettingsUseCase: SetNsfwBlurSettingsUseCase,
     observeDefaultSortOrderUseCase: ObserveDefaultSortOrderUseCase,
     private val setDefaultSortOrderUseCase: SetDefaultSortOrderUseCase,
     observeDefaultTimePeriodUseCase: ObserveDefaultTimePeriodUseCase,
@@ -108,6 +114,8 @@ class SettingsViewModel(
         state.copy(notificationsEnabled = enabled)
     }.combine(observePollingIntervalUseCase()) { state, interval ->
         state.copy(pollingInterval = interval)
+    }.combine(observeNsfwBlurSettingsUseCase()) { state, blur ->
+        state.copy(nsfwBlurSettings = blur)
     }.combine(_mutableState) { observed, mutable ->
         observed.copy(
             hiddenModels = mutable.hiddenModels,
@@ -183,6 +191,10 @@ class SettingsViewModel(
 
     fun onNsfwFilterChanged(level: NsfwFilterLevel) {
         viewModelScope.launch { setNsfwFilterUseCase(level) }
+    }
+
+    fun onNsfwBlurSettingsChanged(settings: NsfwBlurSettings) {
+        viewModelScope.launch { setNsfwBlurSettingsUseCase(settings) }
     }
 
     fun onSortOrderChanged(sort: SortOrder) {

--- a/iosApp/iosApp.xcodeproj/project.pbxproj
+++ b/iosApp/iosApp.xcodeproj/project.pbxproj
@@ -44,6 +44,7 @@
 		CD000B032D00000B000CD001 /* ExcludedTagsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD000B022D00000B000CD001 /* ExcludedTagsView.swift */; };
 		CD000B052D00000B000CD001 /* LicensesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD000B042D00000B000CD001 /* LicensesView.swift */; };
 		CD00CA012D0CC001000CD001 /* CachedAsyncImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD00CA002D0CC001000CD001 /* CachedAsyncImage.swift */; };
+		CD17300A2D173001000CD001 /* NsfwBlurView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD17300B2D173001000CD001 /* NsfwBlurView.swift */; };
 		CD00AD012D1CC001000CD001 /* AdaptiveGrid.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD00AD002D1CC001000CD001 /* AdaptiveGrid.swift */; };
 		CD00CE012D2CC001000CD001 /* ComparisonState.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD00CE002D2CC001000CD001 /* ComparisonState.swift */; };
 		CD00CE032D2CC001000CD001 /* ModelCompareScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD00CE022D2CC001000CD001 /* ModelCompareScreen.swift */; };
@@ -94,6 +95,7 @@
 		CD000B022D00000B000CD001 /* ExcludedTagsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExcludedTagsView.swift; sourceTree = "<group>"; };
 		CD000B042D00000B000CD001 /* LicensesView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LicensesView.swift; sourceTree = "<group>"; };
 		CD00CA002D0CC001000CD001 /* CachedAsyncImage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CachedAsyncImage.swift; sourceTree = "<group>"; };
+		CD17300B2D173001000CD001 /* NsfwBlurView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NsfwBlurView.swift; sourceTree = "<group>"; };
 		CD00AD002D1CC001000CD001 /* AdaptiveGrid.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdaptiveGrid.swift; sourceTree = "<group>"; };
 		CD00CE002D2CC001000CD001 /* ComparisonState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ComparisonState.swift; sourceTree = "<group>"; };
 		CD00CE022D2CC001000CD001 /* ModelCompareScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModelCompareScreen.swift; sourceTree = "<group>"; };
@@ -179,6 +181,7 @@
 				CD00060A2D000006000CD001 /* CivitDeckMotion.swift */,
 				CD0006102D000036000CD001 /* ShimmerModifier.swift */,
 				CD00CA002D0CC001000CD001 /* CachedAsyncImage.swift */,
+				CD17300B2D173001000CD001 /* NsfwBlurView.swift */,
 				CD00AD002D1CC001000CD001 /* AdaptiveGrid.swift */,
 			);
 			path = DesignSystem;
@@ -443,6 +446,7 @@
 				CD000B032D00000B000CD001 /* ExcludedTagsView.swift in Sources */,
 				CD000B052D00000B000CD001 /* LicensesView.swift in Sources */,
 				CD00CA012D0CC001000CD001 /* CachedAsyncImage.swift in Sources */,
+				CD17300A2D173001000CD001 /* NsfwBlurView.swift in Sources */,
 				CD00AD012D1CC001000CD001 /* AdaptiveGrid.swift in Sources */,
 				CD00CE012D2CC001000CD001 /* ComparisonState.swift in Sources */,
 				CD00CE032D2CC001000CD001 /* ModelCompareScreen.swift in Sources */,

--- a/iosApp/iosApp/DesignSystem/NsfwBlurView.swift
+++ b/iosApp/iosApp/DesignSystem/NsfwBlurView.swift
@@ -1,0 +1,31 @@
+import SwiftUI
+
+/// Wraps content with a blur overlay based on a blur radius.
+/// Supports tap-to-reveal: tapping the blurred area temporarily removes the blur.
+struct NsfwBlurView<Content: View>: View {
+    let blurRadius: CGFloat
+    @ViewBuilder let content: () -> Content
+    @State private var isRevealed: Bool = false
+
+    var body: some View {
+        ZStack {
+            content()
+                .blur(radius: isRevealed ? 0 : blurRadius)
+
+            if !isRevealed && blurRadius > 0 {
+                Color.clear
+                    .contentShape(Rectangle())
+                    .onTapGesture {
+                        withAnimation(MotionAnimation.standard) {
+                            isRevealed = true
+                        }
+                    }
+                    .overlay {
+                        Text("Tap to reveal")
+                            .font(.civitLabelMedium)
+                            .foregroundColor(.civitOnSurface.opacity(0.7))
+                    }
+            }
+        }
+    }
+}

--- a/iosApp/iosApp/Features/Gallery/ImageGalleryScreen.swift
+++ b/iosApp/iosApp/Features/Gallery/ImageGalleryScreen.swift
@@ -23,6 +23,9 @@ struct ImageGalleryScreen: View {
         .task {
             await viewModel.observeNsfwFilter()
         }
+        .task {
+            await viewModel.observeNsfwBlurSettings()
+        }
         .fullScreenCover(isPresented: Binding(
             get: { viewModel.selectedImageIndex != nil },
             set: { if !$0 { viewModel.onDismissViewer() } }
@@ -154,34 +157,37 @@ struct ImageGalleryScreen: View {
         let aspectRatio: CGFloat = (image.width > 0 && image.height > 0)
             ? CGFloat(image.width) / CGFloat(image.height)
             : 1.0
+        let blurRadius = CGFloat(viewModel.nsfwBlurSettings.blurRadiusFor(level: image.nsfwLevel))
 
         return Button {
             viewModel.onImageSelected(index)
         } label: {
-            CachedAsyncImage(url: URL(string: image.url)) { phase in
-                switch phase {
-                case .success(let img):
-                    img
-                        .resizable()
-                        .scaledToFill()
-                        .transition(.opacity)
-                case .failure:
-                    Rectangle()
-                        .fill(Color.civitSurfaceVariant)
-                        .overlay {
-                            SwiftUI.Image(systemName: "photo")
-                                .foregroundColor(.civitOnSurfaceVariant)
-                        }
-                case .empty:
-                    Rectangle()
-                        .fill(Color.civitSurfaceVariant)
-                        .shimmer()
-                @unknown default:
-                    EmptyView()
+            NsfwBlurView(blurRadius: blurRadius) {
+                CachedAsyncImage(url: URL(string: image.url)) { phase in
+                    switch phase {
+                    case .success(let img):
+                        img
+                            .resizable()
+                            .scaledToFill()
+                            .transition(.opacity)
+                    case .failure:
+                        Rectangle()
+                            .fill(Color.civitSurfaceVariant)
+                            .overlay {
+                                SwiftUI.Image(systemName: "photo")
+                                    .foregroundColor(.civitOnSurfaceVariant)
+                            }
+                    case .empty:
+                        Rectangle()
+                            .fill(Color.civitSurfaceVariant)
+                            .shimmer()
+                    @unknown default:
+                        EmptyView()
+                    }
                 }
+                .aspectRatio(aspectRatio, contentMode: .fill)
+                .clipped()
             }
-            .aspectRatio(aspectRatio, contentMode: .fill)
-            .clipped()
             .clipShape(RoundedRectangle(cornerRadius: CornerRadius.image))
         }
         .buttonStyle(.plain)

--- a/iosApp/iosApp/Features/Gallery/ImageGalleryViewModel.swift
+++ b/iosApp/iosApp/Features/Gallery/ImageGalleryViewModel.swift
@@ -16,6 +16,9 @@ final class ImageGalleryViewModel: ObservableObject {
     @Published var selectedSort: CivitSortOrder = .highestRated
     @Published var selectedPeriod: TimePeriod = .allTime
     @Published var nsfwFilterLevel: NsfwFilterLevel = .off
+    @Published var nsfwBlurSettings: NsfwBlurSettings = NsfwBlurSettings(
+        softIntensity: 75, matureIntensity: 25, explicitIntensity: 0
+    )
     @Published var selectedAspectRatio: AspectRatioFilter?
     @Published var isLoading: Bool = false
     @Published var isLoadingMore: Bool = false
@@ -40,6 +43,7 @@ final class ImageGalleryViewModel: ObservableObject {
     private let getImagesUseCase: GetImagesUseCase
     private let savePromptUseCase: SavePromptUseCase
     private let observeNsfwFilterUseCase: ObserveNsfwFilterUseCase
+    private let observeNsfwBlurSettingsUseCase: ObserveNsfwBlurSettingsUseCase
     private let autoSavePromptUseCase: AutoSavePromptUseCase
     private var nextCursor: String?
     private var loadTask: Task<Void, Never>?
@@ -52,8 +56,15 @@ final class ImageGalleryViewModel: ObservableObject {
         self.getImagesUseCase = KoinHelper.shared.getImagesUseCase()
         self.savePromptUseCase = KoinHelper.shared.getSavePromptUseCase()
         self.observeNsfwFilterUseCase = KoinHelper.shared.getObserveNsfwFilterUseCase()
+        self.observeNsfwBlurSettingsUseCase = KoinHelper.shared.getObserveNsfwBlurSettingsUseCase()
         self.autoSavePromptUseCase = KoinHelper.shared.getAutoSavePromptUseCase()
         loadImages()
+    }
+
+    func observeNsfwBlurSettings() async {
+        for await value in observeNsfwBlurSettingsUseCase.invoke() {
+            nsfwBlurSettings = value
+        }
     }
 
     func observeNsfwFilter() async {

--- a/iosApp/iosApp/Features/Settings/SettingsScreen.swift
+++ b/iosApp/iosApp/Features/Settings/SettingsScreen.swift
@@ -18,6 +18,7 @@ struct SettingsScreen: View {
             .navigationBarTitleDisplayMode(.inline)
             .task { await viewModel.observeApiKey() }
             .task { await viewModel.observeNsfwFilter() }
+            .task { await viewModel.observeNsfwBlurSettings() }
             .task { await viewModel.observeSortOrder() }
             .task { await viewModel.observeTimePeriod() }
             .task { await viewModel.observeGridColumns() }
@@ -52,6 +53,12 @@ struct SettingsScreen: View {
                         .font(.civitBodySmall)
                         .foregroundColor(.civitOnSurfaceVariant)
                 }
+            }
+            if viewModel.nsfwFilterLevel != .off {
+                NsfwBlurSettingsSection(
+                    settings: viewModel.nsfwBlurSettings,
+                    onChanged: viewModel.onNsfwBlurSettingsChanged
+                )
             }
         }
     }
@@ -234,6 +241,67 @@ private struct ApiKeyInputRow: View {
             Text("Get your key at civitai.com/user/account")
                 .font(.civitBodySmall)
                 .foregroundColor(.civitOnSurfaceVariant)
+        }
+    }
+}
+
+private struct NsfwBlurSettingsSection: View {
+    let settings: NsfwBlurSettings
+    let onChanged: (NsfwBlurSettings) -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: Spacing.sm) {
+            Text("Blur Intensity")
+                .font(.civitBodySmall)
+                .foregroundColor(.civitOnSurfaceVariant)
+            BlurSliderRow(label: "Soft", intensity: Int(settings.softIntensity)) { value in
+                onChanged(NsfwBlurSettings(
+                    softIntensity: Int32(value),
+                    matureIntensity: settings.matureIntensity,
+                    explicitIntensity: settings.explicitIntensity
+                ))
+            }
+            BlurSliderRow(label: "Mature", intensity: Int(settings.matureIntensity)) { value in
+                onChanged(NsfwBlurSettings(
+                    softIntensity: settings.softIntensity,
+                    matureIntensity: Int32(value),
+                    explicitIntensity: settings.explicitIntensity
+                ))
+            }
+            BlurSliderRow(label: "Explicit", intensity: Int(settings.explicitIntensity)) { value in
+                onChanged(NsfwBlurSettings(
+                    softIntensity: settings.softIntensity,
+                    matureIntensity: settings.matureIntensity,
+                    explicitIntensity: Int32(value)
+                ))
+            }
+        }
+    }
+}
+
+private struct BlurSliderRow: View {
+    let label: String
+    let intensity: Int
+    let onChanged: (Int) -> Void
+
+    var body: some View {
+        VStack(spacing: 2) {
+            HStack {
+                Text(label)
+                    .font(.civitBodyMedium)
+                Spacer()
+                Text(intensity == 0 ? "Hidden" : "\(intensity)%")
+                    .font(.civitBodySmall)
+                    .foregroundColor(.civitOnSurfaceVariant)
+            }
+            Slider(
+                value: Binding(
+                    get: { Double(intensity) },
+                    set: { onChanged(Int($0)) }
+                ),
+                in: 0...100,
+                step: 25
+            )
         }
     }
 }

--- a/iosApp/iosApp/Features/Settings/SettingsViewModel.swift
+++ b/iosApp/iosApp/Features/Settings/SettingsViewModel.swift
@@ -4,6 +4,9 @@ import Shared
 @MainActor
 final class SettingsViewModel: ObservableObject {
     @Published var nsfwFilterLevel: NsfwFilterLevel = .off
+    @Published var nsfwBlurSettings: NsfwBlurSettings = NsfwBlurSettings(
+        softIntensity: 75, matureIntensity: 25, explicitIntensity: 0
+    )
     @Published var defaultSortOrder: CivitSortOrder = .mostDownloaded
     @Published var defaultTimePeriod: TimePeriod = .allTime
     @Published var gridColumns: Int32 = 2
@@ -17,6 +20,8 @@ final class SettingsViewModel: ObservableObject {
 
     private let observeNsfwFilterUseCase: ObserveNsfwFilterUseCase
     private let setNsfwFilterUseCase: SetNsfwFilterUseCase
+    private let observeNsfwBlurSettingsUseCase: ObserveNsfwBlurSettingsUseCase
+    private let setNsfwBlurSettingsUseCase: SetNsfwBlurSettingsUseCase
     private let observeDefaultSortOrderUseCase: ObserveDefaultSortOrderUseCase
     private let setDefaultSortOrderUseCase: SetDefaultSortOrderUseCase
     private let observeDefaultTimePeriodUseCase: ObserveDefaultTimePeriodUseCase
@@ -40,6 +45,8 @@ final class SettingsViewModel: ObservableObject {
     init() {
         self.observeNsfwFilterUseCase = KoinHelper.shared.getObserveNsfwFilterUseCase()
         self.setNsfwFilterUseCase = KoinHelper.shared.getSetNsfwFilterUseCase()
+        self.observeNsfwBlurSettingsUseCase = KoinHelper.shared.getObserveNsfwBlurSettingsUseCase()
+        self.setNsfwBlurSettingsUseCase = KoinHelper.shared.getSetNsfwBlurSettingsUseCase()
         self.observeDefaultSortOrderUseCase = KoinHelper.shared.getObserveDefaultSortOrderUseCase()
         self.setDefaultSortOrderUseCase = KoinHelper.shared.getSetDefaultSortOrderUseCase()
         self.observeDefaultTimePeriodUseCase = KoinHelper.shared.getObserveDefaultTimePeriodUseCase()
@@ -87,10 +94,21 @@ final class SettingsViewModel: ObservableObject {
         }
     }
 
+    func observeNsfwBlurSettings() async {
+        for await value in observeNsfwBlurSettingsUseCase.invoke() {
+            nsfwBlurSettings = value
+        }
+    }
+
     func onNsfwFilterToggle() {
         let newLevel: NsfwFilterLevel = nsfwFilterLevel == .off ? .all : .off
         nsfwFilterLevel = newLevel
         Task { try? await setNsfwFilterUseCase.invoke(level: newLevel) }
+    }
+
+    func onNsfwBlurSettingsChanged(_ settings: NsfwBlurSettings) {
+        nsfwBlurSettings = settings
+        Task { try? await setNsfwBlurSettingsUseCase.invoke(settings: settings) }
     }
 
     func onSortOrderChanged(_ sort: CivitSortOrder) {

--- a/shared/schemas/com.riox432.civitdeck.data.local.CivitDeckDatabase/13.json
+++ b/shared/schemas/com.riox432.civitdeck.data.local.CivitDeckDatabase/13.json
@@ -1,0 +1,715 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 13,
+    "identityHash": "9895a1a81861e37cde7257be238a4b74",
+    "entities": [
+      {
+        "tableName": "collections",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL, `isDefault` INTEGER NOT NULL, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isDefault",
+            "columnName": "isDefault",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "collection_model_entries",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`collectionId` INTEGER NOT NULL, `modelId` INTEGER NOT NULL, `name` TEXT NOT NULL, `type` TEXT NOT NULL, `nsfw` INTEGER NOT NULL, `thumbnailUrl` TEXT, `creatorName` TEXT, `downloadCount` INTEGER NOT NULL, `favoriteCount` INTEGER NOT NULL, `rating` REAL NOT NULL, `addedAt` INTEGER NOT NULL, PRIMARY KEY(`collectionId`, `modelId`), FOREIGN KEY(`collectionId`) REFERENCES `collections`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "collectionId",
+            "columnName": "collectionId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "modelId",
+            "columnName": "modelId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "nsfw",
+            "columnName": "nsfw",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "thumbnailUrl",
+            "columnName": "thumbnailUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "creatorName",
+            "columnName": "creatorName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "downloadCount",
+            "columnName": "downloadCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "favoriteCount",
+            "columnName": "favoriteCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "rating",
+            "columnName": "rating",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "addedAt",
+            "columnName": "addedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "collectionId",
+            "modelId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_collection_model_entries_modelId",
+            "unique": false,
+            "columnNames": [
+              "modelId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_collection_model_entries_modelId` ON `${TABLE_NAME}` (`modelId`)"
+          },
+          {
+            "name": "index_collection_model_entries_collectionId",
+            "unique": false,
+            "columnNames": [
+              "collectionId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_collection_model_entries_collectionId` ON `${TABLE_NAME}` (`collectionId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "collections",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "collectionId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "cached_api_responses",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`cacheKey` TEXT NOT NULL, `responseJson` TEXT NOT NULL, `cachedAt` INTEGER NOT NULL, PRIMARY KEY(`cacheKey`))",
+        "fields": [
+          {
+            "fieldPath": "cacheKey",
+            "columnName": "cacheKey",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "responseJson",
+            "columnName": "responseJson",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cachedAt",
+            "columnName": "cachedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "cacheKey"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_cached_api_responses_cachedAt",
+            "unique": false,
+            "columnNames": [
+              "cachedAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_cached_api_responses_cachedAt` ON `${TABLE_NAME}` (`cachedAt`)"
+          }
+        ]
+      },
+      {
+        "tableName": "user_preferences",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `nsfwFilterLevel` TEXT NOT NULL, `defaultSortOrder` TEXT NOT NULL, `defaultTimePeriod` TEXT NOT NULL, `gridColumns` INTEGER NOT NULL, `apiKey` TEXT, `powerUserMode` INTEGER NOT NULL, `notificationsEnabled` INTEGER NOT NULL, `pollingIntervalMinutes` INTEGER NOT NULL, `nsfwBlurSoft` INTEGER NOT NULL, `nsfwBlurMature` INTEGER NOT NULL, `nsfwBlurExplicit` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "nsfwFilterLevel",
+            "columnName": "nsfwFilterLevel",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "defaultSortOrder",
+            "columnName": "defaultSortOrder",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "defaultTimePeriod",
+            "columnName": "defaultTimePeriod",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "gridColumns",
+            "columnName": "gridColumns",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "apiKey",
+            "columnName": "apiKey",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "powerUserMode",
+            "columnName": "powerUserMode",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "notificationsEnabled",
+            "columnName": "notificationsEnabled",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "pollingIntervalMinutes",
+            "columnName": "pollingIntervalMinutes",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "nsfwBlurSoft",
+            "columnName": "nsfwBlurSoft",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "nsfwBlurMature",
+            "columnName": "nsfwBlurMature",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "nsfwBlurExplicit",
+            "columnName": "nsfwBlurExplicit",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "saved_prompts",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `prompt` TEXT NOT NULL, `negativePrompt` TEXT, `sampler` TEXT, `steps` INTEGER, `cfgScale` REAL, `seed` INTEGER, `modelName` TEXT, `size` TEXT, `sourceImageUrl` TEXT, `savedAt` INTEGER NOT NULL, `isTemplate` INTEGER NOT NULL, `templateName` TEXT, `autoSaved` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "prompt",
+            "columnName": "prompt",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "negativePrompt",
+            "columnName": "negativePrompt",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "sampler",
+            "columnName": "sampler",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "steps",
+            "columnName": "steps",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "cfgScale",
+            "columnName": "cfgScale",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "seed",
+            "columnName": "seed",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "modelName",
+            "columnName": "modelName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "size",
+            "columnName": "size",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "sourceImageUrl",
+            "columnName": "sourceImageUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "savedAt",
+            "columnName": "savedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isTemplate",
+            "columnName": "isTemplate",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "templateName",
+            "columnName": "templateName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "autoSaved",
+            "columnName": "autoSaved",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "search_history",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `query` TEXT NOT NULL, `searchedAt` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "query",
+            "columnName": "query",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "searchedAt",
+            "columnName": "searchedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "browsing_history",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `modelId` INTEGER NOT NULL, `modelType` TEXT NOT NULL, `creatorName` TEXT, `tags` TEXT NOT NULL, `viewedAt` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "modelId",
+            "columnName": "modelId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "modelType",
+            "columnName": "modelType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "creatorName",
+            "columnName": "creatorName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "tags",
+            "columnName": "tags",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "viewedAt",
+            "columnName": "viewedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_browsing_history_modelId",
+            "unique": false,
+            "columnNames": [
+              "modelId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_browsing_history_modelId` ON `${TABLE_NAME}` (`modelId`)"
+          },
+          {
+            "name": "index_browsing_history_viewedAt",
+            "unique": false,
+            "columnNames": [
+              "viewedAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_browsing_history_viewedAt` ON `${TABLE_NAME}` (`viewedAt`)"
+          }
+        ]
+      },
+      {
+        "tableName": "excluded_tags",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`tag` TEXT NOT NULL, `addedAt` INTEGER NOT NULL, PRIMARY KEY(`tag`))",
+        "fields": [
+          {
+            "fieldPath": "tag",
+            "columnName": "tag",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "addedAt",
+            "columnName": "addedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "tag"
+          ]
+        }
+      },
+      {
+        "tableName": "hidden_models",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`modelId` INTEGER NOT NULL, `modelName` TEXT NOT NULL, `hiddenAt` INTEGER NOT NULL, PRIMARY KEY(`modelId`))",
+        "fields": [
+          {
+            "fieldPath": "modelId",
+            "columnName": "modelId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "modelName",
+            "columnName": "modelName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "hiddenAt",
+            "columnName": "hiddenAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "modelId"
+          ]
+        }
+      },
+      {
+        "tableName": "model_directories",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `path` TEXT NOT NULL, `label` TEXT, `lastScannedAt` INTEGER, `isEnabled` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "path",
+            "columnName": "path",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "label",
+            "columnName": "label",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "lastScannedAt",
+            "columnName": "lastScannedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "isEnabled",
+            "columnName": "isEnabled",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "local_model_files",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `directoryId` INTEGER NOT NULL, `filePath` TEXT NOT NULL, `fileName` TEXT NOT NULL, `sha256Hash` TEXT NOT NULL, `sizeBytes` INTEGER NOT NULL, `scannedAt` INTEGER NOT NULL, `matchedModelId` INTEGER, `matchedModelName` TEXT, `matchedVersionId` INTEGER, `matchedVersionName` TEXT, `latestVersionId` INTEGER, `hasUpdate` INTEGER NOT NULL, FOREIGN KEY(`directoryId`) REFERENCES `model_directories`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "directoryId",
+            "columnName": "directoryId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "filePath",
+            "columnName": "filePath",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fileName",
+            "columnName": "fileName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sha256Hash",
+            "columnName": "sha256Hash",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sizeBytes",
+            "columnName": "sizeBytes",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "scannedAt",
+            "columnName": "scannedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "matchedModelId",
+            "columnName": "matchedModelId",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "matchedModelName",
+            "columnName": "matchedModelName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "matchedVersionId",
+            "columnName": "matchedVersionId",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "matchedVersionName",
+            "columnName": "matchedVersionName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "latestVersionId",
+            "columnName": "latestVersionId",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "hasUpdate",
+            "columnName": "hasUpdate",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_local_model_files_directoryId",
+            "unique": false,
+            "columnNames": [
+              "directoryId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_local_model_files_directoryId` ON `${TABLE_NAME}` (`directoryId`)"
+          },
+          {
+            "name": "index_local_model_files_sha256Hash",
+            "unique": false,
+            "columnNames": [
+              "sha256Hash"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_local_model_files_sha256Hash` ON `${TABLE_NAME}` (`sha256Hash`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "model_directories",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "directoryId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "model_version_checkpoints",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`modelId` INTEGER NOT NULL, `lastKnownVersionId` INTEGER NOT NULL, `lastCheckedAt` INTEGER NOT NULL, PRIMARY KEY(`modelId`))",
+        "fields": [
+          {
+            "fieldPath": "modelId",
+            "columnName": "modelId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastKnownVersionId",
+            "columnName": "lastKnownVersionId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastCheckedAt",
+            "columnName": "lastCheckedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "modelId"
+          ]
+        }
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '9895a1a81861e37cde7257be238a4b74')"
+    ]
+  }
+}

--- a/shared/src/commonMain/kotlin/com/riox432/civitdeck/data/local/CivitDeckDatabase.kt
+++ b/shared/src/commonMain/kotlin/com/riox432/civitdeck/data/local/CivitDeckDatabase.kt
@@ -48,7 +48,7 @@ import kotlinx.coroutines.IO
         LocalModelFileEntity::class,
         ModelVersionCheckpointEntity::class,
     ],
-    version = 12,
+    version = 13,
 )
 @ConstructedBy(CivitDeckDatabaseConstructor::class)
 abstract class CivitDeckDatabase : RoomDatabase() {
@@ -307,6 +307,20 @@ val MIGRATION_11_12 = object : Migration(11, 12) {
     }
 }
 
+val MIGRATION_12_13 = object : Migration(12, 13) {
+    override fun migrate(connection: SQLiteConnection) {
+        connection.execSQL(
+            "ALTER TABLE user_preferences ADD COLUMN nsfwBlurSoft INTEGER NOT NULL DEFAULT 75",
+        )
+        connection.execSQL(
+            "ALTER TABLE user_preferences ADD COLUMN nsfwBlurMature INTEGER NOT NULL DEFAULT 25",
+        )
+        connection.execSQL(
+            "ALTER TABLE user_preferences ADD COLUMN nsfwBlurExplicit INTEGER NOT NULL DEFAULT 0",
+        )
+    }
+}
+
 fun getRoomDatabase(builder: RoomDatabase.Builder<CivitDeckDatabase>): CivitDeckDatabase {
     return builder
         .addMigrations(
@@ -321,6 +335,7 @@ fun getRoomDatabase(builder: RoomDatabase.Builder<CivitDeckDatabase>): CivitDeck
             MIGRATION_9_10,
             MIGRATION_10_11,
             MIGRATION_11_12,
+            MIGRATION_12_13,
         )
         .setDriver(BundledSQLiteDriver())
         .setQueryCoroutineContext(Dispatchers.IO)

--- a/shared/src/commonMain/kotlin/com/riox432/civitdeck/data/local/entity/UserPreferencesEntity.kt
+++ b/shared/src/commonMain/kotlin/com/riox432/civitdeck/data/local/entity/UserPreferencesEntity.kt
@@ -14,4 +14,7 @@ data class UserPreferencesEntity(
     val powerUserMode: Boolean = false,
     val notificationsEnabled: Boolean = false,
     val pollingIntervalMinutes: Int = 0,
+    val nsfwBlurSoft: Int = 75,
+    val nsfwBlurMature: Int = 25,
+    val nsfwBlurExplicit: Int = 0,
 )

--- a/shared/src/commonMain/kotlin/com/riox432/civitdeck/data/repository/UserPreferencesRepositoryImpl.kt
+++ b/shared/src/commonMain/kotlin/com/riox432/civitdeck/data/repository/UserPreferencesRepositoryImpl.kt
@@ -3,6 +3,7 @@ package com.riox432.civitdeck.data.repository
 import com.riox432.civitdeck.data.api.ApiKeyProvider
 import com.riox432.civitdeck.data.local.dao.UserPreferencesDao
 import com.riox432.civitdeck.data.local.entity.UserPreferencesEntity
+import com.riox432.civitdeck.domain.model.NsfwBlurSettings
 import com.riox432.civitdeck.domain.model.NsfwFilterLevel
 import com.riox432.civitdeck.domain.model.PollingInterval
 import com.riox432.civitdeck.domain.model.SortOrder
@@ -93,5 +94,25 @@ class UserPreferencesRepositoryImpl(
     override suspend fun setPollingInterval(interval: PollingInterval) {
         val existing = dao.getPreferences() ?: UserPreferencesEntity()
         dao.upsert(existing.copy(pollingIntervalMinutes = interval.minutes))
+    }
+
+    override fun observeNsfwBlurSettings(): Flow<NsfwBlurSettings> =
+        dao.observePreferences().map { entity ->
+            NsfwBlurSettings(
+                softIntensity = entity?.nsfwBlurSoft ?: NsfwBlurSettings.DEFAULT_SOFT,
+                matureIntensity = entity?.nsfwBlurMature ?: NsfwBlurSettings.DEFAULT_MATURE,
+                explicitIntensity = entity?.nsfwBlurExplicit ?: NsfwBlurSettings.DEFAULT_EXPLICIT,
+            )
+        }
+
+    override suspend fun setNsfwBlurSettings(settings: NsfwBlurSettings) {
+        val existing = dao.getPreferences() ?: UserPreferencesEntity()
+        dao.upsert(
+            existing.copy(
+                nsfwBlurSoft = settings.softIntensity,
+                nsfwBlurMature = settings.matureIntensity,
+                nsfwBlurExplicit = settings.explicitIntensity,
+            ),
+        )
     }
 }

--- a/shared/src/commonMain/kotlin/com/riox432/civitdeck/di/DomainModule.kt
+++ b/shared/src/commonMain/kotlin/com/riox432/civitdeck/di/DomainModule.kt
@@ -37,6 +37,7 @@ import com.riox432.civitdeck.domain.usecase.ObserveLocalModelFilesUseCase
 import com.riox432.civitdeck.domain.usecase.ObserveModelCollectionsUseCase
 import com.riox432.civitdeck.domain.usecase.ObserveModelDirectoriesUseCase
 import com.riox432.civitdeck.domain.usecase.ObserveNotificationsEnabledUseCase
+import com.riox432.civitdeck.domain.usecase.ObserveNsfwBlurSettingsUseCase
 import com.riox432.civitdeck.domain.usecase.ObserveNsfwFilterUseCase
 import com.riox432.civitdeck.domain.usecase.ObserveOwnedModelHashesUseCase
 import com.riox432.civitdeck.domain.usecase.ObservePollingIntervalUseCase
@@ -56,6 +57,7 @@ import com.riox432.civitdeck.domain.usecase.SetDefaultSortOrderUseCase
 import com.riox432.civitdeck.domain.usecase.SetDefaultTimePeriodUseCase
 import com.riox432.civitdeck.domain.usecase.SetGridColumnsUseCase
 import com.riox432.civitdeck.domain.usecase.SetNotificationsEnabledUseCase
+import com.riox432.civitdeck.domain.usecase.SetNsfwBlurSettingsUseCase
 import com.riox432.civitdeck.domain.usecase.SetNsfwFilterUseCase
 import com.riox432.civitdeck.domain.usecase.SetPollingIntervalUseCase
 import com.riox432.civitdeck.domain.usecase.SetPowerUserModeUseCase
@@ -78,6 +80,8 @@ val domainModule = module {
     factory { ObserveIsFavoriteUseCase(get()) }
     factory { ObserveNsfwFilterUseCase(get()) }
     factory { SetNsfwFilterUseCase(get()) }
+    factory { ObserveNsfwBlurSettingsUseCase(get()) }
+    factory { SetNsfwBlurSettingsUseCase(get()) }
     factory { SavePromptUseCase(get()) }
     factory { ObserveSavedPromptsUseCase(get()) }
     factory { DeleteSavedPromptUseCase(get()) }

--- a/shared/src/commonMain/kotlin/com/riox432/civitdeck/domain/model/NsfwBlurSettings.kt
+++ b/shared/src/commonMain/kotlin/com/riox432/civitdeck/domain/model/NsfwBlurSettings.kt
@@ -1,0 +1,52 @@
+package com.riox432.civitdeck.domain.model
+
+/**
+ * Per-NSFW-level blur intensity settings.
+ * Each value is 0..100 representing blur percentage.
+ * 0 = completely hidden (no image shown), 25/50/75/100 = visible with decreasing blur.
+ */
+data class NsfwBlurSettings(
+    val softIntensity: Int = DEFAULT_SOFT,
+    val matureIntensity: Int = DEFAULT_MATURE,
+    val explicitIntensity: Int = DEFAULT_EXPLICIT,
+) {
+    /**
+     * Returns blur radius in dp for the given NSFW level.
+     * 0% intensity -> MAX_BLUR_RADIUS (fully blurred / hidden)
+     * 100% intensity -> 0 (no blur, fully visible)
+     */
+    fun blurRadiusFor(level: NsfwLevel): Float = when (level) {
+        NsfwLevel.None -> 0f
+        NsfwLevel.Soft -> intensityToRadius(softIntensity)
+        NsfwLevel.Mature -> intensityToRadius(matureIntensity)
+        NsfwLevel.X -> intensityToRadius(explicitIntensity)
+    }
+
+    /**
+     * Returns whether the image should be shown at all for the given level.
+     * An intensity of 0 means "hidden" (don't show the image).
+     */
+    fun isVisibleFor(level: NsfwLevel): Boolean = when (level) {
+        NsfwLevel.None -> true
+        NsfwLevel.Soft -> softIntensity > 0
+        NsfwLevel.Mature -> matureIntensity > 0
+        NsfwLevel.X -> explicitIntensity > 0
+    }
+
+    companion object {
+        const val DEFAULT_SOFT = 75
+        const val DEFAULT_MATURE = 25
+        const val DEFAULT_EXPLICIT = 0
+        const val MAX_BLUR_RADIUS = 30f
+        const val MIN_INTENSITY = 0
+        const val MAX_INTENSITY = 100
+    }
+}
+
+private fun intensityToRadius(intensity: Int): Float {
+    // intensity 0 -> hidden (handled by isVisibleFor)
+    // intensity 100 -> 0 blur radius
+    // intensity 25 -> 22.5 blur radius
+    val clamped = intensity.coerceIn(NsfwBlurSettings.MIN_INTENSITY, NsfwBlurSettings.MAX_INTENSITY)
+    return NsfwBlurSettings.MAX_BLUR_RADIUS * (1f - clamped / 100f)
+}

--- a/shared/src/commonMain/kotlin/com/riox432/civitdeck/domain/repository/UserPreferencesRepository.kt
+++ b/shared/src/commonMain/kotlin/com/riox432/civitdeck/domain/repository/UserPreferencesRepository.kt
@@ -1,5 +1,6 @@
 package com.riox432.civitdeck.domain.repository
 
+import com.riox432.civitdeck.domain.model.NsfwBlurSettings
 import com.riox432.civitdeck.domain.model.NsfwFilterLevel
 import com.riox432.civitdeck.domain.model.PollingInterval
 import com.riox432.civitdeck.domain.model.SortOrder
@@ -25,4 +26,6 @@ interface UserPreferencesRepository {
     suspend fun setNotificationsEnabled(enabled: Boolean)
     fun observePollingInterval(): Flow<PollingInterval>
     suspend fun setPollingInterval(interval: PollingInterval)
+    fun observeNsfwBlurSettings(): Flow<NsfwBlurSettings>
+    suspend fun setNsfwBlurSettings(settings: NsfwBlurSettings)
 }

--- a/shared/src/commonMain/kotlin/com/riox432/civitdeck/domain/usecase/ObserveNsfwBlurSettingsUseCase.kt
+++ b/shared/src/commonMain/kotlin/com/riox432/civitdeck/domain/usecase/ObserveNsfwBlurSettingsUseCase.kt
@@ -1,0 +1,9 @@
+package com.riox432.civitdeck.domain.usecase
+
+import com.riox432.civitdeck.domain.model.NsfwBlurSettings
+import com.riox432.civitdeck.domain.repository.UserPreferencesRepository
+import kotlinx.coroutines.flow.Flow
+
+class ObserveNsfwBlurSettingsUseCase(private val repository: UserPreferencesRepository) {
+    operator fun invoke(): Flow<NsfwBlurSettings> = repository.observeNsfwBlurSettings()
+}

--- a/shared/src/commonMain/kotlin/com/riox432/civitdeck/domain/usecase/SetNsfwBlurSettingsUseCase.kt
+++ b/shared/src/commonMain/kotlin/com/riox432/civitdeck/domain/usecase/SetNsfwBlurSettingsUseCase.kt
@@ -1,0 +1,8 @@
+package com.riox432.civitdeck.domain.usecase
+
+import com.riox432.civitdeck.domain.model.NsfwBlurSettings
+import com.riox432.civitdeck.domain.repository.UserPreferencesRepository
+
+class SetNsfwBlurSettingsUseCase(private val repository: UserPreferencesRepository) {
+    suspend operator fun invoke(settings: NsfwBlurSettings) = repository.setNsfwBlurSettings(settings)
+}

--- a/shared/src/commonTest/kotlin/com/riox432/civitdeck/domain/usecase/GetRecommendationsUseCaseTest.kt
+++ b/shared/src/commonTest/kotlin/com/riox432/civitdeck/domain/usecase/GetRecommendationsUseCaseTest.kt
@@ -107,6 +107,8 @@ class GetRecommendationsUseCaseTest {
         override suspend fun setNotificationsEnabled(enabled: Boolean) = error("not used")
         override fun observePollingInterval(): Flow<com.riox432.civitdeck.domain.model.PollingInterval> = error("not used")
         override suspend fun setPollingInterval(interval: com.riox432.civitdeck.domain.model.PollingInterval) = error("not used")
+        override fun observeNsfwBlurSettings(): Flow<com.riox432.civitdeck.domain.model.NsfwBlurSettings> = error("not used")
+        override suspend fun setNsfwBlurSettings(settings: com.riox432.civitdeck.domain.model.NsfwBlurSettings) = error("not used")
     }
 
     @Test

--- a/shared/src/commonTest/kotlin/com/riox432/civitdeck/domain/usecase/UserPreferencesUseCasesTest.kt
+++ b/shared/src/commonTest/kotlin/com/riox432/civitdeck/domain/usecase/UserPreferencesUseCasesTest.kt
@@ -1,5 +1,6 @@
 package com.riox432.civitdeck.domain.usecase
 
+import com.riox432.civitdeck.domain.model.NsfwBlurSettings
 import com.riox432.civitdeck.domain.model.NsfwFilterLevel
 import com.riox432.civitdeck.domain.model.PollingInterval
 import com.riox432.civitdeck.domain.model.SortOrder
@@ -50,6 +51,10 @@ class UserPreferencesUseCasesTest {
         val pollingInterval = MutableStateFlow(PollingInterval.Off)
         override fun observePollingInterval(): Flow<PollingInterval> = pollingInterval
         override suspend fun setPollingInterval(interval: PollingInterval) { pollingInterval.value = interval }
+
+        val nsfwBlurSettings = MutableStateFlow(NsfwBlurSettings())
+        override fun observeNsfwBlurSettings(): Flow<NsfwBlurSettings> = nsfwBlurSettings
+        override suspend fun setNsfwBlurSettings(settings: NsfwBlurSettings) { nsfwBlurSettings.value = settings }
     }
 
     private val repo = FakeUserPreferencesRepository()

--- a/shared/src/iosMain/kotlin/com/riox432/civitdeck/di/KoinHelper.kt
+++ b/shared/src/iosMain/kotlin/com/riox432/civitdeck/di/KoinHelper.kt
@@ -38,6 +38,7 @@ import com.riox432.civitdeck.domain.usecase.ObserveLocalModelFilesUseCase
 import com.riox432.civitdeck.domain.usecase.ObserveModelCollectionsUseCase
 import com.riox432.civitdeck.domain.usecase.ObserveModelDirectoriesUseCase
 import com.riox432.civitdeck.domain.usecase.ObserveNotificationsEnabledUseCase
+import com.riox432.civitdeck.domain.usecase.ObserveNsfwBlurSettingsUseCase
 import com.riox432.civitdeck.domain.usecase.ObserveNsfwFilterUseCase
 import com.riox432.civitdeck.domain.usecase.ObserveOwnedModelHashesUseCase
 import com.riox432.civitdeck.domain.usecase.ObservePollingIntervalUseCase
@@ -57,6 +58,7 @@ import com.riox432.civitdeck.domain.usecase.SetDefaultSortOrderUseCase
 import com.riox432.civitdeck.domain.usecase.SetDefaultTimePeriodUseCase
 import com.riox432.civitdeck.domain.usecase.SetGridColumnsUseCase
 import com.riox432.civitdeck.domain.usecase.SetNotificationsEnabledUseCase
+import com.riox432.civitdeck.domain.usecase.SetNsfwBlurSettingsUseCase
 import com.riox432.civitdeck.domain.usecase.SetNsfwFilterUseCase
 import com.riox432.civitdeck.domain.usecase.SetPollingIntervalUseCase
 import com.riox432.civitdeck.domain.usecase.SetPowerUserModeUseCase
@@ -79,6 +81,8 @@ object KoinHelper {
     fun getObserveIsFavoriteUseCase(): ObserveIsFavoriteUseCase = getKoin().get()
     fun getObserveNsfwFilterUseCase(): ObserveNsfwFilterUseCase = getKoin().get()
     fun getSetNsfwFilterUseCase(): SetNsfwFilterUseCase = getKoin().get()
+    fun getObserveNsfwBlurSettingsUseCase(): ObserveNsfwBlurSettingsUseCase = getKoin().get()
+    fun getSetNsfwBlurSettingsUseCase(): SetNsfwBlurSettingsUseCase = getKoin().get()
     fun getSavePromptUseCase(): SavePromptUseCase = getKoin().get()
     fun getObserveSavedPromptsUseCase(): ObserveSavedPromptsUseCase = getKoin().get()
     fun getDeleteSavedPromptUseCase(): DeleteSavedPromptUseCase = getKoin().get()


### PR DESCRIPTION
## Description

Replace the binary NSFW show/hide toggle with a slider-based blur intensity control. Users can now configure per-NSFW-level (Soft, Mature, Explicit) blur strength from 0% (hidden) to 100% (fully visible) with preset steps at 25/50/75. Images with blur applied show a "Tap to reveal" overlay for temporary unblur.

## Related Issues

Closes #173

## Screenshots / Video

<!-- If applicable, add screenshots or screen recordings -->

## Test Plan

- [ ] Enable NSFW content in Settings and verify blur sliders appear
- [ ] Adjust Soft/Mature/Explicit sliders and verify values persist across app restart
- [ ] Browse image gallery with NSFW content enabled, verify blur is applied according to settings
- [ ] Tap a blurred image to verify "tap to reveal" removes the blur
- [ ] Set intensity to 0% (Hidden) and verify images are completely blurred
- [ ] Set intensity to 100% and verify no blur is applied
- [ ] Disable NSFW content and verify blur sliders are hidden
- [ ] Verify DB migration from v12 to v13 succeeds without data loss
- [ ] Verify iOS blur settings UI matches Android behavior

## Review Checklist

- [x] Code follows project architecture (Clean Architecture + MVVM)
- [x] Shared logic is in `commonMain`, platform-specific code only when necessary
- [x] No unnecessary dependencies added
- [x] Tests added/updated as needed

## Breaking Changes

None