### PR TITLE
Replace fullScreenCover with overlay for image viewer dismiss

### DIFF
--- a/iosApp/iosApp/Features/Detail/ModelDetailComponents.swift
+++ b/iosApp/iosApp/Features/Detail/ModelDetailComponents.swift
@@ -25,6 +25,7 @@ struct CarouselViewer: View {
                 Color.civitScrim
                     .opacity(backgroundOpacity)
                     .ignoresSafeArea()
+                    .onTapGesture { selectedIndex = nil }
 
                 TabView(selection: Binding(
                     get: { index },
@@ -42,7 +43,9 @@ struct CarouselViewer: View {
                                     controlsVisible = !isFocusMode
                                 },
                                 onDismiss: {
-                                    selectedIndex = nil
+                                    withAnimation(.easeOut(duration: 0.25)) {
+                                        selectedIndex = nil
+                                    }
                                 },
                                 onDragYChanged: { dragOffset = $0 },
                                 pageIndex: i,
@@ -64,6 +67,7 @@ struct CarouselViewer: View {
                     toastView(message: message)
                 }
             }
+            .transition(.opacity)
             .animation(MotionAnimation.fast, value: controlsVisible)
             .sheet(isPresented: $showShareSheet) {
                 if let image = images[safe: index] {
@@ -82,7 +86,9 @@ struct CarouselViewer: View {
         VStack {
             HStack {
                 ViewerCircleButton(systemName: "xmark", label: "Close") {
-                    selectedIndex = nil
+                    withAnimation(.easeOut(duration: 0.25)) {
+                        selectedIndex = nil
+                    }
                 }
                 Spacer()
             }
@@ -310,7 +316,9 @@ struct GridImageViewer: View {
         VStack {
             HStack {
                 ViewerCircleButton(systemName: "xmark", label: "Close") {
-                    selectedIndex = nil
+                    withAnimation(.easeOut(duration: 0.25)) {
+                        selectedIndex = nil
+                    }
                 }
                 Spacer()
             }

--- a/iosApp/iosApp/Features/Detail/ModelDetailScreen.swift
+++ b/iosApp/iosApp/Features/Detail/ModelDetailScreen.swift
@@ -100,14 +100,13 @@ struct ModelDetailScreen: View {
                 onCreateCollection: { viewModel.createCollectionAndAdd(name: $0) }
             )
         }
-        .fullScreenCover(isPresented: Binding(
-            get: { selectedCarouselIndex != nil },
-            set: { if !$0 { selectedCarouselIndex = nil } }
-        )) {
+        .overlay {
             CarouselViewer(
                 images: filteredImages,
                 selectedIndex: $selectedCarouselIndex
             )
+            .ignoresSafeArea()
+            .animation(.easeInOut(duration: 0.25), value: selectedCarouselIndex != nil)
         }
         .sheet(isPresented: $showImageGrid) {
             ImageGridSheet(
@@ -116,14 +115,13 @@ struct ModelDetailScreen: View {
                 onImageSelected: { gridSelectedIndex = $0 }
             )
         }
-        .fullScreenCover(isPresented: Binding(
-            get: { gridSelectedIndex != nil },
-            set: { if !$0 { gridSelectedIndex = nil } }
-        )) {
+        .overlay {
             GridImageViewer(
                 images: filteredImages,
                 selectedIndex: $gridSelectedIndex
             )
+            .ignoresSafeArea()
+            .animation(.easeInOut(duration: 0.25), value: gridSelectedIndex != nil)
         }
         .sheet(isPresented: $showComfyUIGeneration) {
             NavigationView {
@@ -205,9 +203,11 @@ struct ModelDetailScreen: View {
                     ForEach(Array(images.enumerated()), id: \.offset) { index, image in
                         CivitAsyncImageView(imageUrl: image.url, aspectRatio: 1)
                             .contentShape(Rectangle())
-                            .simultaneousGesture(TapGesture().onEnded {
-                                selectedCarouselIndex = index
-                            })
+                            .onTapGesture {
+                                withAnimation(.easeInOut(duration: 0.25)) {
+                                    selectedCarouselIndex = index
+                                }
+                            }
                             .accessibilityLabel("Image \(index + 1) of \(images.count)")
                             .accessibilityAddTraits(.isButton)
                             .tag(index)


### PR DESCRIPTION
## Description

Fixes black screen on dismiss and delayed tap issues by replacing `fullScreenCover` with `.overlay` for CarouselViewer and GridImageViewer.

### Problems with fullScreenCover
1. Setting `selectedIndex = nil` causes content to vanish before fullScreenCover finishes its dismiss animation → black screen
2. fullScreenCover's presentation adds latency to the tap → open flow

### Fix
- Use `.overlay { CarouselViewer(...) }` instead of `.fullScreenCover`
- CarouselViewer uses `if let index = selectedIndex` for conditional rendering — with overlay, this provides instant show/hide
- Added `.transition(.opacity)` and `withAnimation(.easeOut)` for smooth open/close
- Close button and drag-to-dismiss both use `withAnimation` for smooth fade-out

## Test Plan
- [x] SwiftLint pass
- [x] iOS build pass
- [ ] Manual: Tap carousel image → viewer opens instantly (no delay)
- [ ] Manual: Tap × → viewer closes with fade animation (no black screen)
- [ ] Manual: Drag down → dismiss with opacity fade