### PR TITLE
Rewrite CarouselViewer/GridImageViewer to match working ImageViewerScreen pattern

### DIFF
--- a/iosApp/iosApp/Features/Detail/ModelDetailComponents.swift
+++ b/iosApp/iosApp/Features/Detail/ModelDetailComponents.swift
@@ -4,35 +4,49 @@ import SwiftUI
 import Shared
 
 // MARK: - Carousel Viewer
+// Follows the same proven pattern as ImageViewerScreen (Gallery):
+// - Pass all gesture callbacks to ZoomableImageView
+// - Conditional control visibility via controlsVisible + dragOffset
+// - Drag-to-dismiss with background opacity fade
+// - Direct selectedIndex = nil for dismiss (not @Environment(\.dismiss))
 
 struct CarouselViewer: View {
     let images: [ModelImage]
     @Binding var selectedIndex: Int?
-    @State private var currentPage: Int = 0
+
+    @State private var controlsVisible = true
+    @State private var dragOffset: CGFloat = 0
     @State private var toastMessage: String?
     @State private var showShareSheet = false
 
     var body: some View {
-        // Use fallback index during dismiss animation to prevent black screen
-        let displayIndex = selectedIndex ?? currentPage
-        ZStack {
-            Color.civitScrim.ignoresSafeArea()
+        if let index = selectedIndex {
+            ZStack {
+                Color.civitScrim
+                    .opacity(backgroundOpacity)
+                    .ignoresSafeArea()
 
-            if !images.isEmpty {
                 TabView(selection: Binding(
-                    get: { displayIndex },
-                    set: { selectedIndex = $0; currentPage = $0 }
+                    get: { index },
+                    set: { selectedIndex = $0 }
                 )) {
                     ForEach(Array(images.enumerated()), id: \.offset) { i, image in
                         if image.contentType == .video, let videoUrl = URL(string: image.url) {
-                            VideoPlayerView(url: videoUrl, autoPlay: i == displayIndex)
+                            VideoPlayerView(url: videoUrl, autoPlay: i == index)
                                 .ignoresSafeArea()
                                 .tag(i)
                         } else {
                             ZoomableImageView(
                                 url: image.url,
+                                onFocusModeChanged: { isFocusMode in
+                                    controlsVisible = !isFocusMode
+                                },
+                                onDismiss: {
+                                    selectedIndex = nil
+                                },
+                                onDragYChanged: { dragOffset = $0 },
                                 pageIndex: i,
-                                currentPageIndex: displayIndex
+                                currentPageIndex: index
                             )
                             .ignoresSafeArea()
                             .tag(i)
@@ -40,20 +54,28 @@ struct CarouselViewer: View {
                     }
                 }
                 .tabViewStyle(.page(indexDisplayMode: .automatic))
+
+                if controlsVisible && dragOffset == 0 {
+                    viewerControls(currentIndex: index)
+                        .transition(.opacity)
+                }
+
+                if let message = toastMessage {
+                    toastView(message: message)
+                }
             }
-
-            viewerControls(currentIndex: displayIndex)
-
-            if let message = toastMessage {
-                toastView(message: message)
+            .animation(MotionAnimation.fast, value: controlsVisible)
+            .sheet(isPresented: $showShareSheet) {
+                if let image = images[safe: index] {
+                    ShareSheet(items: [image.url])
+                }
             }
         }
-        .onAppear { currentPage = selectedIndex ?? 0 }
-        .sheet(isPresented: $showShareSheet) {
-            if let image = images[safe: displayIndex] {
-                ShareSheet(items: [image.url])
-            }
-        }
+    }
+
+    private var backgroundOpacity: Double {
+        let progress = abs(dragOffset) / 100
+        return Double(max(1.0 - progress / 4.0, 0.0))
     }
 
     private func viewerControls(currentIndex: Int) -> some View {
@@ -120,7 +142,7 @@ struct CarouselViewer: View {
             Text(message)
                 .font(.subheadline)
                 .fontWeight(.medium)
-                .foregroundColor(.civitInverseOnSurface)
+                .foregroundColor(.white)
                 .padding(.horizontal, Spacing.lg)
                 .padding(.vertical, Spacing.smPlus)
                 .background(.ultraThinMaterial, in: Capsule())
@@ -193,7 +215,7 @@ struct ImageGridSheet: View {
                 if image.contentType == .video {
                     SwiftUI.Image(systemName: "play.circle.fill")
                         .font(.civitIconLarge)
-                        .foregroundColor(.civitInverseOnSurface)
+                        .foregroundColor(.white)
                         .accessibilityHidden(true)
                 }
             }
@@ -203,35 +225,45 @@ struct ImageGridSheet: View {
     }
 }
 
-// MARK: - Grid Image Viewer
+// MARK: - Grid Image Viewer (same pattern as CarouselViewer)
 
 struct GridImageViewer: View {
     let images: [ModelImage]
     @Binding var selectedIndex: Int?
-    @State private var currentPage: Int = 0
+
+    @State private var controlsVisible = true
+    @State private var dragOffset: CGFloat = 0
     @State private var toastMessage: String?
     @State private var showShareSheet = false
 
     var body: some View {
-        let displayIndex = selectedIndex ?? currentPage
-        ZStack {
-            Color.civitScrim.ignoresSafeArea()
+        if let index = selectedIndex {
+            ZStack {
+                Color.civitScrim
+                    .opacity(backgroundOpacity)
+                    .ignoresSafeArea()
 
-            if !images.isEmpty {
                 TabView(selection: Binding(
-                    get: { displayIndex },
-                    set: { selectedIndex = $0; currentPage = $0 }
+                    get: { index },
+                    set: { selectedIndex = $0 }
                 )) {
                     ForEach(Array(images.enumerated()), id: \.offset) { i, image in
                         if image.contentType == .video, let videoUrl = URL(string: image.url) {
-                            VideoPlayerView(url: videoUrl, autoPlay: i == displayIndex)
+                            VideoPlayerView(url: videoUrl, autoPlay: i == index)
                                 .ignoresSafeArea()
                                 .tag(i)
                         } else {
                             ZoomableImageView(
                                 url: image.url,
+                                onFocusModeChanged: { isFocusMode in
+                                    controlsVisible = !isFocusMode
+                                },
+                                onDismiss: {
+                                    selectedIndex = nil
+                                },
+                                onDragYChanged: { dragOffset = $0 },
                                 pageIndex: i,
-                                currentPageIndex: displayIndex
+                                currentPageIndex: index
                             )
                             .ignoresSafeArea()
                             .tag(i)
@@ -239,51 +271,63 @@ struct GridImageViewer: View {
                     }
                 }
                 .tabViewStyle(.page(indexDisplayMode: .automatic))
+
+                if controlsVisible && dragOffset == 0 {
+                    viewerControls(currentIndex: index)
+                        .transition(.opacity)
+                }
+
+                if let message = toastMessage {
+                    VStack {
+                        Spacer()
+                        Text(message)
+                            .font(.subheadline)
+                            .fontWeight(.medium)
+                            .foregroundColor(.white)
+                            .padding(.horizontal, Spacing.lg)
+                            .padding(.vertical, Spacing.smPlus)
+                            .background(.ultraThinMaterial, in: Capsule())
+                            .padding(.bottom, Spacing.floatingOffset)
+                    }
+                    .transition(.opacity)
+                }
             }
-
-            VStack {
-                HStack {
-                    ViewerCircleButton(systemName: "xmark", label: "Close") {
-                        selectedIndex = nil
-                    }
-                    Spacer()
+            .animation(MotionAnimation.fast, value: controlsVisible)
+            .sheet(isPresented: $showShareSheet) {
+                if let image = images[safe: index] {
+                    ShareSheet(items: [image.url])
                 }
-                .padding(Spacing.lg)
-
-                Spacer()
-
-                HStack {
-                    Spacer()
-                    ViewerCircleButton(systemName: "arrow.down.to.line", label: "Download") {
-                        downloadImage(at: displayIndex)
-                    }
-                    ViewerCircleButton(systemName: "square.and.arrow.up", label: "Share") {
-                        showShareSheet = true
-                    }
-                }
-                .padding(Spacing.lg)
-            }
-
-            if let message = toastMessage {
-                VStack {
-                    Spacer()
-                    Text(message)
-                        .font(.subheadline)
-                        .fontWeight(.medium)
-                        .foregroundColor(.civitInverseOnSurface)
-                        .padding(.horizontal, Spacing.lg)
-                        .padding(.vertical, Spacing.smPlus)
-                        .background(.ultraThinMaterial, in: Capsule())
-                        .padding(.bottom, Spacing.floatingOffset)
-                }
-                .transition(.opacity)
             }
         }
-        .onAppear { currentPage = selectedIndex ?? 0 }
-        .sheet(isPresented: $showShareSheet) {
-            if let image = images[safe: displayIndex] {
-                ShareSheet(items: [image.url])
+    }
+
+    private var backgroundOpacity: Double {
+        let progress = abs(dragOffset) / 100
+        return Double(max(1.0 - progress / 4.0, 0.0))
+    }
+
+    private func viewerControls(currentIndex: Int) -> some View {
+        VStack {
+            HStack {
+                ViewerCircleButton(systemName: "xmark", label: "Close") {
+                    selectedIndex = nil
+                }
+                Spacer()
             }
+            .padding(Spacing.lg)
+
+            Spacer()
+
+            HStack {
+                Spacer()
+                ViewerCircleButton(systemName: "arrow.down.to.line", label: "Download") {
+                    downloadImage(at: currentIndex)
+                }
+                ViewerCircleButton(systemName: "square.and.arrow.up", label: "Share") {
+                    showShareSheet = true
+                }
+            }
+            .padding(Spacing.lg)
         }
     }
 
@@ -338,7 +382,6 @@ struct ViewerCircleButton: View {
                 .background(.ultraThinMaterial, in: Circle())
         }
         .accessibilityLabel(label ?? systemName)
-        .contentShape(Circle())
     }
 }
 

--- a/iosApp/iosApp/Features/Detail/ModelDetailScreen.swift
+++ b/iosApp/iosApp/Features/Detail/ModelDetailScreen.swift
@@ -197,20 +197,22 @@ struct ModelDetailScreen: View {
         let allImages = viewModel.selectedVersion?.images ?? []
         return allImages.filter { $0.isAllowedByFilter(viewModel.nsfwFilterLevel) }
     }
-
     private func imageCarousel(model: Model) -> some View {
         let images = filteredImages
         return Group {
             if !images.isEmpty {
                 TabView(selection: $currentCarouselPage) {
                     ForEach(Array(images.enumerated()), id: \.offset) { index, image in
-                        CivitAsyncImageView(imageUrl: image.url, aspectRatio: 1)
-                            .onTapGesture {
-                                selectedCarouselIndex = index
-                            }
-                            .accessibilityLabel("Image \(index + 1) of \(images.count)")
-                            .accessibilityAddTraits(.isButton)
-                            .tag(index)
+                        Button {
+                            selectedCarouselIndex = index
+                        } label: {
+                            CivitAsyncImageView(imageUrl: image.url, aspectRatio: 1)
+                        }
+                        .buttonStyle(.plain)
+                        .contentShape(Rectangle())
+                        .accessibilityLabel("Image \(index + 1) of \(images.count)")
+                        .accessibilityAddTraits(.isButton)
+                        .tag(index)
                     }
                 }
                 .tabViewStyle(.page(indexDisplayMode: .never))
@@ -340,7 +342,6 @@ struct ModelDetailScreen: View {
     }
 
     // MARK: - Version Selector
-
     @ViewBuilder
     private func versionSelector(model: Model) -> some View {
         let versions = model.modelVersions


### PR DESCRIPTION
## Description

Complete rewrite of CarouselViewer and GridImageViewer to follow the exact same pattern as the working ImageViewerScreen (Gallery).

### Root cause analysis
The Gallery's ImageViewerScreen works perfectly. The Model Detail's CarouselViewer was fundamentally broken because:
1. **Missing gesture callbacks** — ZoomableImageView was not receiving `onFocusModeChanged`, `onDismiss`, `onDragYChanged`
2. **No focus mode** — Controls were always visible, couldn't be toggled by single-tap
3. **No drag-to-dismiss** — Swipe down to dismiss didn't work
4. **Broken dismiss** — Used `dismiss()` or fallback patterns instead of direct `selectedIndex = nil`
5. **Carousel tap unresponsive** — `onTapGesture` inside `TabView(.page)` conflicts with swipe gesture

### Changes
- **CarouselViewer**: Full rewrite matching ImageViewerScreen pattern — conditional rendering via `if let index = selectedIndex`, all ZoomableImageView callbacks, `controlsVisible` + `dragOffset` state, background opacity fade
- **GridImageViewer**: Same rewrite
- **Image carousel tap**: Replaced `onTapGesture` with `Button` + `.buttonStyle(.plain)` + `.contentShape(Rectangle())` for reliable tap handling inside `TabView(.page)`
- **Button color**: White foreground for visibility on dark scrim

### SwiftUI best practices applied
- `fullScreenCover` content uses `if let` conditional rendering (not computed binding)
- Controls shown only when `controlsVisible && dragOffset == 0`
- All ZoomableImageView gesture callbacks properly wired
- Buttons use proper hit-test areas

## Test Plan
- [x] SwiftLint pass (0 violations)
- [x] iOS build pass (BUILD SUCCEEDED)