### PR TITLE
Add saved search filters (Android + iOS)

### DIFF
--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/CivitDeckApplication.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/CivitDeckApplication.kt
@@ -122,7 +122,7 @@ val androidModule = module {
             get(), get(), get(), get(), get(), get(),
             get(), get(), get(), get(), get(), get(),
             get(), get(), get(), get(), get(), get(),
-            get(),
+            get(), get(), get(), get(),
         )
     }
     viewModel { CollectionsViewModel(get(), get(), get(), get()) }

--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/search/ModelSearchScreen.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/search/ModelSearchScreen.kt
@@ -42,6 +42,8 @@ import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.CompareArrows
 import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.BookmarkAdd
+import androidx.compose.material.icons.filled.Bookmarks
 import androidx.compose.material.icons.filled.Check
 import androidx.compose.material.icons.filled.Clear
 import androidx.compose.material.icons.filled.Close
@@ -49,6 +51,7 @@ import androidx.compose.material.icons.filled.ContentCopy
 import androidx.compose.material.icons.filled.Style
 import androidx.compose.material.icons.filled.VisibilityOff
 import androidx.compose.material.icons.outlined.FilterList
+import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Badge
 import androidx.compose.material3.BadgedBox
 import androidx.compose.material3.CircularProgressIndicator
@@ -256,6 +259,10 @@ private fun SearchScreenBody(
     val layoutDirection = LocalLayoutDirection.current
     val density = LocalDensity.current
     var showFilterSheet by remember { mutableStateOf(false) }
+    var showSavedFiltersSheet by remember { mutableStateOf(false) }
+    var showSaveDialog by remember { mutableStateOf(false) }
+    var saveFilterName by remember { mutableStateOf("") }
+    val savedFilters by viewModel.savedFilters.collectAsStateWithLifecycle()
     val activeFilterCount = countActiveFilters(uiState)
     val isFabVisible by remember {
         derivedStateOf {
@@ -331,6 +338,51 @@ private fun SearchScreenBody(
             uiState = uiState,
             viewModel = viewModel,
             onDismiss = { showFilterSheet = false },
+            onShowSavedFilters = { showSavedFiltersSheet = true },
+            onSaveFilter = { showSaveDialog = true },
+        )
+    }
+    if (showSavedFiltersSheet) {
+        SavedFiltersSheet(
+            savedFilters = savedFilters,
+            onApply = { filter ->
+                viewModel.applyFilter(filter)
+                showFilterSheet = false
+            },
+            onDelete = viewModel::deleteSavedFilter,
+            onDismiss = { showSavedFiltersSheet = false },
+        )
+    }
+    if (showSaveDialog) {
+        AlertDialog(
+            onDismissRequest = {
+                showSaveDialog = false
+                saveFilterName = ""
+            },
+            title = { Text("Save Filter") },
+            text = {
+                OutlinedTextField(
+                    value = saveFilterName,
+                    onValueChange = { saveFilterName = it },
+                    label = { Text("Filter name") },
+                    singleLine = true,
+                )
+            },
+            confirmButton = {
+                TextButton(onClick = {
+                    if (saveFilterName.isNotBlank()) {
+                        viewModel.saveCurrentFilter(saveFilterName.trim())
+                    }
+                    showSaveDialog = false
+                    saveFilterName = ""
+                }) { Text("Save") }
+            },
+            dismissButton = {
+                TextButton(onClick = {
+                    showSaveDialog = false
+                    saveFilterName = ""
+                }) { Text("Cancel") }
+            },
         )
     }
 }
@@ -531,6 +583,8 @@ private fun FilterBottomSheet(
     uiState: ModelSearchUiState,
     viewModel: ModelSearchViewModel,
     onDismiss: () -> Unit,
+    onShowSavedFilters: () -> Unit = {},
+    onSaveFilter: () -> Unit = {},
 ) {
     val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
 
@@ -538,7 +592,13 @@ private fun FilterBottomSheet(
         onDismissRequest = onDismiss,
         sheetState = sheetState,
     ) {
-        FilterSheetContent(uiState = uiState, viewModel = viewModel, onDismiss = onDismiss)
+        FilterSheetContent(
+            uiState = uiState,
+            viewModel = viewModel,
+            onDismiss = onDismiss,
+            onShowSavedFilters = onShowSavedFilters,
+            onSaveFilter = onSaveFilter,
+        )
     }
 }
 
@@ -548,6 +608,8 @@ private fun FilterSheetContent(
     uiState: ModelSearchUiState,
     viewModel: ModelSearchViewModel,
     onDismiss: () -> Unit,
+    onShowSavedFilters: () -> Unit = {},
+    onSaveFilter: () -> Unit = {},
 ) {
     LazyColumn(
         verticalArrangement = Arrangement.spacedBy(Spacing.md),
@@ -562,11 +624,19 @@ private fun FilterSheetContent(
                 verticalAlignment = Alignment.CenterVertically,
             ) {
                 Text(text = "Filters", style = MaterialTheme.typography.titleMedium)
-                TextButton(onClick = {
-                    viewModel.resetFilters()
-                    onDismiss()
-                }) {
-                    Text("Reset")
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    IconButton(onClick = onShowSavedFilters) {
+                        Icon(Icons.Default.Bookmarks, contentDescription = "Saved filters")
+                    }
+                    IconButton(onClick = onSaveFilter) {
+                        Icon(Icons.Default.BookmarkAdd, contentDescription = "Save current filter")
+                    }
+                    TextButton(onClick = {
+                        viewModel.resetFilters()
+                        onDismiss()
+                    }) {
+                        Text("Reset")
+                    }
                 }
             }
         }

--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/search/SavedFiltersSheet.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/search/SavedFiltersSheet.kt
@@ -1,0 +1,129 @@
+package com.riox432.civitdeck.ui.search
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.Text
+import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextOverflow
+import com.riox432.civitdeck.domain.model.SavedSearchFilter
+import com.riox432.civitdeck.ui.theme.Spacing
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun SavedFiltersSheet(
+    savedFilters: List<SavedSearchFilter>,
+    onApply: (SavedSearchFilter) -> Unit,
+    onDelete: (Long) -> Unit,
+    onDismiss: () -> Unit,
+) {
+    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = false)
+
+    ModalBottomSheet(
+        onDismissRequest = onDismiss,
+        sheetState = sheetState,
+    ) {
+        LazyColumn(
+            contentPadding = PaddingValues(bottom = Spacing.lg),
+        ) {
+            item {
+                Text(
+                    text = "Saved Filters",
+                    style = MaterialTheme.typography.titleMedium,
+                    modifier = Modifier.padding(horizontal = Spacing.lg, vertical = Spacing.md),
+                )
+                HorizontalDivider(modifier = Modifier.padding(horizontal = Spacing.lg))
+            }
+            if (savedFilters.isEmpty()) {
+                item {
+                    Text(
+                        text = "No saved filters yet.",
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        modifier = Modifier.padding(Spacing.lg),
+                    )
+                }
+            } else {
+                items(savedFilters, key = { it.id }) { filter ->
+                    SavedFilterRow(
+                        filter = filter,
+                        onApply = {
+                            onApply(filter)
+                            onDismiss()
+                        },
+                        onDelete = { onDelete(filter.id) },
+                    )
+                    HorizontalDivider(modifier = Modifier.padding(horizontal = Spacing.lg))
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun SavedFilterRow(
+    filter: SavedSearchFilter,
+    onApply: () -> Unit,
+    onDelete: () -> Unit,
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable(onClick = onApply)
+            .padding(start = Spacing.lg, top = Spacing.sm, bottom = Spacing.sm),
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Column(modifier = Modifier.weight(1f).padding(end = Spacing.sm)) {
+            Text(
+                text = filter.name,
+                style = MaterialTheme.typography.bodyLarge,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+            )
+            Text(
+                text = filterSummary(filter),
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+            )
+        }
+        IconButton(onClick = onDelete) {
+            Icon(
+                Icons.Default.Delete,
+                contentDescription = "Delete filter",
+                tint = MaterialTheme.colorScheme.error,
+            )
+        }
+    }
+}
+
+private fun filterSummary(filter: SavedSearchFilter): String {
+    val parts = buildList {
+        filter.selectedType?.let { add(it.name) }
+        add(filter.selectedSort.name)
+        if (filter.selectedBaseModels.isNotEmpty()) {
+            add(filter.selectedBaseModels.joinToString(", ") { it.displayName })
+        }
+        if (filter.query.isNotBlank()) add("\"${filter.query}\"")
+    }
+    return if (parts.isEmpty()) "All models" else parts.joinToString(" · ")
+}

--- a/core/core-database/schemas/com.riox432.civitdeck.data.local.CivitDeckDatabase/26.json
+++ b/core/core-database/schemas/com.riox432.civitdeck.data.local.CivitDeckDatabase/26.json
@@ -1,0 +1,1210 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 26,
+    "identityHash": "ef3741fb1d93fbde2c82f7bc008256e5",
+    "entities": [
+      {
+        "tableName": "collections",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL, `isDefault` INTEGER NOT NULL, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isDefault",
+            "columnName": "isDefault",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "collection_model_entries",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`collectionId` INTEGER NOT NULL, `modelId` INTEGER NOT NULL, `name` TEXT NOT NULL, `type` TEXT NOT NULL, `nsfw` INTEGER NOT NULL, `thumbnailUrl` TEXT, `creatorName` TEXT, `downloadCount` INTEGER NOT NULL, `favoriteCount` INTEGER NOT NULL, `rating` REAL NOT NULL, `addedAt` INTEGER NOT NULL, PRIMARY KEY(`collectionId`, `modelId`), FOREIGN KEY(`collectionId`) REFERENCES `collections`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "collectionId",
+            "columnName": "collectionId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "modelId",
+            "columnName": "modelId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "nsfw",
+            "columnName": "nsfw",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "thumbnailUrl",
+            "columnName": "thumbnailUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "creatorName",
+            "columnName": "creatorName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "downloadCount",
+            "columnName": "downloadCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "favoriteCount",
+            "columnName": "favoriteCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "rating",
+            "columnName": "rating",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "addedAt",
+            "columnName": "addedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "collectionId",
+            "modelId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_collection_model_entries_modelId",
+            "unique": false,
+            "columnNames": [
+              "modelId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_collection_model_entries_modelId` ON `${TABLE_NAME}` (`modelId`)"
+          },
+          {
+            "name": "index_collection_model_entries_collectionId",
+            "unique": false,
+            "columnNames": [
+              "collectionId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_collection_model_entries_collectionId` ON `${TABLE_NAME}` (`collectionId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "collections",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "collectionId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "cached_api_responses",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`cacheKey` TEXT NOT NULL, `responseJson` TEXT NOT NULL, `cachedAt` INTEGER NOT NULL, `isOfflinePinned` INTEGER NOT NULL, PRIMARY KEY(`cacheKey`))",
+        "fields": [
+          {
+            "fieldPath": "cacheKey",
+            "columnName": "cacheKey",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "responseJson",
+            "columnName": "responseJson",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cachedAt",
+            "columnName": "cachedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isOfflinePinned",
+            "columnName": "isOfflinePinned",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "cacheKey"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_cached_api_responses_cachedAt",
+            "unique": false,
+            "columnNames": [
+              "cachedAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_cached_api_responses_cachedAt` ON `${TABLE_NAME}` (`cachedAt`)"
+          }
+        ]
+      },
+      {
+        "tableName": "user_preferences",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `nsfwFilterLevel` TEXT NOT NULL, `defaultSortOrder` TEXT NOT NULL, `defaultTimePeriod` TEXT NOT NULL, `gridColumns` INTEGER NOT NULL, `apiKey` TEXT, `powerUserMode` INTEGER NOT NULL, `notificationsEnabled` INTEGER NOT NULL, `pollingIntervalMinutes` INTEGER NOT NULL, `nsfwBlurSoft` INTEGER NOT NULL, `nsfwBlurMature` INTEGER NOT NULL, `nsfwBlurExplicit` INTEGER NOT NULL, `offlineCacheEnabled` INTEGER NOT NULL, `cacheSizeLimitMb` INTEGER NOT NULL, `accentColor` TEXT NOT NULL, `amoledDarkMode` INTEGER NOT NULL, `seenTutorialVersion` INTEGER NOT NULL, `civitaiLinkKey` TEXT, `themeMode` TEXT NOT NULL, `customNavShortcuts` TEXT NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "nsfwFilterLevel",
+            "columnName": "nsfwFilterLevel",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "defaultSortOrder",
+            "columnName": "defaultSortOrder",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "defaultTimePeriod",
+            "columnName": "defaultTimePeriod",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "gridColumns",
+            "columnName": "gridColumns",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "apiKey",
+            "columnName": "apiKey",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "powerUserMode",
+            "columnName": "powerUserMode",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "notificationsEnabled",
+            "columnName": "notificationsEnabled",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "pollingIntervalMinutes",
+            "columnName": "pollingIntervalMinutes",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "nsfwBlurSoft",
+            "columnName": "nsfwBlurSoft",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "nsfwBlurMature",
+            "columnName": "nsfwBlurMature",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "nsfwBlurExplicit",
+            "columnName": "nsfwBlurExplicit",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "offlineCacheEnabled",
+            "columnName": "offlineCacheEnabled",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cacheSizeLimitMb",
+            "columnName": "cacheSizeLimitMb",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "accentColor",
+            "columnName": "accentColor",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "amoledDarkMode",
+            "columnName": "amoledDarkMode",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "seenTutorialVersion",
+            "columnName": "seenTutorialVersion",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "civitaiLinkKey",
+            "columnName": "civitaiLinkKey",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "themeMode",
+            "columnName": "themeMode",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "customNavShortcuts",
+            "columnName": "customNavShortcuts",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "saved_prompts",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `prompt` TEXT NOT NULL, `negativePrompt` TEXT, `sampler` TEXT, `steps` INTEGER, `cfgScale` REAL, `seed` INTEGER, `modelName` TEXT, `size` TEXT, `sourceImageUrl` TEXT, `savedAt` INTEGER NOT NULL, `isTemplate` INTEGER NOT NULL DEFAULT 0, `templateName` TEXT, `autoSaved` INTEGER NOT NULL DEFAULT 0, `templateVariables` TEXT, `templateType` TEXT)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "prompt",
+            "columnName": "prompt",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "negativePrompt",
+            "columnName": "negativePrompt",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "sampler",
+            "columnName": "sampler",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "steps",
+            "columnName": "steps",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "cfgScale",
+            "columnName": "cfgScale",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "seed",
+            "columnName": "seed",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "modelName",
+            "columnName": "modelName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "size",
+            "columnName": "size",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "sourceImageUrl",
+            "columnName": "sourceImageUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "savedAt",
+            "columnName": "savedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isTemplate",
+            "columnName": "isTemplate",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "templateName",
+            "columnName": "templateName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "autoSaved",
+            "columnName": "autoSaved",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "templateVariables",
+            "columnName": "templateVariables",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "templateType",
+            "columnName": "templateType",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "search_history",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `query` TEXT NOT NULL, `searchedAt` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "query",
+            "columnName": "query",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "searchedAt",
+            "columnName": "searchedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "browsing_history",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `modelId` INTEGER NOT NULL, `modelType` TEXT NOT NULL, `creatorName` TEXT, `tags` TEXT NOT NULL, `viewedAt` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "modelId",
+            "columnName": "modelId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "modelType",
+            "columnName": "modelType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "creatorName",
+            "columnName": "creatorName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "tags",
+            "columnName": "tags",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "viewedAt",
+            "columnName": "viewedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_browsing_history_modelId",
+            "unique": false,
+            "columnNames": [
+              "modelId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_browsing_history_modelId` ON `${TABLE_NAME}` (`modelId`)"
+          },
+          {
+            "name": "index_browsing_history_viewedAt",
+            "unique": false,
+            "columnNames": [
+              "viewedAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_browsing_history_viewedAt` ON `${TABLE_NAME}` (`viewedAt`)"
+          }
+        ]
+      },
+      {
+        "tableName": "excluded_tags",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`tag` TEXT NOT NULL, `addedAt` INTEGER NOT NULL, PRIMARY KEY(`tag`))",
+        "fields": [
+          {
+            "fieldPath": "tag",
+            "columnName": "tag",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "addedAt",
+            "columnName": "addedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "tag"
+          ]
+        }
+      },
+      {
+        "tableName": "hidden_models",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`modelId` INTEGER NOT NULL, `modelName` TEXT NOT NULL, `hiddenAt` INTEGER NOT NULL, PRIMARY KEY(`modelId`))",
+        "fields": [
+          {
+            "fieldPath": "modelId",
+            "columnName": "modelId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "modelName",
+            "columnName": "modelName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "hiddenAt",
+            "columnName": "hiddenAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "modelId"
+          ]
+        }
+      },
+      {
+        "tableName": "model_directories",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `path` TEXT NOT NULL, `label` TEXT, `lastScannedAt` INTEGER, `isEnabled` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "path",
+            "columnName": "path",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "label",
+            "columnName": "label",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "lastScannedAt",
+            "columnName": "lastScannedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "isEnabled",
+            "columnName": "isEnabled",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "local_model_files",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `directoryId` INTEGER NOT NULL, `filePath` TEXT NOT NULL, `fileName` TEXT NOT NULL, `sha256Hash` TEXT NOT NULL, `sizeBytes` INTEGER NOT NULL, `scannedAt` INTEGER NOT NULL, `matchedModelId` INTEGER, `matchedModelName` TEXT, `matchedVersionId` INTEGER, `matchedVersionName` TEXT, `latestVersionId` INTEGER, `hasUpdate` INTEGER NOT NULL, FOREIGN KEY(`directoryId`) REFERENCES `model_directories`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "directoryId",
+            "columnName": "directoryId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "filePath",
+            "columnName": "filePath",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fileName",
+            "columnName": "fileName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sha256Hash",
+            "columnName": "sha256Hash",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sizeBytes",
+            "columnName": "sizeBytes",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "scannedAt",
+            "columnName": "scannedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "matchedModelId",
+            "columnName": "matchedModelId",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "matchedModelName",
+            "columnName": "matchedModelName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "matchedVersionId",
+            "columnName": "matchedVersionId",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "matchedVersionName",
+            "columnName": "matchedVersionName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "latestVersionId",
+            "columnName": "latestVersionId",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "hasUpdate",
+            "columnName": "hasUpdate",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_local_model_files_directoryId",
+            "unique": false,
+            "columnNames": [
+              "directoryId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_local_model_files_directoryId` ON `${TABLE_NAME}` (`directoryId`)"
+          },
+          {
+            "name": "index_local_model_files_sha256Hash",
+            "unique": false,
+            "columnNames": [
+              "sha256Hash"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_local_model_files_sha256Hash` ON `${TABLE_NAME}` (`sha256Hash`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "model_directories",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "directoryId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "model_version_checkpoints",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`modelId` INTEGER NOT NULL, `lastKnownVersionId` INTEGER NOT NULL, `lastCheckedAt` INTEGER NOT NULL, PRIMARY KEY(`modelId`))",
+        "fields": [
+          {
+            "fieldPath": "modelId",
+            "columnName": "modelId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastKnownVersionId",
+            "columnName": "lastKnownVersionId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastCheckedAt",
+            "columnName": "lastCheckedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "modelId"
+          ]
+        }
+      },
+      {
+        "tableName": "comfyui_connections",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL, `hostname` TEXT NOT NULL, `port` INTEGER NOT NULL, `isActive` INTEGER NOT NULL, `lastTestedAt` INTEGER, `lastTestSuccess` INTEGER, `createdAt` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "hostname",
+            "columnName": "hostname",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "port",
+            "columnName": "port",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isActive",
+            "columnName": "isActive",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastTestedAt",
+            "columnName": "lastTestedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "lastTestSuccess",
+            "columnName": "lastTestSuccess",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "sdwebui_connections",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL, `hostname` TEXT NOT NULL, `port` INTEGER NOT NULL, `isActive` INTEGER NOT NULL, `lastTestedAt` INTEGER, `lastTestSuccess` INTEGER, `createdAt` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "hostname",
+            "columnName": "hostname",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "port",
+            "columnName": "port",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isActive",
+            "columnName": "isActive",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastTestedAt",
+            "columnName": "lastTestedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "lastTestSuccess",
+            "columnName": "lastTestSuccess",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "dataset_collections",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL, `description` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "dataset_images",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `datasetId` INTEGER NOT NULL, `imageUrl` TEXT NOT NULL, `sourceType` TEXT NOT NULL, `trainable` INTEGER NOT NULL, `addedAt` INTEGER NOT NULL, `licenseNote` TEXT, `pHash` TEXT, `excluded` INTEGER NOT NULL, `width` INTEGER, `height` INTEGER, FOREIGN KEY(`datasetId`) REFERENCES `dataset_collections`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "datasetId",
+            "columnName": "datasetId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "imageUrl",
+            "columnName": "imageUrl",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceType",
+            "columnName": "sourceType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "trainable",
+            "columnName": "trainable",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "addedAt",
+            "columnName": "addedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "licenseNote",
+            "columnName": "licenseNote",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "pHash",
+            "columnName": "pHash",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "excluded",
+            "columnName": "excluded",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "width",
+            "columnName": "width",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "height",
+            "columnName": "height",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_dataset_images_datasetId",
+            "unique": false,
+            "columnNames": [
+              "datasetId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_dataset_images_datasetId` ON `${TABLE_NAME}` (`datasetId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "dataset_collections",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "datasetId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "image_tags",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `datasetImageId` INTEGER NOT NULL, `tag` TEXT NOT NULL, FOREIGN KEY(`datasetImageId`) REFERENCES `dataset_images`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "datasetImageId",
+            "columnName": "datasetImageId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "tag",
+            "columnName": "tag",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_image_tags_datasetImageId",
+            "unique": false,
+            "columnNames": [
+              "datasetImageId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_image_tags_datasetImageId` ON `${TABLE_NAME}` (`datasetImageId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "dataset_images",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "datasetImageId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "captions",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`datasetImageId` INTEGER NOT NULL, `text` TEXT NOT NULL, PRIMARY KEY(`datasetImageId`), FOREIGN KEY(`datasetImageId`) REFERENCES `dataset_images`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "datasetImageId",
+            "columnName": "datasetImageId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "text",
+            "columnName": "text",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "datasetImageId"
+          ]
+        },
+        "foreignKeys": [
+          {
+            "table": "dataset_images",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "datasetImageId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "saved_search_filters",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL, `query` TEXT NOT NULL, `selectedType` TEXT, `selectedSort` TEXT NOT NULL, `selectedPeriod` TEXT NOT NULL, `selectedBaseModels` TEXT NOT NULL, `nsfwFilterLevel` TEXT NOT NULL, `isFreshFindEnabled` INTEGER NOT NULL, `excludedTags` TEXT NOT NULL, `includedTags` TEXT NOT NULL, `savedAt` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "query",
+            "columnName": "query",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "selectedType",
+            "columnName": "selectedType",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "selectedSort",
+            "columnName": "selectedSort",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "selectedPeriod",
+            "columnName": "selectedPeriod",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "selectedBaseModels",
+            "columnName": "selectedBaseModels",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "nsfwFilterLevel",
+            "columnName": "nsfwFilterLevel",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isFreshFindEnabled",
+            "columnName": "isFreshFindEnabled",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "excludedTags",
+            "columnName": "excludedTags",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "includedTags",
+            "columnName": "includedTags",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "savedAt",
+            "columnName": "savedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'ef3741fb1d93fbde2c82f7bc008256e5')"
+    ]
+  }
+}

--- a/core/core-database/src/commonMain/kotlin/com/riox432/civitdeck/data/local/CivitDeckDatabase.kt
+++ b/core/core-database/src/commonMain/kotlin/com/riox432/civitdeck/data/local/CivitDeckDatabase.kt
@@ -15,6 +15,7 @@ import com.riox432.civitdeck.data.local.dao.ComfyUIConnectionDao
 import com.riox432.civitdeck.data.local.dao.DatasetCollectionDao
 import com.riox432.civitdeck.data.local.dao.DatasetImageMetaDao
 import com.riox432.civitdeck.data.local.dao.ExcludedTagDao
+import com.riox432.civitdeck.data.local.dao.SavedSearchFilterDao
 import com.riox432.civitdeck.data.local.dao.HiddenModelDao
 import com.riox432.civitdeck.data.local.dao.LocalModelFileDao
 import com.riox432.civitdeck.data.local.dao.ModelVersionCheckpointDao
@@ -38,6 +39,7 @@ import com.riox432.civitdeck.data.local.entity.ModelDirectoryEntity
 import com.riox432.civitdeck.data.local.entity.ModelVersionCheckpointEntity
 import com.riox432.civitdeck.data.local.entity.SDWebUIConnectionEntity
 import com.riox432.civitdeck.data.local.entity.SavedPromptEntity
+import com.riox432.civitdeck.data.local.entity.SavedSearchFilterEntity
 import com.riox432.civitdeck.data.local.entity.SearchHistoryEntity
 import com.riox432.civitdeck.data.local.entity.UserPreferencesEntity
 import kotlinx.coroutines.Dispatchers
@@ -63,8 +65,9 @@ import kotlinx.coroutines.IO
         DatasetImageEntity::class,
         ImageTagEntity::class,
         CaptionEntity::class,
+        SavedSearchFilterEntity::class,
     ],
-    version = 25,
+    version = 26,
 )
 @ConstructedBy(CivitDeckDatabaseConstructor::class)
 abstract class CivitDeckDatabase : RoomDatabase() {
@@ -82,6 +85,7 @@ abstract class CivitDeckDatabase : RoomDatabase() {
     abstract fun sdWebUIConnectionDao(): SDWebUIConnectionDao
     abstract fun datasetCollectionDao(): DatasetCollectionDao
     abstract fun datasetImageMetaDao(): DatasetImageMetaDao
+    abstract fun savedSearchFilterDao(): SavedSearchFilterDao
 }
 
 @Suppress("NO_ACTUAL_FOR_EXPECT")
@@ -502,6 +506,26 @@ val MIGRATION_24_25 = object : Migration(24, 25) {
     }
 }
 
+val MIGRATION_25_26 = object : Migration(25, 26) {
+    override fun migrate(connection: SQLiteConnection) {
+        connection.execSQL(
+            "CREATE TABLE IF NOT EXISTS `saved_search_filters` (" +
+                "`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, " +
+                "`name` TEXT NOT NULL, " +
+                "`query` TEXT NOT NULL DEFAULT '', " +
+                "`selectedType` TEXT, " +
+                "`selectedSort` TEXT NOT NULL DEFAULT 'MostDownloaded', " +
+                "`selectedPeriod` TEXT NOT NULL DEFAULT 'AllTime', " +
+                "`selectedBaseModels` TEXT NOT NULL DEFAULT '', " +
+                "`nsfwFilterLevel` TEXT NOT NULL DEFAULT 'Off', " +
+                "`isFreshFindEnabled` INTEGER NOT NULL DEFAULT 0, " +
+                "`excludedTags` TEXT NOT NULL DEFAULT '', " +
+                "`includedTags` TEXT NOT NULL DEFAULT '', " +
+                "`savedAt` INTEGER NOT NULL)",
+        )
+    }
+}
+
 // Seed data is inserted via onOpen (not in migrations) because Room migrations only run on
 // upgrades — a fresh install starts directly at the latest schema version, skipping all
 // migration callbacks. Using INSERT OR IGNORE in onOpen ensures required rows are always
@@ -580,6 +604,7 @@ fun getRoomDatabase(builder: RoomDatabase.Builder<CivitDeckDatabase>): CivitDeck
             MIGRATION_22_23,
             MIGRATION_23_24,
             MIGRATION_24_25,
+            MIGRATION_25_26,
         )
         .addCallback(defaultCollectionCallback)
         .setDriver(BundledSQLiteDriver())

--- a/core/core-database/src/commonMain/kotlin/com/riox432/civitdeck/data/local/dao/SavedSearchFilterDao.kt
+++ b/core/core-database/src/commonMain/kotlin/com/riox432/civitdeck/data/local/dao/SavedSearchFilterDao.kt
@@ -1,0 +1,20 @@
+package com.riox432.civitdeck.data.local.dao
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import com.riox432.civitdeck.data.local.entity.SavedSearchFilterEntity
+import kotlinx.coroutines.flow.Flow
+
+@Dao
+interface SavedSearchFilterDao {
+    @Query("SELECT * FROM saved_search_filters ORDER BY savedAt DESC")
+    fun observeAll(): Flow<List<SavedSearchFilterEntity>>
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insert(entity: SavedSearchFilterEntity): Long
+
+    @Query("DELETE FROM saved_search_filters WHERE id = :id")
+    suspend fun deleteById(id: Long)
+}

--- a/core/core-database/src/commonMain/kotlin/com/riox432/civitdeck/data/local/entity/SavedSearchFilterEntity.kt
+++ b/core/core-database/src/commonMain/kotlin/com/riox432/civitdeck/data/local/entity/SavedSearchFilterEntity.kt
@@ -1,0 +1,27 @@
+package com.riox432.civitdeck.data.local.entity
+
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+
+@Entity(tableName = "saved_search_filters")
+data class SavedSearchFilterEntity(
+    @PrimaryKey(autoGenerate = true) val id: Long = 0,
+    val name: String,
+    val query: String = "",
+    // ModelType?.name, null means no type filter
+    val selectedType: String? = null,
+    // SortOrder.name
+    val selectedSort: String = "MostDownloaded",
+    // TimePeriod.name
+    val selectedPeriod: String = "AllTime",
+    // BaseModel.apiValue comma-separated, e.g. "SD 1.5,Pony"
+    val selectedBaseModels: String = "",
+    // NsfwFilterLevel.name
+    val nsfwFilterLevel: String = "Off",
+    // stored as 0/1
+    val isFreshFindEnabled: Int = 0,
+    // newline-separated (tags may contain commas)
+    val excludedTags: String = "",
+    val includedTags: String = "",
+    val savedAt: Long,
+)

--- a/core/core-database/src/commonMain/kotlin/com/riox432/civitdeck/di/DatabaseModule.kt
+++ b/core/core-database/src/commonMain/kotlin/com/riox432/civitdeck/di/DatabaseModule.kt
@@ -28,6 +28,7 @@ val databaseModule = module {
     single { get<CivitDeckDatabase>().sdWebUIConnectionDao() }
     single { get<CivitDeckDatabase>().datasetCollectionDao() }
     single { get<CivitDeckDatabase>().datasetImageMetaDao() }
+    single { get<CivitDeckDatabase>().savedSearchFilterDao() }
 
     // Data Sources
     single { LocalCacheDataSource(get()) }

--- a/core/core-domain/src/commonMain/kotlin/com/riox432/civitdeck/domain/model/SavedSearchFilter.kt
+++ b/core/core-domain/src/commonMain/kotlin/com/riox432/civitdeck/domain/model/SavedSearchFilter.kt
@@ -1,0 +1,16 @@
+package com.riox432.civitdeck.domain.model
+
+data class SavedSearchFilter(
+    val id: Long,
+    val name: String,
+    val query: String,
+    val selectedType: ModelType?,
+    val selectedSort: SortOrder,
+    val selectedPeriod: TimePeriod,
+    val selectedBaseModels: Set<BaseModel>,
+    val nsfwFilterLevel: NsfwFilterLevel,
+    val isFreshFindEnabled: Boolean,
+    val excludedTags: List<String>,
+    val includedTags: List<String>,
+    val savedAt: Long,
+)

--- a/core/core-domain/src/commonMain/kotlin/com/riox432/civitdeck/domain/repository/SavedSearchFilterRepository.kt
+++ b/core/core-domain/src/commonMain/kotlin/com/riox432/civitdeck/domain/repository/SavedSearchFilterRepository.kt
@@ -1,0 +1,10 @@
+package com.riox432.civitdeck.domain.repository
+
+import com.riox432.civitdeck.domain.model.SavedSearchFilter
+import kotlinx.coroutines.flow.Flow
+
+interface SavedSearchFilterRepository {
+    fun observeAll(): Flow<List<SavedSearchFilter>>
+    suspend fun save(filter: SavedSearchFilter): Long
+    suspend fun delete(id: Long)
+}

--- a/feature/feature-search/src/commonMain/kotlin/com/riox432/civitdeck/feature/search/data/repository/SavedSearchFilterRepositoryImpl.kt
+++ b/feature/feature-search/src/commonMain/kotlin/com/riox432/civitdeck/feature/search/data/repository/SavedSearchFilterRepositoryImpl.kt
@@ -1,0 +1,66 @@
+package com.riox432.civitdeck.feature.search.data.repository
+
+import com.riox432.civitdeck.data.local.dao.SavedSearchFilterDao
+import com.riox432.civitdeck.data.local.entity.SavedSearchFilterEntity
+import com.riox432.civitdeck.domain.model.BaseModel
+import com.riox432.civitdeck.domain.model.ModelType
+import com.riox432.civitdeck.domain.model.NsfwFilterLevel
+import com.riox432.civitdeck.domain.model.SavedSearchFilter
+import com.riox432.civitdeck.domain.model.SortOrder
+import com.riox432.civitdeck.domain.model.TimePeriod
+import com.riox432.civitdeck.domain.repository.SavedSearchFilterRepository
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+
+class SavedSearchFilterRepositoryImpl(
+    private val dao: SavedSearchFilterDao,
+) : SavedSearchFilterRepository {
+
+    override fun observeAll(): Flow<List<SavedSearchFilter>> =
+        dao.observeAll().map { entities -> entities.map { it.toDomain() } }
+
+    override suspend fun save(filter: SavedSearchFilter): Long = dao.insert(filter.toEntity())
+
+    override suspend fun delete(id: Long) = dao.deleteById(id)
+
+    private fun SavedSearchFilterEntity.toDomain() = SavedSearchFilter(
+        id = id,
+        name = name,
+        query = query,
+        selectedType = selectedType?.let {
+            runCatching { ModelType.valueOf(it) }.getOrNull()
+        },
+        selectedSort = runCatching { SortOrder.valueOf(selectedSort) }
+            .getOrElse { SortOrder.MostDownloaded },
+        selectedPeriod = runCatching { TimePeriod.valueOf(selectedPeriod) }
+            .getOrElse { TimePeriod.AllTime },
+        selectedBaseModels = if (selectedBaseModels.isBlank()) {
+            emptySet()
+        } else {
+            selectedBaseModels.split(",").mapNotNull { apiValue ->
+                BaseModel.entries.find { it.apiValue == apiValue }
+            }.toSet()
+        },
+        nsfwFilterLevel = runCatching { NsfwFilterLevel.valueOf(nsfwFilterLevel) }
+            .getOrElse { NsfwFilterLevel.Off },
+        isFreshFindEnabled = isFreshFindEnabled != 0,
+        excludedTags = if (excludedTags.isBlank()) emptyList() else excludedTags.split("\n"),
+        includedTags = if (includedTags.isBlank()) emptyList() else includedTags.split("\n"),
+        savedAt = savedAt,
+    )
+
+    private fun SavedSearchFilter.toEntity() = SavedSearchFilterEntity(
+        id = id,
+        name = name,
+        query = query,
+        selectedType = selectedType?.name,
+        selectedSort = selectedSort.name,
+        selectedPeriod = selectedPeriod.name,
+        selectedBaseModels = selectedBaseModels.joinToString(",") { it.apiValue },
+        nsfwFilterLevel = nsfwFilterLevel.name,
+        isFreshFindEnabled = if (isFreshFindEnabled) 1 else 0,
+        excludedTags = excludedTags.joinToString("\n"),
+        includedTags = includedTags.joinToString("\n"),
+        savedAt = savedAt,
+    )
+}

--- a/feature/feature-search/src/commonMain/kotlin/com/riox432/civitdeck/feature/search/di/SearchModule.kt
+++ b/feature/feature-search/src/commonMain/kotlin/com/riox432/civitdeck/feature/search/di/SearchModule.kt
@@ -2,13 +2,16 @@ package com.riox432.civitdeck.feature.search.di
 
 import com.riox432.civitdeck.domain.repository.ExcludedTagRepository
 import com.riox432.civitdeck.domain.repository.HiddenModelRepository
+import com.riox432.civitdeck.domain.repository.SavedSearchFilterRepository
 import com.riox432.civitdeck.domain.repository.SearchHistoryRepository
 import com.riox432.civitdeck.feature.search.data.repository.ExcludedTagRepositoryImpl
 import com.riox432.civitdeck.feature.search.data.repository.HiddenModelRepositoryImpl
+import com.riox432.civitdeck.feature.search.data.repository.SavedSearchFilterRepositoryImpl
 import com.riox432.civitdeck.feature.search.data.repository.SearchHistoryRepositoryImpl
 import com.riox432.civitdeck.feature.search.domain.usecase.AddExcludedTagUseCase
 import com.riox432.civitdeck.feature.search.domain.usecase.AddSearchHistoryUseCase
 import com.riox432.civitdeck.feature.search.domain.usecase.ClearSearchHistoryUseCase
+import com.riox432.civitdeck.feature.search.domain.usecase.DeleteSavedSearchFilterUseCase
 import com.riox432.civitdeck.feature.search.domain.usecase.DeleteSearchHistoryItemUseCase
 import com.riox432.civitdeck.feature.search.domain.usecase.GetDiscoveryModelsUseCase
 import com.riox432.civitdeck.feature.search.domain.usecase.GetExcludedTagsUseCase
@@ -17,7 +20,9 @@ import com.riox432.civitdeck.feature.search.domain.usecase.GetModelsUseCase
 import com.riox432.civitdeck.feature.search.domain.usecase.GetRecommendationsUseCase
 import com.riox432.civitdeck.feature.search.domain.usecase.HideModelUseCase
 import com.riox432.civitdeck.feature.search.domain.usecase.ObserveSearchHistoryUseCase
+import com.riox432.civitdeck.feature.search.domain.usecase.ObserveSavedSearchFiltersUseCase
 import com.riox432.civitdeck.feature.search.domain.usecase.RemoveExcludedTagUseCase
+import com.riox432.civitdeck.feature.search.domain.usecase.SaveSearchFilterUseCase
 import com.riox432.civitdeck.feature.search.domain.usecase.UnhideModelUseCase
 import org.koin.dsl.module
 
@@ -26,6 +31,7 @@ val searchModule = module {
     single<SearchHistoryRepository> { SearchHistoryRepositoryImpl(get()) }
     single<ExcludedTagRepository> { ExcludedTagRepositoryImpl(get()) }
     single<HiddenModelRepository> { HiddenModelRepositoryImpl(get()) }
+    single<SavedSearchFilterRepository> { SavedSearchFilterRepositoryImpl(get()) }
 
     // Use cases
     factory { GetModelsUseCase(get()) }
@@ -41,4 +47,7 @@ val searchModule = module {
     factory { GetHiddenModelIdsUseCase(get()) }
     factory { HideModelUseCase(get()) }
     factory { UnhideModelUseCase(get()) }
+    factory { ObserveSavedSearchFiltersUseCase(get()) }
+    factory { SaveSearchFilterUseCase(get()) }
+    factory { DeleteSavedSearchFilterUseCase(get()) }
 }

--- a/feature/feature-search/src/commonMain/kotlin/com/riox432/civitdeck/feature/search/domain/usecase/SavedSearchFilterUseCases.kt
+++ b/feature/feature-search/src/commonMain/kotlin/com/riox432/civitdeck/feature/search/domain/usecase/SavedSearchFilterUseCases.kt
@@ -1,0 +1,19 @@
+package com.riox432.civitdeck.feature.search.domain.usecase
+
+import com.riox432.civitdeck.data.local.currentTimeMillis
+import com.riox432.civitdeck.domain.model.SavedSearchFilter
+import com.riox432.civitdeck.domain.repository.SavedSearchFilterRepository
+import kotlinx.coroutines.flow.Flow
+
+class ObserveSavedSearchFiltersUseCase(private val repository: SavedSearchFilterRepository) {
+    operator fun invoke(): Flow<List<SavedSearchFilter>> = repository.observeAll()
+}
+
+class SaveSearchFilterUseCase(private val repository: SavedSearchFilterRepository) {
+    suspend operator fun invoke(name: String, filter: SavedSearchFilter): Long =
+        repository.save(filter.copy(id = 0, name = name, savedAt = currentTimeMillis()))
+}
+
+class DeleteSavedSearchFilterUseCase(private val repository: SavedSearchFilterRepository) {
+    suspend operator fun invoke(id: Long) = repository.delete(id)
+}

--- a/feature/feature-search/src/commonMain/kotlin/com/riox432/civitdeck/feature/search/presentation/ModelSearchViewModel.kt
+++ b/feature/feature-search/src/commonMain/kotlin/com/riox432/civitdeck/feature/search/presentation/ModelSearchViewModel.kt
@@ -11,6 +11,7 @@ import com.riox432.civitdeck.domain.model.Model
 import com.riox432.civitdeck.domain.model.ModelType
 import com.riox432.civitdeck.domain.model.NsfwFilterLevel
 import com.riox432.civitdeck.domain.model.RecommendationSection
+import com.riox432.civitdeck.domain.model.SavedSearchFilter
 import com.riox432.civitdeck.domain.model.SortOrder
 import com.riox432.civitdeck.domain.model.TimePeriod
 import com.riox432.civitdeck.domain.usecase.GetViewedModelIdsUseCase
@@ -24,6 +25,7 @@ import com.riox432.civitdeck.domain.usecase.ToggleFavoriteUseCase
 import com.riox432.civitdeck.feature.search.domain.usecase.AddExcludedTagUseCase
 import com.riox432.civitdeck.feature.search.domain.usecase.AddSearchHistoryUseCase
 import com.riox432.civitdeck.feature.search.domain.usecase.ClearSearchHistoryUseCase
+import com.riox432.civitdeck.feature.search.domain.usecase.DeleteSavedSearchFilterUseCase
 import com.riox432.civitdeck.feature.search.domain.usecase.DeleteSearchHistoryItemUseCase
 import com.riox432.civitdeck.feature.search.domain.usecase.GetExcludedTagsUseCase
 import com.riox432.civitdeck.feature.search.domain.usecase.GetHiddenModelIdsUseCase
@@ -31,7 +33,9 @@ import com.riox432.civitdeck.feature.search.domain.usecase.GetModelsUseCase
 import com.riox432.civitdeck.feature.search.domain.usecase.GetRecommendationsUseCase
 import com.riox432.civitdeck.feature.search.domain.usecase.HideModelUseCase
 import com.riox432.civitdeck.feature.search.domain.usecase.ObserveSearchHistoryUseCase
+import com.riox432.civitdeck.feature.search.domain.usecase.ObserveSavedSearchFiltersUseCase
 import com.riox432.civitdeck.feature.search.domain.usecase.RemoveExcludedTagUseCase
+import com.riox432.civitdeck.feature.search.domain.usecase.SaveSearchFilterUseCase
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
@@ -94,6 +98,9 @@ class ModelSearchViewModel(
     observeOwnedModelHashesUseCase: ObserveOwnedModelHashesUseCase,
     private val toggleFavoriteUseCase: ToggleFavoriteUseCase,
     observeFavoritesUseCase: ObserveFavoritesUseCase,
+    observeSavedSearchFiltersUseCase: ObserveSavedSearchFiltersUseCase,
+    private val saveSearchFilterUseCase: SaveSearchFilterUseCase,
+    private val deleteSavedSearchFilterUseCase: DeleteSavedSearchFilterUseCase,
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow(ModelSearchUiState())
@@ -118,6 +125,10 @@ class ModelSearchViewModel(
         observeFavoritesUseCase()
             .map { favorites -> favorites.map { it.id }.toSet() }
             .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), emptySet())
+
+    val savedFilters: StateFlow<List<SavedSearchFilter>> =
+        observeSavedSearchFiltersUseCase()
+            .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), emptyList())
 
     @OptIn(ExperimentalCoroutinesApi::class)
     val pagingData: Flow<PagingData<Model>> = combine(
@@ -305,6 +316,58 @@ class ModelSearchViewModel(
             val ids = getHiddenModelIdsUseCase()
             _hiddenModelIds.value = ids
         }
+    }
+
+    fun saveCurrentFilter(name: String) {
+        val filter = _filterState.value
+        val toSave = SavedSearchFilter(
+            id = 0,
+            name = name,
+            query = filter.query,
+            selectedType = filter.selectedType,
+            selectedSort = filter.selectedSort,
+            selectedPeriod = filter.selectedPeriod,
+            selectedBaseModels = filter.selectedBaseModels,
+            nsfwFilterLevel = filter.nsfwFilterLevel,
+            isFreshFindEnabled = filter.isFreshFindEnabled,
+            excludedTags = filter.excludedTags,
+            includedTags = filter.includedTags,
+            savedAt = 0,
+        )
+        viewModelScope.launch { saveSearchFilterUseCase(name, toSave) }
+    }
+
+    fun applyFilter(filter: SavedSearchFilter) {
+        _uiState.update {
+            it.copy(
+                query = filter.query,
+                selectedType = filter.selectedType,
+                selectedSort = filter.selectedSort,
+                selectedPeriod = filter.selectedPeriod,
+                selectedBaseModels = filter.selectedBaseModels,
+                nsfwFilterLevel = filter.nsfwFilterLevel,
+                isFreshFindEnabled = filter.isFreshFindEnabled,
+                includedTags = filter.includedTags,
+                excludedTags = filter.excludedTags,
+            )
+        }
+        _filterState.update {
+            it.copy(
+                query = filter.query,
+                selectedType = filter.selectedType,
+                selectedSort = filter.selectedSort,
+                selectedPeriod = filter.selectedPeriod,
+                selectedBaseModels = filter.selectedBaseModels,
+                nsfwFilterLevel = filter.nsfwFilterLevel,
+                isFreshFindEnabled = filter.isFreshFindEnabled,
+                includedTags = filter.includedTags,
+                excludedTags = filter.excludedTags,
+            )
+        }
+    }
+
+    fun deleteSavedFilter(id: Long) {
+        viewModelScope.launch { deleteSavedSearchFilterUseCase(id) }
     }
 
     fun toggleFavorite(model: Model) {

--- a/iosApp/iosApp.xcodeproj/project.pbxproj
+++ b/iosApp/iosApp.xcodeproj/project.pbxproj
@@ -19,6 +19,7 @@
 		CD169A012D000169000CD001 /* SwipeableModelCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD169A002D000169000CD001 /* SwipeableModelCardView.swift */; };
 		CD00DC032D0DD003000CD001 /* SearchFilterConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD00DC022D0DD003000CD001 /* SearchFilterConstants.swift */; };
 		CD00DC052D0DD004000CD001 /* TagFilterSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD00DC042D0DD004000CD001 /* TagFilterSection.swift */; };
+		CD00DC072D0E0001000CD001 /* SavedFiltersSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD00DC062D0E0001000CD001 /* SavedFiltersSheet.swift */; };
 		CD0004012D000004000CD001 /* ModelDetailViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD0004002D000004000CD001 /* ModelDetailViewModel.swift */; };
 		CD0004032D000004000CD001 /* ModelDetailScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD0004022D000004000CD001 /* ModelDetailScreen.swift */; };
 		CD00DC012D0DD001000CD001 /* ModelDetailComponents.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD00DC002D0DD001000CD001 /* ModelDetailComponents.swift */; };
@@ -140,6 +141,7 @@
 		CD169A002D000169000CD001 /* SwipeableModelCardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwipeableModelCardView.swift; sourceTree = "<group>"; };
 		CD00DC022D0DD003000CD001 /* SearchFilterConstants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchFilterConstants.swift; sourceTree = "<group>"; };
 		CD00DC042D0DD004000CD001 /* TagFilterSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TagFilterSection.swift; sourceTree = "<group>"; };
+		CD00DC062D0E0001000CD001 /* SavedFiltersSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SavedFiltersSheet.swift; sourceTree = "<group>"; };
 		CD0004002D000004000CD001 /* ModelDetailViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModelDetailViewModel.swift; sourceTree = "<group>"; };
 		CD0004022D000004000CD001 /* ModelDetailScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModelDetailScreen.swift; sourceTree = "<group>"; };
 		CD00DC002D0DD001000CD001 /* ModelDetailComponents.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModelDetailComponents.swift; sourceTree = "<group>"; };
@@ -517,6 +519,7 @@
 				CD169A002D000169000CD001 /* SwipeableModelCardView.swift */,
 				CD00DC022D0DD003000CD001 /* SearchFilterConstants.swift */,
 				CD00DC042D0DD004000CD001 /* TagFilterSection.swift */,
+				CD00DC062D0E0001000CD001 /* SavedFiltersSheet.swift */,
 			);
 			path = Search;
 			sourceTree = "<group>";
@@ -701,6 +704,7 @@
 				CD169A012D000169000CD001 /* SwipeableModelCardView.swift in Sources */,
 				CD00DC032D0DD003000CD001 /* SearchFilterConstants.swift in Sources */,
 				CD00DC052D0DD004000CD001 /* TagFilterSection.swift in Sources */,
+				CD00DC072D0E0001000CD001 /* SavedFiltersSheet.swift in Sources */,
 				CD0004012D000004000CD001 /* ModelDetailViewModel.swift in Sources */,
 				CD0004032D000004000CD001 /* ModelDetailScreen.swift in Sources */,
 				CD00DC012D0DD001000CD001 /* ModelDetailComponents.swift in Sources */,

--- a/iosApp/iosApp/Features/Search/ModelSearchScreen.swift
+++ b/iosApp/iosApp/Features/Search/ModelSearchScreen.swift
@@ -21,6 +21,9 @@ struct ModelSearchScreen: View {
     @State private var includeTagInput: String = ""
     @State private var excludeTagInput: String = ""
     @State private var showFilterSheet: Bool = false
+    @State private var showSavedFiltersSheet: Bool = false
+    @State private var showSaveFilterAlert: Bool = false
+    @State private var saveFilterName: String = ""
     @State private var navigationPath = NavigationPath()
     @Namespace private var heroNamespace
 
@@ -98,6 +101,7 @@ struct ModelSearchScreen: View {
             .task { await viewModel.observeGridColumns() }
             .task { await viewModel.observeOwnedHashes() }
             .task { await viewModel.observeFavorites() }
+            .task { await viewModel.observeSavedFilters() }
             .onChange(of: router.pendingDeepLink) { link in
                 guard case .modelDetail(let id) = link else { return }
                 navigationPath.append(id)
@@ -184,14 +188,48 @@ struct ModelSearchScreen: View {
                     }
                 }
                 ToolbarItem(placement: .navigationBarTrailing) {
-                    Button("Done") {
-                        showFilterSheet = false
+                    HStack(spacing: Spacing.xs) {
+                        Button {
+                            showSavedFiltersSheet = true
+                        } label: {
+                            Image(systemName: "bookmark.fill")
+                        }
+                        Button {
+                            saveFilterName = ""
+                            showSaveFilterAlert = true
+                        } label: {
+                            Image(systemName: "bookmark.badge.plus")
+                        }
+                        Button("Done") {
+                            showFilterSheet = false
+                        }
+                        .fontWeight(.semibold)
                     }
-                    .fontWeight(.semibold)
                 }
             }
         }
         .presentationDetents([.medium, .large])
+        .sheet(isPresented: $showSavedFiltersSheet) {
+            SavedFiltersSheet(
+                savedFilters: viewModel.savedFilters,
+                onApply: { filter in
+                    viewModel.applyFilter(filter)
+                    showFilterSheet = false
+                },
+                onDelete: { id in viewModel.deleteSavedFilter(id: id) },
+                onDismiss: { showSavedFiltersSheet = false }
+            )
+        }
+        .alert("Save Filter", isPresented: $showSaveFilterAlert) {
+            TextField("Filter name", text: $saveFilterName)
+            Button("Save") {
+                let name = saveFilterName.trimmingCharacters(in: .whitespaces)
+                if !name.isEmpty {
+                    viewModel.saveCurrentFilter(name: name)
+                }
+            }
+            Button("Cancel", role: .cancel) {}
+        }
     }
 
     @ViewBuilder

--- a/iosApp/iosApp/Features/Search/ModelSearchViewModel.swift
+++ b/iosApp/iosApp/Features/Search/ModelSearchViewModel.swift
@@ -26,6 +26,7 @@ final class ModelSearchViewModel: ObservableObject {
     @Published var gridColumns: Int32 = 2
     @Published var ownedHashes: Set<String> = []
     @Published var favoriteIds: Set<Int64> = []
+    @Published var savedFilters: [SavedSearchFilter] = []
 
     private let getModelsUseCase: GetModelsUseCase
     private let getRecommendationsUseCase: GetRecommendationsUseCase
@@ -46,6 +47,9 @@ final class ModelSearchViewModel: ObservableObject {
     private let observeOwnedModelHashesUseCase: ObserveOwnedModelHashesUseCase
     private let toggleFavoriteUseCase: ToggleFavoriteUseCase
     private let observeFavoritesUseCase: ObserveFavoritesUseCase
+    private let observeSavedSearchFiltersUseCase: ObserveSavedSearchFiltersUseCase
+    private let saveSearchFilterUseCase: SaveSearchFilterUseCase
+    private let deleteSavedSearchFilterUseCase: DeleteSavedSearchFilterUseCase
     private var nextCursor: String?
     private var loadTask: Task<Void, Never>?
     private var hiddenModelIds: Set<KotlinLong> = []
@@ -75,6 +79,9 @@ final class ModelSearchViewModel: ObservableObject {
         self.observeOwnedModelHashesUseCase = KoinHelper.shared.getObserveOwnedModelHashesUseCase()
         self.toggleFavoriteUseCase = KoinHelper.shared.getToggleFavoriteUseCase()
         self.observeFavoritesUseCase = KoinHelper.shared.getObserveFavoritesUseCase()
+        self.observeSavedSearchFiltersUseCase = KoinHelper.shared.getObserveSavedSearchFiltersUseCase()
+        self.saveSearchFilterUseCase = KoinHelper.shared.getSaveSearchFilterUseCase()
+        self.deleteSavedSearchFilterUseCase = KoinHelper.shared.getDeleteSavedSearchFilterUseCase()
         loadExcludedTags()
         loadDefaults()
         loadRecommendations()
@@ -257,6 +264,48 @@ final class ModelSearchViewModel: ObservableObject {
             let summaries = list.compactMap { $0 as? FavoriteModelSummary }
             favoriteIds = Set(summaries.map { $0.id })
         }
+    }
+
+    func observeSavedFilters() async {
+        for await list in observeSavedSearchFiltersUseCase.invoke() {
+            savedFilters = list.compactMap { $0 as? SavedSearchFilter }
+        }
+    }
+
+    func saveCurrentFilter(name: String) {
+        let filter = SavedSearchFilter(
+            id: 0,
+            name: name,
+            query: query,
+            selectedType: selectedType,
+            selectedSort: selectedSort,
+            selectedPeriod: selectedPeriod,
+            selectedBaseModels: selectedBaseModels,
+            nsfwFilterLevel: nsfwFilterLevel,
+            isFreshFindEnabled: isFreshFindEnabled,
+            excludedTags: excludedTags,
+            includedTags: includedTags,
+            savedAt: 0
+        )
+        Task { try? await saveSearchFilterUseCase.invoke(name: name, filter: filter) }
+    }
+
+    func applyFilter(_ filter: SavedSearchFilter) {
+        loadTask?.cancel()
+        query = filter.query
+        selectedType = filter.selectedType
+        selectedSort = filter.selectedSort
+        selectedPeriod = filter.selectedPeriod
+        selectedBaseModels = Set(filter.selectedBaseModels.compactMap { $0 as? BaseModel })
+        nsfwFilterLevel = filter.nsfwFilterLevel
+        isFreshFindEnabled = filter.isFreshFindEnabled
+        includedTags = filter.includedTags.compactMap { $0 as? String }
+        excludedTags = filter.excludedTags.compactMap { $0 as? String }
+        reloadModels()
+    }
+
+    func deleteSavedFilter(id: Int64) {
+        Task { try? await deleteSavedSearchFilterUseCase.invoke(id: id) }
     }
     func hideModel(_ modelId: Int64, name: String) {
         Task {

--- a/iosApp/iosApp/Features/Search/SavedFiltersSheet.swift
+++ b/iosApp/iosApp/Features/Search/SavedFiltersSheet.swift
@@ -1,0 +1,80 @@
+import SwiftUI
+import Shared
+
+struct SavedFiltersSheet: View {
+    let savedFilters: [SavedSearchFilter]
+    let onApply: (SavedSearchFilter) -> Void
+    let onDelete: (Int64) -> Void
+    let onDismiss: () -> Void
+
+    var body: some View {
+        NavigationStack {
+            filterContent
+                .navigationTitle("Saved Filters")
+                .navigationBarTitleDisplayMode(.inline)
+                .toolbar {
+                    ToolbarItem(placement: .navigationBarTrailing) {
+                        Button("Done") { onDismiss() }
+                            .fontWeight(.semibold)
+                    }
+                }
+        }
+        .presentationDetents([.medium, .large])
+    }
+
+    @ViewBuilder
+    private var filterContent: some View {
+        if savedFilters.isEmpty {
+            Text("No saved filters yet.")
+                .font(.civitBodyMedium)
+                .foregroundColor(.civitOnSurfaceVariant)
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+        } else {
+            List {
+                ForEach(savedFilters, id: \.id) { filter in
+                    Button {
+                        onApply(filter)
+                        onDismiss()
+                    } label: {
+                        VStack(alignment: .leading, spacing: Spacing.xs) {
+                            Text(filter.name)
+                                .font(.civitBodyMedium)
+                                .foregroundColor(.civitOnSurface)
+                                .lineLimit(1)
+                            Text(filterSummary(filter))
+                                .font(.civitBodySmall)
+                                .foregroundColor(.civitOnSurfaceVariant)
+                                .lineLimit(1)
+                        }
+                        .contentShape(Rectangle())
+                    }
+                    .buttonStyle(.plain)
+                    .swipeActions(edge: .trailing) {
+                        Button(role: .destructive) {
+                            onDelete(filter.id)
+                        } label: {
+                            Label("Delete", systemImage: "trash")
+                        }
+                    }
+                }
+            }
+            .listStyle(.plain)
+        }
+    }
+
+    private func filterSummary(_ filter: SavedSearchFilter) -> String {
+        var parts: [String] = []
+        if let type = filter.selectedType {
+            parts.append(type.name)
+        }
+        parts.append(filter.selectedSort.name)
+        let baseModels = filter.selectedBaseModels.compactMap { $0 as? BaseModel }
+        if !baseModels.isEmpty {
+            parts.append(baseModels.map { $0.displayName }.joined(separator: ", "))
+        }
+        if !filter.query.isEmpty {
+            parts.append("\"\(filter.query)\"")
+        }
+        return parts.isEmpty ? "All models" : parts.joined(separator: " · ")
+    }
+}

--- a/iosApp/iosApp/SharedTypeAliases.swift
+++ b/iosApp/iosApp/SharedTypeAliases.swift
@@ -52,6 +52,7 @@ typealias QueueJob = Core_domainQueueJob
 typealias QueueJobStatus = Core_domainQueueJobStatus
 typealias RecommendationSection = Core_domainRecommendationSection
 typealias SavedPrompt = Core_domainSavedPrompt
+typealias SavedSearchFilter = Core_domainSavedSearchFilter
 typealias CivitaiLinkResource = Core_domainCivitaiLinkResource
 typealias SDWebUIConnection = Core_domainSDWebUIConnection
 typealias SDWebUIGenerationParams = Core_domainSDWebUIGenerationParams
@@ -158,9 +159,12 @@ typealias GetExcludedTagsUseCase = Feature_searchGetExcludedTagsUseCase
 typealias GetHiddenModelIdsUseCase = Feature_searchGetHiddenModelIdsUseCase
 typealias GetModelsUseCase = Feature_searchGetModelsUseCase
 typealias GetRecommendationsUseCase = Feature_searchGetRecommendationsUseCase
+typealias DeleteSavedSearchFilterUseCase = Feature_searchDeleteSavedSearchFilterUseCase
 typealias HideModelUseCase = Feature_searchHideModelUseCase
+typealias ObserveSavedSearchFiltersUseCase = Feature_searchObserveSavedSearchFiltersUseCase
 typealias ObserveSearchHistoryUseCase = Feature_searchObserveSearchHistoryUseCase
 typealias RemoveExcludedTagUseCase = Feature_searchRemoveExcludedTagUseCase
+typealias SaveSearchFilterUseCase = Feature_searchSaveSearchFilterUseCase
 typealias UnhideModelUseCase = Feature_searchUnhideModelUseCase
 
 // MARK: - Feature: Gallery

--- a/shared/src/iosMain/kotlin/com/riox432/civitdeck/di/KoinHelper.kt
+++ b/shared/src/iosMain/kotlin/com/riox432/civitdeck/di/KoinHelper.kt
@@ -140,6 +140,7 @@ import com.riox432.civitdeck.feature.prompts.domain.usecase.ToggleTemplateUseCas
 import com.riox432.civitdeck.feature.search.domain.usecase.AddExcludedTagUseCase
 import com.riox432.civitdeck.feature.search.domain.usecase.AddSearchHistoryUseCase
 import com.riox432.civitdeck.feature.search.domain.usecase.ClearSearchHistoryUseCase
+import com.riox432.civitdeck.feature.search.domain.usecase.DeleteSavedSearchFilterUseCase
 import com.riox432.civitdeck.feature.search.domain.usecase.DeleteSearchHistoryItemUseCase
 import com.riox432.civitdeck.feature.search.domain.usecase.GetDiscoveryModelsUseCase
 import com.riox432.civitdeck.feature.search.domain.usecase.GetExcludedTagsUseCase
@@ -148,7 +149,9 @@ import com.riox432.civitdeck.feature.search.domain.usecase.GetModelsUseCase
 import com.riox432.civitdeck.feature.search.domain.usecase.GetRecommendationsUseCase
 import com.riox432.civitdeck.feature.search.domain.usecase.HideModelUseCase
 import com.riox432.civitdeck.feature.search.domain.usecase.ObserveSearchHistoryUseCase
+import com.riox432.civitdeck.feature.search.domain.usecase.ObserveSavedSearchFiltersUseCase
 import com.riox432.civitdeck.feature.search.domain.usecase.RemoveExcludedTagUseCase
+import com.riox432.civitdeck.feature.search.domain.usecase.SaveSearchFilterUseCase
 import com.riox432.civitdeck.feature.search.domain.usecase.UnhideModelUseCase
 import com.riox432.civitdeck.feature.settings.presentation.SettingsViewModel
 import org.koin.mp.KoinPlatform.getKoin
@@ -182,6 +185,9 @@ object KoinHelper {
     fun getHiddenModelIdsUseCase(): GetHiddenModelIdsUseCase = getKoin().get()
     fun getHideModelUseCase(): HideModelUseCase = getKoin().get()
     fun getUnhideModelUseCase(): UnhideModelUseCase = getKoin().get()
+    fun getObserveSavedSearchFiltersUseCase(): ObserveSavedSearchFiltersUseCase = getKoin().get()
+    fun getSaveSearchFilterUseCase(): SaveSearchFilterUseCase = getKoin().get()
+    fun getDeleteSavedSearchFilterUseCase(): DeleteSavedSearchFilterUseCase = getKoin().get()
     fun getObserveDefaultSortOrderUseCase(): ObserveDefaultSortOrderUseCase = getKoin().get()
     fun getSetDefaultSortOrderUseCase(): SetDefaultSortOrderUseCase = getKoin().get()
     fun getObserveDefaultTimePeriodUseCase(): ObserveDefaultTimePeriodUseCase = getKoin().get()


### PR DESCRIPTION
## Summary

- Add named saved search filter feature to the model search screen
- Users can save current filter state (query, sort, type, base models, NSFW level, tags, etc.) with a custom name
- Saved filters can be viewed in a bottom sheet, applied with a tap, and deleted

## Changes

**KMP Shared**
- `SavedSearchFilterEntity` + `SavedSearchFilterDao` (Room KMP, DB v25→26 with `MIGRATION_25_26`)
- `SavedSearchFilter` domain model + `SavedSearchFilterRepository` interface
- `SavedSearchFilterRepositoryImpl` with enum ↔ string serialization (`BaseModel` via `apiValue`, others via `.name`)
- `ObserveSavedSearchFiltersUseCase` / `SaveSearchFilterUseCase` / `DeleteSavedSearchFilterUseCase`
- `ModelSearchViewModel` (KMP): added `savedFilters: StateFlow`, `saveCurrentFilter`, `applyFilter`, `deleteSavedFilter`
- `KoinHelper` (iOS): 3 new getters

**Android**
- `SavedFiltersSheet.kt`: `ModalBottomSheet` with filter list, summary text, delete button
- `ModelSearchScreen.kt`: bookmark icon buttons in filter sheet header to open saved list / save dialog

**iOS**
- `SavedFiltersSheet.swift`: `List` with swipe-to-delete, `@ViewBuilder` content
- `ModelSearchViewModel.swift`: 3 use cases, `@Published savedFilters`, observe/save/apply/delete functions
- `ModelSearchScreen.swift`: toolbar bookmark buttons, `.sheet` + `.alert` for name input
- `SharedTypeAliases.swift`: 4 new typealiases for KMP types
- `project.pbxproj`: 4 entries for `SavedFiltersSheet.swift`