### PR TITLE
Move FormatUtils to core-domain, remove shared dep from core-ui (#607)

### DIFF
--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/compare/ModelCompareScreen.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/compare/ModelCompareScreen.kt
@@ -51,6 +51,7 @@ import com.riox432.civitdeck.domain.model.Model
 import com.riox432.civitdeck.domain.model.ModelImage
 import com.riox432.civitdeck.domain.model.ModelVersion
 import com.riox432.civitdeck.domain.model.filterByNsfwLevel
+import com.riox432.civitdeck.domain.util.FormatUtils
 import com.riox432.civitdeck.feature.detail.presentation.ModelDetailUiState
 import com.riox432.civitdeck.feature.detail.presentation.ModelDetailViewModel
 import com.riox432.civitdeck.ui.components.ErrorStateView
@@ -59,7 +60,6 @@ import com.riox432.civitdeck.ui.components.LoadingStateOverlay
 import com.riox432.civitdeck.ui.theme.Duration
 import com.riox432.civitdeck.ui.theme.Spacing
 import com.riox432.civitdeck.ui.theme.shimmer
-import com.riox432.civitdeck.util.FormatUtils
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable

--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/detail/FileDownloadRow.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/detail/FileDownloadRow.kt
@@ -26,8 +26,8 @@ import com.riox432.civitdeck.R
 import com.riox432.civitdeck.domain.model.DownloadStatus
 import com.riox432.civitdeck.domain.model.ModelDownload
 import com.riox432.civitdeck.domain.model.ModelFile
+import com.riox432.civitdeck.domain.util.FormatUtils
 import com.riox432.civitdeck.ui.theme.Spacing
-import com.riox432.civitdeck.util.FormatUtils
 
 @Composable
 fun FileDownloadRow(

--- a/core/core-domain/src/commonMain/kotlin/com/riox432/civitdeck/domain/util/FormatUtils.kt
+++ b/core/core-domain/src/commonMain/kotlin/com/riox432/civitdeck/domain/util/FormatUtils.kt
@@ -1,4 +1,4 @@
-package com.riox432.civitdeck.util
+package com.riox432.civitdeck.domain.util
 
 import kotlin.math.round
 

--- a/core/core-ui/build.gradle.kts
+++ b/core/core-ui/build.gradle.kts
@@ -9,7 +9,6 @@ kotlin {
         commonMain.dependencies {
             api(project(":core:core-domain"))
             implementation(project(":core:core-plugin"))
-            implementation(project(":shared"))
             implementation(libs.koin.core)
             implementation(compose.material3)
             implementation(compose.materialIconsExtended)

--- a/core/core-ui/src/commonMain/kotlin/com/riox432/civitdeck/ui/components/ModelStatsRow.kt
+++ b/core/core-ui/src/commonMain/kotlin/com/riox432/civitdeck/ui/components/ModelStatsRow.kt
@@ -17,9 +17,9 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.unit.dp
+import com.riox432.civitdeck.domain.util.FormatUtils
 import com.riox432.civitdeck.ui.theme.IconSize
 import com.riox432.civitdeck.ui.theme.Spacing
-import com.riox432.civitdeck.util.FormatUtils
 
 /**
  * Displays model statistics (downloads, favorites, rating, optional comments).

--- a/desktopApp/src/jvmMain/kotlin/com/riox432/civitdeck/ui/compare/DesktopCompareScreen.kt
+++ b/desktopApp/src/jvmMain/kotlin/com/riox432/civitdeck/ui/compare/DesktopCompareScreen.kt
@@ -42,7 +42,7 @@ import com.riox432.civitdeck.feature.detail.presentation.ModelDetailViewModel
 import com.riox432.civitdeck.ui.theme.Spacing
 import com.riox432.civitdeck.ui.theme.shimmer
 import com.riox432.civitdeck.ui.theme.Elevation
-import com.riox432.civitdeck.util.FormatUtils
+import com.riox432.civitdeck.domain.util.FormatUtils
 
 @Composable
 fun DesktopCompareScreen(

--- a/desktopApp/src/jvmMain/kotlin/com/riox432/civitdeck/ui/detail/DesktopDetailScreen.kt
+++ b/desktopApp/src/jvmMain/kotlin/com/riox432/civitdeck/ui/detail/DesktopDetailScreen.kt
@@ -73,7 +73,7 @@ import com.riox432.civitdeck.ui.theme.CornerRadius
 import com.riox432.civitdeck.ui.theme.Spacing
 import com.riox432.civitdeck.ui.theme.shimmer
 import com.riox432.civitdeck.ui.theme.Elevation
-import com.riox432.civitdeck.util.FormatUtils
+import com.riox432.civitdeck.domain.util.FormatUtils
 
 @Composable
 fun DesktopDetailScreen(


### PR DESCRIPTION
## Summary
- Move `FormatUtils` from `shared/util/` to `core/core-domain/domain/util/`
- Remove `implementation(project(":shared"))` from `core-ui/build.gradle.kts`
- Update all import references across androidApp, desktopApp, and core-ui

Closes #607