### PR TITLE
Fix viewer close causing navigation pop by removing withAnimation

### DIFF
--- a/iosApp/iosApp/Features/Detail/ModelDetailComponents.swift
+++ b/iosApp/iosApp/Features/Detail/ModelDetailComponents.swift
@@ -25,7 +25,6 @@ struct CarouselViewer: View {
                 Color.civitScrim
                     .opacity(backgroundOpacity)
                     .ignoresSafeArea()
-                    .onTapGesture { selectedIndex = nil }
 
                 TabView(selection: Binding(
                     get: { index },
@@ -43,9 +42,7 @@ struct CarouselViewer: View {
                                     controlsVisible = !isFocusMode
                                 },
                                 onDismiss: {
-                                    withAnimation(.easeOut(duration: 0.25)) {
-                                        selectedIndex = nil
-                                    }
+                                    selectedIndex = nil
                                 },
                                 onDragYChanged: { dragOffset = $0 },
                                 pageIndex: i,
@@ -67,7 +64,6 @@ struct CarouselViewer: View {
                     toastView(message: message)
                 }
             }
-            .transition(.opacity)
             .animation(MotionAnimation.fast, value: controlsVisible)
             .sheet(isPresented: $showShareSheet) {
                 if let image = images[safe: index] {
@@ -86,9 +82,7 @@ struct CarouselViewer: View {
         VStack {
             HStack {
                 ViewerCircleButton(systemName: "xmark", label: "Close") {
-                    withAnimation(.easeOut(duration: 0.25)) {
-                        selectedIndex = nil
-                    }
+                    selectedIndex = nil
                 }
                 Spacer()
             }
@@ -316,9 +310,7 @@ struct GridImageViewer: View {
         VStack {
             HStack {
                 ViewerCircleButton(systemName: "xmark", label: "Close") {
-                    withAnimation(.easeOut(duration: 0.25)) {
-                        selectedIndex = nil
-                    }
+                    selectedIndex = nil
                 }
                 Spacer()
             }

--- a/iosApp/iosApp/Features/Detail/ModelDetailScreen.swift
+++ b/iosApp/iosApp/Features/Detail/ModelDetailScreen.swift
@@ -106,7 +106,6 @@ struct ModelDetailScreen: View {
                 selectedIndex: $selectedCarouselIndex
             )
             .ignoresSafeArea()
-            .animation(.easeInOut(duration: 0.25), value: selectedCarouselIndex != nil)
         }
         .sheet(isPresented: $showImageGrid) {
             ImageGridSheet(
@@ -121,7 +120,6 @@ struct ModelDetailScreen: View {
                 selectedIndex: $gridSelectedIndex
             )
             .ignoresSafeArea()
-            .animation(.easeInOut(duration: 0.25), value: gridSelectedIndex != nil)
         }
         .sheet(isPresented: $showComfyUIGeneration) {
             NavigationView {
@@ -204,9 +202,7 @@ struct ModelDetailScreen: View {
                         CivitAsyncImageView(imageUrl: image.url, aspectRatio: 1)
                             .contentShape(Rectangle())
                             .onTapGesture {
-                                withAnimation(.easeInOut(duration: 0.25)) {
-                                    selectedCarouselIndex = index
-                                }
+                                selectedCarouselIndex = index
                             }
                             .accessibilityLabel("Image \(index + 1) of \(images.count)")
                             .accessibilityAddTraits(.isButton)


### PR DESCRIPTION
## Description

`withAnimation` on `selectedCarouselIndex` changes was animating the entire view hierarchy including navigation state, causing the screen to pop back to search on viewer dismiss.

### Fix
- Remove all `withAnimation` wrappers from `selectedIndex = nil` and `selectedCarouselIndex = index`
- Remove `.transition(.opacity)` and `.animation(value:)` on overlay containers
- Remove background `onTapGesture` (unnecessary gesture conflict source)
- State changes are now immediate — overlay shows/hides instantly via `if let` conditional rendering