### PR TITLE
Fix non-atomic state updates in Desktop ViewModels (#621)

### DIFF
--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/analytics/AnalyticsViewModel.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/analytics/AnalyticsViewModel.kt
@@ -9,6 +9,7 @@ import com.riox432.civitdeck.domain.usecase.GetBrowsingStatsUseCase
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 
 data class AnalyticsUiState(
@@ -41,7 +42,7 @@ class AnalyticsViewModel(
 
     private fun loadStats() {
         viewModelScope.launch {
-            _uiState.value = _uiState.value.copy(isLoading = true, error = null)
+            _uiState.update { it.copy(isLoading = true, error = null) }
             try {
                 val stats: BrowsingStats = getBrowsingStatsUseCase()
                 _uiState.value = AnalyticsUiState(
@@ -58,10 +59,12 @@ class AnalyticsViewModel(
             } catch (e: CancellationException) {
                 throw e
             } catch (e: Exception) {
-                _uiState.value = _uiState.value.copy(
-                    isLoading = false,
-                    error = e.message ?: "Failed to load stats",
-                )
+                _uiState.update {
+                    it.copy(
+                        isLoading = false,
+                        error = e.message ?: "Failed to load stats",
+                    )
+                }
             }
         }
     }

--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/feed/FeedViewModel.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/feed/FeedViewModel.kt
@@ -9,6 +9,7 @@ import com.riox432.civitdeck.domain.usecase.MarkFeedReadUseCase
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 
 data class FeedUiState(
@@ -45,27 +46,33 @@ class FeedViewModel(
 
     private fun loadFeed(forceRefresh: Boolean = false) {
         viewModelScope.launch {
-            _uiState.value = _uiState.value.copy(
-                isLoading = !forceRefresh && _uiState.value.feedItems.isEmpty(),
-                isRefreshing = forceRefresh,
-                error = null,
-            )
+            _uiState.update {
+                it.copy(
+                    isLoading = !forceRefresh && it.feedItems.isEmpty(),
+                    isRefreshing = forceRefresh,
+                    error = null,
+                )
+            }
             try {
                 val items = getCreatorFeedUseCase(forceRefresh)
-                _uiState.value = _uiState.value.copy(
-                    feedItems = items,
-                    isLoading = false,
-                    isRefreshing = false,
-                )
+                _uiState.update {
+                    it.copy(
+                        feedItems = items,
+                        isLoading = false,
+                        isRefreshing = false,
+                    )
+                }
                 if (items.isNotEmpty()) markFeedReadUseCase()
             } catch (e: CancellationException) {
                 throw e
             } catch (e: Exception) {
-                _uiState.value = _uiState.value.copy(
-                    isLoading = false,
-                    isRefreshing = false,
-                    error = e.message ?: "Failed to load feed",
-                )
+                _uiState.update {
+                    it.copy(
+                        isLoading = false,
+                        isRefreshing = false,
+                        error = e.message ?: "Failed to load feed",
+                    )
+                }
             }
         }
     }
@@ -73,7 +80,7 @@ class FeedViewModel(
     private fun observeUnreadCount() {
         viewModelScope.launch {
             getUnreadFeedCountUseCase().collect { count ->
-                _uiState.value = _uiState.value.copy(unreadCount = count)
+                _uiState.update { it.copy(unreadCount = count) }
             }
         }
     }

--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/plugin/PluginManagementViewModel.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/plugin/PluginManagementViewModel.kt
@@ -13,6 +13,7 @@ import com.riox432.civitdeck.domain.usecase.UpdatePluginConfigUseCase
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 
 data class PluginManagementUiState(
@@ -41,10 +42,7 @@ class PluginManagementViewModel(
     private fun observePlugins() {
         viewModelScope.launch {
             observeInstalledPluginsUseCase().collect { plugins ->
-                _uiState.value = _uiState.value.copy(
-                    plugins = plugins,
-                    isLoading = false,
-                )
+                _uiState.update { it.copy(plugins = plugins, isLoading = false) }
             }
         }
     }
@@ -60,9 +58,7 @@ class PluginManagementViewModel(
             } catch (e: CancellationException) {
                 throw e
             } catch (e: Exception) {
-                _uiState.value = _uiState.value.copy(
-                    error = e.message ?: "Failed to toggle plugin",
-                )
+                _uiState.update { it.copy(error = e.message ?: "Failed to toggle plugin") }
             }
         }
     }
@@ -71,13 +67,11 @@ class PluginManagementViewModel(
         viewModelScope.launch {
             try {
                 val config = getPluginConfigUseCase(pluginId)
-                _uiState.value = _uiState.value.copy(selectedPluginConfig = config)
+                _uiState.update { it.copy(selectedPluginConfig = config) }
             } catch (e: CancellationException) {
                 throw e
             } catch (e: Exception) {
-                _uiState.value = _uiState.value.copy(
-                    error = e.message ?: "Failed to load config",
-                )
+                _uiState.update { it.copy(error = e.message ?: "Failed to load config") }
             }
         }
     }
@@ -86,13 +80,11 @@ class PluginManagementViewModel(
         viewModelScope.launch {
             try {
                 updatePluginConfigUseCase(pluginId, configJson)
-                _uiState.value = _uiState.value.copy(selectedPluginConfig = configJson)
+                _uiState.update { it.copy(selectedPluginConfig = configJson) }
             } catch (e: CancellationException) {
                 throw e
             } catch (e: Exception) {
-                _uiState.value = _uiState.value.copy(
-                    error = e.message ?: "Failed to save config",
-                )
+                _uiState.update { it.copy(error = e.message ?: "Failed to save config") }
             }
         }
     }
@@ -104,9 +96,7 @@ class PluginManagementViewModel(
             } catch (e: CancellationException) {
                 throw e
             } catch (e: Exception) {
-                _uiState.value = _uiState.value.copy(
-                    error = e.message ?: "Failed to uninstall plugin",
-                )
+                _uiState.update { it.copy(error = e.message ?: "Failed to uninstall plugin") }
             }
         }
     }
@@ -115,6 +105,6 @@ class PluginManagementViewModel(
         plugin.state == InstalledPluginState.ACTIVE
 
     fun clearError() {
-        _uiState.value = _uiState.value.copy(error = null)
+        _uiState.update { it.copy(error = null) }
     }
 }

--- a/desktopApp/src/jvmMain/kotlin/com/riox432/civitdeck/ui/analytics/DesktopAnalyticsViewModel.kt
+++ b/desktopApp/src/jvmMain/kotlin/com/riox432/civitdeck/ui/analytics/DesktopAnalyticsViewModel.kt
@@ -7,6 +7,7 @@ import androidx.lifecycle.viewModelScope
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 
 data class DesktopAnalyticsUiState(
@@ -39,7 +40,7 @@ class DesktopAnalyticsViewModel(
 
     private fun loadStats() {
         scope.launch {
-            _uiState.value = _uiState.value.copy(isLoading = true, error = null)
+            _uiState.update { it.copy(isLoading = true, error = null) }
             try {
                 val stats = getBrowsingStatsUseCase()
                 _uiState.value = DesktopAnalyticsUiState(
@@ -54,10 +55,12 @@ class DesktopAnalyticsViewModel(
             } catch (e: CancellationException) {
                 throw e
             } catch (e: Exception) {
-                _uiState.value = _uiState.value.copy(
-                    isLoading = false,
-                    error = e.message ?: "Failed to load stats",
-                )
+                _uiState.update {
+                    it.copy(
+                        isLoading = false,
+                        error = e.message ?: "Failed to load stats",
+                    )
+                }
             }
         }
     }

--- a/desktopApp/src/jvmMain/kotlin/com/riox432/civitdeck/ui/discovery/DesktopDiscoveryViewModel.kt
+++ b/desktopApp/src/jvmMain/kotlin/com/riox432/civitdeck/ui/discovery/DesktopDiscoveryViewModel.kt
@@ -8,6 +8,7 @@ import androidx.lifecycle.viewModelScope
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 
 data class DesktopDiscoveryUiState(
@@ -35,23 +36,19 @@ class DesktopDiscoveryViewModel(
 
     private fun loadRecommendations() {
         scope.launch {
-            _uiState.value = _uiState.value.copy(
-                isLoading = true,
-                error = null,
-            )
+            _uiState.update { it.copy(isLoading = true, error = null) }
             try {
                 val sections = getRecommendationsUseCase()
-                _uiState.value = _uiState.value.copy(
-                    sections = sections,
-                    isLoading = false,
-                )
+                _uiState.update { it.copy(sections = sections, isLoading = false) }
             } catch (e: CancellationException) {
                 throw e
             } catch (e: Exception) {
-                _uiState.value = _uiState.value.copy(
-                    isLoading = false,
-                    error = e.message ?: "Failed to load recommendations",
-                )
+                _uiState.update {
+                    it.copy(
+                        isLoading = false,
+                        error = e.message ?: "Failed to load recommendations",
+                    )
+                }
             }
         }
     }

--- a/desktopApp/src/jvmMain/kotlin/com/riox432/civitdeck/ui/feed/DesktopFeedViewModel.kt
+++ b/desktopApp/src/jvmMain/kotlin/com/riox432/civitdeck/ui/feed/DesktopFeedViewModel.kt
@@ -8,6 +8,7 @@ import androidx.lifecycle.viewModelScope
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 
 data class DesktopFeedUiState(
@@ -37,27 +38,33 @@ class DesktopFeedViewModel(
 
     private fun loadFeed(forceRefresh: Boolean = false) {
         scope.launch {
-            _uiState.value = _uiState.value.copy(
-                isLoading = !forceRefresh && _uiState.value.feedItems.isEmpty(),
-                isRefreshing = forceRefresh,
-                error = null,
-            )
+            _uiState.update {
+                it.copy(
+                    isLoading = !forceRefresh && it.feedItems.isEmpty(),
+                    isRefreshing = forceRefresh,
+                    error = null,
+                )
+            }
             try {
                 val items = getCreatorFeedUseCase(forceRefresh)
-                _uiState.value = _uiState.value.copy(
-                    feedItems = items,
-                    isLoading = false,
-                    isRefreshing = false,
-                )
+                _uiState.update {
+                    it.copy(
+                        feedItems = items,
+                        isLoading = false,
+                        isRefreshing = false,
+                    )
+                }
                 if (items.isNotEmpty()) markFeedReadUseCase()
             } catch (e: CancellationException) {
                 throw e
             } catch (e: Exception) {
-                _uiState.value = _uiState.value.copy(
-                    isLoading = false,
-                    isRefreshing = false,
-                    error = e.message ?: "Failed to load feed",
-                )
+                _uiState.update {
+                    it.copy(
+                        isLoading = false,
+                        isRefreshing = false,
+                        error = e.message ?: "Failed to load feed",
+                    )
+                }
             }
         }
     }

--- a/desktopApp/src/jvmMain/kotlin/com/riox432/civitdeck/ui/plugin/DesktopPluginViewModel.kt
+++ b/desktopApp/src/jvmMain/kotlin/com/riox432/civitdeck/ui/plugin/DesktopPluginViewModel.kt
@@ -13,6 +13,7 @@ import androidx.lifecycle.viewModelScope
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 
 data class DesktopPluginUiState(
@@ -43,7 +44,7 @@ class DesktopPluginViewModel(
     private fun observePlugins() {
         scope.launch {
             observeInstalledPluginsUseCase().collect { plugins ->
-                _uiState.value = _uiState.value.copy(plugins = plugins, isLoading = false)
+                _uiState.update { it.copy(plugins = plugins, isLoading = false) }
             }
         }
     }
@@ -55,7 +56,7 @@ class DesktopPluginViewModel(
             } catch (e: CancellationException) {
                 throw e
             } catch (e: Exception) {
-                _uiState.value = _uiState.value.copy(error = e.message ?: "Failed to toggle plugin")
+                _uiState.update { it.copy(error = e.message ?: "Failed to toggle plugin") }
             }
         }
     }
@@ -64,11 +65,11 @@ class DesktopPluginViewModel(
         scope.launch {
             try {
                 val config = getPluginConfigUseCase(pluginId)
-                _uiState.value = _uiState.value.copy(selectedPluginConfig = config)
+                _uiState.update { it.copy(selectedPluginConfig = config) }
             } catch (e: CancellationException) {
                 throw e
             } catch (e: Exception) {
-                _uiState.value = _uiState.value.copy(error = e.message ?: "Failed to load config")
+                _uiState.update { it.copy(error = e.message ?: "Failed to load config") }
             }
         }
     }
@@ -77,11 +78,11 @@ class DesktopPluginViewModel(
         scope.launch {
             try {
                 updatePluginConfigUseCase(pluginId, configJson)
-                _uiState.value = _uiState.value.copy(selectedPluginConfig = configJson)
+                _uiState.update { it.copy(selectedPluginConfig = configJson) }
             } catch (e: CancellationException) {
                 throw e
             } catch (e: Exception) {
-                _uiState.value = _uiState.value.copy(error = e.message ?: "Failed to save config")
+                _uiState.update { it.copy(error = e.message ?: "Failed to save config") }
             }
         }
     }
@@ -93,7 +94,7 @@ class DesktopPluginViewModel(
             } catch (e: CancellationException) {
                 throw e
             } catch (e: Exception) {
-                _uiState.value = _uiState.value.copy(error = e.message ?: "Failed to uninstall plugin")
+                _uiState.update { it.copy(error = e.message ?: "Failed to uninstall plugin") }
             }
         }
     }


### PR DESCRIPTION
Closes #621

Replace all `_uiState.value = _uiState.value.copy(...)` with `_uiState.update { it.copy(...) }` for atomic read-modify-write.

**Files changed:**
- `desktopApp/` — DesktopDiscoveryViewModel, DesktopAnalyticsViewModel, DesktopPluginViewModel, DesktopFeedViewModel
- `androidApp/` — AnalyticsViewModel, PluginManagementViewModel, FeedViewModel