### PR TITLE
Fix UIKit gesture recognizers blocking SwiftUI overlay buttons

### DIFF
--- a/iosApp/iosApp/Features/Detail/ModelDetailScreen.swift
+++ b/iosApp/iosApp/Features/Detail/ModelDetailScreen.swift
@@ -203,16 +203,14 @@ struct ModelDetailScreen: View {
             if !images.isEmpty {
                 TabView(selection: $currentCarouselPage) {
                     ForEach(Array(images.enumerated()), id: \.offset) { index, image in
-                        Button {
-                            selectedCarouselIndex = index
-                        } label: {
-                            CivitAsyncImageView(imageUrl: image.url, aspectRatio: 1)
-                        }
-                        .buttonStyle(.plain)
-                        .contentShape(Rectangle())
-                        .accessibilityLabel("Image \(index + 1) of \(images.count)")
-                        .accessibilityAddTraits(.isButton)
-                        .tag(index)
+                        CivitAsyncImageView(imageUrl: image.url, aspectRatio: 1)
+                            .contentShape(Rectangle())
+                            .simultaneousGesture(TapGesture().onEnded {
+                                selectedCarouselIndex = index
+                            })
+                            .accessibilityLabel("Image \(index + 1) of \(images.count)")
+                            .accessibilityAddTraits(.isButton)
+                            .tag(index)
                     }
                 }
                 .tabViewStyle(.page(indexDisplayMode: .never))

--- a/iosApp/iosApp/Features/Gallery/ZoomableImageView.swift
+++ b/iosApp/iosApp/Features/Gallery/ZoomableImageView.swift
@@ -89,7 +89,30 @@ final class ZoomableImageViewController: UIViewController, UIScrollViewDelegate,
         _ gestureRecognizer: UIGestureRecognizer,
         shouldRecognizeSimultaneouslyWith otherGestureRecognizer: UIGestureRecognizer
     ) -> Bool {
-        true
+        // Only allow pan recognizer to fire simultaneously (needed for dismiss drag).
+        // Tap recognizers must NOT fire simultaneously — they interfere with
+        // SwiftUI overlay buttons (close, download, share).
+        gestureRecognizer == panRecognizer
+    }
+
+    func gestureRecognizer(
+        _ gestureRecognizer: UIGestureRecognizer,
+        shouldReceive touch: UITouch
+    ) -> Bool {
+        // For tap recognizers, ignore touches near screen edges where
+        // SwiftUI overlay buttons (close, download, share) live.
+        // This prevents the UIKit single-tap from consuming taps meant for buttons.
+        guard gestureRecognizer == singleTapRecognizer
+                || gestureRecognizer == doubleTapRecognizer else {
+            return true
+        }
+        let location = touch.location(in: view)
+        let bounds = view.bounds
+        let edgeInset: CGFloat = 80
+        let topSafe = bounds.minY + edgeInset
+        let bottomSafe = bounds.maxY - edgeInset
+        // Ignore taps in top or bottom edge areas where controls are placed
+        return location.y > topSafe && location.y < bottomSafe
     }
 
     override func viewDidLayoutSubviews() {


### PR DESCRIPTION
## Description

Root cause fix for image viewer buttons not responding to taps.

### Problem
ZoomableImageView (UIKit-based UIScrollView) has `singleTapRecognizer` and `doubleTapRecognizer` that cover the entire screen. These UIKit gesture recognizers intercept taps before SwiftUI overlay buttons (close, download, share) can receive them:

1. `shouldRecognizeSimultaneouslyWith` returning `true` for ALL gestures lets tap recognizers fire alongside SwiftUI
2. `singleTapRecognizer.require(toFail: doubleTapRecognizer)` adds 0.3s delay
3. Single tap toggles focus mode → controls disappear → button never receives tap

### Fixes

**ZoomableImageView.swift:**
- `shouldRecognizeSimultaneouslyWith` now returns `true` only for `panRecognizer` (needed for dismiss drag). Tap recognizers no longer fire simultaneously with other gestures.
- Added `shouldReceive touch:` — ignores taps in the top/bottom 80pt edge areas where overlay buttons live. This ensures SwiftUI buttons always receive taps in those regions.

**ModelDetailScreen.swift:**
- Carousel image tap: Changed from `Button` to `.simultaneousGesture(TapGesture())` — works reliably alongside `TabView(.page)` swipe gesture.

## Test Plan
- [x] SwiftLint pass (0 violations)
- [x] iOS build pass (BUILD SUCCEEDED)
- [ ] Manual: Tap × button in image viewer → should close
- [ ] Manual: Tap download/share buttons → should work
- [ ] Manual: Tap carousel image → should open fullscreen viewer
- [ ] Manual: Double-tap image center → should zoom
- [ ] Manual: Single-tap image center → should toggle controls visibility