### PR TITLE
Fix iOS followup: double chevron, viewer button color, output resolution

### DIFF
--- a/iosApp/iosApp/Features/Collections/CollectionsScreen.swift
+++ b/iosApp/iosApp/Features/Collections/CollectionsScreen.swift
@@ -157,10 +157,6 @@ private struct CollectionRow: View {
                     .foregroundColor(.civitOnSurfaceVariant)
             }
             Spacer()
-            Image(systemName: "chevron.right")
-                .accessibilityHidden(true)
-                .foregroundColor(.civitOnSurfaceVariant)
-                .font(.caption)
         }
         .padding(.vertical, Spacing.xs)
     }

--- a/iosApp/iosApp/Features/ComfyUI/ComfyUIOutputDetailView.swift
+++ b/iosApp/iosApp/Features/ComfyUI/ComfyUIOutputDetailView.swift
@@ -103,7 +103,7 @@ private struct ComfyUIOutputDetailPage: View {
     // MARK: - Full Image
 
     private var fullImage: some View {
-        CachedAsyncImage(url: URL(string: image.imageUrl)) { phase in
+        CachedAsyncImage(url: URL(string: image.imageUrl), maxPixelSize: 1200) { phase in
             switch phase {
             case .success(let img):
                 img

--- a/iosApp/iosApp/Features/Detail/ModelDetailComponents.swift
+++ b/iosApp/iosApp/Features/Detail/ModelDetailComponents.swift
@@ -8,7 +8,6 @@ import Shared
 struct CarouselViewer: View {
     let images: [ModelImage]
     @Binding var selectedIndex: Int?
-    @Environment(\.dismiss) private var dismiss
     @State private var currentPage: Int = 0
     @State private var toastMessage: String?
     @State private var showShareSheet = false
@@ -61,7 +60,7 @@ struct CarouselViewer: View {
         VStack {
             HStack {
                 ViewerCircleButton(systemName: "xmark", label: "Close") {
-                    dismiss()
+                    selectedIndex = nil
                 }
                 Spacer()
             }
@@ -209,7 +208,6 @@ struct ImageGridSheet: View {
 struct GridImageViewer: View {
     let images: [ModelImage]
     @Binding var selectedIndex: Int?
-    @Environment(\.dismiss) private var dismiss
     @State private var currentPage: Int = 0
     @State private var toastMessage: String?
     @State private var showShareSheet = false
@@ -246,7 +244,7 @@ struct GridImageViewer: View {
             VStack {
                 HStack {
                     ViewerCircleButton(systemName: "xmark", label: "Close") {
-                        dismiss()
+                        selectedIndex = nil
                     }
                     Spacer()
                 }
@@ -335,11 +333,12 @@ struct ViewerCircleButton: View {
             SwiftUI.Image(systemName: systemName)
                 .font(.title3)
                 .fontWeight(.semibold)
-                .foregroundColor(.civitInverseOnSurface)
+                .foregroundColor(.white)
                 .padding(Spacing.smPlus)
                 .background(.ultraThinMaterial, in: Circle())
         }
         .accessibilityLabel(label ?? systemName)
+        .contentShape(Circle())
     }
 }
 


### PR DESCRIPTION
## Description

Follow-up fixes for iOS QA issues:

- **Double chevron in Collections** — Remove manual `chevron.right` from `CollectionRow` since `NavigationLink` already provides one
- **Viewer buttons invisible in dark mode** — Change `ViewerCircleButton` foreground from `.civitInverseOnSurface` (dark gray `#303034` in dark mode) to `.white` for consistent visibility on dark scrim
- **Close button not working** — Replace `dismiss()` with direct `selectedIndex = nil` for reliable fullScreenCover dismissal
- **Output image low resolution** — `CachedAsyncImage` was downsampling to 400px. Set `maxPixelSize: 1200` for ComfyUI output detail view

## Test Plan

- [x] SwiftLint pass (0 violations)
- [x] iOS build pass (BUILD SUCCEEDED)