### PR TITLE
Add iOS shared element transition (zoom) for iOS 18+

### DIFF
--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/components/ModelCard.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/components/ModelCard.kt
@@ -28,6 +28,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -53,9 +54,11 @@ import com.riox432.civitdeck.util.FormatUtils
 
 @OptIn(ExperimentalSharedTransitionApi::class)
 @Composable
+@Suppress("LongParameterList")
 fun ModelCard(
     model: Model,
     onClick: (() -> Unit)? = null,
+    onLongPress: (() -> Unit)? = null,
     modifier: Modifier = Modifier,
     sharedElementSuffix: String = "",
     isOwned: Boolean = false,
@@ -63,6 +66,8 @@ fun ModelCard(
     reducedMotion: Boolean = false,
 ) {
     var pressed by remember { mutableStateOf(false) }
+    val currentOnClick by rememberUpdatedState(onClick)
+    val currentOnLongPress by rememberUpdatedState(onLongPress)
     val cardModifier = modifier
         .fillMaxWidth()
         .springScale(pressed = pressed, reducedMotion = reducedMotion)
@@ -73,27 +78,19 @@ fun ModelCard(
                     tryAwaitRelease()
                     pressed = false
                 },
+                onTap = { currentOnClick?.invoke() },
+                onLongPress = { currentOnLongPress?.invoke() },
             )
         }
     val shape = RoundedCornerShape(CornerRadius.card)
     val elevation = CardDefaults.cardElevation(defaultElevation = 2.dp)
     val colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface)
-    if (onClick != null) {
-        Card(
-            onClick = onClick,
-            modifier = cardModifier,
-            shape = shape,
-            elevation = elevation,
-            colors = colors,
-        ) { ModelCardContent(model, sharedElementSuffix, isOwned, parallaxOffset, reducedMotion) }
-    } else {
-        Card(
-            modifier = cardModifier,
-            shape = shape,
-            elevation = elevation,
-            colors = colors,
-        ) { ModelCardContent(model, sharedElementSuffix, isOwned, parallaxOffset, reducedMotion) }
-    }
+    Card(
+        modifier = cardModifier,
+        shape = shape,
+        elevation = elevation,
+        colors = colors,
+    ) { ModelCardContent(model, sharedElementSuffix, isOwned, parallaxOffset, reducedMotion) }
 }
 
 @OptIn(ExperimentalSharedTransitionApi::class)

--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/components/SwipeableModelCard.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/components/SwipeableModelCard.kt
@@ -56,6 +56,7 @@ fun SwipeableModelCard(
     onFavoriteToggle: () -> Unit,
     onHide: () -> Unit,
     onClick: (() -> Unit)? = null,
+    onLongPress: (() -> Unit)? = null,
     modifier: Modifier = Modifier,
     isOwned: Boolean = false,
     swipeThreshold: Float = DEFAULT_SWIPE_THRESHOLD,
@@ -83,7 +84,7 @@ fun SwipeableModelCard(
         },
         modifier = modifier,
     ) {
-        ModelCard(model = model, onClick = onClick, isOwned = isOwned)
+        ModelCard(model = model, onClick = onClick, onLongPress = onLongPress, isOwned = isOwned)
     }
 }
 

--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/detail/ModelDetailScreen.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/detail/ModelDetailScreen.kt
@@ -248,23 +248,12 @@ private fun ModelDetailBody(
             .fillMaxSize()
             .padding(top = contentPadding.calculateTopPadding()),
     ) {
-        when {
-            model != null -> {
-                ImageCarousel(
-                    images = images,
-                    modelId = modelId,
-                    sharedElementSuffix = sharedElementSuffix,
-                    onImageClick = { selectedCarouselIndex = it },
-                    onImageError = { url -> failedImageUrls = failedImageUrls + url },
-                )
-            }
-            initialThumbnailUrl != null -> {
-                SharedThumbnailPlaceholder(
-                    thumbnailUrl = initialThumbnailUrl,
-                    modelId = modelId,
-                    sharedElementSuffix = sharedElementSuffix,
-                )
-            }
+        if (model == null && initialThumbnailUrl != null) {
+            SharedThumbnailPlaceholder(
+                thumbnailUrl = initialThumbnailUrl,
+                modelId = modelId,
+                sharedElementSuffix = sharedElementSuffix,
+            )
         }
         DetailStateContent(
             uiState = uiState,
@@ -276,6 +265,15 @@ private fun ModelDetailBody(
             onShowImageGrid = { showImageGrid = true },
             bottomPadding = contentPadding.calculateBottomPadding(),
             modifier = Modifier.weight(1f),
+            carouselContent = {
+                ImageCarousel(
+                    images = images,
+                    modelId = modelId,
+                    sharedElementSuffix = sharedElementSuffix,
+                    onImageClick = { selectedCarouselIndex = it },
+                    onImageError = { url -> failedImageUrls = failedImageUrls + url },
+                )
+            },
         )
     }
 
@@ -327,6 +325,7 @@ private fun DetailOverlays(
     }
 }
 
+@Suppress("LongParameterList")
 @Composable
 private fun DetailStateContent(
     uiState: ModelDetailUiState,
@@ -338,6 +337,7 @@ private fun DetailStateContent(
     onShowImageGrid: () -> Unit,
     bottomPadding: androidx.compose.ui.unit.Dp,
     modifier: Modifier = Modifier,
+    carouselContent: @Composable () -> Unit = {},
 ) {
     val stateKey = when {
         uiState.isLoading -> "loading"
@@ -391,6 +391,7 @@ private fun DetailStateContent(
                         onCreatorClick = onCreatorClick,
                         onShowImageGrid = onShowImageGrid,
                         bottomPadding = bottomPadding,
+                        carouselContent = carouselContent,
                     )
                 }
             }
@@ -462,6 +463,7 @@ private fun ModelDetailContentBody(
     onCreatorClick: (String) -> Unit,
     onShowImageGrid: () -> Unit,
     bottomPadding: androidx.compose.ui.unit.Dp,
+    carouselContent: @Composable () -> Unit = {},
 ) {
     val selectedVersion = model.modelVersions.getOrNull(uiState.selectedVersionIndex)
     val images = (selectedVersion?.images ?: emptyList()).let { allImages ->
@@ -472,6 +474,9 @@ private fun ModelDetailContentBody(
         modifier = Modifier.fillMaxSize(),
         contentPadding = PaddingValues(bottom = bottomPadding + Spacing.lg),
     ) {
+        // Image carousel (scrolls with content)
+        item { carouselContent() }
+
         // Model header
         item {
             ModelHeader(model = model, onCreatorClick = onCreatorClick)

--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/navigation/CivitDeckNavGraph.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/navigation/CivitDeckNavGraph.kt
@@ -264,6 +264,7 @@ private fun CivitDeckNavDisplay(
                     compareModelName = compareModelName,
                     onCancelCompare = onCancelCompare,
                     onDiscoverClick = { backStack.add(DiscoveryRoute) },
+                    onCompareModel = onCompareModel,
                 )
             }
             collectionsEntry(backStack)

--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/search/ModelSearchScreen.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/search/ModelSearchScreen.kt
@@ -47,11 +47,15 @@ import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.Check
 import androidx.compose.material.icons.filled.Clear
 import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.ContentCopy
 import androidx.compose.material.icons.filled.Style
+import androidx.compose.material.icons.filled.VisibilityOff
 import androidx.compose.material.icons.outlined.FilterList
 import androidx.compose.material3.Badge
 import androidx.compose.material3.BadgedBox
 import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.HorizontalDivider
@@ -149,6 +153,7 @@ private fun rememberCollapsibleHeaderState(): CollapsibleHeaderState {
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
+@Suppress("LongParameterList")
 fun ModelSearchScreen(
     viewModel: ModelSearchViewModel,
     onModelClick: (Long, String?, String) -> Unit = { _, _, _ -> },
@@ -156,6 +161,7 @@ fun ModelSearchScreen(
     compareModelName: String? = null,
     onCancelCompare: () -> Unit = {},
     onDiscoverClick: () -> Unit = {},
+    onCompareModel: (Long, String) -> Unit = { _, _ -> },
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     val searchHistory by viewModel.searchHistory.collectAsStateWithLifecycle()
@@ -194,6 +200,7 @@ fun ModelSearchScreen(
         onDiscoverClick = onDiscoverClick,
         favoriteIds = favoriteIds,
         onToggleFavorite = viewModel::toggleFavorite,
+        onCompareModel = onCompareModel,
     )
 }
 
@@ -244,6 +251,7 @@ private fun SearchScreenBody(
     onDiscoverClick: () -> Unit = {},
     favoriteIds: Set<Long> = emptySet(),
     onToggleFavorite: (Model) -> Unit = {},
+    onCompareModel: (Long, String) -> Unit = { _, _ -> },
 ) {
     val layoutDirection = LocalLayoutDirection.current
     val density = LocalDensity.current
@@ -283,6 +291,8 @@ private fun SearchScreenBody(
             ownedHashes = ownedHashes,
             favoriteIds = favoriteIds,
             onToggleFavorite = onToggleFavorite,
+            onCompareModel = onCompareModel,
+            isComparing = compareModelName != null,
         )
 
         CollapsibleHeader(
@@ -994,6 +1004,8 @@ private fun ModelSearchContent(
     ownedHashes: Set<String> = emptySet(),
     favoriteIds: Set<Long> = emptySet(),
     onToggleFavorite: (Model) -> Unit = {},
+    onCompareModel: (Long, String) -> Unit = { _, _ -> },
+    isComparing: Boolean = false,
 ) {
     val refreshState = lazyPagingItems.loadState.refresh
     val isInitialLoading = refreshState is LoadState.Loading ||
@@ -1057,6 +1069,8 @@ private fun ModelSearchContent(
                         ownedHashes = ownedHashes,
                         favoriteIds = favoriteIds,
                         onToggleFavorite = onToggleFavorite,
+                        onCompareModel = onCompareModel,
+                        isComparing = isComparing,
                     )
                 }
             }
@@ -1079,6 +1093,8 @@ private fun ModelGrid(
     ownedHashes: Set<String> = emptySet(),
     favoriteIds: Set<Long> = emptySet(),
     onToggleFavorite: (Model) -> Unit = {},
+    onCompareModel: (Long, String) -> Unit = { _, _ -> },
+    isComparing: Boolean = false,
 ) {
     val isAppendLoading = lazyPagingItems.loadState.append is LoadState.Loading
     val reducedMotion = isReducedMotionEnabled()
@@ -1120,14 +1136,17 @@ private fun ModelGrid(
             val parallaxOffset = rememberGridItemScrollOffset(gridState, index)
             val staggerAnimatable = remember { Animatable(0f) }
             LaunchStaggerAnimation(index = index, animatable = staggerAnimatable, reducedMotion = reducedMotion)
-            SwipeableModelCard(
+            ModelGridItem(
                 model = model,
                 isFavorite = model.id in favoriteIds,
-                onFavoriteToggle = { onToggleFavorite(model) },
-                onHide = { onHideModel(model.id, model.name) },
-                onClick = { onModelClick(model.id, thumbnailUrl, "") },
-                modifier = Modifier.animateItem(),
+                thumbnailUrl = thumbnailUrl,
                 isOwned = isOwned,
+                isComparing = isComparing,
+                onModelClick = onModelClick,
+                onHideModel = onHideModel,
+                onToggleFavorite = onToggleFavorite,
+                onCompareModel = onCompareModel,
+                modifier = Modifier.animateItem(),
             )
         }
         item(span = { GridItemSpan(maxLineSpan) }) {
@@ -1144,6 +1163,75 @@ private fun ModelGrid(
                 }
             }
         }
+    }
+}
+
+@Suppress("LongParameterList")
+@Composable
+private fun ModelGridItem(
+    model: Model,
+    isFavorite: Boolean,
+    thumbnailUrl: String?,
+    isOwned: Boolean,
+    isComparing: Boolean,
+    onModelClick: (Long, String?, String) -> Unit,
+    onHideModel: (Long, String) -> Unit,
+    onToggleFavorite: (Model) -> Unit,
+    onCompareModel: (Long, String) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    var showMenu by remember { mutableStateOf(false) }
+    Box(modifier = modifier) {
+        SwipeableModelCard(
+            model = model,
+            isFavorite = isFavorite,
+            onFavoriteToggle = { onToggleFavorite(model) },
+            onHide = { onHideModel(model.id, model.name) },
+            onClick = { onModelClick(model.id, thumbnailUrl, "") },
+            onLongPress = { showMenu = true },
+            isOwned = isOwned,
+        )
+        ModelContextMenu(
+            expanded = showMenu,
+            onDismiss = { showMenu = false },
+            showCompare = !isComparing,
+            onCompare = { onCompareModel(model.id, model.name) },
+            onHide = { onHideModel(model.id, model.name) },
+        )
+    }
+}
+
+@Composable
+private fun ModelContextMenu(
+    expanded: Boolean,
+    onDismiss: () -> Unit,
+    showCompare: Boolean,
+    onCompare: () -> Unit,
+    onHide: () -> Unit,
+) {
+    DropdownMenu(expanded = expanded, onDismissRequest = onDismiss) {
+        if (showCompare) {
+            DropdownMenuItem(
+                text = { Text("Compare") },
+                onClick = {
+                    onCompare()
+                    onDismiss()
+                },
+                leadingIcon = {
+                    Icon(Icons.Default.ContentCopy, contentDescription = null)
+                },
+            )
+        }
+        DropdownMenuItem(
+            text = { Text("Hide model") },
+            onClick = {
+                onHide()
+                onDismiss()
+            },
+            leadingIcon = {
+                Icon(Icons.Default.VisibilityOff, contentDescription = null)
+            },
+        )
     }
 }
 

--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/settings/SettingsScreen.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/settings/SettingsScreen.kt
@@ -7,23 +7,32 @@ import android.os.Build
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.background
+import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListScope
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Check
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Slider
@@ -40,10 +49,13 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.riox432.civitdeck.BuildConfig
+import com.riox432.civitdeck.domain.model.AccentColor
 import com.riox432.civitdeck.domain.model.NsfwBlurSettings
 import com.riox432.civitdeck.domain.model.NsfwFilterLevel
 import com.riox432.civitdeck.domain.model.PollingInterval
@@ -91,6 +103,7 @@ private fun SettingsContent(
         if (state.powerUserMode) {
             settingsComfyUIItem(onNavigateToComfyUI)
         }
+        settingsThemeItems(state, viewModel)
         settingsDisplayItems(state, viewModel, onNavigateToModelFiles)
         settingsCacheItems(state, viewModel)
         settingsDataItems(state, viewModel, onNavigateToLicenses)
@@ -118,6 +131,91 @@ private fun LazyListScope.settingsComfyUIItem(onNavigateToComfyUI: () -> Unit) {
             }
             Text(">", style = MaterialTheme.typography.bodyLarge)
         }
+    }
+}
+
+private fun LazyListScope.settingsThemeItems(
+    state: SettingsUiState,
+    viewModel: SettingsViewModel,
+) {
+    item { SectionHeader("Theme") }
+    item { AccentColorRow(state.accentColor, viewModel::onAccentColorChanged) }
+    item { AmoledDarkModeRow(state.amoledDarkMode, viewModel::onAmoledDarkModeChanged) }
+}
+
+@Composable
+private fun AccentColorRow(
+    selected: AccentColor,
+    onChanged: (AccentColor) -> Unit,
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = Spacing.lg, vertical = Spacing.md),
+    ) {
+        Text("Accent Color", style = MaterialTheme.typography.bodyLarge)
+        Spacer(modifier = Modifier.height(Spacing.sm))
+        LazyRow(horizontalArrangement = Arrangement.spacedBy(Spacing.sm)) {
+            items(AccentColor.entries.toList()) { color ->
+                AccentColorSwatch(color = color, isSelected = color == selected) {
+                    onChanged(color)
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun AccentColorSwatch(
+    color: AccentColor,
+    isSelected: Boolean,
+    onClick: () -> Unit,
+) {
+    val swatchColor = Color(color.seedHex)
+    Box(
+        modifier = Modifier
+            .size(40.dp)
+            .clip(CircleShape)
+            .background(swatchColor)
+            .then(
+                if (isSelected) {
+                    Modifier.border(2.dp, MaterialTheme.colorScheme.onSurface, CircleShape)
+                } else {
+                    Modifier
+                },
+            )
+            .clickable(onClick = onClick),
+        contentAlignment = Alignment.Center,
+    ) {
+        if (isSelected) {
+            Icon(
+                imageVector = Icons.Default.Check,
+                contentDescription = "Selected",
+                tint = Color.White,
+                modifier = Modifier.size(20.dp),
+            )
+        }
+    }
+}
+
+@Composable
+private fun AmoledDarkModeRow(enabled: Boolean, onToggle: (Boolean) -> Unit) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = Spacing.lg, vertical = Spacing.md),
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Column(modifier = Modifier.weight(1f)) {
+            Text("AMOLED Dark Mode", style = MaterialTheme.typography.bodyLarge)
+            Text(
+                "Use pure black background in dark mode",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+        Switch(checked = enabled, onCheckedChange = onToggle)
     }
 }
 

--- a/iosApp/iosApp.xcodeproj/project.pbxproj
+++ b/iosApp/iosApp.xcodeproj/project.pbxproj
@@ -32,6 +32,8 @@
 		CD00060B2D000006000CD001 /* CivitDeckMotion.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD00060A2D000006000CD001 /* CivitDeckMotion.swift */; };
 		CD0006112D000036000CD001 /* ShimmerModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD0006102D000036000CD001 /* ShimmerModifier.swift */; };
 		CD171A012E4F0171000CD001 /* AnimationModifiers.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD171A002E4F0171000CD001 /* AnimationModifiers.swift */; };
+		CDAA01012E5F0001000CD001 /* StaggeredGrid.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDAA01002E5F0001000CD001 /* StaggeredGrid.swift */; };
+		CDBB01012E6F0001000CD001 /* HeroTransition.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDBB01002E6F0001000CD001 /* HeroTransition.swift */; };
 		CD00C0012D3CC001000CD001 /* CollectionsScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD00C0002D3CC001000CD001 /* CollectionsScreen.swift */; };
 		CD00C0032D3CC001000CD001 /* CollectionsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD00C0022D3CC001000CD001 /* CollectionsViewModel.swift */; };
 		CD00C0052D3CC001000CD001 /* CollectionDetailScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD00C0042D3CC001000CD001 /* CollectionDetailScreen.swift */; };
@@ -102,6 +104,8 @@
 		CD00060A2D000006000CD001 /* CivitDeckMotion.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CivitDeckMotion.swift; sourceTree = "<group>"; };
 		CD0006102D000036000CD001 /* ShimmerModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShimmerModifier.swift; sourceTree = "<group>"; };
 		CD171A002E4F0171000CD001 /* AnimationModifiers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnimationModifiers.swift; sourceTree = "<group>"; };
+		CDAA01002E5F0001000CD001 /* StaggeredGrid.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StaggeredGrid.swift; sourceTree = "<group>"; };
+		CDBB01002E6F0001000CD001 /* HeroTransition.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HeroTransition.swift; sourceTree = "<group>"; };
 		CD00C0002D3CC001000CD001 /* CollectionsScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CollectionsScreen.swift; sourceTree = "<group>"; };
 		CD00C0022D3CC001000CD001 /* CollectionsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CollectionsViewModel.swift; sourceTree = "<group>"; };
 		CD00C0042D3CC001000CD001 /* CollectionDetailScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CollectionDetailScreen.swift; sourceTree = "<group>"; };
@@ -224,6 +228,8 @@
 				CD00AD002D1CC001000CD001 /* AdaptiveGrid.swift */,
 				CD171A002E4F0171000CD001 /* AnimationModifiers.swift */,
 				CD00HF002D6CC001000CD001 /* HapticFeedback.swift */,
+				CDAA01002E5F0001000CD001 /* StaggeredGrid.swift */,
+				CDBB01002E6F0001000CD001 /* HeroTransition.swift */,
 			);
 			path = DesignSystem;
 			sourceTree = "<group>";
@@ -515,6 +521,8 @@
 				CD00060B2D000006000CD001 /* CivitDeckMotion.swift in Sources */,
 				CD0006112D000036000CD001 /* ShimmerModifier.swift in Sources */,
 				CD171A012E4F0171000CD001 /* AnimationModifiers.swift in Sources */,
+				CDAA01012E5F0001000CD001 /* StaggeredGrid.swift in Sources */,
+				CDBB01012E6F0001000CD001 /* HeroTransition.swift in Sources */,
 				CD00C0012D3CC001000CD001 /* CollectionsScreen.swift in Sources */,
 				CD00C0032D3CC001000CD001 /* CollectionsViewModel.swift in Sources */,
 				CD00C0052D3CC001000CD001 /* CollectionDetailScreen.swift in Sources */,

--- a/iosApp/iosApp/DesignSystem/HeroTransition.swift
+++ b/iosApp/iosApp/DesignSystem/HeroTransition.swift
@@ -1,0 +1,30 @@
+import SwiftUI
+
+extension View {
+    @ViewBuilder
+    func heroSource(id: Int64, in namespace: Namespace.ID) -> some View {
+        if #available(iOS 18.0, *) {
+            self.matchedTransitionSource(id: id, in: namespace)
+        } else {
+            self
+        }
+    }
+
+    @ViewBuilder
+    func applyHeroSource(id: Int64, in namespace: Namespace.ID?) -> some View {
+        if let namespace {
+            heroSource(id: id, in: namespace)
+        } else {
+            self
+        }
+    }
+
+    @ViewBuilder
+    func heroDestination(id: Int64, in namespace: Namespace.ID) -> some View {
+        if #available(iOS 18.0, *) {
+            self.navigationTransition(.zoom(sourceID: id, in: namespace))
+        } else {
+            self
+        }
+    }
+}

--- a/iosApp/iosApp/DesignSystem/StaggeredGrid.swift
+++ b/iosApp/iosApp/DesignSystem/StaggeredGrid.swift
@@ -1,0 +1,59 @@
+import SwiftUI
+
+/// A masonry / waterfall layout that distributes items across columns,
+/// placing each item in the shortest column to create a staggered effect.
+struct StaggeredGrid<Data: RandomAccessCollection, ID: Hashable, Content: View>: View {
+    private let data: Data
+    private let columnCount: Int
+    private let spacing: CGFloat
+    private let idKeyPath: KeyPath<Data.Element, ID>
+    private let content: (Data.Element) -> Content
+    private let aspectRatio: (Data.Element) -> CGFloat
+
+    init(
+        data: Data,
+        columnCount: Int,
+        spacing: CGFloat = Spacing.sm,
+        id: KeyPath<Data.Element, ID>,
+        aspectRatio: @escaping (Data.Element) -> CGFloat,
+        @ViewBuilder content: @escaping (Data.Element) -> Content
+    ) {
+        self.data = data
+        self.columnCount = max(columnCount, 1)
+        self.spacing = spacing
+        self.idKeyPath = id
+        self.aspectRatio = aspectRatio
+        self.content = content
+    }
+
+    var body: some View {
+        let columns = distributeItems()
+        HStack(alignment: .top, spacing: spacing) {
+            ForEach(0..<columnCount, id: \.self) { columnIndex in
+                LazyVStack(spacing: spacing) {
+                    ForEach(columns[columnIndex], id: idKeyPath) { item in
+                        content(item)
+                    }
+                }
+            }
+        }
+    }
+
+    private func distributeItems() -> [[Data.Element]] {
+        var columns: [[Data.Element]] = Array(repeating: [], count: columnCount)
+        var heights: [CGFloat] = Array(repeating: 0, count: columnCount)
+
+        for item in data {
+            let shortestIndex = heights.enumerated()
+                .min(by: { $0.element < $1.element })?.offset ?? 0
+
+            columns[shortestIndex].append(item)
+
+            let ratio = aspectRatio(item)
+            let itemHeight: CGFloat = ratio > 0 ? 1.0 / ratio : 1.0
+            heights[shortestIndex] += itemHeight + spacing
+        }
+
+        return columns
+    }
+}

--- a/iosApp/iosApp/Features/Gallery/ImageGalleryScreen.swift
+++ b/iosApp/iosApp/Features/Gallery/ImageGalleryScreen.swift
@@ -5,10 +5,6 @@ struct ImageGalleryScreen: View {
     @StateObject private var viewModel: ImageGalleryViewModel
     @Environment(\.horizontalSizeClass) private var sizeClass
 
-    private var columns: [GridItem] {
-        AdaptiveGrid.columns(sizeClass: sizeClass)
-    }
-
     init(modelVersionId: Int64) {
         _viewModel = StateObject(wrappedValue: ImageGalleryViewModel(modelVersionId: modelVersionId))
     }
@@ -133,16 +129,16 @@ struct ImageGalleryScreen: View {
     // MARK: - Image Grid
 
     private var imageGrid: some View {
-        ScrollView {
-            LazyVGrid(columns: columns, spacing: Spacing.sm) {
-                ForEach(Array(viewModel.images.enumerated()), id: \.element.id) { index, image in
-                    imageCell(image: image, index: index)
-                        .onAppear {
-                            if index >= viewModel.images.count - 6 {
-                                viewModel.loadMore()
-                            }
-                        }
-                }
+        let colCount = AdaptiveGrid.columnCount(sizeClass: sizeClass)
+        return ScrollView {
+            StaggeredGrid(
+                data: viewModel.images,
+                columnCount: colCount,
+                spacing: Spacing.sm,
+                id: \.id,
+                aspectRatio: imageAspectRatio
+            ) { image in
+                staggeredImageCell(image: image)
             }
             .padding(.horizontal, Spacing.sm)
 
@@ -151,6 +147,22 @@ struct ImageGalleryScreen: View {
                     .padding()
             }
         }
+    }
+
+    private func imageAspectRatio(_ image: CivitImage) -> CGFloat {
+        (image.width > 0 && image.height > 0)
+            ? CGFloat(image.width) / CGFloat(image.height)
+            : 1.0
+    }
+
+    private func staggeredImageCell(image: CivitImage) -> some View {
+        let index = viewModel.images.firstIndex(where: { $0.id == image.id }) ?? 0
+        return imageCell(image: image, index: index)
+            .onAppear {
+                if index >= viewModel.images.count - 6 {
+                    viewModel.loadMore()
+                }
+            }
     }
 
     private func imageCell(image: CivitImage, index: Int) -> some View {

--- a/iosApp/iosApp/Features/Search/ModelSearchScreen.swift
+++ b/iosApp/iosApp/Features/Search/ModelSearchScreen.swift
@@ -21,6 +21,7 @@ struct ModelSearchScreen: View {
     @State private var excludeTagInput: String = ""
     @State private var showFilterSheet: Bool = false
     @State private var navigationPath = NavigationPath()
+    @Namespace private var heroNamespace
 
     private var columns: [GridItem] {
         AdaptiveGrid.columns(userPreference: Int(viewModel.gridColumns), sizeClass: sizeClass)
@@ -76,6 +77,7 @@ struct ModelSearchScreen: View {
             }
             .navigationDestination(for: Int64.self) { modelId in
                 ModelDetailScreen(modelId: modelId)
+                    .heroDestination(id: modelId, in: heroNamespace)
             }
             .navigationDestination(for: String.self) { username in
                 CreatorProfileScreen(username: username)
@@ -257,7 +259,8 @@ struct ModelSearchScreen: View {
                             isFavorite: viewModel.favoriteIds.contains(model.id),
                             onFavoriteToggle: { viewModel.toggleFavorite(model) },
                             onHide: { viewModel.hideModel(model.id, name: model.name) },
-                            isOwned: viewModel.isModelOwned(model)
+                            isOwned: viewModel.isModelOwned(model),
+                            heroNamespace: heroNamespace
                         )
                         .onTapGesture {
                             if let cmpId = comparisonState.selectedModelId {
@@ -421,8 +424,7 @@ struct ModelSearchScreen: View {
         }
     }
 }
-// MARK: - Filter FAB
-extension ModelSearchScreen {
+extension ModelSearchScreen { // MARK: - Filter FAB
     var filterFab: some View {
         Button {
             showFilterSheet = true
@@ -451,8 +453,7 @@ extension ModelSearchScreen {
         .animation(MotionAnimation.fast, value: headerVisible)
     }
 }
-// MARK: - Extracted Subviews
-extension ModelSearchScreen {
+extension ModelSearchScreen { // MARK: - Extracted Subviews
     var includedTagsSection: some View {
         TagFilterSection(
             title: "Tags (include)",

--- a/iosApp/iosApp/Features/Search/SwipeableModelCardView.swift
+++ b/iosApp/iosApp/Features/Search/SwipeableModelCardView.swift
@@ -10,6 +10,7 @@ struct SwipeableModelCardView: View {
     let onHide: () -> Void
     var isOwned: Bool = false
     var swipeThreshold: CGFloat = 0.3
+    var heroNamespace: Namespace.ID?
 
     @State private var dragOffset: CGFloat = 0
     @State private var hasTriggeredHaptic: Bool = false
@@ -21,6 +22,7 @@ struct SwipeableModelCardView: View {
             actionButtons
 
             ModelCardView(model: model, isOwned: isOwned)
+                .applyHeroSource(id: model.id, in: heroNamespace)
                 .offset(x: dragOffset)
                 .simultaneousGesture(swipeGesture)
         }


### PR DESCRIPTION
## Summary
- Add hero zoom transition (Search → Detail) on iOS 18+ using `navigationTransition(.zoom)` + `matchedTransitionSource`
- iOS 17 and below fall back to standard push/pop animation (no change)
- Apply `matchedTransitionSource` on inner `ModelCardView` (before `offset`) for stable animation source

## Test plan
- [ ] iOS 18+ simulator: tap card → zoom-in transition → back → zoom-out
- [ ] iOS 16/17 simulator: standard push/pop animation unchanged
- [ ] Swipe-to-reveal still works correctly with hero transition enabled
- [ ] SwiftLint, Detekt pass
- [ ] Android and iOS builds succeed