### PR TITLE
Bump version to v2.0.0

### DIFF
--- a/androidApp/build.gradle.kts
+++ b/androidApp/build.gradle.kts
@@ -10,8 +10,8 @@ android {
 
     defaultConfig {
         applicationId = "com.riox432.civitdeck"
-        versionCode = 3
-        versionName = "1.2.0"
+        versionCode = 4
+        versionName = "2.0.0"
     }
 
     buildFeatures {

--- a/desktopApp/build.gradle.kts
+++ b/desktopApp/build.gradle.kts
@@ -35,7 +35,7 @@ compose.desktop {
         nativeDistributions {
             targetFormats(TargetFormat.Dmg, TargetFormat.Msi, TargetFormat.Deb, TargetFormat.Rpm)
             packageName = "CivitDeck"
-            packageVersion = "1.0.0"
+            packageVersion = "2.0.0"
             description = "Browse and manage CivitAI models from your desktop"
             vendor = "riox432"
 

--- a/iosApp/iosApp/Info.plist
+++ b/iosApp/iosApp/Info.plist
@@ -15,9 +15,9 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.2</string>
+	<string>2.0</string>
 	<key>CFBundleVersion</key>
-	<string>3</string>
+	<string>4</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>CADisableMinimumFrameDurationOnPhone</key>


### PR DESCRIPTION
## Description

Bump version to 2.0.0 across all platforms to mark Desktop support and feature completeness.

- Android: `1.2.0` (versionCode 3) → `2.0.0` (versionCode 4)
- iOS: `1.2` (build 3) → `2.0` (build 4)
- Desktop: `1.0.0` → `2.0.0`