### PR TITLE
Extract PaginatedLoader helper for shared pagination pattern (#620)

### DIFF
--- a/core/core-domain/src/commonMain/kotlin/com/riox432/civitdeck/domain/util/PaginatedLoader.kt
+++ b/core/core-domain/src/commonMain/kotlin/com/riox432/civitdeck/domain/util/PaginatedLoader.kt
@@ -1,0 +1,115 @@
+package com.riox432.civitdeck.domain.util
+
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+
+/**
+ * Reusable helper for cursor-based paginated loading.
+ *
+ * Handles: guard checks, loading state management, cursor tracking,
+ * appending results, and error handling with CancellationException rethrow.
+ */
+class PaginatedLoader<T>(
+    private val scope: CoroutineScope,
+    private val pageSize: Int = DEFAULT_PAGE_SIZE,
+    private val load: suspend (cursor: String?, limit: Int) -> LoadResult<T>,
+    private val onStateChanged: (PaginatedLoadState<T>) -> Unit,
+) {
+    private var job: Job? = null
+    private val _state = MutableStateFlow(PaginatedLoadState<T>())
+
+    val state: PaginatedLoadState<T> get() = _state.value
+
+    /**
+     * Load the first page. Cancels any in-progress load and resets state.
+     */
+    fun loadFirst() {
+        job?.cancel()
+        _state.update {
+            PaginatedLoadState(isLoading = true)
+        }
+        notifyState()
+        doLoad(isLoadMore = false)
+    }
+
+    /**
+     * Load the next page. No-op if already loading or no more pages.
+     */
+    fun loadMore() {
+        val current = _state.value
+        if (current.isLoading || current.isLoadingMore || !current.hasMore) return
+        _state.update { it.copy(isLoadingMore = true) }
+        notifyState()
+        doLoad(isLoadMore = true)
+    }
+
+    /**
+     * Cancel any in-progress load.
+     */
+    fun cancel() {
+        job?.cancel()
+    }
+
+    private fun doLoad(isLoadMore: Boolean) {
+        job = scope.launch {
+            try {
+                val cursor = if (isLoadMore) _state.value.nextCursor else null
+                val result = load(cursor, pageSize)
+                _state.update {
+                    it.copy(
+                        items = if (isLoadMore) it.items + result.items else result.items,
+                        isLoading = false,
+                        isLoadingMore = false,
+                        error = null,
+                        nextCursor = result.nextCursor,
+                        hasMore = result.nextCursor != null,
+                    )
+                }
+                notifyState()
+            } catch (e: CancellationException) {
+                throw e
+            } catch (@Suppress("TooGenericExceptionCaught") e: Exception) {
+                _state.update {
+                    it.copy(
+                        isLoading = false,
+                        isLoadingMore = false,
+                        error = e.message ?: "Unknown error",
+                    )
+                }
+                notifyState()
+            }
+        }
+    }
+
+    private fun notifyState() {
+        onStateChanged(_state.value)
+    }
+
+    companion object {
+        private const val DEFAULT_PAGE_SIZE = 20
+    }
+}
+
+/**
+ * Immutable state snapshot for paginated loading.
+ */
+data class PaginatedLoadState<T>(
+    val items: List<T> = emptyList(),
+    val isLoading: Boolean = false,
+    val isLoadingMore: Boolean = false,
+    val error: String? = null,
+    val nextCursor: String? = null,
+    val hasMore: Boolean = true,
+)
+
+/**
+ * Result of a single page load.
+ */
+data class LoadResult<T>(
+    val items: List<T>,
+    val nextCursor: String?,
+)

--- a/desktopApp/src/jvmMain/kotlin/com/riox432/civitdeck/ui/search/DesktopSearchViewModel.kt
+++ b/desktopApp/src/jvmMain/kotlin/com/riox432/civitdeck/ui/search/DesktopSearchViewModel.kt
@@ -1,5 +1,7 @@
 package com.riox432.civitdeck.ui.search
 
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
 import com.riox432.civitdeck.domain.model.BaseModel
 import com.riox432.civitdeck.domain.model.Model
 import com.riox432.civitdeck.domain.model.ModelSource
@@ -8,11 +10,9 @@ import com.riox432.civitdeck.domain.model.SortOrder
 import com.riox432.civitdeck.domain.model.TimePeriod
 import com.riox432.civitdeck.domain.usecase.ObserveDefaultSortOrderUseCase
 import com.riox432.civitdeck.domain.usecase.ObserveDefaultTimePeriodUseCase
+import com.riox432.civitdeck.domain.util.LoadResult
+import com.riox432.civitdeck.domain.util.PaginatedLoader
 import com.riox432.civitdeck.feature.search.domain.usecase.GetModelsUseCase
-import androidx.lifecycle.ViewModel
-import androidx.lifecycle.viewModelScope
-import kotlinx.coroutines.CancellationException
-import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -42,19 +42,33 @@ class DesktopSearchViewModel(
     private val observeDefaultTimePeriodUseCase: ObserveDefaultTimePeriodUseCase,
 ) : ViewModel() {
 
-    private val scope = viewModelScope
-
     private val _uiState = MutableStateFlow(DesktopSearchUiState())
     val uiState: StateFlow<DesktopSearchUiState> = _uiState.asStateFlow()
 
-    private var searchJob: Job? = null
+    private val paginatedLoader = PaginatedLoader<Model>(
+        scope = viewModelScope,
+        pageSize = PAGE_SIZE,
+        load = { cursor, limit -> loadPage(cursor, limit) },
+        onStateChanged = { loadState ->
+            _uiState.update {
+                it.copy(
+                    models = loadState.items,
+                    isLoading = loadState.isLoading,
+                    isLoadingMore = loadState.isLoadingMore,
+                    error = loadState.error,
+                    nextCursor = loadState.nextCursor,
+                    hasMore = loadState.hasMore,
+                )
+            }
+        },
+    )
 
     init {
-        scope.launch {
+        viewModelScope.launch {
             val sort = observeDefaultSortOrderUseCase().first()
             val period = observeDefaultTimePeriodUseCase().first()
             _uiState.update { it.copy(selectedSort = sort, selectedPeriod = period) }
-            search()
+            paginatedLoader.loadFirst()
         }
     }
 
@@ -63,23 +77,22 @@ class DesktopSearchViewModel(
     }
 
     fun onSearch() {
-        _uiState.update { it.copy(nextCursor = null, hasMore = true, models = emptyList()) }
-        search()
+        paginatedLoader.loadFirst()
     }
 
     fun onTypeSelected(type: ModelType?) {
-        _uiState.update { it.copy(selectedType = type, nextCursor = null, hasMore = true, models = emptyList()) }
-        search()
+        _uiState.update { it.copy(selectedType = type) }
+        paginatedLoader.loadFirst()
     }
 
     fun onSortSelected(sort: SortOrder) {
-        _uiState.update { it.copy(selectedSort = sort, nextCursor = null, hasMore = true, models = emptyList()) }
-        search()
+        _uiState.update { it.copy(selectedSort = sort) }
+        paginatedLoader.loadFirst()
     }
 
     fun onPeriodSelected(period: TimePeriod) {
-        _uiState.update { it.copy(selectedPeriod = period, nextCursor = null, hasMore = true, models = emptyList()) }
-        search()
+        _uiState.update { it.copy(selectedPeriod = period) }
+        paginatedLoader.loadFirst()
     }
 
     fun onBaseModelToggled(baseModel: BaseModel) {
@@ -87,9 +100,9 @@ class DesktopSearchViewModel(
             val updated = state.selectedBaseModels.toMutableSet().apply {
                 if (baseModel in this) remove(baseModel) else add(baseModel)
             }.toSet()
-            state.copy(selectedBaseModels = updated, nextCursor = null, hasMore = true, models = emptyList())
+            state.copy(selectedBaseModels = updated)
         }
-        search()
+        paginatedLoader.loadFirst()
     }
 
     fun onQualityFilterToggled() {
@@ -104,73 +117,35 @@ class DesktopSearchViewModel(
             } else {
                 updated.add(source)
             }
-            state.copy(
-                selectedSources = updated.toSet(),
-                nextCursor = null,
-                hasMore = true,
-                models = emptyList(),
-            )
+            state.copy(selectedSources = updated.toSet())
         }
-        search()
+        paginatedLoader.loadFirst()
     }
 
     fun resetFilters() {
-        _uiState.update {
-            DesktopSearchUiState()
-        }
-        search()
+        _uiState.update { DesktopSearchUiState() }
+        paginatedLoader.loadFirst()
     }
 
     fun loadMore() {
+        paginatedLoader.loadMore()
+    }
+
+    private suspend fun loadPage(cursor: String?, limit: Int): LoadResult<Model> {
         val state = _uiState.value
-        if (state.isLoading || state.isLoadingMore || !state.hasMore) return
-        search(isLoadMore = true)
-    }
-
-    private fun search(isLoadMore: Boolean = false) {
-        searchJob?.cancel()
-        searchJob = scope.launch {
-            _uiState.update {
-                if (isLoadMore) it.copy(isLoadingMore = true)
-                else it.copy(isLoading = true, error = null)
-            }
-            try {
-                val state = _uiState.value
-                val result = getModelsUseCase(
-                    query = state.query.ifBlank { null },
-                    type = state.selectedType,
-                    sort = state.selectedSort,
-                    period = state.selectedPeriod,
-                    baseModels = state.selectedBaseModels.toList().ifEmpty { null },
-                    cursor = if (isLoadMore) state.nextCursor else null,
-                    limit = PAGE_SIZE,
-                )
-                _uiState.update {
-                    it.copy(
-                        models = if (isLoadMore) it.models + result.items else result.items,
-                        isLoading = false,
-                        isLoadingMore = false,
-                        error = null,
-                        nextCursor = result.metadata.nextCursor,
-                        hasMore = result.metadata.nextCursor != null,
-                    )
-                }
-            } catch (e: CancellationException) {
-                throw e
-            } catch (e: Exception) {
-                _uiState.update {
-                    it.copy(
-                        isLoading = false,
-                        isLoadingMore = false,
-                        error = e.message ?: "Unknown error",
-                    )
-                }
-            }
-        }
-    }
-
-    public override fun onCleared() {
-        super.onCleared()
+        val result = getModelsUseCase(
+            query = state.query.ifBlank { null },
+            type = state.selectedType,
+            sort = state.selectedSort,
+            period = state.selectedPeriod,
+            baseModels = state.selectedBaseModels.toList().ifEmpty { null },
+            cursor = cursor,
+            limit = limit,
+        )
+        return LoadResult(
+            items = result.items,
+            nextCursor = result.metadata.nextCursor,
+        )
     }
 
     companion object {

--- a/feature/feature-creator/src/commonMain/kotlin/com/riox432/civitdeck/feature/creator/presentation/CreatorProfileViewModel.kt
+++ b/feature/feature-creator/src/commonMain/kotlin/com/riox432/civitdeck/feature/creator/presentation/CreatorProfileViewModel.kt
@@ -6,9 +6,9 @@ import com.riox432.civitdeck.domain.model.Model
 import com.riox432.civitdeck.domain.usecase.FollowCreatorUseCase
 import com.riox432.civitdeck.domain.usecase.IsFollowingCreatorUseCase
 import com.riox432.civitdeck.domain.usecase.UnfollowCreatorUseCase
+import com.riox432.civitdeck.domain.util.LoadResult
+import com.riox432.civitdeck.domain.util.PaginatedLoader
 import com.riox432.civitdeck.feature.creator.domain.usecase.GetCreatorModelsUseCase
-import kotlinx.coroutines.CancellationException
-import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -38,23 +38,36 @@ class CreatorProfileViewModel(
     private val _uiState = MutableStateFlow(CreatorProfileUiState(username = username))
     val uiState: StateFlow<CreatorProfileUiState> = _uiState.asStateFlow()
 
-    private var loadJob: Job? = null
+    private val paginatedLoader = PaginatedLoader<Model>(
+        scope = viewModelScope,
+        pageSize = PAGE_SIZE,
+        load = { cursor, limit -> loadPage(cursor, limit) },
+        onStateChanged = { loadState ->
+            _uiState.update {
+                it.copy(
+                    models = loadState.items,
+                    isLoading = loadState.isLoading,
+                    isLoadingMore = loadState.isLoadingMore,
+                    error = loadState.error,
+                    nextCursor = loadState.nextCursor,
+                    hasMore = loadState.hasMore,
+                )
+            }
+        },
+    )
 
     init {
-        loadModels()
+        paginatedLoader.loadFirst()
         observeFollowState()
     }
 
     fun loadMore() {
-        val state = _uiState.value
-        if (state.isLoading || state.isLoadingMore || !state.hasMore) return
-        loadModels(isLoadMore = true)
+        paginatedLoader.loadMore()
     }
 
     fun refresh() {
-        loadJob?.cancel()
-        _uiState.update { it.copy(nextCursor = null, hasMore = true) }
-        loadModels(isRefresh = true)
+        _uiState.update { it.copy(isRefreshing = true) }
+        paginatedLoader.loadFirst()
     }
 
     fun toggleFollow() {
@@ -81,46 +94,18 @@ class CreatorProfileViewModel(
         }
     }
 
-    private fun loadModels(isLoadMore: Boolean = false, isRefresh: Boolean = false) {
-        loadJob = viewModelScope.launch {
-            _uiState.update {
-                when {
-                    isLoadMore -> it.copy(isLoadingMore = true)
-                    isRefresh -> it.copy(isRefreshing = true)
-                    else -> it.copy(isLoading = true)
-                }
-            }
-            try {
-                val state = _uiState.value
-                val result = getCreatorModelsUseCase(
-                    username = username,
-                    cursor = if (isLoadMore) state.nextCursor else null,
-                    limit = PAGE_SIZE,
-                )
-                _uiState.update {
-                    it.copy(
-                        models = if (isLoadMore) it.models + result.items else result.items,
-                        isLoading = false,
-                        isLoadingMore = false,
-                        isRefreshing = false,
-                        error = null,
-                        nextCursor = result.metadata.nextCursor,
-                        hasMore = result.metadata.nextCursor != null,
-                    )
-                }
-            } catch (e: CancellationException) {
-                throw e
-            } catch (e: Exception) {
-                _uiState.update {
-                    it.copy(
-                        isLoading = false,
-                        isLoadingMore = false,
-                        isRefreshing = false,
-                        error = e.message ?: "Unknown error",
-                    )
-                }
-            }
-        }
+    private suspend fun loadPage(cursor: String?, limit: Int): LoadResult<Model> {
+        val result = getCreatorModelsUseCase(
+            username = username,
+            cursor = cursor,
+            limit = limit,
+        )
+        // Clear refreshing flag when load completes
+        _uiState.update { it.copy(isRefreshing = false) }
+        return LoadResult(
+            items = result.items,
+            nextCursor = result.metadata.nextCursor,
+        )
     }
 
     companion object {

--- a/feature/feature-gallery/src/commonMain/kotlin/com/riox432/civitdeck/feature/gallery/presentation/ImageGalleryViewModel.kt
+++ b/feature/feature-gallery/src/commonMain/kotlin/com/riox432/civitdeck/feature/gallery/presentation/ImageGalleryViewModel.kt
@@ -14,9 +14,9 @@ import com.riox432.civitdeck.domain.usecase.AutoSavePromptUseCase
 import com.riox432.civitdeck.domain.usecase.ObserveNsfwBlurSettingsUseCase
 import com.riox432.civitdeck.domain.usecase.ObserveNsfwFilterUseCase
 import com.riox432.civitdeck.domain.usecase.SavePromptUseCase
+import com.riox432.civitdeck.domain.util.LoadResult
+import com.riox432.civitdeck.domain.util.PaginatedLoader
 import com.riox432.civitdeck.feature.gallery.domain.usecase.GetImagesUseCase
-import kotlinx.coroutines.CancellationException
-import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -53,12 +53,28 @@ class ImageGalleryViewModel(
     private val _uiState = MutableStateFlow(ImageGalleryUiState())
     val uiState: StateFlow<ImageGalleryUiState> = _uiState.asStateFlow()
 
-    private var loadJob: Job? = null
+    private val paginatedLoader = PaginatedLoader<Image>(
+        scope = viewModelScope,
+        pageSize = PAGE_SIZE,
+        load = { cursor, limit -> loadPage(cursor, limit) },
+        onStateChanged = { loadState ->
+            _uiState.update {
+                it.copy(
+                    allImages = loadState.items,
+                    isLoading = loadState.isLoading,
+                    isLoadingMore = loadState.isLoadingMore,
+                    error = loadState.error,
+                    nextCursor = loadState.nextCursor,
+                    hasMore = loadState.hasMore,
+                )
+            }
+        },
+    )
 
     init {
         observeNsfwFilter()
         observeBlurSettings()
-        loadImages()
+        paginatedLoader.loadFirst()
     }
 
     private fun observeBlurSettings() {
@@ -75,40 +91,20 @@ class ImageGalleryViewModel(
                 val prev = _uiState.value.nsfwFilterLevel
                 _uiState.update { it.copy(nsfwFilterLevel = level) }
                 if (prev != level) {
-                    loadJob?.cancel()
-                    _uiState.update {
-                        it.copy(nextCursor = null, allImages = emptyList(), hasMore = true)
-                    }
-                    loadImages()
+                    paginatedLoader.loadFirst()
                 }
             }
         }
     }
 
     fun onSortSelected(sort: SortOrder) {
-        loadJob?.cancel()
-        _uiState.update {
-            it.copy(
-                selectedSort = sort,
-                nextCursor = null,
-                allImages = emptyList(),
-                hasMore = true,
-            )
-        }
-        loadImages()
+        _uiState.update { it.copy(selectedSort = sort) }
+        paginatedLoader.loadFirst()
     }
 
     fun onPeriodSelected(period: TimePeriod) {
-        loadJob?.cancel()
-        _uiState.update {
-            it.copy(
-                selectedPeriod = period,
-                nextCursor = null,
-                allImages = emptyList(),
-                hasMore = true,
-            )
-        }
-        loadImages()
+        _uiState.update { it.copy(selectedPeriod = period) }
+        paginatedLoader.loadFirst()
     }
 
     fun onAspectRatioSelected(filter: AspectRatioFilter?) {
@@ -116,9 +112,7 @@ class ImageGalleryViewModel(
     }
 
     fun loadMore() {
-        val state = _uiState.value
-        if (state.isLoading || state.isLoadingMore || !state.hasMore) return
-        loadImages(isLoadMore = true)
+        paginatedLoader.loadMore()
     }
 
     fun onImageSelected(index: Int) {
@@ -140,7 +134,7 @@ class ImageGalleryViewModel(
     }
 
     fun retry() {
-        loadImages()
+        paginatedLoader.loadFirst()
     }
 
     fun savePrompt(meta: ImageGenerationMeta, sourceImageUrl: String?) {
@@ -149,52 +143,25 @@ class ImageGalleryViewModel(
         }
     }
 
-    private fun loadImages(isLoadMore: Boolean = false) {
-        loadJob = viewModelScope.launch {
-            _uiState.update {
-                if (isLoadMore) {
-                    it.copy(isLoadingMore = true)
-                } else {
-                    it.copy(isLoading = true)
-                }
-            }
-            try {
-                val state = _uiState.value
-                val nsfwLevel = when (state.nsfwFilterLevel) {
-                    NsfwFilterLevel.Off -> NsfwLevel.None
-                    NsfwFilterLevel.Soft -> NsfwLevel.Soft
-                    NsfwFilterLevel.All -> null
-                }
-                val result = getImagesUseCase(
-                    modelVersionId = modelVersionId,
-                    sort = state.selectedSort,
-                    period = state.selectedPeriod,
-                    nsfwLevel = nsfwLevel,
-                    cursor = if (isLoadMore) state.nextCursor else null,
-                    limit = PAGE_SIZE,
-                )
-                _uiState.update {
-                    it.copy(
-                        allImages = if (isLoadMore) it.allImages + result.items else result.items,
-                        isLoading = false,
-                        isLoadingMore = false,
-                        error = null,
-                        nextCursor = result.metadata.nextCursor,
-                        hasMore = result.metadata.nextCursor != null,
-                    )
-                }
-            } catch (e: CancellationException) {
-                throw e
-            } catch (e: Exception) {
-                _uiState.update {
-                    it.copy(
-                        isLoading = false,
-                        isLoadingMore = false,
-                        error = e.message ?: "Unknown error",
-                    )
-                }
-            }
+    private suspend fun loadPage(cursor: String?, limit: Int): LoadResult<Image> {
+        val state = _uiState.value
+        val nsfwLevel = when (state.nsfwFilterLevel) {
+            NsfwFilterLevel.Off -> NsfwLevel.None
+            NsfwFilterLevel.Soft -> NsfwLevel.Soft
+            NsfwFilterLevel.All -> null
         }
+        val result = getImagesUseCase(
+            modelVersionId = modelVersionId,
+            sort = state.selectedSort,
+            period = state.selectedPeriod,
+            nsfwLevel = nsfwLevel,
+            cursor = cursor,
+            limit = limit,
+        )
+        return LoadResult(
+            items = result.items,
+            nextCursor = result.metadata.nextCursor,
+        )
     }
 
     companion object {


### PR DESCRIPTION
## Summary
- Add `PaginatedLoader<T>` helper in `core-domain` that encapsulates cursor-based pagination: guard checks, loading state management, cursor tracking, item appending, and error handling with `CancellationException` rethrow
- Migrate `ImageGalleryViewModel`, `CreatorProfileViewModel`, and `DesktopSearchViewModel` to use `PaginatedLoader`, removing ~73 lines of duplicated boilerplate
- Skip `ModelSearchViewModel` (uses Paging 3) and `ExternalServerGalleryViewModel` (page-based, not cursor-based)

Closes #620