### PR TITLE
#454 Replace remaining hardcoded colors with design tokens in iOS views

### DIFF
--- a/iosApp/iosApp/DesignSystem/CivitDeckColors.swift
+++ b/iosApp/iosApp/DesignSystem/CivitDeckColors.swift
@@ -47,6 +47,9 @@ extension Color {
     static let civitInverseOnSurface = Color(light: hex(0xF2F0F4), dark: hex(0x303034))
     static let civitInversePrimary = Color(light: hex(0xB8C4FF), dark: hex(0x3755C3))
 
+    // MARK: - Scrim
+    static let civitScrim = hex(0x000000)
+
     // MARK: - AMOLED Dark Mode
     static let amoledSurface = hex(0x000000)
     static let amoledSurfaceContainer = hex(0x0F0F0F)

--- a/iosApp/iosApp/Features/ComfyUI/ComfyUIOutputDetailView.swift
+++ b/iosApp/iosApp/Features/ComfyUI/ComfyUIOutputDetailView.swift
@@ -314,7 +314,7 @@ private struct SingleImageViewer: View {
 
     var body: some View {
         ZStack {
-            Color.black
+            Color.civitScrim
                 .opacity(backgroundOpacity)
                 .ignoresSafeArea()
 

--- a/iosApp/iosApp/Features/Compare/ImageComparisonOverlay.swift
+++ b/iosApp/iosApp/Features/Compare/ImageComparisonOverlay.swift
@@ -14,7 +14,7 @@ struct ImageComparisonOverlay: View {
 
     var body: some View {
         ZStack {
-            Color.black.ignoresSafeArea()
+            Color.civitScrim.ignoresSafeArea()
 
             ImageComparisonSlider(
                 beforeImageUrl: beforeImageUrl,
@@ -92,7 +92,7 @@ private struct ComparisonLabelChip: View {
             .foregroundColor(.civitInverseOnSurface)
             .padding(.horizontal, chipHPadding)
             .padding(.vertical, chipVPadding)
-            .background(Color.black.opacity(chipAlpha), in: Capsule())
+            .background(Color.civitScrim.opacity(chipAlpha), in: Capsule())
     }
 }
 

--- a/iosApp/iosApp/Features/Dataset/ExportDatasetSheet.swift
+++ b/iosApp/iosApp/Features/Dataset/ExportDatasetSheet.swift
@@ -151,7 +151,7 @@ struct ExportProgressOverlay: View {
             Spacer()
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
-        .background(Color.black.opacity(0.3))
+        .background(Color.civitScrim.opacity(0.3))
     }
 
     private func completedView(path: String, warnings: Int) -> some View {
@@ -184,7 +184,7 @@ struct ExportProgressOverlay: View {
             Spacer()
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
-        .background(Color.black.opacity(0.3))
+        .background(Color.civitScrim.opacity(0.3))
     }
 
     private func failedView(message: String) -> some View {
@@ -205,6 +205,6 @@ struct ExportProgressOverlay: View {
             Spacer()
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
-        .background(Color.black.opacity(0.3))
+        .background(Color.civitScrim.opacity(0.3))
     }
 }

--- a/iosApp/iosApp/Features/Detail/ModelDetailComponents.swift
+++ b/iosApp/iosApp/Features/Detail/ModelDetailComponents.swift
@@ -11,7 +11,7 @@ struct CarouselViewer: View {
     var body: some View {
         if let startIndex = selectedIndex, !images.isEmpty {
             ZStack {
-                Color.black.ignoresSafeArea()
+                Color.civitScrim.ignoresSafeArea()
 
                 TabView(selection: Binding(
                     get: { startIndex },
@@ -120,7 +120,7 @@ struct ImageGridSheet: View {
                 if image.contentType == .video {
                     SwiftUI.Image(systemName: "play.circle.fill")
                         .font(.civitIconLarge)
-                        .foregroundColor(.white.opacity(0.85))
+                        .foregroundColor(.civitInverseOnSurface)
                         .accessibilityHidden(true)
                 }
             }
@@ -139,7 +139,7 @@ struct GridImageViewer: View {
     var body: some View {
         if let startIndex = selectedIndex, !images.isEmpty {
             ZStack {
-                Color.black.ignoresSafeArea()
+                Color.civitScrim.ignoresSafeArea()
                 TabView(selection: Binding(
                     get: { startIndex },
                     set: { selectedIndex = $0 }

--- a/iosApp/iosApp/Features/ExternalServer/ExternalServerGalleryView.swift
+++ b/iosApp/iosApp/Features/ExternalServer/ExternalServerGalleryView.swift
@@ -142,7 +142,7 @@ private struct ServerImageCell: View {
                     .font(.civitLabelSmall)
                     .foregroundColor(.civitOnSurface)
                     .padding(Spacing.xs)
-                    .background(Color.black.opacity(0.5))
+                    .background(Color.civitScrim.opacity(0.5))
                     .cornerRadius(Spacing.xs)
                     .padding(Spacing.xs)
             }

--- a/iosApp/iosApp/Features/Gallery/ImageViewerScreen.swift
+++ b/iosApp/iosApp/Features/Gallery/ImageViewerScreen.swift
@@ -21,7 +21,7 @@ struct ImageViewerScreen: View {
         if let index = selectedIndex {
             ZStack {
                 // Layer 1: Background (stays in place, fades)
-                Color.black
+                Color.civitScrim
                     .opacity(backgroundOpacity)
                     .ignoresSafeArea()
 

--- a/iosApp/iosApp/Features/QRCode/QRScannerView.swift
+++ b/iosApp/iosApp/Features/QRCode/QRScannerView.swift
@@ -17,7 +17,7 @@ struct QRScannerView: View {
             } else if cameraPermission == .denied {
                 permissionDeniedView
             } else {
-                Color.black.ignoresSafeArea()
+                Color.civitScrim.ignoresSafeArea()
             }
         }
         .navigationTitle("Scan QR Code")
@@ -41,7 +41,7 @@ struct QRScannerView: View {
                 .foregroundColor(.civitOnSurface)
                 .padding(.horizontal, Spacing.md)
                 .padding(.vertical, Spacing.sm)
-                .background(Color.black.opacity(0.6))
+                .background(Color.civitScrim.opacity(0.6))
                 .clipShape(RoundedRectangle(cornerRadius: Spacing.sm))
             Spacer()
         }


### PR DESCRIPTION
## Description

Replace remaining hardcoded `Color.black` and `.white` with design tokens in iOS feature views, completing the work started in #452.

Changes:
- Add `civitScrim` design token (Material 3 scrim color) to `CivitDeckColors`
- Replace `Color.black` → `Color.civitScrim` in media viewer backgrounds and overlay scrims (8 files)
- Replace `.foregroundColor(.white.opacity(0.85))` → `.civitInverseOnSurface` for video play icon overlay

Closes #454

## Test Plan

- [x] SwiftLint passes (0 violations)
- [x] iOS Simulator build succeeds
- [ ] Verify image viewer backgrounds remain black
- [ ] Verify overlay scrims render correctly in light/dark mode
- [ ] Verify video play icon is visible on thumbnails