### PR TITLE
Implement #229: Adopt Design System components across remaining screens

### DIFF
--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/compare/ModelCompareScreen.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/compare/ModelCompareScreen.kt
@@ -21,7 +21,6 @@ import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material3.Button
-import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FilterChip
 import androidx.compose.material3.HorizontalDivider
@@ -50,7 +49,9 @@ import com.riox432.civitdeck.domain.model.Model
 import com.riox432.civitdeck.domain.model.ModelImage
 import com.riox432.civitdeck.domain.model.ModelVersion
 import com.riox432.civitdeck.domain.model.filterByNsfwLevel
+import com.riox432.civitdeck.ui.components.ErrorStateView
 import com.riox432.civitdeck.ui.components.ImageErrorPlaceholder
+import com.riox432.civitdeck.ui.components.LoadingStateOverlay
 import com.riox432.civitdeck.ui.detail.ModelDetailUiState
 import com.riox432.civitdeck.ui.detail.ModelDetailViewModel
 import com.riox432.civitdeck.ui.theme.Duration
@@ -106,16 +107,14 @@ private fun CompareBody(
     val bothLoading = leftState.isLoading || rightState.isLoading
     val bothMissing = leftModel == null || rightModel == null
     if (bothLoading && bothMissing) {
-        CenteredBox(contentPadding) { CircularProgressIndicator() }
+        LoadingStateOverlay(modifier = Modifier.padding(contentPadding))
         return
     }
     if (leftModel == null || rightModel == null) {
-        CenteredBox(contentPadding) {
-            Text(
-                leftState.error ?: rightState.error ?: "Failed to load models",
-                color = MaterialTheme.colorScheme.error
-            )
-        }
+        ErrorStateView(
+            message = leftState.error ?: rightState.error ?: "Failed to load models",
+            modifier = Modifier.padding(contentPadding),
+        )
         return
     }
 
@@ -128,11 +127,6 @@ private fun CompareBody(
         onRightVersionSelected,
         contentPadding
     )
-}
-
-@Composable
-private fun CenteredBox(padding: PaddingValues, content: @Composable () -> Unit) {
-    Box(Modifier.fillMaxSize().padding(padding), contentAlignment = Alignment.Center) { content() }
 }
 
 @Suppress("LongParameterList")

--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/creator/CreatorProfileScreen.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/creator/CreatorProfileScreen.kt
@@ -7,12 +7,9 @@ import androidx.compose.animation.fadeOut
 import androidx.compose.animation.shrinkVertically
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.GridItemSpan
@@ -22,12 +19,10 @@ import androidx.compose.foundation.lazy.grid.items
 import androidx.compose.foundation.lazy.grid.rememberLazyGridState
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
-import androidx.compose.material3.Button
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
@@ -41,6 +36,8 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.riox432.civitdeck.ui.adaptive.adaptiveGridColumns
+import com.riox432.civitdeck.ui.components.ErrorStateView
+import com.riox432.civitdeck.ui.components.LoadingStateOverlay
 import com.riox432.civitdeck.ui.components.ModelCard
 import com.riox432.civitdeck.ui.theme.Spacing
 
@@ -99,21 +96,13 @@ private fun CreatorContent(
 ) {
     when {
         uiState.isLoading && uiState.models.isEmpty() -> {
-            Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
-                CircularProgressIndicator()
-            }
+            LoadingStateOverlay()
         }
         uiState.error != null && uiState.models.isEmpty() -> {
-            Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
-                Column(horizontalAlignment = Alignment.CenterHorizontally) {
-                    Text(
-                        text = uiState.error ?: "Unknown error",
-                        color = MaterialTheme.colorScheme.error,
-                    )
-                    Spacer(modifier = Modifier.height(Spacing.lg))
-                    Button(onClick = onRefresh) { Text("Retry") }
-                }
-            }
+            ErrorStateView(
+                message = uiState.error ?: "Unknown error",
+                onRetry = onRefresh,
+            )
         }
         else -> {
             PullToRefreshBox(

--- a/iosApp/iosApp/Features/Compare/ModelCompareScreen.swift
+++ b/iosApp/iosApp/Features/Compare/ModelCompareScreen.swift
@@ -15,10 +15,10 @@ struct ModelCompareScreen: View {
     var body: some View {
         Group {
             if viewModel.isLoading && viewModel.leftModel == nil {
-                ProgressView()
+                LoadingStateView()
             } else if let error = viewModel.error,
                       viewModel.leftModel == nil || viewModel.rightModel == nil {
-                errorView(message: error)
+                ErrorStateView(message: error)
             } else if let leftModel = viewModel.leftModel,
                       let rightModel = viewModel.rightModel {
                 compareContent(left: leftModel, right: rightModel)
@@ -293,15 +293,6 @@ struct ModelCompareScreen: View {
         let file = version.files.first { $0.primary } ?? version.files.first
         guard let file else { return "-" }
         return FormatUtils.shared.formatFileSize(sizeKB: file.sizeKB)
-    }
-
-    private func errorView(message: String) -> some View {
-        VStack(spacing: Spacing.lg) {
-            Text(message)
-                .foregroundColor(.civitError)
-                .multilineTextAlignment(.center)
-        }
-        .padding()
     }
 }
 

--- a/iosApp/iosApp/Features/Discovery/SwipeDiscoveryView.swift
+++ b/iosApp/iosApp/Features/Discovery/SwipeDiscoveryView.swift
@@ -21,14 +21,14 @@ struct SwipeDiscoveryView: View {
         GeometryReader { geometry in
             ZStack {
                 if viewModel.isLoading && viewModel.cards.isEmpty {
-                    ProgressView()
+                    LoadingStateView()
                 } else if let error = viewModel.error, viewModel.cards.isEmpty {
-                    Text(error)
-                        .foregroundColor(.civitError)
+                    ErrorStateView(message: error)
                 } else if viewModel.cards.isEmpty {
-                    Text("No more models to discover")
-                        .font(.civitBodyMedium)
-                        .foregroundColor(.civitOnSurfaceVariant)
+                    EmptyStateView(
+                        icon: "books.vertical",
+                        title: "No more models to discover"
+                    )
                 } else {
                     cardStack(in: geometry)
                 }

--- a/iosApp/iosApp/Features/ModelFileBrowser/ModelFileBrowserScreen.swift
+++ b/iosApp/iosApp/Features/ModelFileBrowser/ModelFileBrowserScreen.swift
@@ -87,13 +87,11 @@ struct ModelFileBrowserScreen: View {
     @ViewBuilder
     private var emptyOverlay: some View {
         if viewModel.directories.isEmpty {
-            VStack(spacing: Spacing.sm) {
-                Text("No model directories configured")
-                    .font(.civitTitleMedium)
-                Text("Tap + to add a directory path")
-                    .font(.civitBodyMedium)
-                    .foregroundColor(.civitOnSurfaceVariant)
-            }
+            EmptyStateView(
+                icon: "folder.badge.plus",
+                title: "No model directories configured",
+                subtitle: "Tap + to add a directory path"
+            )
         }
     }
 


### PR DESCRIPTION
## Description

Completes Design System adoption (#229) by replacing inline loading/error/empty state implementations with the extracted DesignSystem components across 5 screens. Components were extracted in PRs #230–#239; this PR applies them to the remaining screens that still used inline implementations.

**Android:**
- `CreatorProfileScreen`: inline `Box + CircularProgressIndicator` → `LoadingStateOverlay`; inline `Box + Column + Text + Button` error → `ErrorStateView(onRetry:)`. Removed unused imports.
- `ModelCompareScreen`: inline `CenteredBox + CircularProgressIndicator` → `LoadingStateOverlay`; inline `CenteredBox + Text(error)` → `ErrorStateView`. Removed unused `CenteredBox` helper.

**iOS:**
- `SwipeDiscoveryView`: inline `ProgressView()` → `LoadingStateView`; inline `Text(error)` → `ErrorStateView`; inline empty text → `EmptyStateView`
- `ModelCompareScreen`: inline `ProgressView()` → `LoadingStateView`; custom `errorView()` helper → `ErrorStateView`. Removed helper function.
- `ModelFileBrowserScreen`: inline empty overlay `VStack` → `EmptyStateView`

## Related Issues

Closes #229

## Test Plan

- [x] Android debug build passes (`./gradlew :androidApp:assembleDebug`)
- [x] Unit tests pass (`./gradlew :shared:testDebugUnitTest`)
- [x] Detekt pass (`./gradlew detekt`)
- [x] SwiftLint pass (0 violations in 84 files)

## Review Checklist

- [x] All inline state patterns replaced with DesignSystem components
- [x] No logic changes — visual equivalence maintained
- [x] Unused imports and helper functions cleaned up
- [x] No new files added

## Breaking Changes

None