### PR TITLE
#560 Extend SocialShareSheet to all image screens

### DIFF
--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/CivitDeckApplication.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/CivitDeckApplication.kt
@@ -170,4 +170,5 @@ val androidModule = module {
     viewModel { FeedViewModel(get(), get(), get()) }
     viewModel { BackupViewModel(get(), get(), get()) }
     viewModel { PluginManagementViewModel(get(), get(), get(), get(), get(), get()) }
+    viewModel { com.riox432.civitdeck.ui.share.ShareViewModel(get(), get(), get(), get()) }
 }

--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/detail/ModelDetailScreen.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/detail/ModelDetailScreen.kt
@@ -1,6 +1,5 @@
 package com.riox432.civitdeck.ui.detail
 
-import android.content.Intent
 import androidx.compose.animation.ExperimentalSharedTransitionApi
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
@@ -37,6 +36,7 @@ import com.riox432.civitdeck.domain.model.HapticFeedbackType
 import com.riox432.civitdeck.domain.model.Model
 import com.riox432.civitdeck.domain.model.ModelFile
 import com.riox432.civitdeck.domain.model.ModelImage
+import com.riox432.civitdeck.domain.model.ShareHashtag
 import com.riox432.civitdeck.domain.model.filterByNsfwLevel
 import com.riox432.civitdeck.domain.model.stripCdnWidth
 import com.riox432.civitdeck.download.DownloadScheduler
@@ -45,9 +45,10 @@ import com.riox432.civitdeck.feature.detail.presentation.ModelDetailViewModel
 import com.riox432.civitdeck.ui.collections.AddToCollectionSheet
 import com.riox432.civitdeck.ui.components.rememberHapticFeedback
 import com.riox432.civitdeck.ui.qrcode.QRCodeSheet
+import com.riox432.civitdeck.ui.share.SocialShareSheet
 
 @Composable
-@Suppress("LongParameterList")
+@Suppress("LongParameterList", "LongMethod")
 fun ModelDetailScreen(
     viewModel: ModelDetailViewModel,
     modelId: Long,
@@ -64,6 +65,10 @@ fun ModelDetailScreen(
         ) -> Unit
     )? = null,
     sharedElementSuffix: String = "",
+    shareHashtags: List<ShareHashtag> = emptyList(),
+    onToggleShareHashtag: (String, Boolean) -> Unit = { _, _ -> },
+    onAddShareHashtag: (String) -> Unit = {},
+    onRemoveShareHashtag: (String) -> Unit = {},
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     val collections by viewModel.collections.collectAsStateWithLifecycle()
@@ -72,6 +77,7 @@ fun ModelDetailScreen(
     var showSendToPCSheet by remember { mutableStateOf(false) }
     var showQRCodeSheet by remember { mutableStateOf(false) }
     var showSubmitReviewSheet by remember { mutableStateOf(false) }
+    var showShareSheet by remember { mutableStateOf(false) }
     val haptic = rememberHapticFeedback()
     val context = LocalContext.current
 
@@ -96,6 +102,7 @@ fun ModelDetailScreen(
         onShowSendToPCSheet = { showSendToPCSheet = true },
         onShowQRCodeSheet = { showQRCodeSheet = true },
         onShowSubmitReviewSheet = { showSubmitReviewSheet = true },
+        onShowShareSheet = { showShareSheet = true },
     )
 
     ReviewSubmitHandler(
@@ -118,6 +125,16 @@ fun ModelDetailScreen(
         onDismissQRCode = { showQRCodeSheet = false },
         modelId = modelId,
     )
+
+    if (showShareSheet) {
+        SocialShareSheet(
+            hashtags = shareHashtags,
+            onToggleHashtag = onToggleShareHashtag,
+            onAddHashtag = onAddShareHashtag,
+            onRemoveHashtag = onRemoveShareHashtag,
+            onDismiss = { showShareSheet = false },
+        )
+    }
 }
 
 @Suppress("LongParameterList")
@@ -138,6 +155,7 @@ private fun ModelDetailScaffold(
     onShowSendToPCSheet: () -> Unit,
     onShowQRCodeSheet: () -> Unit,
     onShowSubmitReviewSheet: () -> Unit,
+    onShowShareSheet: () -> Unit = {},
 ) {
     Scaffold(
         topBar = {
@@ -150,6 +168,7 @@ private fun ModelDetailScaffold(
                 },
                 onAddToCollection = onShowCollectionSheet,
                 onShowQRCode = onShowQRCodeSheet,
+                onShareClick = onShowShareSheet,
             )
         },
         contentWindowInsets = WindowInsets(0, 0, 0, 0),
@@ -254,8 +273,8 @@ private fun ModelDetailTopBar(
     onFavoriteToggle: () -> Unit,
     onAddToCollection: () -> Unit,
     onShowQRCode: () -> Unit,
+    onShareClick: () -> Unit,
 ) {
-    val context = LocalContext.current
     TopAppBar(
         windowInsets = WindowInsets(0, 0, 0, 0),
         title = {
@@ -280,16 +299,7 @@ private fun ModelDetailTopBar(
             IconButton(onClick = onShowQRCode) {
                 Icon(Icons.Default.QrCode2, contentDescription = stringResource(R.string.cd_share_qr_code))
             }
-            IconButton(
-                onClick = {
-                    val model = uiState.model ?: return@IconButton
-                    val shareIntent = Intent(Intent.ACTION_SEND).apply {
-                        type = "text/plain"
-                        putExtra(Intent.EXTRA_TEXT, "https://civitai.com/models/${model.id}")
-                    }
-                    context.startActivity(Intent.createChooser(shareIntent, "Share model"))
-                },
-            ) {
+            IconButton(onClick = onShareClick) {
                 Icon(Icons.Default.Share, contentDescription = stringResource(R.string.cd_share))
             }
             IconButton(onClick = onFavoriteToggle) {

--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/externalserver/ExternalServerImageDetailScreen.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/externalserver/ExternalServerImageDetailScreen.kt
@@ -16,6 +16,7 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.ContentCopy
+import androidx.compose.material.icons.filled.Share
 import androidx.compose.material3.Card
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
@@ -26,6 +27,10 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.ContentScale
@@ -33,7 +38,9 @@ import androidx.compose.ui.platform.LocalContext
 import coil3.compose.SubcomposeAsyncImage
 import coil3.request.ImageRequest
 import coil3.request.crossfade
+import com.riox432.civitdeck.domain.model.ShareHashtag
 import com.riox432.civitdeck.feature.externalserver.domain.model.ServerImage
+import com.riox432.civitdeck.ui.share.SocialShareSheet
 import com.riox432.civitdeck.ui.theme.Spacing
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -41,8 +48,13 @@ import com.riox432.civitdeck.ui.theme.Spacing
 fun ExternalServerImageDetailScreen(
     image: ServerImage,
     onBack: () -> Unit,
+    shareHashtags: List<ShareHashtag> = emptyList(),
+    onToggleShareHashtag: (String, Boolean) -> Unit = { _, _ -> },
+    onAddShareHashtag: (String) -> Unit = {},
+    onRemoveShareHashtag: (String) -> Unit = {},
 ) {
     val context = LocalContext.current
+    var showShareSheet by remember { mutableStateOf(false) }
 
     Scaffold(
         topBar = {
@@ -51,6 +63,11 @@ fun ExternalServerImageDetailScreen(
                 navigationIcon = {
                     IconButton(onClick = onBack) {
                         Icon(Icons.AutoMirrored.Filled.ArrowBack, "Back")
+                    }
+                },
+                actions = {
+                    IconButton(onClick = { showShareSheet = true }) {
+                        Icon(Icons.Default.Share, contentDescription = "Share")
                     }
                 },
             )
@@ -91,6 +108,15 @@ fun ExternalServerImageDetailScreen(
                 MetadataGrid(image = image)
             }
         }
+    }
+    if (showShareSheet) {
+        SocialShareSheet(
+            hashtags = shareHashtags,
+            onToggleHashtag = onToggleShareHashtag,
+            onAddHashtag = onAddShareHashtag,
+            onRemoveHashtag = onRemoveShareHashtag,
+            onDismiss = { showShareSheet = false },
+        )
     }
 }
 

--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/gallery/ImageGalleryScreen.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/gallery/ImageGalleryScreen.kt
@@ -46,6 +46,7 @@ import com.riox432.civitdeck.domain.model.AspectRatioFilter
 import com.riox432.civitdeck.domain.model.Image
 import com.riox432.civitdeck.domain.model.MediaContentType
 import com.riox432.civitdeck.domain.model.NsfwBlurSettings
+import com.riox432.civitdeck.domain.model.ShareHashtag
 import com.riox432.civitdeck.domain.model.SortOrder
 import com.riox432.civitdeck.domain.model.TimePeriod
 import com.riox432.civitdeck.feature.gallery.presentation.ImageGalleryUiState
@@ -66,6 +67,10 @@ import com.riox432.civitdeck.ui.theme.Spacing
 fun ImageGalleryScreen(
     viewModel: ImageGalleryViewModel,
     onBack: () -> Unit,
+    shareHashtags: List<ShareHashtag> = emptyList(),
+    onToggleShareHashtag: (String, Boolean) -> Unit = { _, _ -> },
+    onAddShareHashtag: (String) -> Unit = {},
+    onRemoveShareHashtag: (String) -> Unit = {},
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
 
@@ -94,6 +99,10 @@ fun ImageGalleryScreen(
             initialIndex = uiState.selectedImageIndex!!,
             onDismiss = viewModel::onDismissViewer,
             onSavePrompt = viewModel::savePrompt,
+            shareHashtags = shareHashtags,
+            onToggleShareHashtag = onToggleShareHashtag,
+            onAddShareHashtag = onAddShareHashtag,
+            onRemoveShareHashtag = onRemoveShareHashtag,
         )
     }
 }

--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/gallery/ImageViewerOverlay.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/gallery/ImageViewerOverlay.kt
@@ -1,6 +1,5 @@
 package com.riox432.civitdeck.ui.gallery
 
-import android.content.Intent
 import android.widget.Toast
 import androidx.activity.compose.BackHandler
 import androidx.compose.animation.AnimatedVisibility
@@ -77,23 +76,41 @@ fun ImageViewerOverlay(
     initialIndex: Int,
     onDismiss: () -> Unit,
     onSavePrompt: (ImageGenerationMeta, String?) -> Unit = { _, _ -> },
+    shareHashtags: List<com.riox432.civitdeck.domain.model.ShareHashtag> = emptyList(),
+    onToggleShareHashtag: (String, Boolean) -> Unit = { _, _ -> },
+    onAddShareHashtag: (String) -> Unit = {},
+    onRemoveShareHashtag: (String) -> Unit = {},
 ) {
     Dialog(
         onDismissRequest = onDismiss,
         properties = DialogProperties(usePlatformDefaultWidth = false, decorFitsSystemWindows = false),
     ) {
         BackHandler(onBack = onDismiss)
-        ImageViewerContent(images, initialIndex, onDismiss, onSavePrompt)
+        ImageViewerContent(
+            images,
+            initialIndex,
+            onDismiss,
+            onSavePrompt,
+            shareHashtags,
+            onToggleShareHashtag,
+            onAddShareHashtag,
+            onRemoveShareHashtag,
+        )
     }
 }
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
+@Suppress("LongParameterList")
 private fun ImageViewerContent(
     images: List<ViewerImage>,
     initialIndex: Int,
     onDismiss: () -> Unit,
     onSavePrompt: (ImageGenerationMeta, String?) -> Unit,
+    shareHashtags: List<com.riox432.civitdeck.domain.model.ShareHashtag>,
+    onToggleShareHashtag: (String, Boolean) -> Unit,
+    onAddShareHashtag: (String) -> Unit,
+    onRemoveShareHashtag: (String) -> Unit,
 ) {
     val context = LocalContext.current
     val scope = rememberCoroutineScope()
@@ -102,6 +119,7 @@ private fun ImageViewerContent(
     var controlsVisible by remember { mutableStateOf(true) }
     val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
     var currentDragY by remember { mutableFloatStateOf(0f) }
+    var showShareSheet by remember { mutableStateOf(false) }
 
     Box(Modifier.fillMaxSize()) {
         // Layer 1: Background (stays in place, fades with drag)
@@ -133,7 +151,7 @@ private fun ImageViewerContent(
             controlsVisible && currentDragY == 0f,
             onDismiss,
             onInfoClick = { showMetadata = true },
-            onShareClick = { shareImage(context, it.url, it.meta) },
+            onShareClick = { showShareSheet = true },
             onDownloadClick = { image ->
                 scope.launch {
                     val success = ImageDownloader.download(context, image.url)
@@ -145,6 +163,16 @@ private fun ImageViewerContent(
     }
 
     ViewerMetadataSheet(images, pagerState, sheetState, showMetadata, { showMetadata = false }, onSavePrompt)
+
+    if (showShareSheet) {
+        com.riox432.civitdeck.ui.share.SocialShareSheet(
+            hashtags = shareHashtags,
+            onToggleHashtag = onToggleShareHashtag,
+            onAddHashtag = onAddShareHashtag,
+            onRemoveHashtag = onRemoveShareHashtag,
+            onDismiss = { showShareSheet = false },
+        )
+    }
 }
 
 private fun backgroundAlpha(dragY: Float): Float {
@@ -344,41 +372,6 @@ private fun ControlButton(onClick: () -> Unit, icon: ImageVector, label: String)
         ),
     ) {
         Icon(icon, contentDescription = label)
-    }
-}
-
-private fun shareImage(
-    context: android.content.Context,
-    imageUrl: String,
-    meta: ImageGenerationMeta?,
-) {
-    val text = formatShareText(imageUrl, meta)
-    val intent = Intent(Intent.ACTION_SEND).apply {
-        type = "text/plain"
-        putExtra(Intent.EXTRA_TEXT, text)
-    }
-    context.startActivity(Intent.createChooser(intent, "Share image"))
-}
-
-private fun formatShareText(imageUrl: String, meta: ImageGenerationMeta?): String {
-    return buildString {
-        appendLine(imageUrl)
-        if (meta != null) {
-            appendLine()
-            meta.prompt?.let { appendLine("Prompt: $it") }
-            meta.negativePrompt?.let { appendLine("Negative: $it") }
-            val params = listOfNotNull(
-                meta.model?.let { "Model: $it" },
-                meta.steps?.let { "Steps: $it" },
-                meta.cfgScale?.let { "CFG: $it" },
-                meta.sampler?.let { "Sampler: $it" },
-            )
-            if (params.isNotEmpty()) {
-                appendLine(params.joinToString(" | "))
-            }
-        }
-        appendLine()
-        append("Shared via CivitDeck")
     }
 }
 

--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/navigation/CivitDeckNavGraph.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/navigation/CivitDeckNavGraph.kt
@@ -123,6 +123,7 @@ import com.riox432.civitdeck.ui.settings.LicensesScreen
 import com.riox432.civitdeck.ui.settings.NavShortcutsSettingsScreen
 import com.riox432.civitdeck.ui.settings.SettingsScreen
 import com.riox432.civitdeck.ui.settings.StorageSettingsScreen
+import com.riox432.civitdeck.ui.share.ShareViewModel
 import com.riox432.civitdeck.ui.theme.Duration
 import com.riox432.civitdeck.ui.theme.Easing
 import org.koin.compose.viewmodel.koinViewModel
@@ -628,12 +629,18 @@ private fun EntryProviderScope<Any>.detailEntry(backStack: MutableList<Any>) {
         val viewModel: ModelDetailViewModel = koinViewModel(
             key = key.modelId.toString(),
         ) { parametersOf(key.modelId) }
+        val shareVm: ShareViewModel = koinViewModel()
         val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+        val shareHashtags by shareVm.hashtags.collectAsStateWithLifecycle()
         ModelDetailScreen(
             viewModel = viewModel,
             modelId = key.modelId,
             initialThumbnailUrl = key.thumbnailUrl,
             sharedElementSuffix = key.sharedElementSuffix,
+            shareHashtags = shareHashtags,
+            onToggleShareHashtag = shareVm::onToggle,
+            onAddShareHashtag = shareVm::onAdd,
+            onRemoveShareHashtag = shareVm::onRemove,
             onBack = { backStack.removeLastOrNull() },
             onViewImages = { modelVersionId ->
                 backStack.add(ImageGalleryRoute(modelVersionId))
@@ -724,9 +731,15 @@ private fun EntryProviderScope<Any>.galleryEntry(backStack: MutableList<Any>) {
         val viewModel: ImageGalleryViewModel = koinViewModel(
             key = "gallery_${key.modelVersionId}",
         ) { parametersOf(key.modelVersionId) }
+        val shareVm: ShareViewModel = koinViewModel()
+        val shareHashtags by shareVm.hashtags.collectAsStateWithLifecycle()
         ImageGalleryScreen(
             viewModel = viewModel,
             onBack = { backStack.removeLastOrNull() },
+            shareHashtags = shareHashtags,
+            onToggleShareHashtag = shareVm::onToggle,
+            onAddShareHashtag = shareVm::onAdd,
+            onRemoveShareHashtag = shareVm::onRemove,
         )
     }
 }
@@ -734,9 +747,15 @@ private fun EntryProviderScope<Any>.galleryEntry(backStack: MutableList<Any>) {
 private fun EntryProviderScope<Any>.browseImagesEntry(backStack: MutableList<Any>) {
     entry<BrowseImagesRoute> {
         val viewModel: ImageGalleryViewModel = koinViewModel(key = "browse_images") { parametersOf(0L) }
+        val shareVm: ShareViewModel = koinViewModel()
+        val shareHashtags by shareVm.hashtags.collectAsStateWithLifecycle()
         ImageGalleryScreen(
             viewModel = viewModel,
             onBack = { backStack.removeLastOrNull() },
+            shareHashtags = shareHashtags,
+            onToggleShareHashtag = shareVm::onToggle,
+            onAddShareHashtag = shareVm::onAdd,
+            onRemoveShareHashtag = shareVm::onRemove,
         )
     }
 }
@@ -970,12 +989,18 @@ private fun EntryProviderScope<Any>.externalServerEntries(backStack: MutableList
     }
     entry<ExternalServerImageDetailRoute> { route ->
         val galleryVm: ExternalServerGalleryViewModel = koinViewModel()
+        val shareVm: ShareViewModel = koinViewModel()
         val state by galleryVm.uiState.collectAsStateWithLifecycle()
+        val shareHashtags by shareVm.hashtags.collectAsStateWithLifecycle()
         val image = state.images.find { it.id == route.imageId }
         if (image != null) {
             ExternalServerImageDetailScreen(
                 image = image,
                 onBack = { backStack.removeLastOrNull() },
+                shareHashtags = shareHashtags,
+                onToggleShareHashtag = shareVm::onToggle,
+                onAddShareHashtag = shareVm::onAdd,
+                onRemoveShareHashtag = shareVm::onRemove,
             )
         }
     }

--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/share/ShareViewModel.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/share/ShareViewModel.kt
@@ -1,0 +1,39 @@
+package com.riox432.civitdeck.ui.share
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.riox432.civitdeck.domain.model.ShareHashtag
+import com.riox432.civitdeck.domain.usecase.AddShareHashtagUseCase
+import com.riox432.civitdeck.domain.usecase.ObserveShareHashtagsUseCase
+import com.riox432.civitdeck.domain.usecase.RemoveShareHashtagUseCase
+import com.riox432.civitdeck.domain.usecase.ToggleShareHashtagUseCase
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
+
+private const val STOP_TIMEOUT = 5_000L
+
+class ShareViewModel(
+    observeShareHashtags: ObserveShareHashtagsUseCase,
+    private val addShareHashtag: AddShareHashtagUseCase,
+    private val removeShareHashtag: RemoveShareHashtagUseCase,
+    private val toggleShareHashtag: ToggleShareHashtagUseCase,
+) : ViewModel() {
+
+    val hashtags: StateFlow<List<ShareHashtag>> =
+        observeShareHashtags()
+            .stateIn(viewModelScope, SharingStarted.WhileSubscribed(STOP_TIMEOUT), emptyList())
+
+    fun onToggle(tag: String, isEnabled: Boolean) {
+        viewModelScope.launch { toggleShareHashtag(tag, isEnabled) }
+    }
+
+    fun onAdd(tag: String) {
+        viewModelScope.launch { addShareHashtag(tag) }
+    }
+
+    fun onRemove(tag: String) {
+        viewModelScope.launch { removeShareHashtag(tag) }
+    }
+}

--- a/iosApp/iosApp/Features/Detail/ModelDetailScreen.swift
+++ b/iosApp/iosApp/Features/Detail/ModelDetailScreen.swift
@@ -21,6 +21,8 @@ struct ModelDetailScreen: View {
     @State private var showLinkSheet = false
     @State private var showQRCodeSheet = false
     @State private var showSubmitReviewSheet = false
+    @State private var showShareSheet = false
+    @StateObject private var shareHashtagVM = ShareHashtagViewModel()
 
     var body: some View {
         Group {
@@ -70,12 +72,11 @@ struct ModelDetailScreen: View {
                 }
             }
             ToolbarItem(placement: .navigationBarTrailing) {
-                if let model = viewModel.model,
-                   let url = URL(string: "https://civitai.com/models/\(model.id)") {
-                    ShareLink(item: url) {
-                        Image(systemName: "square.and.arrow.up")
-                            .accessibilityLabel("Share")
-                    }
+                Button {
+                    showShareSheet = true
+                } label: {
+                    Image(systemName: "square.and.arrow.up")
+                        .accessibilityLabel("Share")
                 }
             }
             ToolbarItem(placement: .navigationBarTrailing) {
@@ -95,6 +96,14 @@ struct ModelDetailScreen: View {
                 group.addTask { await viewModel.observeModelCollections() }
             }
         }
+        .sheet(isPresented: $showShareSheet) {
+            SocialShareSheet(hashtags: shareHashtagVM.hashtags,
+                             onToggle: { tag, e in shareHashtagVM.toggle(tag: tag, isEnabled: e) },
+                             onAdd: { shareHashtagVM.add(tag: $0) },
+                             onRemove: { shareHashtagVM.remove(tag: $0) })
+            .presentationDetents([.medium, .large])
+        }
+        .task { await shareHashtagVM.startObserving() }
         .sheet(isPresented: $showCollectionSheet) {
             AddToCollectionSheet(
                 collections: viewModel.collections,
@@ -150,7 +159,6 @@ struct ModelDetailScreen: View {
     }
 
     // MARK: - Content
-
     private func modelContent(model: Model) -> some View {
         ScrollView {
             VStack(spacing: Spacing.lg) {
@@ -192,7 +200,6 @@ struct ModelDetailScreen: View {
     }
 
     // MARK: - Image Carousel
-
     private var filteredImages: [ModelImage] {
         let allImages = viewModel.selectedVersion?.images ?? []
         return allImages.filter { $0.isAllowedByFilter(viewModel.nsfwFilterLevel) }
@@ -221,7 +228,6 @@ struct ModelDetailScreen: View {
     }
 
     // MARK: - Model Header
-
     private func modelHeader(model: Model) -> some View {
         VStack(alignment: .leading, spacing: Spacing.xs) {
             Text(model.name)
@@ -250,7 +256,6 @@ struct ModelDetailScreen: View {
     }
 
     // MARK: - Image Actions Row
-
     private func imageActionsRow(modelVersionId: Int64) -> some View {
         VStack(spacing: Spacing.sm) {
             HStack(spacing: Spacing.sm) {
@@ -298,7 +303,6 @@ struct ModelDetailScreen: View {
     }
 
     // MARK: - Tags Section
-
     @ViewBuilder
     private func tagsSection(tags: [String]) -> some View {
         if !tags.isEmpty {
@@ -314,7 +318,6 @@ struct ModelDetailScreen: View {
     }
 
     // MARK: - Description Section
-
     @ViewBuilder
     private func descriptionSection(description: String?) -> some View {
         if let description, !description.isEmpty {
@@ -386,7 +389,6 @@ struct ModelDetailScreen: View {
     }
 
     // MARK: - Version Detail
-
     @ViewBuilder
     private var versionDetail: some View {
         if let version = viewModel.selectedVersion {
@@ -418,7 +420,6 @@ struct ModelDetailScreen: View {
 }
 
 // MARK: - Civitai Link Send
-
 @MainActor
 private class CivitaiLinkSendViewModel: ObservableObject {
     @Published var status: CivitaiLinkStatus = .disconnected

--- a/iosApp/iosApp/Features/ExternalServer/ExternalServerImageDetailView.swift
+++ b/iosApp/iosApp/Features/ExternalServer/ExternalServerImageDetailView.swift
@@ -4,6 +4,8 @@ import Shared
 struct ExternalServerImageDetailView: View {
     let image: ServerImage
     @Environment(\.dismiss) private var dismiss
+    @State private var showShareSheet = false
+    @StateObject private var shareHashtagVM = ShareHashtagViewModel()
 
     var body: some View {
         ScrollView {
@@ -37,7 +39,25 @@ struct ExternalServerImageDetailView: View {
             ToolbarItem(placement: .cancellationAction) {
                 Button("Close") { dismiss() }
             }
+            ToolbarItem(placement: .topBarTrailing) {
+                Button {
+                    showShareSheet = true
+                } label: {
+                    Image(systemName: "square.and.arrow.up")
+                        .accessibilityLabel("Share")
+                }
+            }
         }
+        .sheet(isPresented: $showShareSheet) {
+            SocialShareSheet(
+                hashtags: shareHashtagVM.hashtags,
+                onToggle: { tag, enabled in shareHashtagVM.toggle(tag: tag, isEnabled: enabled) },
+                onAdd: { tag in shareHashtagVM.add(tag: tag) },
+                onRemove: { tag in shareHashtagVM.remove(tag: tag) }
+            )
+            .presentationDetents([.medium, .large])
+        }
+        .task { await shareHashtagVM.startObserving() }
     }
 }
 

--- a/iosApp/iosApp/Features/Gallery/ImageViewerScreen.swift
+++ b/iosApp/iosApp/Features/Gallery/ImageViewerScreen.swift
@@ -10,6 +10,7 @@ struct ImageViewerScreen: View {
     @State private var showMetadata = false
     @State private var controlsVisible = true
     @State private var showShareSheet = false
+    @StateObject private var shareHashtagVM = ShareHashtagViewModel()
 
     // Swipe-to-dismiss state
     @State private var dragOffset: CGFloat = 0
@@ -90,11 +91,15 @@ struct ImageViewerScreen: View {
                 }
             }
             .sheet(isPresented: $showShareSheet) {
-                if let image = images[safe: index] {
-                    let text = Self.formatShareText(imageUrl: image.url, meta: image.meta)
-                    ShareSheet(items: [text])
-                }
+                SocialShareSheet(
+                    hashtags: shareHashtagVM.hashtags,
+                    onToggle: { tag, enabled in shareHashtagVM.toggle(tag: tag, isEnabled: enabled) },
+                    onAdd: { tag in shareHashtagVM.add(tag: tag) },
+                    onRemove: { tag in shareHashtagVM.remove(tag: tag) }
+                )
+                .presentationDetents([.medium, .large])
             }
+            .task { await shareHashtagVM.startObserving() }
         }
     }
 


### PR DESCRIPTION
## Description

- Add `SocialShareSheet` with hashtag management to **External Server image detail**, **Image Gallery viewer**, and **Model detail** screens (Android + iOS)
- Create lightweight `ShareViewModel` (Android) for hashtag state management independent of `ComfyUIHistoryViewModel`
- Replace existing plain-text share (`Intent.ACTION_SEND` / `ShareLink`) with `SocialShareSheet` on Model detail and Gallery viewer
- iOS uses `ShareHashtagViewModel` (@StateObject) on each screen

## Related Issues

Closes #560

## Screenshots / Video

<!-- If applicable, add screenshots or screen recordings -->

## Test Plan

- [x] Ran detekt — zero issues
- [x] Ran SwiftLint — zero violations
- [x] Android debug build succeeds
- [x] iOS Simulator build succeeds

## Review Checklist

- [x] Code follows project architecture (Clean Architecture + MVVM)
- [x] Shared logic is in `commonMain`, platform-specific code only when necessary
- [x] No unnecessary dependencies added
- [x] Tests added/updated as needed

## Breaking Changes

None