### PR TITLE
Implement #264: Migrate search/discovery to :feature:feature-search

### DIFF
--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/CivitDeckApplication.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/CivitDeckApplication.kt
@@ -24,9 +24,9 @@ import com.riox432.civitdeck.feature.comfyui.presentation.ComfyUISettingsViewMod
 import com.riox432.civitdeck.feature.comfyui.presentation.ModelFileBrowserViewModel
 import com.riox432.civitdeck.feature.detail.presentation.ModelDetailViewModel
 import com.riox432.civitdeck.feature.gallery.presentation.ImageGalleryViewModel
+import com.riox432.civitdeck.feature.search.presentation.ModelSearchViewModel
+import com.riox432.civitdeck.feature.search.presentation.SwipeDiscoveryViewModel
 import com.riox432.civitdeck.notification.ModelUpdateScheduler
-import com.riox432.civitdeck.ui.discovery.SwipeDiscoveryViewModel
-import com.riox432.civitdeck.ui.search.ModelSearchViewModel
 import com.riox432.civitdeck.ui.tutorial.GestureTutorialViewModel
 import com.riox432.civitdeck.widget.WidgetRefreshWorker
 import kotlinx.coroutines.CoroutineScope

--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/discovery/SwipeDiscoveryScreen.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/discovery/SwipeDiscoveryScreen.kt
@@ -29,6 +29,8 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.riox432.civitdeck.feature.search.presentation.SwipeDiscoveryState
+import com.riox432.civitdeck.feature.search.presentation.SwipeDiscoveryViewModel
 import com.riox432.civitdeck.ui.components.LoadingStateOverlay
 import com.riox432.civitdeck.ui.theme.Spacing
 

--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/navigation/CivitDeckNavGraph.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/navigation/CivitDeckNavGraph.kt
@@ -53,6 +53,8 @@ import com.riox432.civitdeck.feature.creator.presentation.CreatorProfileViewMode
 import com.riox432.civitdeck.feature.detail.presentation.ModelDetailViewModel
 import com.riox432.civitdeck.feature.gallery.presentation.ImageGalleryViewModel
 import com.riox432.civitdeck.feature.prompts.presentation.SavedPromptsViewModel
+import com.riox432.civitdeck.feature.search.presentation.ModelSearchViewModel
+import com.riox432.civitdeck.feature.search.presentation.SwipeDiscoveryViewModel
 import com.riox432.civitdeck.feature.settings.presentation.SettingsViewModel
 import com.riox432.civitdeck.ui.collections.CollectionDetailScreen
 import com.riox432.civitdeck.ui.collections.CollectionsScreen
@@ -62,12 +64,10 @@ import com.riox432.civitdeck.ui.compare.ModelCompareScreen
 import com.riox432.civitdeck.ui.creator.CreatorProfileScreen
 import com.riox432.civitdeck.ui.detail.ModelDetailScreen
 import com.riox432.civitdeck.ui.discovery.SwipeDiscoveryScreen
-import com.riox432.civitdeck.ui.discovery.SwipeDiscoveryViewModel
 import com.riox432.civitdeck.ui.gallery.ImageGalleryScreen
 import com.riox432.civitdeck.ui.modelfiles.ModelFileBrowserScreen
 import com.riox432.civitdeck.ui.prompts.SavedPromptsScreen
 import com.riox432.civitdeck.ui.search.ModelSearchScreen
-import com.riox432.civitdeck.ui.search.ModelSearchViewModel
 import com.riox432.civitdeck.ui.settings.AdvancedSettingsScreen
 import com.riox432.civitdeck.ui.settings.AppearanceSettingsScreen
 import com.riox432.civitdeck.ui.settings.ContentFilterSettingsScreen

--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/search/ModelSearchScreen.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/search/ModelSearchScreen.kt
@@ -115,6 +115,8 @@ import com.riox432.civitdeck.domain.model.RecommendationSection
 import com.riox432.civitdeck.domain.model.SortOrder
 import com.riox432.civitdeck.domain.model.TimePeriod
 import com.riox432.civitdeck.domain.model.thumbnailUrl
+import com.riox432.civitdeck.feature.search.presentation.ModelSearchUiState
+import com.riox432.civitdeck.feature.search.presentation.ModelSearchViewModel
 import com.riox432.civitdeck.ui.adaptive.adaptiveGridColumns
 import com.riox432.civitdeck.ui.adaptive.isExpandedWidth
 import com.riox432.civitdeck.ui.components.LaunchStaggerAnimation

--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/widget/WidgetRefreshWorker.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/widget/WidgetRefreshWorker.kt
@@ -4,7 +4,7 @@ import android.content.Context
 import androidx.glance.appwidget.updateAll
 import androidx.work.CoroutineWorker
 import androidx.work.WorkerParameters
-import com.riox432.civitdeck.domain.usecase.GetRecommendationsUseCase
+import com.riox432.civitdeck.feature.search.domain.usecase.GetRecommendationsUseCase
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
 import kotlin.coroutines.cancellation.CancellationException

--- a/core/core-domain/src/commonMain/kotlin/com/riox432/civitdeck/di/DomainModule.kt
+++ b/core/core-domain/src/commonMain/kotlin/com/riox432/civitdeck/di/DomainModule.kt
@@ -1,23 +1,14 @@
 package com.riox432.civitdeck.di
 
-import com.riox432.civitdeck.domain.usecase.AddExcludedTagUseCase
 import com.riox432.civitdeck.domain.usecase.AddModelDirectoryUseCase
-import com.riox432.civitdeck.domain.usecase.AddSearchHistoryUseCase
 import com.riox432.civitdeck.domain.usecase.CheckModelUpdatesUseCase
 import com.riox432.civitdeck.domain.usecase.ClearBrowsingHistoryUseCase
 import com.riox432.civitdeck.domain.usecase.ClearCacheUseCase
-import com.riox432.civitdeck.domain.usecase.ClearSearchHistoryUseCase
 import com.riox432.civitdeck.domain.usecase.EvictCacheUseCase
 import com.riox432.civitdeck.domain.usecase.GetCacheInfoUseCase
-import com.riox432.civitdeck.domain.usecase.GetDiscoveryModelsUseCase
-import com.riox432.civitdeck.domain.usecase.GetExcludedTagsUseCase
-import com.riox432.civitdeck.domain.usecase.GetHiddenModelIdsUseCase
 import com.riox432.civitdeck.domain.usecase.GetHiddenModelsUseCase
 import com.riox432.civitdeck.domain.usecase.GetModelDetailUseCase
-import com.riox432.civitdeck.domain.usecase.GetModelsUseCase
-import com.riox432.civitdeck.domain.usecase.GetRecommendationsUseCase
 import com.riox432.civitdeck.domain.usecase.GetViewedModelIdsUseCase
-import com.riox432.civitdeck.domain.usecase.HideModelUseCase
 import com.riox432.civitdeck.domain.usecase.ObserveAccentColorUseCase
 import com.riox432.civitdeck.domain.usecase.ObserveAmoledDarkModeUseCase
 import com.riox432.civitdeck.domain.usecase.ObserveApiKeyUseCase
@@ -37,9 +28,7 @@ import com.riox432.civitdeck.domain.usecase.ObserveOfflineCacheEnabledUseCase
 import com.riox432.civitdeck.domain.usecase.ObserveOwnedModelHashesUseCase
 import com.riox432.civitdeck.domain.usecase.ObservePollingIntervalUseCase
 import com.riox432.civitdeck.domain.usecase.ObservePowerUserModeUseCase
-import com.riox432.civitdeck.domain.usecase.ObserveSearchHistoryUseCase
 import com.riox432.civitdeck.domain.usecase.ObserveSeenTutorialVersionUseCase
-import com.riox432.civitdeck.domain.usecase.RemoveExcludedTagUseCase
 import com.riox432.civitdeck.domain.usecase.RemoveModelDirectoryUseCase
 import com.riox432.civitdeck.domain.usecase.ScanModelDirectoriesUseCase
 import com.riox432.civitdeck.domain.usecase.SetAccentColorUseCase
@@ -58,15 +47,12 @@ import com.riox432.civitdeck.domain.usecase.SetPowerUserModeUseCase
 import com.riox432.civitdeck.domain.usecase.SetSeenTutorialVersionUseCase
 import com.riox432.civitdeck.domain.usecase.ToggleFavoriteUseCase
 import com.riox432.civitdeck.domain.usecase.TrackModelViewUseCase
-import com.riox432.civitdeck.domain.usecase.UnhideModelUseCase
 import com.riox432.civitdeck.domain.usecase.ValidateApiKeyUseCase
 import com.riox432.civitdeck.domain.usecase.VerifyModelHashUseCase
 import org.koin.dsl.module
 
 val domainModule = module {
-    factory { GetModelsUseCase(get()) }
     factory { GetModelDetailUseCase(get()) }
-    factory { GetDiscoveryModelsUseCase(get()) }
     factory { ToggleFavoriteUseCase(get()) }
     factory { ObserveFavoritesUseCase(get()) }
     factory { ObserveIsFavoriteUseCase(get()) }
@@ -74,18 +60,8 @@ val domainModule = module {
     factory { SetNsfwFilterUseCase(get()) }
     factory { ObserveNsfwBlurSettingsUseCase(get()) }
     factory { SetNsfwBlurSettingsUseCase(get()) }
-    factory { ObserveSearchHistoryUseCase(get()) }
-    factory { AddSearchHistoryUseCase(get()) }
-    factory { ClearSearchHistoryUseCase(get()) }
     factory { TrackModelViewUseCase(get()) }
-    factory { GetRecommendationsUseCase(get(), get(), get(), get()) }
     factory { GetViewedModelIdsUseCase(get()) }
-    factory { GetExcludedTagsUseCase(get()) }
-    factory { AddExcludedTagUseCase(get()) }
-    factory { RemoveExcludedTagUseCase(get()) }
-    factory { GetHiddenModelIdsUseCase(get()) }
-    factory { HideModelUseCase(get()) }
-    factory { UnhideModelUseCase(get()) }
     factory { ObserveDefaultSortOrderUseCase(get()) }
     factory { SetDefaultSortOrderUseCase(get()) }
     factory { ObserveDefaultTimePeriodUseCase(get()) }

--- a/feature/feature-search/build.gradle.kts
+++ b/feature/feature-search/build.gradle.kts
@@ -2,6 +2,19 @@ plugins {
     id("civitdeck.kmp.feature")
 }
 
+kotlin {
+    sourceSets {
+        commonMain.dependencies {
+            implementation(libs.androidx.lifecycle.viewmodel)
+            implementation(libs.paging.common)
+        }
+        commonTest.dependencies {
+            implementation(libs.kotlin.test)
+            implementation(libs.kotlinx.coroutines.test)
+        }
+    }
+}
+
 android {
     namespace = "com.riox432.civitdeck.feature.search"
 }

--- a/feature/feature-search/src/commonMain/kotlin/com/riox432/civitdeck/feature/search/data/repository/ExcludedTagRepositoryImpl.kt
+++ b/feature/feature-search/src/commonMain/kotlin/com/riox432/civitdeck/feature/search/data/repository/ExcludedTagRepositoryImpl.kt
@@ -1,4 +1,4 @@
-package com.riox432.civitdeck.data.repository
+package com.riox432.civitdeck.feature.search.data.repository
 
 import com.riox432.civitdeck.data.local.currentTimeMillis
 import com.riox432.civitdeck.data.local.dao.ExcludedTagDao

--- a/feature/feature-search/src/commonMain/kotlin/com/riox432/civitdeck/feature/search/data/repository/HiddenModelRepositoryImpl.kt
+++ b/feature/feature-search/src/commonMain/kotlin/com/riox432/civitdeck/feature/search/data/repository/HiddenModelRepositoryImpl.kt
@@ -1,4 +1,4 @@
-package com.riox432.civitdeck.data.repository
+package com.riox432.civitdeck.feature.search.data.repository
 
 import com.riox432.civitdeck.data.local.currentTimeMillis
 import com.riox432.civitdeck.data.local.dao.HiddenModelDao

--- a/feature/feature-search/src/commonMain/kotlin/com/riox432/civitdeck/feature/search/data/repository/SearchHistoryRepositoryImpl.kt
+++ b/feature/feature-search/src/commonMain/kotlin/com/riox432/civitdeck/feature/search/data/repository/SearchHistoryRepositoryImpl.kt
@@ -1,4 +1,4 @@
-package com.riox432.civitdeck.data.repository
+package com.riox432.civitdeck.feature.search.data.repository
 
 import com.riox432.civitdeck.data.local.currentTimeMillis
 import com.riox432.civitdeck.data.local.dao.SearchHistoryDao

--- a/feature/feature-search/src/commonMain/kotlin/com/riox432/civitdeck/feature/search/di/SearchModule.kt
+++ b/feature/feature-search/src/commonMain/kotlin/com/riox432/civitdeck/feature/search/di/SearchModule.kt
@@ -1,0 +1,42 @@
+package com.riox432.civitdeck.feature.search.di
+
+import com.riox432.civitdeck.domain.repository.ExcludedTagRepository
+import com.riox432.civitdeck.domain.repository.HiddenModelRepository
+import com.riox432.civitdeck.domain.repository.SearchHistoryRepository
+import com.riox432.civitdeck.feature.search.data.repository.ExcludedTagRepositoryImpl
+import com.riox432.civitdeck.feature.search.data.repository.HiddenModelRepositoryImpl
+import com.riox432.civitdeck.feature.search.data.repository.SearchHistoryRepositoryImpl
+import com.riox432.civitdeck.feature.search.domain.usecase.AddExcludedTagUseCase
+import com.riox432.civitdeck.feature.search.domain.usecase.AddSearchHistoryUseCase
+import com.riox432.civitdeck.feature.search.domain.usecase.ClearSearchHistoryUseCase
+import com.riox432.civitdeck.feature.search.domain.usecase.GetDiscoveryModelsUseCase
+import com.riox432.civitdeck.feature.search.domain.usecase.GetExcludedTagsUseCase
+import com.riox432.civitdeck.feature.search.domain.usecase.GetHiddenModelIdsUseCase
+import com.riox432.civitdeck.feature.search.domain.usecase.GetModelsUseCase
+import com.riox432.civitdeck.feature.search.domain.usecase.GetRecommendationsUseCase
+import com.riox432.civitdeck.feature.search.domain.usecase.HideModelUseCase
+import com.riox432.civitdeck.feature.search.domain.usecase.ObserveSearchHistoryUseCase
+import com.riox432.civitdeck.feature.search.domain.usecase.RemoveExcludedTagUseCase
+import com.riox432.civitdeck.feature.search.domain.usecase.UnhideModelUseCase
+import org.koin.dsl.module
+
+val searchModule = module {
+    // Repositories
+    single<SearchHistoryRepository> { SearchHistoryRepositoryImpl(get()) }
+    single<ExcludedTagRepository> { ExcludedTagRepositoryImpl(get()) }
+    single<HiddenModelRepository> { HiddenModelRepositoryImpl(get()) }
+
+    // Use cases
+    factory { GetModelsUseCase(get()) }
+    factory { GetDiscoveryModelsUseCase(get()) }
+    factory { GetRecommendationsUseCase(get(), get(), get(), get()) }
+    factory { ObserveSearchHistoryUseCase(get()) }
+    factory { AddSearchHistoryUseCase(get()) }
+    factory { ClearSearchHistoryUseCase(get()) }
+    factory { GetExcludedTagsUseCase(get()) }
+    factory { AddExcludedTagUseCase(get()) }
+    factory { RemoveExcludedTagUseCase(get()) }
+    factory { GetHiddenModelIdsUseCase(get()) }
+    factory { HideModelUseCase(get()) }
+    factory { UnhideModelUseCase(get()) }
+}

--- a/feature/feature-search/src/commonMain/kotlin/com/riox432/civitdeck/feature/search/domain/usecase/ExcludedTagUseCases.kt
+++ b/feature/feature-search/src/commonMain/kotlin/com/riox432/civitdeck/feature/search/domain/usecase/ExcludedTagUseCases.kt
@@ -1,4 +1,4 @@
-package com.riox432.civitdeck.domain.usecase
+package com.riox432.civitdeck.feature.search.domain.usecase
 
 import com.riox432.civitdeck.domain.repository.ExcludedTagRepository
 

--- a/feature/feature-search/src/commonMain/kotlin/com/riox432/civitdeck/feature/search/domain/usecase/GetDiscoveryModelsUseCase.kt
+++ b/feature/feature-search/src/commonMain/kotlin/com/riox432/civitdeck/feature/search/domain/usecase/GetDiscoveryModelsUseCase.kt
@@ -1,4 +1,4 @@
-package com.riox432.civitdeck.domain.usecase
+package com.riox432.civitdeck.feature.search.domain.usecase
 
 import com.riox432.civitdeck.domain.model.Model
 import com.riox432.civitdeck.domain.model.SortOrder

--- a/feature/feature-search/src/commonMain/kotlin/com/riox432/civitdeck/feature/search/domain/usecase/GetModelsUseCase.kt
+++ b/feature/feature-search/src/commonMain/kotlin/com/riox432/civitdeck/feature/search/domain/usecase/GetModelsUseCase.kt
@@ -1,4 +1,4 @@
-package com.riox432.civitdeck.domain.usecase
+package com.riox432.civitdeck.feature.search.domain.usecase
 
 import com.riox432.civitdeck.domain.model.BaseModel
 import com.riox432.civitdeck.domain.model.Model

--- a/feature/feature-search/src/commonMain/kotlin/com/riox432/civitdeck/feature/search/domain/usecase/GetRecommendationsUseCase.kt
+++ b/feature/feature-search/src/commonMain/kotlin/com/riox432/civitdeck/feature/search/domain/usecase/GetRecommendationsUseCase.kt
@@ -1,4 +1,4 @@
-package com.riox432.civitdeck.domain.usecase
+package com.riox432.civitdeck.feature.search.domain.usecase
 
 import com.riox432.civitdeck.domain.model.ModelType
 import com.riox432.civitdeck.domain.model.NsfwFilterLevel

--- a/feature/feature-search/src/commonMain/kotlin/com/riox432/civitdeck/feature/search/domain/usecase/HiddenModelUseCases.kt
+++ b/feature/feature-search/src/commonMain/kotlin/com/riox432/civitdeck/feature/search/domain/usecase/HiddenModelUseCases.kt
@@ -1,4 +1,4 @@
-package com.riox432.civitdeck.domain.usecase
+package com.riox432.civitdeck.feature.search.domain.usecase
 
 import com.riox432.civitdeck.domain.repository.HiddenModelRepository
 

--- a/feature/feature-search/src/commonMain/kotlin/com/riox432/civitdeck/feature/search/domain/usecase/SearchHistoryUseCases.kt
+++ b/feature/feature-search/src/commonMain/kotlin/com/riox432/civitdeck/feature/search/domain/usecase/SearchHistoryUseCases.kt
@@ -1,4 +1,4 @@
-package com.riox432.civitdeck.domain.usecase
+package com.riox432.civitdeck.feature.search.domain.usecase
 
 import com.riox432.civitdeck.domain.repository.SearchHistoryRepository
 import kotlinx.coroutines.flow.Flow

--- a/feature/feature-search/src/commonMain/kotlin/com/riox432/civitdeck/feature/search/presentation/ModelPagingSource.kt
+++ b/feature/feature-search/src/commonMain/kotlin/com/riox432/civitdeck/feature/search/presentation/ModelPagingSource.kt
@@ -1,4 +1,4 @@
-package com.riox432.civitdeck.ui.search
+package com.riox432.civitdeck.feature.search.presentation
 
 import androidx.paging.PagingSource
 import androidx.paging.PagingState
@@ -6,8 +6,8 @@ import com.riox432.civitdeck.domain.model.Model
 import com.riox432.civitdeck.domain.model.NsfwFilterLevel
 import com.riox432.civitdeck.domain.model.SortOrder
 import com.riox432.civitdeck.domain.model.filterNsfwImages
-import com.riox432.civitdeck.domain.usecase.GetModelsUseCase
 import com.riox432.civitdeck.domain.usecase.GetViewedModelIdsUseCase
+import com.riox432.civitdeck.feature.search.domain.usecase.GetModelsUseCase
 
 internal class ModelPagingSource(
     private val getModelsUseCase: GetModelsUseCase,

--- a/feature/feature-search/src/commonMain/kotlin/com/riox432/civitdeck/feature/search/presentation/ModelSearchViewModel.kt
+++ b/feature/feature-search/src/commonMain/kotlin/com/riox432/civitdeck/feature/search/presentation/ModelSearchViewModel.kt
@@ -1,4 +1,4 @@
-package com.riox432.civitdeck.ui.search
+package com.riox432.civitdeck.feature.search.presentation
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
@@ -13,24 +13,24 @@ import com.riox432.civitdeck.domain.model.NsfwFilterLevel
 import com.riox432.civitdeck.domain.model.RecommendationSection
 import com.riox432.civitdeck.domain.model.SortOrder
 import com.riox432.civitdeck.domain.model.TimePeriod
-import com.riox432.civitdeck.domain.usecase.AddExcludedTagUseCase
-import com.riox432.civitdeck.domain.usecase.AddSearchHistoryUseCase
-import com.riox432.civitdeck.domain.usecase.ClearSearchHistoryUseCase
-import com.riox432.civitdeck.domain.usecase.GetExcludedTagsUseCase
-import com.riox432.civitdeck.domain.usecase.GetHiddenModelIdsUseCase
-import com.riox432.civitdeck.domain.usecase.GetModelsUseCase
-import com.riox432.civitdeck.domain.usecase.GetRecommendationsUseCase
 import com.riox432.civitdeck.domain.usecase.GetViewedModelIdsUseCase
-import com.riox432.civitdeck.domain.usecase.HideModelUseCase
 import com.riox432.civitdeck.domain.usecase.ObserveDefaultSortOrderUseCase
 import com.riox432.civitdeck.domain.usecase.ObserveDefaultTimePeriodUseCase
 import com.riox432.civitdeck.domain.usecase.ObserveFavoritesUseCase
 import com.riox432.civitdeck.domain.usecase.ObserveGridColumnsUseCase
 import com.riox432.civitdeck.domain.usecase.ObserveNsfwFilterUseCase
 import com.riox432.civitdeck.domain.usecase.ObserveOwnedModelHashesUseCase
-import com.riox432.civitdeck.domain.usecase.ObserveSearchHistoryUseCase
-import com.riox432.civitdeck.domain.usecase.RemoveExcludedTagUseCase
 import com.riox432.civitdeck.domain.usecase.ToggleFavoriteUseCase
+import com.riox432.civitdeck.feature.search.domain.usecase.AddExcludedTagUseCase
+import com.riox432.civitdeck.feature.search.domain.usecase.AddSearchHistoryUseCase
+import com.riox432.civitdeck.feature.search.domain.usecase.ClearSearchHistoryUseCase
+import com.riox432.civitdeck.feature.search.domain.usecase.GetExcludedTagsUseCase
+import com.riox432.civitdeck.feature.search.domain.usecase.GetHiddenModelIdsUseCase
+import com.riox432.civitdeck.feature.search.domain.usecase.GetModelsUseCase
+import com.riox432.civitdeck.feature.search.domain.usecase.GetRecommendationsUseCase
+import com.riox432.civitdeck.feature.search.domain.usecase.HideModelUseCase
+import com.riox432.civitdeck.feature.search.domain.usecase.ObserveSearchHistoryUseCase
+import com.riox432.civitdeck.feature.search.domain.usecase.RemoveExcludedTagUseCase
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
@@ -60,7 +60,7 @@ data class ModelSearchUiState(
     val includedTags: List<String> = emptyList(),
 )
 
-internal data class FilterState(
+data class FilterState(
     val query: String = "",
     val selectedType: ModelType? = null,
     val selectedSort: SortOrder = SortOrder.MostDownloaded,

--- a/feature/feature-search/src/commonMain/kotlin/com/riox432/civitdeck/feature/search/presentation/SwipeDiscoveryViewModel.kt
+++ b/feature/feature-search/src/commonMain/kotlin/com/riox432/civitdeck/feature/search/presentation/SwipeDiscoveryViewModel.kt
@@ -1,10 +1,10 @@
-package com.riox432.civitdeck.ui.discovery
+package com.riox432.civitdeck.feature.search.presentation
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.riox432.civitdeck.domain.model.Model
-import com.riox432.civitdeck.domain.usecase.GetDiscoveryModelsUseCase
 import com.riox432.civitdeck.domain.usecase.ToggleFavoriteUseCase
+import com.riox432.civitdeck.feature.search.domain.usecase.GetDiscoveryModelsUseCase
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow

--- a/feature/feature-search/src/commonTest/kotlin/com/riox432/civitdeck/feature/search/data/repository/SearchHistoryRepositoryImplTest.kt
+++ b/feature/feature-search/src/commonTest/kotlin/com/riox432/civitdeck/feature/search/data/repository/SearchHistoryRepositoryImplTest.kt
@@ -1,4 +1,4 @@
-package com.riox432.civitdeck.data.repository
+package com.riox432.civitdeck.feature.search.data.repository
 
 import com.riox432.civitdeck.data.local.dao.SearchHistoryDao
 import com.riox432.civitdeck.data.local.entity.SearchHistoryEntity

--- a/feature/feature-search/src/commonTest/kotlin/com/riox432/civitdeck/feature/search/domain/usecase/ExcludedTagUseCasesTest.kt
+++ b/feature/feature-search/src/commonTest/kotlin/com/riox432/civitdeck/feature/search/domain/usecase/ExcludedTagUseCasesTest.kt
@@ -1,10 +1,9 @@
-package com.riox432.civitdeck.domain.usecase
+package com.riox432.civitdeck.feature.search.domain.usecase
 
 import com.riox432.civitdeck.domain.repository.ExcludedTagRepository
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
-import kotlin.test.assertTrue
 
 class ExcludedTagUseCasesTest {
 

--- a/feature/feature-search/src/commonTest/kotlin/com/riox432/civitdeck/feature/search/domain/usecase/HiddenModelUseCasesTest.kt
+++ b/feature/feature-search/src/commonTest/kotlin/com/riox432/civitdeck/feature/search/domain/usecase/HiddenModelUseCasesTest.kt
@@ -1,4 +1,4 @@
-package com.riox432.civitdeck.domain.usecase
+package com.riox432.civitdeck.feature.search.domain.usecase
 
 import com.riox432.civitdeck.domain.model.HiddenModel
 import com.riox432.civitdeck.domain.repository.HiddenModelRepository
@@ -38,14 +38,6 @@ class HiddenModelUseCasesTest {
     fun getHiddenModelIds_returns_set() = runTest {
         val useCase = GetHiddenModelIdsUseCase(repo)
         assertEquals(setOf(1L, 2L), useCase())
-    }
-
-    @Test
-    fun getHiddenModels_returns_domain_models() = runTest {
-        val useCase = GetHiddenModelsUseCase(repo)
-        val result = useCase()
-        assertEquals(2, result.size)
-        assertEquals("Model A", result[0].modelName)
     }
 
     @Test

--- a/feature/feature-search/src/commonTest/kotlin/com/riox432/civitdeck/feature/search/domain/usecase/SearchHistoryUseCasesTest.kt
+++ b/feature/feature-search/src/commonTest/kotlin/com/riox432/civitdeck/feature/search/domain/usecase/SearchHistoryUseCasesTest.kt
@@ -1,4 +1,4 @@
-package com.riox432.civitdeck.domain.usecase
+package com.riox432.civitdeck.feature.search.domain.usecase
 
 import com.riox432.civitdeck.domain.repository.SearchHistoryRepository
 import kotlinx.coroutines.flow.Flow

--- a/feature/feature-settings/build.gradle.kts
+++ b/feature/feature-settings/build.gradle.kts
@@ -6,6 +6,7 @@ kotlin {
     sourceSets {
         commonMain.dependencies {
             implementation(libs.androidx.lifecycle.viewmodel)
+            implementation(project(":feature:feature-search"))
         }
     }
 }

--- a/feature/feature-settings/src/commonMain/kotlin/com/riox432/civitdeck/feature/settings/di/SettingsModule.kt
+++ b/feature/feature-settings/src/commonMain/kotlin/com/riox432/civitdeck/feature/settings/di/SettingsModule.kt
@@ -1,13 +1,10 @@
 package com.riox432.civitdeck.feature.settings.di
 
 import com.riox432.civitdeck.domain.repository.UserPreferencesRepository
-import com.riox432.civitdeck.domain.usecase.AddExcludedTagUseCase
 import com.riox432.civitdeck.domain.usecase.ClearBrowsingHistoryUseCase
 import com.riox432.civitdeck.domain.usecase.ClearCacheUseCase
-import com.riox432.civitdeck.domain.usecase.ClearSearchHistoryUseCase
 import com.riox432.civitdeck.domain.usecase.EvictCacheUseCase
 import com.riox432.civitdeck.domain.usecase.GetCacheInfoUseCase
-import com.riox432.civitdeck.domain.usecase.GetExcludedTagsUseCase
 import com.riox432.civitdeck.domain.usecase.GetHiddenModelsUseCase
 import com.riox432.civitdeck.domain.usecase.ObserveAccentColorUseCase
 import com.riox432.civitdeck.domain.usecase.ObserveAmoledDarkModeUseCase
@@ -23,7 +20,6 @@ import com.riox432.civitdeck.domain.usecase.ObserveNsfwFilterUseCase
 import com.riox432.civitdeck.domain.usecase.ObserveOfflineCacheEnabledUseCase
 import com.riox432.civitdeck.domain.usecase.ObservePollingIntervalUseCase
 import com.riox432.civitdeck.domain.usecase.ObservePowerUserModeUseCase
-import com.riox432.civitdeck.domain.usecase.RemoveExcludedTagUseCase
 import com.riox432.civitdeck.domain.usecase.SetAccentColorUseCase
 import com.riox432.civitdeck.domain.usecase.SetAmoledDarkModeUseCase
 import com.riox432.civitdeck.domain.usecase.SetApiKeyUseCase
@@ -37,8 +33,12 @@ import com.riox432.civitdeck.domain.usecase.SetNsfwFilterUseCase
 import com.riox432.civitdeck.domain.usecase.SetOfflineCacheEnabledUseCase
 import com.riox432.civitdeck.domain.usecase.SetPollingIntervalUseCase
 import com.riox432.civitdeck.domain.usecase.SetPowerUserModeUseCase
-import com.riox432.civitdeck.domain.usecase.UnhideModelUseCase
 import com.riox432.civitdeck.domain.usecase.ValidateApiKeyUseCase
+import com.riox432.civitdeck.feature.search.domain.usecase.AddExcludedTagUseCase
+import com.riox432.civitdeck.feature.search.domain.usecase.ClearSearchHistoryUseCase
+import com.riox432.civitdeck.feature.search.domain.usecase.GetExcludedTagsUseCase
+import com.riox432.civitdeck.feature.search.domain.usecase.RemoveExcludedTagUseCase
+import com.riox432.civitdeck.feature.search.domain.usecase.UnhideModelUseCase
 import com.riox432.civitdeck.feature.settings.data.repository.UserPreferencesRepositoryImpl
 import com.riox432.civitdeck.feature.settings.presentation.SettingsViewModel
 import org.koin.core.module.dsl.viewModel

--- a/feature/feature-settings/src/commonMain/kotlin/com/riox432/civitdeck/feature/settings/presentation/SettingsViewModel.kt
+++ b/feature/feature-settings/src/commonMain/kotlin/com/riox432/civitdeck/feature/settings/presentation/SettingsViewModel.kt
@@ -10,13 +10,10 @@ import com.riox432.civitdeck.domain.model.NsfwFilterLevel
 import com.riox432.civitdeck.domain.model.PollingInterval
 import com.riox432.civitdeck.domain.model.SortOrder
 import com.riox432.civitdeck.domain.model.TimePeriod
-import com.riox432.civitdeck.domain.usecase.AddExcludedTagUseCase
 import com.riox432.civitdeck.domain.usecase.ClearBrowsingHistoryUseCase
 import com.riox432.civitdeck.domain.usecase.ClearCacheUseCase
-import com.riox432.civitdeck.domain.usecase.ClearSearchHistoryUseCase
 import com.riox432.civitdeck.domain.usecase.EvictCacheUseCase
 import com.riox432.civitdeck.domain.usecase.GetCacheInfoUseCase
-import com.riox432.civitdeck.domain.usecase.GetExcludedTagsUseCase
 import com.riox432.civitdeck.domain.usecase.GetHiddenModelsUseCase
 import com.riox432.civitdeck.domain.usecase.ObserveAccentColorUseCase
 import com.riox432.civitdeck.domain.usecase.ObserveAmoledDarkModeUseCase
@@ -32,7 +29,6 @@ import com.riox432.civitdeck.domain.usecase.ObserveNsfwFilterUseCase
 import com.riox432.civitdeck.domain.usecase.ObserveOfflineCacheEnabledUseCase
 import com.riox432.civitdeck.domain.usecase.ObservePollingIntervalUseCase
 import com.riox432.civitdeck.domain.usecase.ObservePowerUserModeUseCase
-import com.riox432.civitdeck.domain.usecase.RemoveExcludedTagUseCase
 import com.riox432.civitdeck.domain.usecase.SetAccentColorUseCase
 import com.riox432.civitdeck.domain.usecase.SetAmoledDarkModeUseCase
 import com.riox432.civitdeck.domain.usecase.SetApiKeyUseCase
@@ -46,8 +42,12 @@ import com.riox432.civitdeck.domain.usecase.SetNsfwFilterUseCase
 import com.riox432.civitdeck.domain.usecase.SetOfflineCacheEnabledUseCase
 import com.riox432.civitdeck.domain.usecase.SetPollingIntervalUseCase
 import com.riox432.civitdeck.domain.usecase.SetPowerUserModeUseCase
-import com.riox432.civitdeck.domain.usecase.UnhideModelUseCase
 import com.riox432.civitdeck.domain.usecase.ValidateApiKeyUseCase
+import com.riox432.civitdeck.feature.search.domain.usecase.AddExcludedTagUseCase
+import com.riox432.civitdeck.feature.search.domain.usecase.ClearSearchHistoryUseCase
+import com.riox432.civitdeck.feature.search.domain.usecase.GetExcludedTagsUseCase
+import com.riox432.civitdeck.feature.search.domain.usecase.RemoveExcludedTagUseCase
+import com.riox432.civitdeck.feature.search.domain.usecase.UnhideModelUseCase
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -51,6 +51,7 @@ coil-compose = { module = "io.coil-kt.coil3:coil-compose", version.ref = "coil" 
 coil-network-ktor3 = { module = "io.coil-kt.coil3:coil-network-ktor3", version.ref = "coil" }
 
 # Paging
+paging-common = { module = "androidx.paging:paging-common", version.ref = "paging" }
 paging-compose = { module = "androidx.paging:paging-compose", version.ref = "paging" }
 
 # AndroidX

--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -29,6 +29,7 @@ kotlin {
             api(project(":feature:feature-collections"))
             api(project(":feature:feature-detail"))
             api(project(":feature:feature-comfyui"))
+            api(project(":feature:feature-search"))
             api(libs.androidx.lifecycle.viewmodel)
             implementation(libs.ktor.client.core)
             implementation(libs.kotlinx.serialization.json)

--- a/shared/src/commonMain/kotlin/com/riox432/civitdeck/di/DataModule.kt
+++ b/shared/src/commonMain/kotlin/com/riox432/civitdeck/di/DataModule.kt
@@ -3,25 +3,19 @@ package com.riox432.civitdeck.di
 import com.riox432.civitdeck.data.repository.AuthRepositoryImpl
 import com.riox432.civitdeck.data.repository.BrowsingHistoryRepositoryImpl
 import com.riox432.civitdeck.data.repository.CacheRepositoryImpl
-import com.riox432.civitdeck.data.repository.ExcludedTagRepositoryImpl
 import com.riox432.civitdeck.data.repository.FavoriteRepositoryImpl
-import com.riox432.civitdeck.data.repository.HiddenModelRepositoryImpl
 import com.riox432.civitdeck.data.repository.LocalModelFileRepositoryImpl
 import com.riox432.civitdeck.data.repository.ModelRepositoryImpl
 import com.riox432.civitdeck.data.repository.ModelVersionCheckpointRepositoryImpl
-import com.riox432.civitdeck.data.repository.SearchHistoryRepositoryImpl
 import com.riox432.civitdeck.data.repository.TagRepositoryImpl
 import com.riox432.civitdeck.data.scanner.FileScanner
 import com.riox432.civitdeck.domain.repository.AuthRepository
 import com.riox432.civitdeck.domain.repository.BrowsingHistoryRepository
 import com.riox432.civitdeck.domain.repository.CacheRepository
-import com.riox432.civitdeck.domain.repository.ExcludedTagRepository
 import com.riox432.civitdeck.domain.repository.FavoriteRepository
-import com.riox432.civitdeck.domain.repository.HiddenModelRepository
 import com.riox432.civitdeck.domain.repository.LocalModelFileRepository
 import com.riox432.civitdeck.domain.repository.ModelRepository
 import com.riox432.civitdeck.domain.repository.ModelVersionCheckpointRepository
-import com.riox432.civitdeck.domain.repository.SearchHistoryRepository
 import com.riox432.civitdeck.domain.repository.TagRepository
 import org.koin.dsl.module
 
@@ -35,10 +29,7 @@ val dataModule = module {
     single<ModelRepository> { ModelRepositoryImpl(get(), get(), get()) }
     single<TagRepository> { TagRepositoryImpl(get()) }
     single<FavoriteRepository> { FavoriteRepositoryImpl(get()) }
-    single<SearchHistoryRepository> { SearchHistoryRepositoryImpl(get()) }
     single<BrowsingHistoryRepository> { BrowsingHistoryRepositoryImpl(get()) }
-    single<ExcludedTagRepository> { ExcludedTagRepositoryImpl(get()) }
-    single<HiddenModelRepository> { HiddenModelRepositoryImpl(get()) }
     single<LocalModelFileRepository> { LocalModelFileRepositoryImpl(get(), get(), get()) }
     single<ModelVersionCheckpointRepository> { ModelVersionCheckpointRepositoryImpl(get()) }
 }

--- a/shared/src/commonMain/kotlin/com/riox432/civitdeck/di/Koin.kt
+++ b/shared/src/commonMain/kotlin/com/riox432/civitdeck/di/Koin.kt
@@ -8,6 +8,7 @@ import com.riox432.civitdeck.feature.creator.di.creatorModule
 import com.riox432.civitdeck.feature.detail.di.detailModule
 import com.riox432.civitdeck.feature.gallery.di.galleryModule
 import com.riox432.civitdeck.feature.prompts.di.promptsModule
+import com.riox432.civitdeck.feature.search.di.searchModule
 import com.riox432.civitdeck.feature.settings.di.settingsModule
 import org.koin.core.context.startKoin
 import org.koin.core.module.Module
@@ -28,6 +29,7 @@ val sharedModules: List<Module>
         collectionsModule,
         detailModule,
         comfyuiModule,
+        searchModule,
     )
 
 fun initKoin(appDeclaration: KoinAppDeclaration = {}) {

--- a/shared/src/commonTest/kotlin/com/riox432/civitdeck/data/repository/SimpleRepositoriesImplTest.kt
+++ b/shared/src/commonTest/kotlin/com/riox432/civitdeck/data/repository/SimpleRepositoriesImplTest.kt
@@ -1,10 +1,6 @@
 package com.riox432.civitdeck.data.repository
 
-import com.riox432.civitdeck.data.local.dao.ExcludedTagDao
-import com.riox432.civitdeck.data.local.dao.HiddenModelDao
 import com.riox432.civitdeck.data.local.dao.SavedPromptDao
-import com.riox432.civitdeck.data.local.entity.ExcludedTagEntity
-import com.riox432.civitdeck.data.local.entity.HiddenModelEntity
 import com.riox432.civitdeck.data.local.entity.SavedPromptEntity
 import com.riox432.civitdeck.domain.model.ImageGenerationMeta
 import com.riox432.civitdeck.feature.prompts.data.repository.SavedPromptRepositoryImpl
@@ -18,95 +14,6 @@ import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
 class SimpleRepositoriesImplTest {
-
-    // --- ExcludedTagRepositoryImpl ---
-
-    private class FakeExcludedTagDao : ExcludedTagDao {
-        val entities = mutableListOf<ExcludedTagEntity>()
-
-        override suspend fun getAll(): List<ExcludedTagEntity> = entities.toList()
-
-        override suspend fun insert(entity: ExcludedTagEntity) {
-            if (entities.none { it.tag == entity.tag }) entities.add(entity)
-        }
-
-        override suspend fun delete(tag: String) {
-            entities.removeAll { it.tag == tag }
-        }
-    }
-
-    @Test
-    fun excludedTag_getAll_maps_to_strings() = runTest {
-        val dao = FakeExcludedTagDao()
-        dao.entities.add(ExcludedTagEntity(tag = "nsfw", addedAt = 1000L))
-        dao.entities.add(ExcludedTagEntity(tag = "gore", addedAt = 2000L))
-        val repo = ExcludedTagRepositoryImpl(dao)
-        assertEquals(listOf("nsfw", "gore"), repo.getExcludedTags())
-    }
-
-    @Test
-    fun excludedTag_add_inserts() = runTest {
-        val dao = FakeExcludedTagDao()
-        val repo = ExcludedTagRepositoryImpl(dao)
-        repo.addExcludedTag("violence")
-        assertEquals(1, dao.entities.size)
-        assertEquals("violence", dao.entities[0].tag)
-    }
-
-    @Test
-    fun excludedTag_remove_deletes() = runTest {
-        val dao = FakeExcludedTagDao()
-        dao.entities.add(ExcludedTagEntity(tag = "nsfw", addedAt = 1000L))
-        val repo = ExcludedTagRepositoryImpl(dao)
-        repo.removeExcludedTag("nsfw")
-        assertTrue(dao.entities.isEmpty())
-    }
-
-    // --- HiddenModelRepositoryImpl ---
-
-    private class FakeHiddenModelDao : HiddenModelDao {
-        val entities = mutableListOf<HiddenModelEntity>()
-
-        override suspend fun getAllIds(): List<Long> = entities.map { it.modelId }
-        override suspend fun getAll(): List<HiddenModelEntity> =
-            entities.sortedByDescending { it.hiddenAt }
-
-        override suspend fun insert(entity: HiddenModelEntity) {
-            if (entities.none { it.modelId == entity.modelId }) entities.add(entity)
-        }
-
-        override suspend fun delete(modelId: Long) {
-            entities.removeAll { it.modelId == modelId }
-        }
-    }
-
-    @Test
-    fun hiddenModel_getIds_returns_set() = runTest {
-        val dao = FakeHiddenModelDao()
-        dao.entities.add(HiddenModelEntity(modelId = 1L, modelName = "A", hiddenAt = 1000L))
-        dao.entities.add(HiddenModelEntity(modelId = 2L, modelName = "B", hiddenAt = 2000L))
-        val repo = HiddenModelRepositoryImpl(dao)
-        assertEquals(setOf(1L, 2L), repo.getHiddenModelIds())
-    }
-
-    @Test
-    fun hiddenModel_hide_inserts() = runTest {
-        val dao = FakeHiddenModelDao()
-        val repo = HiddenModelRepositoryImpl(dao)
-        repo.hideModel(42L, "Hidden Model")
-        assertEquals(1, dao.entities.size)
-        assertEquals(42L, dao.entities[0].modelId)
-        assertEquals("Hidden Model", dao.entities[0].modelName)
-    }
-
-    @Test
-    fun hiddenModel_unhide_deletes() = runTest {
-        val dao = FakeHiddenModelDao()
-        dao.entities.add(HiddenModelEntity(modelId = 1L, modelName = "A", hiddenAt = 1000L))
-        val repo = HiddenModelRepositoryImpl(dao)
-        repo.unhideModel(1L)
-        assertTrue(dao.entities.isEmpty())
-    }
 
     // --- SavedPromptRepositoryImpl ---
 

--- a/shared/src/commonTest/kotlin/com/riox432/civitdeck/domain/usecase/GetRecommendationsUseCaseTest.kt
+++ b/shared/src/commonTest/kotlin/com/riox432/civitdeck/domain/usecase/GetRecommendationsUseCaseTest.kt
@@ -1,5 +1,6 @@
 package com.riox432.civitdeck.domain.usecase
 
+import com.riox432.civitdeck.feature.search.domain.usecase.GetRecommendationsUseCase
 import com.riox432.civitdeck.domain.model.BaseModel
 import com.riox432.civitdeck.domain.model.FavoriteModelSummary
 import com.riox432.civitdeck.domain.model.Model

--- a/shared/src/commonTest/kotlin/com/riox432/civitdeck/domain/usecase/ModelUseCasesTest.kt
+++ b/shared/src/commonTest/kotlin/com/riox432/civitdeck/domain/usecase/ModelUseCasesTest.kt
@@ -9,6 +9,7 @@ import com.riox432.civitdeck.domain.model.SortOrder
 import com.riox432.civitdeck.domain.model.TimePeriod
 import com.riox432.civitdeck.domain.repository.ModelRepository
 import com.riox432.civitdeck.feature.creator.domain.usecase.GetCreatorModelsUseCase
+import com.riox432.civitdeck.feature.search.domain.usecase.GetModelsUseCase
 import com.riox432.civitdeck.testModel
 import com.riox432.civitdeck.testPaginatedResult
 import kotlinx.coroutines.test.runTest

--- a/shared/src/iosMain/kotlin/com/riox432/civitdeck/di/KoinHelper.kt
+++ b/shared/src/iosMain/kotlin/com/riox432/civitdeck/di/KoinHelper.kt
@@ -1,24 +1,15 @@
 package com.riox432.civitdeck.di
 
 import com.riox432.civitdeck.data.api.ApiKeyProvider
-import com.riox432.civitdeck.domain.usecase.AddExcludedTagUseCase
 import com.riox432.civitdeck.domain.usecase.AddModelDirectoryUseCase
-import com.riox432.civitdeck.domain.usecase.AddSearchHistoryUseCase
 import com.riox432.civitdeck.domain.usecase.CheckModelUpdatesUseCase
 import com.riox432.civitdeck.domain.usecase.ClearBrowsingHistoryUseCase
 import com.riox432.civitdeck.domain.usecase.ClearCacheUseCase
-import com.riox432.civitdeck.domain.usecase.ClearSearchHistoryUseCase
 import com.riox432.civitdeck.domain.usecase.EvictCacheUseCase
 import com.riox432.civitdeck.domain.usecase.GetCacheInfoUseCase
-import com.riox432.civitdeck.domain.usecase.GetDiscoveryModelsUseCase
-import com.riox432.civitdeck.domain.usecase.GetExcludedTagsUseCase
-import com.riox432.civitdeck.domain.usecase.GetHiddenModelIdsUseCase
 import com.riox432.civitdeck.domain.usecase.GetHiddenModelsUseCase
 import com.riox432.civitdeck.domain.usecase.GetModelDetailUseCase
-import com.riox432.civitdeck.domain.usecase.GetModelsUseCase
-import com.riox432.civitdeck.domain.usecase.GetRecommendationsUseCase
 import com.riox432.civitdeck.domain.usecase.GetViewedModelIdsUseCase
-import com.riox432.civitdeck.domain.usecase.HideModelUseCase
 import com.riox432.civitdeck.domain.usecase.ObserveAccentColorUseCase
 import com.riox432.civitdeck.domain.usecase.ObserveAmoledDarkModeUseCase
 import com.riox432.civitdeck.domain.usecase.ObserveApiKeyUseCase
@@ -38,9 +29,7 @@ import com.riox432.civitdeck.domain.usecase.ObserveOfflineCacheEnabledUseCase
 import com.riox432.civitdeck.domain.usecase.ObserveOwnedModelHashesUseCase
 import com.riox432.civitdeck.domain.usecase.ObservePollingIntervalUseCase
 import com.riox432.civitdeck.domain.usecase.ObservePowerUserModeUseCase
-import com.riox432.civitdeck.domain.usecase.ObserveSearchHistoryUseCase
 import com.riox432.civitdeck.domain.usecase.ObserveSeenTutorialVersionUseCase
-import com.riox432.civitdeck.domain.usecase.RemoveExcludedTagUseCase
 import com.riox432.civitdeck.domain.usecase.RemoveModelDirectoryUseCase
 import com.riox432.civitdeck.domain.usecase.ScanModelDirectoriesUseCase
 import com.riox432.civitdeck.domain.usecase.SetAccentColorUseCase
@@ -59,7 +48,6 @@ import com.riox432.civitdeck.domain.usecase.SetPowerUserModeUseCase
 import com.riox432.civitdeck.domain.usecase.SetSeenTutorialVersionUseCase
 import com.riox432.civitdeck.domain.usecase.ToggleFavoriteUseCase
 import com.riox432.civitdeck.domain.usecase.TrackModelViewUseCase
-import com.riox432.civitdeck.domain.usecase.UnhideModelUseCase
 import com.riox432.civitdeck.domain.usecase.ValidateApiKeyUseCase
 import com.riox432.civitdeck.domain.usecase.VerifyModelHashUseCase
 import com.riox432.civitdeck.feature.collections.domain.usecase.AddModelToCollectionUseCase
@@ -91,6 +79,18 @@ import com.riox432.civitdeck.feature.prompts.domain.usecase.ObserveTemplatesUseC
 import com.riox432.civitdeck.feature.prompts.domain.usecase.SavePromptUseCase
 import com.riox432.civitdeck.feature.prompts.domain.usecase.SearchSavedPromptsUseCase
 import com.riox432.civitdeck.feature.prompts.domain.usecase.ToggleTemplateUseCase
+import com.riox432.civitdeck.feature.search.domain.usecase.AddExcludedTagUseCase
+import com.riox432.civitdeck.feature.search.domain.usecase.AddSearchHistoryUseCase
+import com.riox432.civitdeck.feature.search.domain.usecase.ClearSearchHistoryUseCase
+import com.riox432.civitdeck.feature.search.domain.usecase.GetDiscoveryModelsUseCase
+import com.riox432.civitdeck.feature.search.domain.usecase.GetExcludedTagsUseCase
+import com.riox432.civitdeck.feature.search.domain.usecase.GetHiddenModelIdsUseCase
+import com.riox432.civitdeck.feature.search.domain.usecase.GetModelsUseCase
+import com.riox432.civitdeck.feature.search.domain.usecase.GetRecommendationsUseCase
+import com.riox432.civitdeck.feature.search.domain.usecase.HideModelUseCase
+import com.riox432.civitdeck.feature.search.domain.usecase.ObserveSearchHistoryUseCase
+import com.riox432.civitdeck.feature.search.domain.usecase.RemoveExcludedTagUseCase
+import com.riox432.civitdeck.feature.search.domain.usecase.UnhideModelUseCase
 import com.riox432.civitdeck.feature.settings.presentation.SettingsViewModel
 import org.koin.mp.KoinPlatform.getKoin
 


### PR DESCRIPTION
## Description

- **#264**: Feature module split: feature-search — Migrate search/discovery feature into `:feature:feature-search` Gradle module following the established `civitdeck.kmp.feature` convention plugin pattern.

**What moved to `feature/feature-search/src/commonMain/`:**
- Use cases: `GetModelsUseCase`, `GetDiscoveryModelsUseCase`, `GetRecommendationsUseCase`, `SearchHistoryUseCases`, `ExcludedTagUseCases`, `HiddenModelUseCases`
- Repository impls: `SearchHistoryRepositoryImpl`, `ExcludedTagRepositoryImpl`, `HiddenModelRepositoryImpl`
- ViewModels: `ModelSearchViewModel`, `SwipeDiscoveryViewModel`
- Paging: `ModelPagingSource` (paging-common 3.3.x is KMP-compatible)
- New: `SearchModule.kt` (Koin DI)

**Kept in place:**
- `ModelRepositoryImpl` — stays in shared (used by feature-detail)
- `TagRepositoryImpl` — stays in shared (multi-feature use)
- `ObserveNsfwFilterUseCase` — stays in core-domain (shared with feature-settings)
- Android/iOS UI screens — stay in androidApp/iosApp

**Tests moved to `feature/feature-search/src/commonTest/`:**
- `SearchHistoryRepositoryImplTest`, `SearchHistoryUseCasesTest`, `HiddenModelUseCasesTest`, `ExcludedTagUseCasesTest`

## Related Issues

Closes #264

## Test Plan

- [x] `./gradlew :androidApp:assembleDebug` — BUILD SUCCESSFUL
- [x] `./gradlew :shared:testDebugUnitTest :feature:feature-search:testDebugUnitTest` — BUILD SUCCESSFUL
- [x] `./gradlew detekt` — BUILD SUCCESSFUL