### PR TITLE
Improve performance: gallery lookup, batch observe, contentType

### DIFF
--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/search/ModelSearchScreen.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/search/ModelSearchScreen.kt
@@ -1261,6 +1261,7 @@ private fun ModelGrid(
         items(
             count = lazyPagingItems.itemCount,
             key = lazyPagingItems.itemKey { it.id },
+            contentType = { "model" },
         ) { index ->
             val model = lazyPagingItems[index] ?: return@items
             val thumbnailUrl = model.modelVersions

--- a/iosApp/iosApp/Features/Detail/ModelDetailScreen.swift
+++ b/iosApp/iosApp/Features/Detail/ModelDetailScreen.swift
@@ -38,19 +38,13 @@ struct ModelDetailScreen: View {
         .navigationTitle(viewModel.model?.name ?? "")
         .navigationBarTitleDisplayMode(.inline)
         .task {
-            await viewModel.observeFavorite()
-        }
-        .task {
-            await viewModel.observeNsfwFilter()
-        }
-        .task {
-            await viewModel.observePowerUserMode()
-        }
-        .task {
-            await viewModel.observeNote()
-        }
-        .task {
-            await viewModel.observePersonalTags()
+            await withTaskGroup(of: Void.self) { group in
+                group.addTask { await viewModel.observeFavorite() }
+                group.addTask { await viewModel.observeNsfwFilter() }
+                group.addTask { await viewModel.observePowerUserMode() }
+                group.addTask { await viewModel.observeNote() }
+                group.addTask { await viewModel.observePersonalTags() }
+            }
         }
         .toolbar {
             ToolbarItem(placement: .navigationBarTrailing) {
@@ -90,10 +84,10 @@ struct ModelDetailScreen: View {
             }
         }
         .task {
-            await viewModel.observeCollections()
-        }
-        .task {
-            await viewModel.observeModelCollections()
+            await withTaskGroup(of: Void.self) { group in
+                group.addTask { await viewModel.observeCollections() }
+                group.addTask { await viewModel.observeModelCollections() }
+            }
         }
         .sheet(isPresented: $showCollectionSheet) {
             AddToCollectionSheet(

--- a/iosApp/iosApp/Features/Gallery/ImageGalleryScreen.swift
+++ b/iosApp/iosApp/Features/Gallery/ImageGalleryScreen.swift
@@ -126,6 +126,10 @@ struct ImageGalleryScreen: View {
 
     private var imageGrid: some View {
         let colCount = AdaptiveGrid.columnCount(sizeClass: sizeClass)
+        let indexLookup = Dictionary(
+            viewModel.images.enumerated().map { ($1.id, $0) },
+            uniquingKeysWith: { first, _ in first }
+        )
         return ScrollView {
             StaggeredGrid(
                 data: viewModel.images,
@@ -134,7 +138,7 @@ struct ImageGalleryScreen: View {
                 id: \.id,
                 aspectRatio: imageAspectRatio
             ) { image in
-                staggeredImageCell(image: image)
+                staggeredImageCell(image: image, index: indexLookup[image.id] ?? 0)
             }
             .padding(.horizontal, Spacing.sm)
 
@@ -151,9 +155,8 @@ struct ImageGalleryScreen: View {
             : 1.0
     }
 
-    private func staggeredImageCell(image: CivitImage) -> some View {
-        let index = viewModel.images.firstIndex(where: { $0.id == image.id }) ?? 0
-        return imageCell(image: image, index: index)
+    private func staggeredImageCell(image: CivitImage, index: Int) -> some View {
+        imageCell(image: image, index: index)
             .task {
                 if index >= viewModel.images.count - 6 {
                     viewModel.loadMore()


### PR DESCRIPTION
## Description

- Replace O(n) `firstIndex(where:)` per cell with O(1) Dictionary lookup in iOS `ImageGalleryScreen` (#377)
- Batch 7 sequential `.task { observe*() }` blocks into 2 `withTaskGroup` calls in iOS `ModelDetailScreen` for parallel loading (#378)
- Add `contentType` to Paging `items()` in Android `ModelSearchScreen` to reduce unnecessary recomposition (#379)

## Related Issues

Closes #377
Closes #378
Closes #379

## Screenshots / Video

<!-- N/A — performance improvements, no visual changes -->

## Test Plan

- [x] Ran detekt — zero issues
- [x] Ran SwiftLint — zero violations
- [x] Android assembleDebug — BUILD SUCCESSFUL
- [x] iOS xcodebuild (Simulator) — BUILD SUCCEEDED

## Review Checklist

- [x] Code follows project architecture (Clean Architecture + MVVM)
- [x] Shared logic is in `commonMain`, platform-specific code only when necessary
- [x] No unnecessary dependencies added
- [x] Tests added/updated as needed

## Breaking Changes

None