### PR TITLE
Create desktopApp module with Compose Desktop shell (#467)

### DIFF
--- a/desktopApp/build.gradle.kts
+++ b/desktopApp/build.gradle.kts
@@ -1,0 +1,37 @@
+import org.jetbrains.compose.desktop.application.dsl.TargetFormat
+
+plugins {
+    alias(libs.plugins.kotlin.multiplatform)
+    alias(libs.plugins.compose.multiplatform)
+    alias(libs.plugins.compose.compiler)
+}
+
+kotlin {
+    jvm()
+
+    sourceSets {
+        jvmMain.dependencies {
+            implementation(project(":shared"))
+            implementation(project(":core:core-ui"))
+            implementation(compose.desktop.currentOs)
+            implementation(compose.material3)
+            implementation(compose.materialIconsExtended)
+            implementation(compose.foundation)
+            implementation(compose.ui)
+            implementation(libs.koin.core)
+            implementation(libs.coil.compose)
+            implementation(libs.coil.network.okhttp)
+        }
+    }
+}
+
+compose.desktop {
+    application {
+        mainClass = "com.riox432.civitdeck.MainKt"
+        nativeDistributions {
+            targetFormats(TargetFormat.Dmg, TargetFormat.Msi, TargetFormat.Deb)
+            packageName = "CivitDeck"
+            packageVersion = "1.0.0"
+        }
+    }
+}

--- a/desktopApp/src/jvmMain/kotlin/com/riox432/civitdeck/DesktopApp.kt
+++ b/desktopApp/src/jvmMain/kotlin/com/riox432/civitdeck/DesktopApp.kt
@@ -1,0 +1,92 @@
+package com.riox432.civitdeck
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.DynamicFeed
+import androidx.compose.material.icons.filled.FolderCopy
+import androidx.compose.material.icons.filled.Search
+import androidx.compose.material.icons.filled.Settings
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.NavigationRail
+import androidx.compose.material3.NavigationRailItem
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.unit.dp
+import com.riox432.civitdeck.ui.theme.CivitDeckTheme
+
+enum class DesktopTab(
+    val label: String,
+    val icon: ImageVector,
+) {
+    Search("Search", Icons.Default.Search),
+    Collections("Collections", Icons.Default.FolderCopy),
+    Feed("Feed", Icons.Default.DynamicFeed),
+    Settings("Settings", Icons.Default.Settings),
+}
+
+@Composable
+fun DesktopApp() {
+    CivitDeckTheme {
+        var selectedTab by remember { mutableStateOf(DesktopTab.Search) }
+
+        Surface(color = MaterialTheme.colorScheme.background) {
+            Row(modifier = Modifier.fillMaxSize()) {
+                DesktopNavigationRail(
+                    selectedTab = selectedTab,
+                    onTabSelected = { selectedTab = it },
+                )
+                DesktopContent(
+                    selectedTab = selectedTab,
+                    modifier = Modifier.weight(1f).fillMaxHeight(),
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun DesktopNavigationRail(
+    selectedTab: DesktopTab,
+    onTabSelected: (DesktopTab) -> Unit,
+) {
+    NavigationRail {
+        DesktopTab.entries.forEach { tab ->
+            NavigationRailItem(
+                selected = selectedTab == tab,
+                onClick = { onTabSelected(tab) },
+                icon = { Icon(tab.icon, contentDescription = tab.label) },
+                label = { Text(tab.label) },
+            )
+        }
+    }
+}
+
+@Composable
+private fun DesktopContent(
+    selectedTab: DesktopTab,
+    modifier: Modifier = Modifier,
+) {
+    Box(
+        modifier = modifier.padding(24.dp),
+        contentAlignment = Alignment.Center,
+    ) {
+        Text(
+            text = "${selectedTab.label} (coming soon)",
+            style = MaterialTheme.typography.headlineMedium,
+            color = MaterialTheme.colorScheme.onBackground,
+        )
+    }
+}

--- a/desktopApp/src/jvmMain/kotlin/com/riox432/civitdeck/Main.kt
+++ b/desktopApp/src/jvmMain/kotlin/com/riox432/civitdeck/Main.kt
@@ -1,0 +1,51 @@
+package com.riox432.civitdeck
+
+import androidx.compose.ui.unit.DpSize
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Window
+import androidx.compose.ui.window.WindowState
+import androidx.compose.ui.window.application
+import coil3.ImageLoader
+import coil3.PlatformContext
+import coil3.SingletonImageLoader
+import coil3.disk.DiskCache
+import coil3.memory.MemoryCache
+import coil3.request.crossfade
+import com.riox432.civitdeck.di.initKoin
+import okio.Path.Companion.toPath
+
+fun main() {
+    initKoin()
+    setupCoilImageLoader()
+
+    application {
+        Window(
+            onCloseRequest = ::exitApplication,
+            title = "CivitDeck",
+            state = WindowState(size = DpSize(1200.dp, 800.dp)),
+        ) {
+            window.minimumSize = java.awt.Dimension(800, 600)
+            DesktopApp()
+        }
+    }
+}
+
+private fun setupCoilImageLoader() {
+    val cacheDir = System.getProperty("user.home") + "/.civitdeck/image_cache"
+    SingletonImageLoader.setSafe {
+        ImageLoader.Builder(PlatformContext.INSTANCE)
+            .crossfade(true)
+            .memoryCache {
+                MemoryCache.Builder()
+                    .maxSizePercent(PlatformContext.INSTANCE, percent = 0.15)
+                    .build()
+            }
+            .diskCache {
+                DiskCache.Builder()
+                    .directory(cacheDir.toPath())
+                    .maxSizeBytes(256L * 1024 * 1024) // 256 MB
+                    .build()
+            }
+            .build()
+    }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -29,6 +29,7 @@ dependencyResolutionManagement {
 rootProject.name = "CivitDeck"
 include(":shared")
 include(":androidApp")
+include(":desktopApp")
 include(":core:core-domain")
 include(":core:core-network")
 include(":core:core-database")


### PR DESCRIPTION
## Description

- Create `desktopApp/` module with Compose Desktop application
- Window: 1200x800 default, 800x600 minimum, title "CivitDeck"
- NavigationRail sidebar with 4 tabs (Search, Collections, Feed, Settings)
- Simple enum-based state navigation (placeholder content per tab)
- Koin initialization reusing shared module's `initKoin()`
- Coil image loader with disk cache at `~/.civitdeck/image_cache/`
- CivitDeckTheme applied from KMP core-ui

## Related Issues

Closes #467

## Test Plan

- [x] `./gradlew :desktopApp:compileKotlinJvm` passes
- [x] `./gradlew :desktopApp:run` launches window with sidebar
- [x] `./gradlew :androidApp:assembleDebug` passes (no regression)
- [x] `./gradlew detekt` passes

## Breaking Changes

None