### PR TITLE
Remove unused parallaxOffset computation (#616)

### DIFF
--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/search/ModelGridSection.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/search/ModelGridSection.kt
@@ -65,7 +65,6 @@ import com.riox432.civitdeck.ui.components.LaunchStaggerAnimation
 import com.riox432.civitdeck.ui.components.ModelCard
 import com.riox432.civitdeck.ui.components.SwipeableModelCard
 import com.riox432.civitdeck.ui.components.isReducedMotionEnabled
-import com.riox432.civitdeck.ui.components.rememberGridItemScrollOffset
 import com.riox432.civitdeck.ui.theme.Duration
 import com.riox432.civitdeck.ui.theme.Easing
 import com.riox432.civitdeck.ui.theme.Spacing
@@ -268,7 +267,7 @@ private fun ModelGrid(
     ) {
         recommendationItems(recommendations, onModelClick)
         modelPagingItems(
-            lazyPagingItems, gridState, ownedHashes, favoriteIds,
+            lazyPagingItems, ownedHashes, favoriteIds,
             isComparing, reducedMotion, onModelClick, onHideModel,
             onToggleFavorite, onCompareModel,
         )
@@ -297,7 +296,6 @@ private fun androidx.compose.foundation.lazy.grid.LazyGridScope.recommendationIt
 @Suppress("LongParameterList")
 private fun androidx.compose.foundation.lazy.grid.LazyGridScope.modelPagingItems(
     lazyPagingItems: LazyPagingItems<Model>,
-    gridState: LazyGridState,
     ownedHashes: Set<String>,
     favoriteIds: Set<Long>,
     isComparing: Boolean,
@@ -317,8 +315,6 @@ private fun androidx.compose.foundation.lazy.grid.LazyGridScope.modelPagingItems
             .firstOrNull()?.images?.firstOrNull()?.thumbnailUrl()
         val isOwned = ownedHashes.isNotEmpty() && model.isOwnedBy(ownedHashes)
 
-        @Suppress("UnusedPrivateProperty")
-        val parallaxOffset = rememberGridItemScrollOffset(gridState, index)
         val staggerAnimatable = remember { Animatable(0f) }
         LaunchStaggerAnimation(index = index, animatable = staggerAnimatable, reducedMotion = reducedMotion)
         ModelGridItem(

--- a/core/core-ui/src/commonMain/kotlin/com/riox432/civitdeck/ui/components/AnimationUtils.kt
+++ b/core/core-ui/src/commonMain/kotlin/com/riox432/civitdeck/ui/components/AnimationUtils.kt
@@ -4,11 +4,8 @@ import androidx.compose.animation.core.Animatable
 import androidx.compose.animation.core.AnimationVector1D
 import androidx.compose.animation.core.spring
 import androidx.compose.animation.core.tween
-import androidx.compose.foundation.lazy.grid.LazyGridState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.derivedStateOf
-import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.composed
@@ -108,28 +105,4 @@ fun Modifier.springScale(
         scaleX = scale.value
         scaleY = scale.value
     }
-}
-
-/**
- * Calculates the approximate scroll offset for a grid item at the given
- * [itemIndex] relative to the visible viewport center.
- */
-@Composable
-fun rememberGridItemScrollOffset(
-    gridState: LazyGridState,
-    itemIndex: Int,
-): Float {
-    val offset by remember(gridState) {
-        derivedStateOf {
-            val visibleItems = gridState.layoutInfo.visibleItemsInfo
-            val item = visibleItems.firstOrNull { it.index == itemIndex }
-                ?: return@derivedStateOf 0f
-            val viewportHeight = gridState.layoutInfo.viewportEndOffset -
-                gridState.layoutInfo.viewportStartOffset
-            val itemCenter = item.offset.y + item.size.height / 2f
-            val viewportCenter = viewportHeight / 2f
-            itemCenter - viewportCenter
-        }
-    }
-    return offset
 }


### PR DESCRIPTION
Closes #616

## Description

- Removed unused `parallaxOffset` variable and its `@Suppress("UnusedPrivateProperty")` annotation from `ModelGridSection.kt`
- Removed `gridState` parameter from `modelPagingItems()` since it was only used for the parallax computation
- Removed `rememberGridItemScrollOffset()` function from `AnimationUtils.kt` as it had no remaining callers
- Cleaned up 3 now-unused imports from `AnimationUtils.kt` (`LazyGridState`, `derivedStateOf`, `getValue`)