### PR TITLE
Fix thread-safety: unsynchronized mutable collections (#611)

### DIFF
--- a/feature/feature-detail/src/commonMain/kotlin/com/riox432/civitdeck/feature/detail/presentation/ModelDetailViewModel.kt
+++ b/feature/feature-detail/src/commonMain/kotlin/com/riox432/civitdeck/feature/detail/presentation/ModelDetailViewModel.kt
@@ -101,7 +101,7 @@ class ModelDetailViewModel(
 
     private val _uiState = MutableStateFlow(ModelDetailUiState())
     val uiState: StateFlow<ModelDetailUiState> = _uiState.asStateFlow()
-    private val enrichedVersionIds = mutableSetOf<Long>()
+    private val enrichedVersionIds = MutableStateFlow<Set<Long>>(emptySet())
     private var viewStartTimeMs: Long = 0L
 
     private val _downloadEnqueuedEvent = MutableSharedFlow<Long>(extraBufferCapacity = 1)
@@ -239,7 +239,16 @@ class ModelDetailViewModel(
         val state = _uiState.value
         val model = state.model ?: return
         val version = model.modelVersions.getOrNull(state.selectedVersionIndex) ?: return
-        if (!enrichedVersionIds.add(version.id)) return
+        var alreadyEnriched = false
+        enrichedVersionIds.update { ids ->
+            if (version.id in ids) {
+                alreadyEnriched = true
+                ids
+            } else {
+                ids + version.id
+            }
+        }
+        if (alreadyEnriched) return
         viewModelScope.launch {
             try {
                 val enriched = enrichModelImagesUseCase(version.id, version.images)
@@ -253,7 +262,7 @@ class ModelDetailViewModel(
             } catch (e: CancellationException) {
                 throw e
             } catch (_: Exception) {
-                enrichedVersionIds.remove(version.id)
+                enrichedVersionIds.update { it - version.id }
             }
         }
     }

--- a/feature/feature-search/src/commonMain/kotlin/com/riox432/civitdeck/feature/search/presentation/SwipeDiscoveryViewModel.kt
+++ b/feature/feature-search/src/commonMain/kotlin/com/riox432/civitdeck/feature/search/presentation/SwipeDiscoveryViewModel.kt
@@ -35,10 +35,8 @@ class SwipeDiscoveryViewModel(
 
     companion object {
         /** Persists dismissed model IDs across ViewModel recreations within the same session. */
-        private val sessionDismissedIds = mutableSetOf<Long>()
+        private val sessionDismissedIds = MutableStateFlow<Set<Long>>(emptySet())
     }
-
-    private val dismissedIds = sessionDismissedIds
 
     init {
         loadModels()
@@ -52,7 +50,7 @@ class SwipeDiscoveryViewModel(
                 val models = getDiscoveryModels()
                 _state.update { current ->
                     val existingIds = current.cards.map { it.id }.toSet()
-                    val allSeenIds = existingIds + dismissedIds
+                    val allSeenIds = existingIds + sessionDismissedIds.value
                     val newModels = models.filterNot { it.id in allSeenIds }
                     current.copy(cards = current.cards + newModels, isLoading = false)
                 }
@@ -90,7 +88,7 @@ class SwipeDiscoveryViewModel(
     }
 
     private fun removeTopCard(model: Model, wasFavorited: Boolean) {
-        dismissedIds.add(model.id)
+        sessionDismissedIds.update { it + model.id }
         _state.update {
             it.copy(
                 cards = it.cards.filterNot { card -> card.id == model.id },


### PR DESCRIPTION
## Description

Replace unsynchronized `mutableSetOf<Long>()` with `MutableStateFlow<Set<Long>>` in two ViewModels to prevent data races from concurrent coroutine access.

- **ModelDetailViewModel.enrichedVersionIds**: Used atomic `update {}` for add/check and removal on error
- **SwipeDiscoveryViewModel.sessionDismissedIds** (companion object): Replaced with `MutableStateFlow` and switched all access sites to `.value` / `.update {}`

## Related Issues

Closes #611

## Screenshots / Video

N/A — internal thread-safety fix, no UI changes.

## Test Plan

- [x] `./gradlew detekt` passes (ran twice)
- [ ] Verify model detail enrichment still works (select version tabs)
- [ ] Verify swipe discovery filtering still excludes dismissed models

## Review Checklist

- [x] Code follows project architecture (Clean Architecture + MVVM)
- [x] Shared logic is in `commonMain`, platform-specific code only when necessary
- [x] No unnecessary dependencies added
- [x] Tests added/updated as needed

## Breaking Changes

None