### PR TITLE
Move combined repos from core-database to shared, fix layer violation (#606)

### DIFF
--- a/core/core-database/build.gradle.kts
+++ b/core/core-database/build.gradle.kts
@@ -8,7 +8,6 @@ kotlin {
     sourceSets {
         commonMain.dependencies {
             api(project(":core:core-domain"))
-            implementation(project(":core:core-network"))
             api(libs.room.runtime)
             api(libs.sqlite.bundled)
             implementation(libs.koin.core)

--- a/core/core-database/src/commonMain/kotlin/com/riox432/civitdeck/di/DatabaseModule.kt
+++ b/core/core-database/src/commonMain/kotlin/com/riox432/civitdeck/di/DatabaseModule.kt
@@ -5,7 +5,6 @@ import com.riox432.civitdeck.data.local.LocalCacheDataSource
 import com.riox432.civitdeck.data.local.getRoomDatabase
 import com.riox432.civitdeck.data.local.repository.AnalyticsRepositoryImpl
 import com.riox432.civitdeck.data.local.repository.CaptionRepositoryImpl
-import com.riox432.civitdeck.data.local.repository.CreatorFollowRepositoryImpl
 import com.riox432.civitdeck.data.local.repository.DatasetCollectionRepositoryImpl
 import com.riox432.civitdeck.data.local.repository.ImageTagRepositoryImpl
 import com.riox432.civitdeck.data.local.repository.ModelDownloadRepositoryImpl
@@ -13,10 +12,8 @@ import com.riox432.civitdeck.data.local.repository.ModelNoteRepositoryImpl
 import com.riox432.civitdeck.data.local.repository.ModelUpdateNotificationRepositoryImpl
 import com.riox432.civitdeck.data.local.repository.PluginRepositoryImpl
 import com.riox432.civitdeck.data.local.repository.ShareHashtagRepositoryImpl
-import com.riox432.civitdeck.data.local.repository.UpdateRepositoryImpl
 import com.riox432.civitdeck.domain.repository.AnalyticsRepository
 import com.riox432.civitdeck.domain.repository.CaptionRepository
-import com.riox432.civitdeck.domain.repository.CreatorFollowRepository
 import com.riox432.civitdeck.domain.repository.DatasetCollectionRepository
 import com.riox432.civitdeck.domain.repository.ImageTagRepository
 import com.riox432.civitdeck.domain.repository.ModelDownloadRepository
@@ -24,7 +21,6 @@ import com.riox432.civitdeck.domain.repository.ModelNoteRepository
 import com.riox432.civitdeck.domain.repository.ModelUpdateNotificationRepository
 import com.riox432.civitdeck.domain.repository.PluginRepository
 import com.riox432.civitdeck.domain.repository.ShareHashtagRepository
-import com.riox432.civitdeck.domain.repository.UpdateRepository
 import org.koin.dsl.module
 
 val databaseModule = module {
@@ -69,9 +65,6 @@ val databaseModule = module {
     // Analytics
     single<AnalyticsRepository> { AnalyticsRepositoryImpl(get(), get(), get()) }
 
-    // Creator Follow
-    single<CreatorFollowRepository> { CreatorFollowRepositoryImpl(get(), get(), get()) }
-
     // Downloads
     single<ModelDownloadRepository> { ModelDownloadRepositoryImpl(get()) }
 
@@ -80,9 +73,6 @@ val databaseModule = module {
 
     // Share Hashtags
     single<ShareHashtagRepository> { ShareHashtagRepositoryImpl(get()) }
-
-    // Update Checker
-    single<UpdateRepository> { UpdateRepositoryImpl(get(), get(), get()) }
 
     // Model Update Notifications
     single<ModelUpdateNotificationRepository> { ModelUpdateNotificationRepositoryImpl(get()) }

--- a/shared/src/commonMain/kotlin/com/riox432/civitdeck/data/repository/CreatorFollowRepositoryImpl.kt
+++ b/shared/src/commonMain/kotlin/com/riox432/civitdeck/data/repository/CreatorFollowRepositoryImpl.kt
@@ -1,4 +1,4 @@
-package com.riox432.civitdeck.data.local.repository
+package com.riox432.civitdeck.data.repository
 
 import com.riox432.civitdeck.data.api.CivitAiApi
 import com.riox432.civitdeck.data.api.dto.toDomain

--- a/shared/src/commonMain/kotlin/com/riox432/civitdeck/data/repository/UpdateRepositoryImpl.kt
+++ b/shared/src/commonMain/kotlin/com/riox432/civitdeck/data/repository/UpdateRepositoryImpl.kt
@@ -1,4 +1,4 @@
-package com.riox432.civitdeck.data.local.repository
+package com.riox432.civitdeck.data.repository
 
 import com.riox432.civitdeck.data.api.GitHubAsset
 import com.riox432.civitdeck.data.api.GitHubReleaseApi

--- a/shared/src/commonMain/kotlin/com/riox432/civitdeck/di/DataModule.kt
+++ b/shared/src/commonMain/kotlin/com/riox432/civitdeck/di/DataModule.kt
@@ -11,17 +11,20 @@ import com.riox432.civitdeck.data.image.ImageSaver
 import com.riox432.civitdeck.data.repository.AuthRepositoryImpl
 import com.riox432.civitdeck.data.repository.BrowsingHistoryRepositoryImpl
 import com.riox432.civitdeck.data.repository.CacheRepositoryImpl
+import com.riox432.civitdeck.data.repository.CreatorFollowRepositoryImpl
 import com.riox432.civitdeck.data.repository.FavoriteRepositoryImpl
 import com.riox432.civitdeck.data.repository.LocalModelFileRepositoryImpl
 import com.riox432.civitdeck.data.repository.ModelRepositoryImpl
 import com.riox432.civitdeck.data.repository.ModelVersionCheckpointRepositoryImpl
 import com.riox432.civitdeck.data.repository.ReviewRepositoryImpl
 import com.riox432.civitdeck.data.repository.TagRepositoryImpl
+import com.riox432.civitdeck.data.repository.UpdateRepositoryImpl
 import com.riox432.civitdeck.data.scanner.FileScanner
 import com.riox432.civitdeck.domain.repository.AuthRepository
 import com.riox432.civitdeck.domain.repository.BackupRepository
 import com.riox432.civitdeck.domain.repository.BrowsingHistoryRepository
 import com.riox432.civitdeck.domain.repository.CacheRepository
+import com.riox432.civitdeck.domain.repository.CreatorFollowRepository
 import com.riox432.civitdeck.domain.repository.ExportRepository
 import com.riox432.civitdeck.domain.repository.FavoriteRepository
 import com.riox432.civitdeck.domain.repository.ModelDirectoryRepository
@@ -31,6 +34,7 @@ import com.riox432.civitdeck.domain.repository.ModelScanRepository
 import com.riox432.civitdeck.domain.repository.ModelVersionCheckpointRepository
 import com.riox432.civitdeck.domain.repository.ReviewRepository
 import com.riox432.civitdeck.domain.repository.TagRepository
+import com.riox432.civitdeck.domain.repository.UpdateRepository
 import com.riox432.civitdeck.usecase.ActivateThemePluginUseCase
 import com.riox432.civitdeck.usecase.ExportWithPluginUseCase
 import com.riox432.civitdeck.usecase.GetActiveThemeUseCase
@@ -62,6 +66,8 @@ val dataModule = module {
     }
     single<ModelVersionCheckpointRepository> { ModelVersionCheckpointRepositoryImpl(get()) }
     single<ReviewRepository> { ReviewRepositoryImpl(get(), get()) }
+    single<CreatorFollowRepository> { CreatorFollowRepositoryImpl(get(), get(), get()) }
+    single<UpdateRepository> { UpdateRepositoryImpl(get(), get(), get()) }
 
     // Export
     single<ExportRepository> { ExportRepositoryImpl(get(), get()) }


### PR DESCRIPTION
## Summary
- Moved `CreatorFollowRepositoryImpl` and `UpdateRepositoryImpl` from `core-database` to `shared` module — these repos depend on both network APIs and database DAOs
- Removed `implementation(project(":core:core-network"))` from `core-database/build.gradle.kts`
- Moved Koin bindings from `DatabaseModule` to `DataModule` in shared

Closes #606