### PR TITLE
Fix image viewer: fullScreenCover + non-optional index + dismiss()

### DIFF
--- a/iosApp/iosApp/Features/Detail/ModelDetailComponents.swift
+++ b/iosApp/iosApp/Features/Detail/ModelDetailComponents.swift
@@ -4,15 +4,13 @@ import SwiftUI
 import Shared
 
 // MARK: - Carousel Viewer
-// Follows the same proven pattern as ImageViewerScreen (Gallery):
-// - Pass all gesture callbacks to ZoomableImageView
-// - Conditional control visibility via controlsVisible + dragOffset
-// - Drag-to-dismiss with background opacity fade
-// - Direct selectedIndex = nil for dismiss (not @Environment(\.dismiss))
+// Uses fullScreenCover(isPresented:) with non-optional selectedIndex.
+// Close uses dismiss() — content stays alive during dismiss animation (no black screen).
 
 struct CarouselViewer: View {
     let images: [ModelImage]
-    @Binding var selectedIndex: Int?
+    @Binding var selectedIndex: Int
+    @Environment(\.dismiss) private var dismiss
 
     @State private var controlsVisible = true
     @State private var dragOffset: CGFloat = 0
@@ -20,19 +18,16 @@ struct CarouselViewer: View {
     @State private var showShareSheet = false
 
     var body: some View {
-        if let index = selectedIndex {
-            ZStack {
-                Color.civitScrim
-                    .opacity(backgroundOpacity)
-                    .ignoresSafeArea()
+        ZStack {
+            Color.civitScrim
+                .opacity(backgroundOpacity)
+                .ignoresSafeArea()
 
-                TabView(selection: Binding(
-                    get: { index },
-                    set: { selectedIndex = $0 }
-                )) {
+            if !images.isEmpty {
+                TabView(selection: $selectedIndex) {
                     ForEach(Array(images.enumerated()), id: \.offset) { i, image in
                         if image.contentType == .video, let videoUrl = URL(string: image.url) {
-                            VideoPlayerView(url: videoUrl, autoPlay: i == index)
+                            VideoPlayerView(url: videoUrl, autoPlay: i == selectedIndex)
                                 .ignoresSafeArea()
                                 .tag(i)
                         } else {
@@ -41,12 +36,10 @@ struct CarouselViewer: View {
                                 onFocusModeChanged: { isFocusMode in
                                     controlsVisible = !isFocusMode
                                 },
-                                onDismiss: {
-                                    selectedIndex = nil
-                                },
+                                onDismiss: { dismiss() },
                                 onDragYChanged: { dragOffset = $0 },
                                 pageIndex: i,
-                                currentPageIndex: index
+                                currentPageIndex: selectedIndex
                             )
                             .ignoresSafeArea()
                             .tag(i)
@@ -54,21 +47,21 @@ struct CarouselViewer: View {
                     }
                 }
                 .tabViewStyle(.page(indexDisplayMode: .automatic))
-
-                if controlsVisible && dragOffset == 0 {
-                    viewerControls(currentIndex: index)
-                        .transition(.opacity)
-                }
-
-                if let message = toastMessage {
-                    toastView(message: message)
-                }
             }
-            .animation(MotionAnimation.fast, value: controlsVisible)
-            .sheet(isPresented: $showShareSheet) {
-                if let image = images[safe: index] {
-                    ShareSheet(items: [image.url])
-                }
+
+            if controlsVisible && dragOffset == 0 {
+                viewerControls
+                    .transition(.opacity)
+            }
+
+            if let message = toastMessage {
+                toastView(message: message)
+            }
+        }
+        .animation(MotionAnimation.fast, value: controlsVisible)
+        .sheet(isPresented: $showShareSheet) {
+            if let image = images[safe: selectedIndex] {
+                ShareSheet(items: [image.url])
             }
         }
     }
@@ -78,11 +71,11 @@ struct CarouselViewer: View {
         return Double(max(1.0 - progress / 4.0, 0.0))
     }
 
-    private func viewerControls(currentIndex: Int) -> some View {
+    private var viewerControls: some View {
         VStack {
             HStack {
                 ViewerCircleButton(systemName: "xmark", label: "Close") {
-                    selectedIndex = nil
+                    dismiss()
                 }
                 Spacer()
             }
@@ -93,7 +86,7 @@ struct CarouselViewer: View {
             HStack {
                 Spacer()
                 ViewerCircleButton(systemName: "arrow.down.to.line", label: "Download") {
-                    downloadImage(at: currentIndex)
+                    downloadImage(at: selectedIndex)
                 }
                 ViewerCircleButton(systemName: "square.and.arrow.up", label: "Share") {
                     showShareSheet = true
@@ -225,11 +218,12 @@ struct ImageGridSheet: View {
     }
 }
 
-// MARK: - Grid Image Viewer (same pattern as CarouselViewer)
+// MARK: - Grid Image Viewer
 
 struct GridImageViewer: View {
     let images: [ModelImage]
-    @Binding var selectedIndex: Int?
+    @Binding var selectedIndex: Int
+    @Environment(\.dismiss) private var dismiss
 
     @State private var controlsVisible = true
     @State private var dragOffset: CGFloat = 0
@@ -237,19 +231,16 @@ struct GridImageViewer: View {
     @State private var showShareSheet = false
 
     var body: some View {
-        if let index = selectedIndex {
-            ZStack {
-                Color.civitScrim
-                    .opacity(backgroundOpacity)
-                    .ignoresSafeArea()
+        ZStack {
+            Color.civitScrim
+                .opacity(backgroundOpacity)
+                .ignoresSafeArea()
 
-                TabView(selection: Binding(
-                    get: { index },
-                    set: { selectedIndex = $0 }
-                )) {
+            if !images.isEmpty {
+                TabView(selection: $selectedIndex) {
                     ForEach(Array(images.enumerated()), id: \.offset) { i, image in
                         if image.contentType == .video, let videoUrl = URL(string: image.url) {
-                            VideoPlayerView(url: videoUrl, autoPlay: i == index)
+                            VideoPlayerView(url: videoUrl, autoPlay: i == selectedIndex)
                                 .ignoresSafeArea()
                                 .tag(i)
                         } else {
@@ -258,12 +249,10 @@ struct GridImageViewer: View {
                                 onFocusModeChanged: { isFocusMode in
                                     controlsVisible = !isFocusMode
                                 },
-                                onDismiss: {
-                                    selectedIndex = nil
-                                },
+                                onDismiss: { dismiss() },
                                 onDragYChanged: { dragOffset = $0 },
                                 pageIndex: i,
-                                currentPageIndex: index
+                                currentPageIndex: selectedIndex
                             )
                             .ignoresSafeArea()
                             .tag(i)
@@ -271,32 +260,32 @@ struct GridImageViewer: View {
                     }
                 }
                 .tabViewStyle(.page(indexDisplayMode: .automatic))
-
-                if controlsVisible && dragOffset == 0 {
-                    viewerControls(currentIndex: index)
-                        .transition(.opacity)
-                }
-
-                if let message = toastMessage {
-                    VStack {
-                        Spacer()
-                        Text(message)
-                            .font(.subheadline)
-                            .fontWeight(.medium)
-                            .foregroundColor(.white)
-                            .padding(.horizontal, Spacing.lg)
-                            .padding(.vertical, Spacing.smPlus)
-                            .background(.ultraThinMaterial, in: Capsule())
-                            .padding(.bottom, Spacing.floatingOffset)
-                    }
-                    .transition(.opacity)
-                }
             }
-            .animation(MotionAnimation.fast, value: controlsVisible)
-            .sheet(isPresented: $showShareSheet) {
-                if let image = images[safe: index] {
-                    ShareSheet(items: [image.url])
+
+            if controlsVisible && dragOffset == 0 {
+                viewerControls
+                    .transition(.opacity)
+            }
+
+            if let message = toastMessage {
+                VStack {
+                    Spacer()
+                    Text(message)
+                        .font(.subheadline)
+                        .fontWeight(.medium)
+                        .foregroundColor(.white)
+                        .padding(.horizontal, Spacing.lg)
+                        .padding(.vertical, Spacing.smPlus)
+                        .background(.ultraThinMaterial, in: Capsule())
+                        .padding(.bottom, Spacing.floatingOffset)
                 }
+                .transition(.opacity)
+            }
+        }
+        .animation(MotionAnimation.fast, value: controlsVisible)
+        .sheet(isPresented: $showShareSheet) {
+            if let image = images[safe: selectedIndex] {
+                ShareSheet(items: [image.url])
             }
         }
     }
@@ -306,11 +295,11 @@ struct GridImageViewer: View {
         return Double(max(1.0 - progress / 4.0, 0.0))
     }
 
-    private func viewerControls(currentIndex: Int) -> some View {
+    private var viewerControls: some View {
         VStack {
             HStack {
                 ViewerCircleButton(systemName: "xmark", label: "Close") {
-                    selectedIndex = nil
+                    dismiss()
                 }
                 Spacer()
             }
@@ -321,7 +310,7 @@ struct GridImageViewer: View {
             HStack {
                 Spacer()
                 ViewerCircleButton(systemName: "arrow.down.to.line", label: "Download") {
-                    downloadImage(at: currentIndex)
+                    downloadImage(at: selectedIndex)
                 }
                 ViewerCircleButton(systemName: "square.and.arrow.up", label: "Share") {
                     showShareSheet = true

--- a/iosApp/iosApp/Features/Detail/ModelDetailScreen.swift
+++ b/iosApp/iosApp/Features/Detail/ModelDetailScreen.swift
@@ -9,10 +9,12 @@ struct ModelDetailScreen: View {
     }
 
     @State private var isDescriptionExpanded = false
-    @State private var selectedCarouselIndex: Int?
+    @State private var showCarouselViewer = false
+    @State private var selectedCarouselIndex: Int = 0
     @State private var currentCarouselPage: Int = 0
     @State private var showImageGrid = false
-    @State private var gridSelectedIndex: Int?
+    @State private var showGridViewer = false
+    @State private var gridSelectedIndex: Int = 0
     @State private var showCollectionSheet = false
     @State private var showComfyUIGeneration = false
     @State private var showLinkSheet = false
@@ -100,26 +102,27 @@ struct ModelDetailScreen: View {
                 onCreateCollection: { viewModel.createCollectionAndAdd(name: $0) }
             )
         }
-        .overlay {
+        .fullScreenCover(isPresented: $showCarouselViewer) {
             CarouselViewer(
                 images: filteredImages,
                 selectedIndex: $selectedCarouselIndex
             )
-            .ignoresSafeArea()
         }
         .sheet(isPresented: $showImageGrid) {
             ImageGridSheet(
                 images: filteredImages,
                 onDismiss: { showImageGrid = false },
-                onImageSelected: { gridSelectedIndex = $0 }
+                onImageSelected: { idx in
+                    gridSelectedIndex = idx
+                    showGridViewer = true
+                }
             )
         }
-        .overlay {
+        .fullScreenCover(isPresented: $showGridViewer) {
             GridImageViewer(
                 images: filteredImages,
                 selectedIndex: $gridSelectedIndex
             )
-            .ignoresSafeArea()
         }
         .sheet(isPresented: $showComfyUIGeneration) {
             NavigationView {
@@ -203,6 +206,7 @@ struct ModelDetailScreen: View {
                             .contentShape(Rectangle())
                             .onTapGesture {
                                 selectedCarouselIndex = index
+                                showCarouselViewer = true
                             }
                             .accessibilityLabel("Image \(index + 1) of \(images.count)")
                             .accessibilityAddTraits(.isButton)


### PR DESCRIPTION
## Description

Proper fix for image viewer dismiss issues. Previous attempts (overlay, withAnimation) caused navigation pop and other regressions.

### Root cause of black screen
`fullScreenCover` content used `if let index = selectedIndex` — setting `selectedIndex = nil` to close made content vanish during the dismiss animation.

### Fix (standard SwiftUI pattern)
- **Separate presentation from content state**: `showCarouselViewer: Bool` controls fullScreenCover, `selectedCarouselIndex: Int` (non-optional) holds the page index
- **`dismiss()` for close**: `@Environment(\.dismiss)` triggers SwiftUI's built-in dismiss animation — content stays alive throughout
- **No `if let` in body**: Content always renders (no conditional unwrapping), so nothing disappears during dismiss
- Same fix applied to GridImageViewer

## Test Plan
- [x] SwiftLint pass
- [x] iOS build pass
- [ ] Tap carousel image → fullscreen viewer opens
- [ ] Tap × → smooth dismiss (no black screen)
- [ ] Swipe between images → works
- [ ] Drag down → dismiss