### PR TITLE
Fix NavDisplay crash: guard onBack against empty backstack

### DIFF
--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/navigation/CivitDeckNavGraph.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/navigation/CivitDeckNavGraph.kt
@@ -189,7 +189,7 @@ private fun CivitDeckNavDisplay(
 ) {
     NavDisplay(
         backStack = backStack,
-        onBack = { backStack.removeLastOrNull() },
+        onBack = { if (backStack.size > 1) backStack.removeLastOrNull() },
         entryDecorators = listOf(
             rememberSaveableStateHolderNavEntryDecorator(),
             rememberViewModelStoreNavEntryDecorator(),


### PR DESCRIPTION
## Summary
- Fix `NavDisplay backstack cannot be empty` crash by guarding `onBack` to not remove the root entry
- When only 1 item remains (the tab's root route), back press is now a no-op instead of emptying the stack

## Root Cause
The `onBack` handler called `backStack.removeLastOrNull()` unconditionally, which could empty the backstack when the user was on a tab's root screen. `NavDisplay` requires at least one entry.