### PR TITLE
Remove quality filtering from Feed, keep only in Search

### DIFF
--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/CivitDeckApplication.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/CivitDeckApplication.kt
@@ -167,7 +167,7 @@ val androidModule = module {
     viewModel { params -> BatchTagEditorViewModel(params.get(), get(), get(), get()) }
     viewModel { params -> DuplicateReviewViewModel(params.get(), get(), get()) }
     viewModel { AnalyticsViewModel(get()) }
-    viewModel { FeedViewModel(get(), get(), get(), get()) }
+    viewModel { FeedViewModel(get(), get(), get()) }
     viewModel { BackupViewModel(get(), get(), get()) }
     viewModel { PluginManagementViewModel(get(), get(), get(), get(), get(), get()) }
 }

--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/feed/FeedViewModel.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/feed/FeedViewModel.kt
@@ -6,8 +6,6 @@ import com.riox432.civitdeck.domain.model.FeedItem
 import com.riox432.civitdeck.domain.usecase.GetCreatorFeedUseCase
 import com.riox432.civitdeck.domain.usecase.GetUnreadFeedCountUseCase
 import com.riox432.civitdeck.domain.usecase.MarkFeedReadUseCase
-import com.riox432.civitdeck.domain.usecase.ObserveQualityThresholdUseCase
-import com.riox432.civitdeck.domain.usecase.QualityScoreCalculator
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -25,17 +23,12 @@ class FeedViewModel(
     private val getCreatorFeedUseCase: GetCreatorFeedUseCase,
     private val getUnreadFeedCountUseCase: GetUnreadFeedCountUseCase,
     private val markFeedReadUseCase: MarkFeedReadUseCase,
-    private val observeQualityThresholdUseCase: ObserveQualityThresholdUseCase,
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow(FeedUiState())
     val uiState: StateFlow<FeedUiState> = _uiState
 
-    private var allItems: List<FeedItem> = emptyList()
-    private var qualityThreshold: Int = 0
-
     init {
-        observeQualityThreshold()
         loadFeed()
         observeUnreadCount()
     }
@@ -58,13 +51,13 @@ class FeedViewModel(
                 error = null,
             )
             try {
-                allItems = getCreatorFeedUseCase(forceRefresh)
+                val items = getCreatorFeedUseCase(forceRefresh)
                 _uiState.value = _uiState.value.copy(
-                    feedItems = filterByQuality(allItems),
+                    feedItems = items,
                     isLoading = false,
                     isRefreshing = false,
                 )
-                if (allItems.isNotEmpty()) markFeedReadUseCase()
+                if (items.isNotEmpty()) markFeedReadUseCase()
             } catch (e: CancellationException) {
                 throw e
             } catch (e: Exception) {
@@ -74,31 +67,6 @@ class FeedViewModel(
                     error = e.message ?: "Failed to load feed",
                 )
             }
-        }
-    }
-
-    private fun observeQualityThreshold() {
-        viewModelScope.launch {
-            observeQualityThresholdUseCase().collect { threshold ->
-                qualityThreshold = threshold
-                if (allItems.isNotEmpty()) {
-                    _uiState.value = _uiState.value.copy(
-                        feedItems = filterByQuality(allItems),
-                    )
-                }
-            }
-        }
-    }
-
-    private fun filterByQuality(items: List<FeedItem>): List<FeedItem> {
-        if (qualityThreshold <= 0) return items
-        return items.filter { item ->
-            val stats = item.stats
-            // Skip filtering for items with unknown stats (e.g., migrated cache entries)
-            if (stats.downloadCount <= 0 && stats.favoriteCount <= 0 && stats.ratingCount <= 0) {
-                return@filter true
-            }
-            QualityScoreCalculator.calculate(stats) >= qualityThreshold
         }
     }
 

--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/settings/ContentFilterSettingsScreen.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/settings/ContentFilterSettingsScreen.kt
@@ -99,7 +99,7 @@ internal fun LazyListScope.feedQualityItems(
     state: AppBehaviorSettingsUiState,
     viewModel: AppBehaviorSettingsViewModel,
 ) {
-    item { SectionHeader("Feed Quality") }
+    item { SectionHeader("Search Quality Filter") }
     item {
         FeedQualityThresholdRow(
             threshold = state.feedQualityThreshold,

--- a/iosApp/iosApp/Features/Feed/FeedViewModel.swift
+++ b/iosApp/iosApp/Features/Feed/FeedViewModel.swift
@@ -12,19 +12,13 @@ final class FeedViewModel: ObservableObject {
     private let getCreatorFeedUseCase: GetCreatorFeedUseCase
     private let getUnreadFeedCountUseCase: GetUnreadFeedCountUseCase
     private let markFeedReadUseCase: MarkFeedReadUseCase
-    private let observeQualityThresholdUseCase: ObserveQualityThresholdUseCase
     private var unreadObserveTask: Task<Void, Never>?
-    private var thresholdObserveTask: Task<Void, Never>?
-    private var allItems: [FeedItem] = []
-    private var qualityThreshold: Int32 = 0
 
     init() {
         self.getCreatorFeedUseCase = KoinHelper.shared.getCreatorFeedUseCase()
         self.getUnreadFeedCountUseCase = KoinHelper.shared.getUnreadFeedCountUseCase()
         self.markFeedReadUseCase = KoinHelper.shared.getMarkFeedReadUseCase()
-        self.observeQualityThresholdUseCase = KoinHelper.shared.getObserveQualityThresholdUseCase()
         observeUnreadCount()
-        observeQualityThreshold()
     }
 
     func loadFeed(forceRefresh: Bool = false) async {
@@ -39,44 +33,16 @@ final class FeedViewModel: ObservableObject {
             let items = try await getCreatorFeedUseCase.invoke(
                 forceRefresh: forceRefresh
             )
-            allItems = items.compactMap { $0 as? FeedItem }
-            feedItems = filterByQuality(allItems)
+            feedItems = items.compactMap { $0 as? FeedItem }
             isLoading = false
             isRefreshing = false
-            if !allItems.isEmpty {
+            if !feedItems.isEmpty {
                 try? await markFeedReadUseCase.invoke()
             }
         } catch {
             errorMessage = error.localizedDescription
             isLoading = false
             isRefreshing = false
-        }
-    }
-
-    private func observeQualityThreshold() {
-        thresholdObserveTask = Task {
-            for await threshold in observeQualityThresholdUseCase.invoke() {
-                guard !Task.isCancelled else { return }
-                if let intThreshold = threshold as? Int32 {
-                    self.qualityThreshold = intThreshold
-                    if !self.allItems.isEmpty {
-                        self.feedItems = self.filterByQuality(self.allItems)
-                    }
-                }
-            }
-        }
-    }
-
-    private func filterByQuality(_ items: [FeedItem]) -> [FeedItem] {
-        guard qualityThreshold > 0 else { return items }
-        return items.filter { item in
-            let stats = item.stats
-            // Skip filtering for items with unknown stats (e.g., migrated cache entries)
-            if stats.downloadCount <= 0 && stats.favoriteCount <= 0 && stats.ratingCount <= 0 {
-                return true
-            }
-            let score = FeedQualityScoreHelper.calculate(stats: stats)
-            return score >= qualityThreshold
         }
     }
 

--- a/iosApp/iosApp/Features/Settings/ContentFilterSettingsView.swift
+++ b/iosApp/iosApp/Features/Settings/ContentFilterSettingsView.swift
@@ -83,7 +83,7 @@ struct ContentFilterSettingsView: View {
     }
 
     private var feedQualitySection: some View {
-        Section("Feed Quality") {
+        Section("Search Quality Filter") {
             VStack(alignment: .leading, spacing: Spacing.xs) {
                 HStack {
                     Text("Quality Threshold")
@@ -93,7 +93,7 @@ struct ContentFilterSettingsView: View {
                         .font(.civitBodySmall)
                         .foregroundColor(.civitOnSurfaceVariant)
                 }
-                Text("Filter low-quality models from your creator feed")
+                Text("Threshold for the quality filter in search results")
                     .font(.civitBodySmall)
                     .foregroundColor(.civitOnSurfaceVariant)
                 Slider(


### PR DESCRIPTION
## Description

- Remove automatic quality filtering from Feed (no user demand, risk of unintended filtering)
- Keep quality filter toggle in Search screen (opt-in, user-controlled)
- Rename Settings label "Feed Quality" → "Search Quality Filter"
- Simplify FeedViewModel (remove quality threshold dependency)

## Test Plan

- [x] Android build pass
- [x] SwiftLint pass (0 violations)
- [x] iOS build pass (BUILD SUCCEEDED)