### PR TITLE
Audit tech debt cleanup: fix 15 codebase health issues

### DIFF
--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/creator/CreatorProfileScreen.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/creator/CreatorProfileScreen.kt
@@ -37,6 +37,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.riox432.civitdeck.R
 import com.riox432.civitdeck.feature.creator.presentation.CreatorProfileUiState
@@ -98,7 +99,7 @@ private fun CreatorTopBar(
     onToggleFollow: () -> Unit,
 ) {
     TopAppBar(
-        title = { Text(username) },
+        title = { Text(username, maxLines = 1, overflow = TextOverflow.Ellipsis) },
         navigationIcon = {
             IconButton(onClick = onBack) {
                 Icon(

--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/dataset/BatchTagEditorViewModel.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/dataset/BatchTagEditorViewModel.kt
@@ -11,6 +11,7 @@ import com.riox432.civitdeck.util.Logger
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 
@@ -25,51 +26,58 @@ class BatchTagEditorViewModel(
         observeDatasetImagesUseCase(datasetId)
             .stateIn(viewModelScope, SharingStarted.WhileSubscribed(STOP_TIMEOUT), emptyList())
 
-    val selectedImageIds = MutableStateFlow<Set<Long>>(emptySet())
-    val tagInput = MutableStateFlow("")
-    val tagSuggestions = MutableStateFlow<List<String>>(emptyList())
-    val isAddMode = MutableStateFlow(true)
+    private val _selectedImageIds = MutableStateFlow<Set<Long>>(emptySet())
+    val selectedImageIds: StateFlow<Set<Long>> = _selectedImageIds.asStateFlow()
+
+    private val _tagInput = MutableStateFlow("")
+    val tagInput: StateFlow<String> = _tagInput.asStateFlow()
+
+    private val _tagSuggestions = MutableStateFlow<List<String>>(emptyList())
+    val tagSuggestions: StateFlow<List<String>> = _tagSuggestions.asStateFlow()
+
+    private val _isAddMode = MutableStateFlow(true)
+    val isAddMode: StateFlow<Boolean> = _isAddMode.asStateFlow()
 
     fun toggleSelection(imageId: Long) {
-        selectedImageIds.value = selectedImageIds.value.let { current ->
+        _selectedImageIds.value = _selectedImageIds.value.let { current ->
             if (imageId in current) current - imageId else current + imageId
         }
     }
 
     fun selectAll() {
-        selectedImageIds.value = images.value.map { it.id }.toSet()
+        _selectedImageIds.value = images.value.map { it.id }.toSet()
     }
 
     fun clearSelection() {
-        selectedImageIds.value = emptySet()
+        _selectedImageIds.value = emptySet()
     }
 
     fun setTagInput(text: String) {
-        tagInput.value = text
+        _tagInput.value = text
         loadSuggestions(text)
     }
 
     fun toggleMode() {
-        isAddMode.value = !isAddMode.value
+        _isAddMode.value = !_isAddMode.value
     }
 
     private fun loadSuggestions(prefix: String) {
         viewModelScope.launch {
             suspendRunCatching { getTagSuggestionsUseCase(datasetId, prefix) }
-                .onSuccess { tagSuggestions.value = it }
+                .onSuccess { _tagSuggestions.value = it }
                 .onFailure { e ->
                     Logger.w(TAG, "Load tag suggestions failed: ${e.message}")
-                    tagSuggestions.value = emptyList()
+                    _tagSuggestions.value = emptyList()
                 }
         }
     }
 
     fun applyTags(tags: List<String>) {
-        val ids = selectedImageIds.value.toList()
+        val ids = _selectedImageIds.value.toList()
         if (ids.isEmpty() || tags.isEmpty()) return
         viewModelScope.launch {
             suspendRunCatching {
-                if (isAddMode.value) {
+                if (_isAddMode.value) {
                     batchEditTagsUseCase(ids, addTags = tags, removeTags = emptyList())
                 } else {
                     batchEditTagsUseCase(ids, addTags = emptyList(), removeTags = tags)

--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/dataset/DatasetDetailViewModel.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/dataset/DatasetDetailViewModel.kt
@@ -18,6 +18,7 @@ import com.riox432.civitdeck.util.Logger
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
@@ -38,21 +39,36 @@ class DatasetDetailViewModel(
         observeDatasetImagesUseCase(datasetId)
             .stateIn(viewModelScope, SharingStarted.WhileSubscribed(STOP_TIMEOUT), emptyList())
 
-    val selectedImageIds = MutableStateFlow<Set<Long>>(emptySet())
-    val isSelectionMode = MutableStateFlow(false)
-    val isLoading = MutableStateFlow(false)
-    val selectedSource = MutableStateFlow<ImageSource?>(null)
-    val detailImage = MutableStateFlow<DatasetImage?>(null)
-    val showResolutionFilter = MutableStateFlow(false)
-    val minWidth = MutableStateFlow(0)
-    val minHeight = MutableStateFlow(0)
+    private val _selectedImageIds = MutableStateFlow<Set<Long>>(emptySet())
+    val selectedImageIds: StateFlow<Set<Long>> = _selectedImageIds.asStateFlow()
 
-    val filteredImages: StateFlow<List<DatasetImage>> = combine(images, selectedSource) { imgs, src ->
+    private val _isSelectionMode = MutableStateFlow(false)
+    val isSelectionMode: StateFlow<Boolean> = _isSelectionMode.asStateFlow()
+
+    private val _isLoading = MutableStateFlow(false)
+    val isLoading: StateFlow<Boolean> = _isLoading.asStateFlow()
+
+    private val _selectedSource = MutableStateFlow<ImageSource?>(null)
+    val selectedSource: StateFlow<ImageSource?> = _selectedSource.asStateFlow()
+
+    private val _detailImage = MutableStateFlow<DatasetImage?>(null)
+    val detailImage: StateFlow<DatasetImage?> = _detailImage.asStateFlow()
+
+    private val _showResolutionFilter = MutableStateFlow(false)
+    val showResolutionFilter: StateFlow<Boolean> = _showResolutionFilter.asStateFlow()
+
+    private val _minWidth = MutableStateFlow(0)
+    val minWidth: StateFlow<Int> = _minWidth.asStateFlow()
+
+    private val _minHeight = MutableStateFlow(0)
+    val minHeight: StateFlow<Int> = _minHeight.asStateFlow()
+
+    val filteredImages: StateFlow<List<DatasetImage>> = combine(images, _selectedSource) { imgs, src ->
         if (src == null) imgs else imgs.filter { it.sourceType == src }
     }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(STOP_TIMEOUT), emptyList())
 
     val lowResImages: StateFlow<List<DatasetImage>> =
-        combine(images, minWidth, minHeight) { imgs, w, h ->
+        combine(images, _minWidth, _minHeight) { imgs, w, h ->
             if (w == 0 && h == 0) {
                 emptyList()
             } else {
@@ -69,53 +85,58 @@ class DatasetDetailViewModel(
             .map { groups -> groups.sumOf { it.images.size } - groups.size }
             .stateIn(viewModelScope, SharingStarted.WhileSubscribed(STOP_TIMEOUT), 0)
 
-    val showExportSheet = MutableStateFlow(false)
-    val exportProgress = MutableStateFlow<ExportProgress?>(null)
-    val selectedExportFormatId = MutableStateFlow<String?>(null)
+    private val _showExportSheet = MutableStateFlow(false)
+    val showExportSheet: StateFlow<Boolean> = _showExportSheet.asStateFlow()
+
+    private val _exportProgress = MutableStateFlow<ExportProgress?>(null)
+    val exportProgress: StateFlow<ExportProgress?> = _exportProgress.asStateFlow()
+
+    private val _selectedExportFormatId = MutableStateFlow<String?>(null)
+    val selectedExportFormatId: StateFlow<String?> = _selectedExportFormatId.asStateFlow()
 
     val availableExportFormats: StateFlow<List<PluginExportFormat>> =
         getAvailableExportFormatsUseCase()
             .stateIn(viewModelScope, SharingStarted.WhileSubscribed(STOP_TIMEOUT), emptyList())
 
-    fun openExportSheet() { showExportSheet.value = true }
-    fun dismissExportSheet() { showExportSheet.value = false }
+    fun openExportSheet() { _showExportSheet.value = true }
+    fun dismissExportSheet() { _showExportSheet.value = false }
 
-    fun selectExportFormat(formatId: String) { selectedExportFormatId.value = formatId }
+    fun selectExportFormat(formatId: String) { _selectedExportFormatId.value = formatId }
 
     fun startExport(formatId: String) {
-        showExportSheet.value = false
+        _showExportSheet.value = false
         viewModelScope.launch {
             exportWithPluginUseCase(datasetId, formatId).collect { progress ->
-                exportProgress.value = progress
+                _exportProgress.value = progress
             }
         }
     }
 
-    fun dismissExportResult() { exportProgress.value = null }
+    fun dismissExportResult() { _exportProgress.value = null }
 
     fun enterSelectionMode(imageId: Long) {
-        isSelectionMode.value = true
-        selectedImageIds.value = setOf(imageId)
+        _isSelectionMode.value = true
+        _selectedImageIds.value = setOf(imageId)
     }
 
     fun toggleSelection(imageId: Long) {
-        selectedImageIds.value = selectedImageIds.value.let { current ->
+        _selectedImageIds.value = _selectedImageIds.value.let { current ->
             if (imageId in current) current - imageId else current + imageId
         }
-        if (selectedImageIds.value.isEmpty()) isSelectionMode.value = false
+        if (_selectedImageIds.value.isEmpty()) _isSelectionMode.value = false
     }
 
     fun selectAll() {
-        selectedImageIds.value = images.value.map { it.id }.toSet()
+        _selectedImageIds.value = images.value.map { it.id }.toSet()
     }
 
     fun clearSelection() {
-        selectedImageIds.value = emptySet()
-        isSelectionMode.value = false
+        _selectedImageIds.value = emptySet()
+        _isSelectionMode.value = false
     }
 
     fun removeSelected() {
-        val ids = selectedImageIds.value.toList()
+        val ids = _selectedImageIds.value.toList()
         if (ids.isEmpty()) return
         viewModelScope.launch {
             suspendRunCatching { removeImageFromDatasetUseCase(ids) }
@@ -131,20 +152,20 @@ class DatasetDetailViewModel(
         }
     }
 
-    fun setSourceFilter(source: ImageSource?) { selectedSource.value = source }
+    fun setSourceFilter(source: ImageSource?) { _selectedSource.value = source }
 
-    fun showDetail(image: DatasetImage) { detailImage.value = image }
+    fun showDetail(image: DatasetImage) { _detailImage.value = image }
 
-    fun dismissDetail() { detailImage.value = null }
+    fun dismissDetail() { _detailImage.value = null }
 
     fun setResolutionFilter(w: Int, h: Int) {
-        minWidth.value = w
-        minHeight.value = h
+        _minWidth.value = w
+        _minHeight.value = h
     }
 
-    fun openResolutionFilter() { showResolutionFilter.value = true }
+    fun openResolutionFilter() { _showResolutionFilter.value = true }
 
-    fun dismissResolutionFilter() { showResolutionFilter.value = false }
+    fun dismissResolutionFilter() { _showResolutionFilter.value = false }
 
     fun updateTrainable(imageId: Long, trainable: Boolean) {
         viewModelScope.launch {

--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/dataset/DatasetListViewModel.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/dataset/DatasetListViewModel.kt
@@ -12,6 +12,7 @@ import com.riox432.civitdeck.util.Logger
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 
@@ -26,8 +27,11 @@ class DatasetListViewModel(
         observeDatasetCollectionsUseCase()
             .stateIn(viewModelScope, SharingStarted.WhileSubscribed(STOP_TIMEOUT), emptyList())
 
-    val isLoading = MutableStateFlow(false)
-    val error = MutableStateFlow<String?>(null)
+    private val _isLoading = MutableStateFlow(false)
+    val isLoading: StateFlow<Boolean> = _isLoading.asStateFlow()
+
+    private val _error = MutableStateFlow<String?>(null)
+    val error: StateFlow<String?> = _error.asStateFlow()
 
     fun createDataset(name: String) {
         viewModelScope.launch {

--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/detail/ModelNotesSection.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/detail/ModelNotesSection.kt
@@ -89,7 +89,7 @@ private fun NoteHeader(
     ) {
         SectionHeader(title = "My Notes", showDivider = true, modifier = Modifier.weight(1f))
         if (!isEditing) {
-            IconButton(onClick = onToggleEdit, modifier = Modifier.size(32.dp)) {
+            IconButton(onClick = onToggleEdit) {
                 Icon(
                     imageVector = if (hasNote) Icons.Default.Edit else Icons.Default.Add,
                     contentDescription = if (hasNote) "Edit note" else "Add note",
@@ -185,7 +185,7 @@ private fun TagsHeader(onAdd: () -> Unit) {
         verticalAlignment = Alignment.CenterVertically,
     ) {
         SectionHeader(title = "My Tags", showDivider = true, modifier = Modifier.weight(1f))
-        IconButton(onClick = onAdd, modifier = Modifier.size(32.dp)) {
+        IconButton(onClick = onAdd) {
             Icon(
                 imageVector = Icons.Default.Add,
                 contentDescription = stringResource(R.string.cd_add_tag),

--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/search/FilterChipComponents.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/search/FilterChipComponents.kt
@@ -246,7 +246,6 @@ private fun TagInputRow(placeholder: String, onAddTag: (String) -> Unit) {
                     keyboardController?.hide()
                 }
             },
-            modifier = Modifier.size(36.dp),
         ) {
             Icon(Icons.Default.Add, contentDescription = stringResource(R.string.cd_add_tag))
         }
@@ -269,11 +268,16 @@ private fun TagChip(
         horizontalArrangement = Arrangement.spacedBy(Spacing.xs),
     ) {
         Text(text = tag, style = MaterialTheme.typography.labelSmall, color = foreground)
-        Icon(
-            imageVector = Icons.Default.Close,
-            contentDescription = stringResource(R.string.cd_remove_tag, tag),
-            modifier = Modifier.size(14.dp).clickable(onClick = onRemove, onClickLabel = "Remove tag"),
-            tint = foreground,
-        )
+        IconButton(
+            onClick = onRemove,
+            modifier = Modifier.size(48.dp),
+        ) {
+            Icon(
+                imageVector = Icons.Default.Close,
+                contentDescription = stringResource(R.string.cd_remove_tag, tag),
+                modifier = Modifier.size(14.dp),
+                tint = foreground,
+            )
+        }
     }
 }

--- a/core/core-ui/src/commonMain/kotlin/com/riox432/civitdeck/ui/components/SwipeableCardLayout.kt
+++ b/core/core-ui/src/commonMain/kotlin/com/riox432/civitdeck/ui/components/SwipeableCardLayout.kt
@@ -38,7 +38,7 @@ import com.riox432.civitdeck.ui.theme.Spacing
 import com.riox432.civitdeck.ui.theme.Tween
 import kotlin.math.roundToInt
 
-private val ACTION_BUTTON_SIZE = 40.dp
+private val ACTION_BUTTON_SIZE = 48.dp
 private val ACTION_AREA_WIDTH = 64.dp
 private const val DEFAULT_SWIPE_THRESHOLD = 0.3f
 

--- a/desktopApp/src/jvmMain/kotlin/com/riox432/civitdeck/ui/collections/DesktopCollectionsScreen.kt
+++ b/desktopApp/src/jvmMain/kotlin/com/riox432/civitdeck/ui/collections/DesktopCollectionsScreen.kt
@@ -114,7 +114,7 @@ private fun CollectionsList(
             Column(horizontalAlignment = Alignment.CenterHorizontally) {
                 Icon(
                     Icons.Default.FolderCopy,
-                    contentDescription = null,
+                    contentDescription = "No collections",
                     modifier = Modifier.size(EMPTY_ICON_SIZE),
                     tint = MaterialTheme.colorScheme.onSurfaceVariant,
                 )

--- a/desktopApp/src/jvmMain/kotlin/com/riox432/civitdeck/ui/create/DesktopCreateHubScreen.kt
+++ b/desktopApp/src/jvmMain/kotlin/com/riox432/civitdeck/ui/create/DesktopCreateHubScreen.kt
@@ -93,7 +93,7 @@ private fun CreateHubCard(
         ) {
             Icon(
                 imageVector = item.icon,
-                contentDescription = null,
+                contentDescription = item.title,
                 modifier = Modifier.size(32.dp),
                 tint = MaterialTheme.colorScheme.primary,
             )
@@ -110,7 +110,7 @@ private fun CreateHubCard(
             }
             Icon(
                 imageVector = Icons.AutoMirrored.Filled.ArrowForward,
-                contentDescription = null,
+                contentDescription = "Navigate",
                 tint = MaterialTheme.colorScheme.onSurfaceVariant,
             )
         }

--- a/desktopApp/src/jvmMain/kotlin/com/riox432/civitdeck/ui/dataset/DesktopDatasetDetailScreen.kt
+++ b/desktopApp/src/jvmMain/kotlin/com/riox432/civitdeck/ui/dataset/DesktopDatasetDetailScreen.kt
@@ -231,7 +231,7 @@ private fun SelectionActionBar(
         horizontalArrangement = Arrangement.spacedBy(Spacing.sm),
     ) {
         Button(onClick = onRemove) {
-            Icon(Icons.Default.Delete, contentDescription = null, modifier = Modifier.size(18.dp))
+            Icon(Icons.Default.Delete, contentDescription = "Remove selected", modifier = Modifier.size(18.dp))
             Spacer(Modifier.width(Spacing.xs))
             Text("Remove $selectedCount ${if (selectedCount == 1) "image" else "images"}")
         }
@@ -256,7 +256,7 @@ private fun DatasetImageGridContent(
             Column(horizontalAlignment = Alignment.CenterHorizontally) {
                 Icon(
                     Icons.Default.Dataset,
-                    contentDescription = null,
+                    contentDescription = "Empty dataset",
                     tint = MaterialTheme.colorScheme.onSurfaceVariant,
                 )
                 Text(
@@ -308,7 +308,7 @@ private fun DesktopDatasetImageItem(
                 .data(image.imageUrl)
                 .size(Size(DATASET_IMAGE_SIZE, DATASET_IMAGE_SIZE))
                 .build(),
-            contentDescription = null,
+            contentDescription = "Dataset image",
             contentScale = ContentScale.Crop,
             modifier = Modifier
                 .fillMaxWidth()

--- a/desktopApp/src/jvmMain/kotlin/com/riox432/civitdeck/ui/dataset/DesktopDatasetListScreen.kt
+++ b/desktopApp/src/jvmMain/kotlin/com/riox432/civitdeck/ui/dataset/DesktopDatasetListScreen.kt
@@ -129,7 +129,7 @@ private fun DatasetListBody(
             Column(horizontalAlignment = Alignment.CenterHorizontally) {
                 Icon(
                     Icons.Default.Dataset,
-                    contentDescription = null,
+                    contentDescription = "Empty dataset list",
                     tint = MaterialTheme.colorScheme.onSurfaceVariant,
                 )
                 Text(
@@ -192,7 +192,7 @@ private fun DesktopDatasetCard(
             ) {
                 Icon(
                     imageVector = Icons.Default.Dataset,
-                    contentDescription = null,
+                    contentDescription = "Dataset",
                     tint = MaterialTheme.colorScheme.primary,
                 )
             }
@@ -225,7 +225,7 @@ private fun DesktopDatasetCard(
                 ) {
                     DropdownMenuItem(
                         text = { Text("Rename") },
-                        leadingIcon = { Icon(Icons.Default.Edit, contentDescription = null) },
+                        leadingIcon = { Icon(Icons.Default.Edit, contentDescription = "Rename") },
                         onClick = {
                             showMenu = false
                             showRenameDialog = true
@@ -233,7 +233,7 @@ private fun DesktopDatasetCard(
                     )
                     DropdownMenuItem(
                         text = { Text("Delete") },
-                        leadingIcon = { Icon(Icons.Default.Delete, contentDescription = null) },
+                        leadingIcon = { Icon(Icons.Default.Delete, contentDescription = "Delete") },
                         onClick = {
                             showMenu = false
                             onDelete()

--- a/desktopApp/src/jvmMain/kotlin/com/riox432/civitdeck/ui/detail/DesktopDetailScreen.kt
+++ b/desktopApp/src/jvmMain/kotlin/com/riox432/civitdeck/ui/detail/DesktopDetailScreen.kt
@@ -1,43 +1,18 @@
 package com.riox432.civitdeck.ui.detail
 
 import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.ExperimentalLayoutApi
-import androidx.compose.foundation.layout.FlowRow
-import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.layout.widthIn
-import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.grid.GridCells
-import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
-import androidx.compose.foundation.lazy.grid.itemsIndexed
-import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.shape.CircleShape
-import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
-import androidx.compose.material.icons.filled.Close
-import androidx.compose.material.icons.filled.OpenInFull
-import androidx.compose.material3.DropdownMenu
-import androidx.compose.material3.DropdownMenuItem
-import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -48,32 +23,16 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
-import androidx.compose.ui.layout.ContentScale
-import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
-import coil3.PlatformContext
-import coil3.compose.SubcomposeAsyncImage
-import coil3.request.ImageRequest
-import coil3.size.Size
-import com.riox432.civitdeck.domain.model.ImageGenerationMeta
 import com.riox432.civitdeck.domain.model.Model
-import com.riox432.civitdeck.domain.model.ModelImage
-import com.riox432.civitdeck.domain.model.ModelVersion
 import com.riox432.civitdeck.domain.model.filterByNsfwLevel
-import com.riox432.civitdeck.domain.model.thumbnailUrl
 import com.riox432.civitdeck.feature.detail.presentation.ModelDetailUiState
 import com.riox432.civitdeck.feature.detail.presentation.ModelDetailViewModel
 import com.riox432.civitdeck.ui.components.ErrorStateView
-import com.riox432.civitdeck.ui.components.ImageErrorPlaceholder
 import com.riox432.civitdeck.ui.components.LoadingStateOverlay
-import com.riox432.civitdeck.ui.components.ModelStatsRow
-import com.riox432.civitdeck.ui.theme.CornerRadius
-import com.riox432.civitdeck.ui.theme.Spacing
-import com.riox432.civitdeck.ui.theme.shimmer
 import com.riox432.civitdeck.ui.theme.Elevation
-import com.riox432.civitdeck.domain.util.FormatUtils
+import com.riox432.civitdeck.ui.theme.Spacing
 
 @Composable
 fun DesktopDetailScreen(
@@ -160,14 +119,14 @@ private fun DetailBody(
                     onImageFullscreen = onImageClick,
                     modifier = Modifier.weight(1f),
                 )
-                if (selectedImageIndex != null) {
-                    val image = images.getOrNull(selectedImageIndex!!)
+                selectedImageIndex?.let { index ->
+                    val image = images.getOrNull(index)
                     if (image != null) {
                         ImageMetadataPanel(
                             image = image,
                             onClose = { selectedImageIndex = null },
                             onOpenFullscreen = {
-                                onImageClick(images.map { it.url }, selectedImageIndex!!)
+                                onImageClick(images.map { it.url }, index)
                             },
                         )
                     }
@@ -187,402 +146,14 @@ private fun DetailBody(
     }
 }
 
-@Composable
-private fun ImageGridPanel(
-    images: List<ModelImage>,
-    selectedIndex: Int?,
-    onImageSelect: (Int) -> Unit,
-    onImageFullscreen: (List<String>, Int) -> Unit,
-    modifier: Modifier = Modifier,
-) {
-    val urls = images.map { it.url }
-    LazyVerticalGrid(
-        columns = GridCells.Adaptive(IMAGE_GRID_MIN_SIZE),
-        modifier = modifier.padding(Spacing.md),
-        contentPadding = PaddingValues(Spacing.xs),
-        horizontalArrangement = Arrangement.spacedBy(Spacing.xs),
-        verticalArrangement = Arrangement.spacedBy(Spacing.xs),
-    ) {
-        itemsIndexed(images, key = { _, img -> img.url }) { index, image ->
-            val isSelected = selectedIndex == index
-            Box {
-                SubcomposeAsyncImage(
-                    model = ImageRequest.Builder(PlatformContext.INSTANCE)
-                        .data(image.thumbnailUrl())
-                        .size(Size(DETAIL_GRID_IMAGE_SIZE, DETAIL_GRID_IMAGE_SIZE))
-                        .build(),
-                    contentDescription = "Image ${index + 1}",
-                    modifier = Modifier
-                        .aspectRatio(1f)
-                        .clip(RoundedCornerShape(CornerRadius.card))
-                        .then(
-                            if (isSelected) {
-                                Modifier.background(
-                                    MaterialTheme.colorScheme.primaryContainer.copy(alpha = 0.3f),
-                                )
-                            } else {
-                                Modifier
-                            },
-                        )
-                        .clickable { onImageSelect(index) },
-                    contentScale = ContentScale.Crop,
-                    loading = { Box(Modifier.fillMaxSize().shimmer()) },
-                    error = { ImageErrorPlaceholder(modifier = Modifier.fillMaxSize()) },
-                )
-            }
-        }
-    }
-}
-
-@Composable
-private fun ImageMetadataPanel(
-    image: ModelImage,
-    onClose: () -> Unit,
-    onOpenFullscreen: () -> Unit,
-) {
-    Surface(
-        tonalElevation = 2.dp,
-        shape = RoundedCornerShape(topStart = CornerRadius.card, topEnd = CornerRadius.card),
-        modifier = Modifier.fillMaxWidth(),
-    ) {
-        Column(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(Spacing.md),
-        ) {
-            MetadataPanelHeader(onClose = onClose, onOpenFullscreen = onOpenFullscreen)
-            Spacer(modifier = Modifier.height(Spacing.sm))
-            Column(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .height(METADATA_PANEL_HEIGHT)
-                    .verticalScroll(rememberScrollState()),
-                verticalArrangement = Arrangement.spacedBy(Spacing.xs),
-            ) {
-                MetadataRow("Dimensions", "${image.width} x ${image.height}")
-                image.hash?.let { MetadataRow("Hash", it) }
-
-                image.meta?.let { meta ->
-                    HorizontalDivider(modifier = Modifier.padding(vertical = Spacing.xs))
-                    Text(
-                        "Generation Parameters",
-                        style = MaterialTheme.typography.titleSmall,
-                    )
-                    Spacer(modifier = Modifier.height(Spacing.xs))
-                    GenerationMetadataContent(meta)
-                }
-            }
-        }
-    }
-}
-
-@Composable
-private fun MetadataPanelHeader(
-    onClose: () -> Unit,
-    onOpenFullscreen: () -> Unit,
-) {
-    Row(
-        modifier = Modifier.fillMaxWidth(),
-        horizontalArrangement = Arrangement.SpaceBetween,
-        verticalAlignment = Alignment.CenterVertically,
-    ) {
-        Text(
-            "Image Metadata",
-            style = MaterialTheme.typography.titleSmall,
-        )
-        Row {
-            IconButton(onClick = onOpenFullscreen) {
-                Icon(
-                    Icons.Default.OpenInFull,
-                    contentDescription = "View full size",
-                    modifier = Modifier.size(ICON_SIZE),
-                )
-            }
-            IconButton(onClick = onClose) {
-                Icon(
-                    Icons.Default.Close,
-                    contentDescription = "Close",
-                    modifier = Modifier.size(ICON_SIZE),
-                )
-            }
-        }
-    }
-}
-
-@Composable
-private fun GenerationMetadataContent(meta: ImageGenerationMeta) {
-    meta.model?.let { MetadataRow("Model", it) }
-    meta.sampler?.let { MetadataRow("Sampler", it) }
-    meta.steps?.let { MetadataRow("Steps", it.toString()) }
-    meta.cfgScale?.let { MetadataRow("CFG Scale", it.toString()) }
-    meta.seed?.let { MetadataRow("Seed", it.toString()) }
-    meta.size?.let { MetadataRow("Size", it) }
-    meta.prompt?.let { prompt ->
-        MetadataRow("Prompt", prompt, monospace = true)
-    }
-    meta.negativePrompt?.let { neg ->
-        MetadataRow("Negative Prompt", neg, monospace = true)
-    }
-    if (meta.additionalParams.isNotEmpty()) {
-        meta.additionalParams.forEach { (key, value) ->
-            MetadataRow(key, value)
-        }
-    }
-}
-
-@Composable
-private fun MetadataRow(
-    label: String,
-    value: String,
-    monospace: Boolean = false,
-) {
-    Column(modifier = Modifier.fillMaxWidth()) {
-        Text(
-            text = label,
-            style = MaterialTheme.typography.labelSmall,
-            color = MaterialTheme.colorScheme.onSurfaceVariant,
-        )
-        Text(
-            text = value,
-            style = if (monospace) {
-                MaterialTheme.typography.bodySmall.copy(fontFamily = FontFamily.Monospace)
-            } else {
-                MaterialTheme.typography.bodySmall
-            },
-            maxLines = if (monospace) MAX_MONOSPACE_LINES else MAX_NORMAL_LINES,
-            overflow = TextOverflow.Ellipsis,
-        )
-    }
-}
-
-@Composable
-private fun InfoPanel(
-    model: Model,
-    uiState: ModelDetailUiState,
-    selectedVersion: ModelVersion?,
-    onVersionSelected: (Int) -> Unit,
-    onCreatorClick: (String) -> Unit,
-    modifier: Modifier = Modifier,
-) {
-    LazyColumn(
-        modifier = modifier.padding(Spacing.lg),
-        verticalArrangement = Arrangement.spacedBy(Spacing.md),
-    ) {
-        item { ModelInfoHeader(model = model, onCreatorClick = onCreatorClick) }
-        item {
-            ModelStatsRow(
-                downloadCount = model.stats.downloadCount,
-                favoriteCount = model.stats.favoriteCount,
-                rating = model.stats.rating,
-                commentCount = model.stats.commentCount,
-            )
-        }
-        if (model.modelVersions.size > 1) {
-            item {
-                VersionDropdown(
-                    versions = model.modelVersions,
-                    selectedIndex = uiState.selectedVersionIndex,
-                    onVersionSelected = onVersionSelected,
-                )
-            }
-        }
-        if (selectedVersion != null) {
-            item { VersionInfo(version = selectedVersion) }
-        }
-        if (model.tags.isNotEmpty()) {
-            item { TagsSection(tags = model.tags) }
-        }
-        if (selectedVersion != null && selectedVersion.files.isNotEmpty()) {
-            item { FilesSection(files = selectedVersion.files) }
-        }
-        if (!model.description.isNullOrBlank()) {
-            item { DescriptionSection(description = model.description!!) }
-        }
-    }
-}
-
-@Composable
-private fun ModelInfoHeader(
-    model: Model,
-    onCreatorClick: (String) -> Unit,
-) {
-    Column(verticalArrangement = Arrangement.spacedBy(Spacing.sm)) {
-        Text(
-            text = model.name,
-            style = MaterialTheme.typography.headlineSmall,
-        )
-        Row(
-            verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.spacedBy(Spacing.sm),
-        ) {
-            Text(
-                text = model.type.name,
-                style = MaterialTheme.typography.labelMedium,
-                modifier = Modifier
-                    .background(
-                        MaterialTheme.colorScheme.surfaceVariant,
-                        RoundedCornerShape(CornerRadius.chip),
-                    )
-                    .padding(horizontal = Spacing.sm, vertical = Spacing.xs),
-            )
-            model.creator?.let { creator ->
-                Row(
-                    verticalAlignment = Alignment.CenterVertically,
-                    modifier = Modifier.clickable { onCreatorClick(creator.username) },
-                ) {
-                    creator.image?.let { avatarUrl ->
-                        SubcomposeAsyncImage(
-                            model = ImageRequest.Builder(PlatformContext.INSTANCE)
-                                .data(avatarUrl)
-                                .size(Size(AVATAR_IMAGE_SIZE, AVATAR_IMAGE_SIZE))
-                                .build(),
-                            contentDescription = creator.username,
-                            modifier = Modifier
-                                .size(AVATAR_SIZE)
-                                .clip(CircleShape),
-                            contentScale = ContentScale.Crop,
-                            loading = { Box(Modifier.fillMaxSize().shimmer()) },
-                            error = { ImageErrorPlaceholder(modifier = Modifier.fillMaxSize()) },
-                        )
-                        Spacer(modifier = Modifier.width(Spacing.xs))
-                    }
-                    Text(
-                        text = creator.username,
-                        style = MaterialTheme.typography.labelLarge,
-                        color = MaterialTheme.colorScheme.primary,
-                    )
-                }
-            }
-        }
-    }
-}
-
-@Composable
-private fun VersionDropdown(
-    versions: List<ModelVersion>,
-    selectedIndex: Int,
-    onVersionSelected: (Int) -> Unit,
-) {
-    var expanded by remember { mutableStateOf(false) }
-    val selectedVersion = versions.getOrNull(selectedIndex)
-
-    Column {
-        Text("Version", style = MaterialTheme.typography.titleSmall)
-        Spacer(modifier = Modifier.height(Spacing.xs))
-        Box {
-            OutlinedButton(onClick = { expanded = true }) {
-                Text(selectedVersion?.name ?: "Select version")
-            }
-            DropdownMenu(expanded = expanded, onDismissRequest = { expanded = false }) {
-                versions.forEachIndexed { index, version ->
-                    DropdownMenuItem(
-                        text = { Text(version.name) },
-                        onClick = {
-                            onVersionSelected(index)
-                            expanded = false
-                        },
-                    )
-                }
-            }
-        }
-    }
-}
-
-@Composable
-private fun VersionInfo(version: ModelVersion) {
-    Column(verticalArrangement = Arrangement.spacedBy(Spacing.xs)) {
-        version.baseModel?.let { base ->
-            Text(
-                text = "Base: $base",
-                style = MaterialTheme.typography.bodySmall,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-            )
-        }
-        if (version.trainedWords.isNotEmpty()) {
-            Text(
-                text = "Trigger: ${version.trainedWords.joinToString(", ")}",
-                style = MaterialTheme.typography.bodySmall,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-            )
-        }
-    }
-}
-
-@OptIn(ExperimentalLayoutApi::class)
-@Composable
-private fun TagsSection(tags: List<String>) {
-    Column {
-        Text("Tags", style = MaterialTheme.typography.titleSmall)
-        Spacer(modifier = Modifier.height(Spacing.xs))
-        FlowRow(
-            horizontalArrangement = Arrangement.spacedBy(Spacing.xs),
-            verticalArrangement = Arrangement.spacedBy(Spacing.xs),
-        ) {
-            tags.forEach { tag ->
-                Text(
-                    text = tag,
-                    style = MaterialTheme.typography.labelSmall,
-                    modifier = Modifier
-                        .background(
-                            MaterialTheme.colorScheme.surfaceVariant,
-                            RoundedCornerShape(CornerRadius.chip),
-                        )
-                        .padding(horizontal = Spacing.sm, vertical = Spacing.xs),
-                )
-            }
-        }
-    }
-}
-
-@Composable
-private fun FilesSection(
-    files: List<com.riox432.civitdeck.domain.model.ModelFile>,
-) {
-    Column(verticalArrangement = Arrangement.spacedBy(Spacing.xs)) {
-        Text("Files", style = MaterialTheme.typography.titleSmall)
-        files.forEach { file ->
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.SpaceBetween,
-            ) {
-                Text(
-                    text = file.name,
-                    style = MaterialTheme.typography.bodySmall,
-                    modifier = Modifier.weight(1f),
-                    maxLines = 1,
-                    overflow = TextOverflow.Ellipsis,
-                )
-                Text(
-                    text = FormatUtils.formatFileSize(file.sizeKB),
-                    style = MaterialTheme.typography.labelSmall,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                )
-            }
-        }
-    }
-}
-
-@Composable
-private fun DescriptionSection(description: String) {
-    Column {
-        Text("Description", style = MaterialTheme.typography.titleSmall)
-        Spacer(modifier = Modifier.height(Spacing.xs))
-        Text(
-            text = description,
-            style = MaterialTheme.typography.bodySmall,
-            color = MaterialTheme.colorScheme.onSurfaceVariant,
-        )
-    }
-}
-
-private const val INFO_PANEL_FRACTION = 0.35f
-private val INFO_PANEL_MIN_WIDTH = 280.dp
-private val INFO_PANEL_MAX_WIDTH = 400.dp
-private val IMAGE_GRID_MIN_SIZE = 180.dp
-private val AVATAR_SIZE = 24.dp
-private val METADATA_PANEL_HEIGHT = 200.dp
-private val ICON_SIZE = 20.dp
-private const val DETAIL_GRID_IMAGE_SIZE = 360
-private const val AVATAR_IMAGE_SIZE = 48
-private const val MAX_MONOSPACE_LINES = 5
-private const val MAX_NORMAL_LINES = 2
+internal const val INFO_PANEL_FRACTION = 0.35f
+internal val INFO_PANEL_MIN_WIDTH = 280.dp
+internal val INFO_PANEL_MAX_WIDTH = 400.dp
+internal val IMAGE_GRID_MIN_SIZE = 180.dp
+internal val AVATAR_SIZE = 24.dp
+internal val METADATA_PANEL_HEIGHT = 200.dp
+internal val ICON_SIZE = 20.dp
+internal const val DETAIL_GRID_IMAGE_SIZE = 360
+internal const val AVATAR_IMAGE_SIZE = 48
+internal const val MAX_MONOSPACE_LINES = 5
+internal const val MAX_NORMAL_LINES = 2

--- a/desktopApp/src/jvmMain/kotlin/com/riox432/civitdeck/ui/detail/ImageGridPanel.kt
+++ b/desktopApp/src/jvmMain/kotlin/com/riox432/civitdeck/ui/detail/ImageGridPanel.kt
@@ -1,0 +1,76 @@
+package com.riox432.civitdeck.ui.detail
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.grid.GridCells
+import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
+import androidx.compose.foundation.lazy.grid.itemsIndexed
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.layout.ContentScale
+import coil3.PlatformContext
+import coil3.compose.SubcomposeAsyncImage
+import coil3.request.ImageRequest
+import coil3.size.Size
+import com.riox432.civitdeck.domain.model.ModelImage
+import com.riox432.civitdeck.domain.model.thumbnailUrl
+import com.riox432.civitdeck.ui.components.ImageErrorPlaceholder
+import com.riox432.civitdeck.ui.theme.CornerRadius
+import com.riox432.civitdeck.ui.theme.Spacing
+import com.riox432.civitdeck.ui.theme.shimmer
+
+@Composable
+internal fun ImageGridPanel(
+    images: List<ModelImage>,
+    selectedIndex: Int?,
+    onImageSelect: (Int) -> Unit,
+    onImageFullscreen: (List<String>, Int) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val urls = images.map { it.url }
+    LazyVerticalGrid(
+        columns = GridCells.Adaptive(IMAGE_GRID_MIN_SIZE),
+        modifier = modifier.padding(Spacing.md),
+        contentPadding = PaddingValues(Spacing.xs),
+        horizontalArrangement = Arrangement.spacedBy(Spacing.xs),
+        verticalArrangement = Arrangement.spacedBy(Spacing.xs),
+    ) {
+        itemsIndexed(images, key = { _, img -> img.url }) { index, image ->
+            val isSelected = selectedIndex == index
+            Box {
+                SubcomposeAsyncImage(
+                    model = ImageRequest.Builder(PlatformContext.INSTANCE)
+                        .data(image.thumbnailUrl())
+                        .size(Size(DETAIL_GRID_IMAGE_SIZE, DETAIL_GRID_IMAGE_SIZE))
+                        .build(),
+                    contentDescription = "Image ${index + 1}",
+                    modifier = Modifier
+                        .aspectRatio(1f)
+                        .clip(RoundedCornerShape(CornerRadius.card))
+                        .then(
+                            if (isSelected) {
+                                Modifier.background(
+                                    MaterialTheme.colorScheme.primaryContainer.copy(alpha = 0.3f),
+                                )
+                            } else {
+                                Modifier
+                            },
+                        )
+                        .clickable { onImageSelect(index) },
+                    contentScale = ContentScale.Crop,
+                    loading = { Box(Modifier.fillMaxSize().shimmer()) },
+                    error = { ImageErrorPlaceholder(modifier = Modifier.fillMaxSize()) },
+                )
+            }
+        }
+    }
+}

--- a/desktopApp/src/jvmMain/kotlin/com/riox432/civitdeck/ui/detail/ImageMetadataPanel.kt
+++ b/desktopApp/src/jvmMain/kotlin/com/riox432/civitdeck/ui/detail/ImageMetadataPanel.kt
@@ -1,0 +1,153 @@
+package com.riox432.civitdeck.ui.detail
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.OpenInFull
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import com.riox432.civitdeck.domain.model.ImageGenerationMeta
+import com.riox432.civitdeck.domain.model.ModelImage
+import com.riox432.civitdeck.ui.theme.CornerRadius
+import com.riox432.civitdeck.ui.theme.Spacing
+
+@Composable
+internal fun ImageMetadataPanel(
+    image: ModelImage,
+    onClose: () -> Unit,
+    onOpenFullscreen: () -> Unit,
+) {
+    Surface(
+        tonalElevation = 2.dp,
+        shape = RoundedCornerShape(topStart = CornerRadius.card, topEnd = CornerRadius.card),
+        modifier = Modifier.fillMaxWidth(),
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(Spacing.md),
+        ) {
+            MetadataPanelHeader(onClose = onClose, onOpenFullscreen = onOpenFullscreen)
+            Spacer(modifier = Modifier.height(Spacing.sm))
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(METADATA_PANEL_HEIGHT)
+                    .verticalScroll(rememberScrollState()),
+                verticalArrangement = Arrangement.spacedBy(Spacing.xs),
+            ) {
+                MetadataRow("Dimensions", "${image.width} x ${image.height}")
+                image.hash?.let { MetadataRow("Hash", it) }
+
+                image.meta?.let { meta ->
+                    HorizontalDivider(modifier = Modifier.padding(vertical = Spacing.xs))
+                    Text(
+                        "Generation Parameters",
+                        style = MaterialTheme.typography.titleSmall,
+                    )
+                    Spacer(modifier = Modifier.height(Spacing.xs))
+                    GenerationMetadataContent(meta)
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun MetadataPanelHeader(
+    onClose: () -> Unit,
+    onOpenFullscreen: () -> Unit,
+) {
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Text(
+            "Image Metadata",
+            style = MaterialTheme.typography.titleSmall,
+        )
+        Row {
+            IconButton(onClick = onOpenFullscreen) {
+                Icon(
+                    Icons.Default.OpenInFull,
+                    contentDescription = "View full size",
+                    modifier = Modifier.size(ICON_SIZE),
+                )
+            }
+            IconButton(onClick = onClose) {
+                Icon(
+                    Icons.Default.Close,
+                    contentDescription = "Close",
+                    modifier = Modifier.size(ICON_SIZE),
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun GenerationMetadataContent(meta: ImageGenerationMeta) {
+    meta.model?.let { MetadataRow("Model", it) }
+    meta.sampler?.let { MetadataRow("Sampler", it) }
+    meta.steps?.let { MetadataRow("Steps", it.toString()) }
+    meta.cfgScale?.let { MetadataRow("CFG Scale", it.toString()) }
+    meta.seed?.let { MetadataRow("Seed", it.toString()) }
+    meta.size?.let { MetadataRow("Size", it) }
+    meta.prompt?.let { prompt ->
+        MetadataRow("Prompt", prompt, monospace = true)
+    }
+    meta.negativePrompt?.let { neg ->
+        MetadataRow("Negative Prompt", neg, monospace = true)
+    }
+    if (meta.additionalParams.isNotEmpty()) {
+        meta.additionalParams.forEach { (key, value) ->
+            MetadataRow(key, value)
+        }
+    }
+}
+
+@Composable
+private fun MetadataRow(
+    label: String,
+    value: String,
+    monospace: Boolean = false,
+) {
+    Column(modifier = Modifier.fillMaxWidth()) {
+        Text(
+            text = label,
+            style = MaterialTheme.typography.labelSmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        Text(
+            text = value,
+            style = if (monospace) {
+                MaterialTheme.typography.bodySmall.copy(fontFamily = FontFamily.Monospace)
+            } else {
+                MaterialTheme.typography.bodySmall
+            },
+            maxLines = if (monospace) MAX_MONOSPACE_LINES else MAX_NORMAL_LINES,
+            overflow = TextOverflow.Ellipsis,
+        )
+    }
+}

--- a/desktopApp/src/jvmMain/kotlin/com/riox432/civitdeck/ui/detail/InfoPanel.kt
+++ b/desktopApp/src/jvmMain/kotlin/com/riox432/civitdeck/ui/detail/InfoPanel.kt
@@ -1,0 +1,268 @@
+package com.riox432.civitdeck.ui.detail
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.text.style.TextOverflow
+import coil3.PlatformContext
+import coil3.compose.SubcomposeAsyncImage
+import coil3.request.ImageRequest
+import coil3.size.Size
+import com.riox432.civitdeck.domain.model.Model
+import com.riox432.civitdeck.domain.model.ModelVersion
+import com.riox432.civitdeck.domain.util.FormatUtils
+import com.riox432.civitdeck.feature.detail.presentation.ModelDetailUiState
+import com.riox432.civitdeck.ui.components.ImageErrorPlaceholder
+import com.riox432.civitdeck.ui.components.ModelStatsRow
+import com.riox432.civitdeck.ui.theme.CornerRadius
+import com.riox432.civitdeck.ui.theme.Spacing
+import com.riox432.civitdeck.ui.theme.shimmer
+
+@Composable
+internal fun InfoPanel(
+    model: Model,
+    uiState: ModelDetailUiState,
+    selectedVersion: ModelVersion?,
+    onVersionSelected: (Int) -> Unit,
+    onCreatorClick: (String) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    LazyColumn(
+        modifier = modifier.padding(Spacing.lg),
+        verticalArrangement = Arrangement.spacedBy(Spacing.md),
+    ) {
+        item { ModelInfoHeader(model = model, onCreatorClick = onCreatorClick) }
+        item {
+            ModelStatsRow(
+                downloadCount = model.stats.downloadCount,
+                favoriteCount = model.stats.favoriteCount,
+                rating = model.stats.rating,
+                commentCount = model.stats.commentCount,
+            )
+        }
+        if (model.modelVersions.size > 1) {
+            item {
+                VersionDropdown(
+                    versions = model.modelVersions,
+                    selectedIndex = uiState.selectedVersionIndex,
+                    onVersionSelected = onVersionSelected,
+                )
+            }
+        }
+        if (selectedVersion != null) {
+            item { VersionInfo(version = selectedVersion) }
+        }
+        if (model.tags.isNotEmpty()) {
+            item { TagsSection(tags = model.tags) }
+        }
+        if (selectedVersion != null && selectedVersion.files.isNotEmpty()) {
+            item { FilesSection(files = selectedVersion.files) }
+        }
+        if (!model.description.isNullOrBlank()) {
+            item { DescriptionSection(description = model.description!!) }
+        }
+    }
+}
+
+@Composable
+private fun ModelInfoHeader(
+    model: Model,
+    onCreatorClick: (String) -> Unit,
+) {
+    Column(verticalArrangement = Arrangement.spacedBy(Spacing.sm)) {
+        Text(
+            text = model.name,
+            style = MaterialTheme.typography.headlineSmall,
+        )
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(Spacing.sm),
+        ) {
+            Text(
+                text = model.type.name,
+                style = MaterialTheme.typography.labelMedium,
+                modifier = Modifier
+                    .background(
+                        MaterialTheme.colorScheme.surfaceVariant,
+                        RoundedCornerShape(CornerRadius.chip),
+                    )
+                    .padding(horizontal = Spacing.sm, vertical = Spacing.xs),
+            )
+            model.creator?.let { creator ->
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    modifier = Modifier.clickable { onCreatorClick(creator.username) },
+                ) {
+                    creator.image?.let { avatarUrl ->
+                        SubcomposeAsyncImage(
+                            model = ImageRequest.Builder(PlatformContext.INSTANCE)
+                                .data(avatarUrl)
+                                .size(Size(AVATAR_IMAGE_SIZE, AVATAR_IMAGE_SIZE))
+                                .build(),
+                            contentDescription = creator.username,
+                            modifier = Modifier
+                                .size(AVATAR_SIZE)
+                                .clip(CircleShape),
+                            contentScale = ContentScale.Crop,
+                            loading = { Box(Modifier.fillMaxSize().shimmer()) },
+                            error = { ImageErrorPlaceholder(modifier = Modifier.fillMaxSize()) },
+                        )
+                        Spacer(modifier = Modifier.width(Spacing.xs))
+                    }
+                    Text(
+                        text = creator.username,
+                        style = MaterialTheme.typography.labelLarge,
+                        color = MaterialTheme.colorScheme.primary,
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun VersionDropdown(
+    versions: List<ModelVersion>,
+    selectedIndex: Int,
+    onVersionSelected: (Int) -> Unit,
+) {
+    var expanded by remember { mutableStateOf(false) }
+    val selectedVersion = versions.getOrNull(selectedIndex)
+
+    Column {
+        Text("Version", style = MaterialTheme.typography.titleSmall)
+        Spacer(modifier = Modifier.height(Spacing.xs))
+        Box {
+            OutlinedButton(onClick = { expanded = true }) {
+                Text(selectedVersion?.name ?: "Select version")
+            }
+            DropdownMenu(expanded = expanded, onDismissRequest = { expanded = false }) {
+                versions.forEachIndexed { index, version ->
+                    DropdownMenuItem(
+                        text = { Text(version.name) },
+                        onClick = {
+                            onVersionSelected(index)
+                            expanded = false
+                        },
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun VersionInfo(version: ModelVersion) {
+    Column(verticalArrangement = Arrangement.spacedBy(Spacing.xs)) {
+        version.baseModel?.let { base ->
+            Text(
+                text = "Base: $base",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+        if (version.trainedWords.isNotEmpty()) {
+            Text(
+                text = "Trigger: ${version.trainedWords.joinToString(", ")}",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+    }
+}
+
+@OptIn(ExperimentalLayoutApi::class)
+@Composable
+private fun TagsSection(tags: List<String>) {
+    Column {
+        Text("Tags", style = MaterialTheme.typography.titleSmall)
+        Spacer(modifier = Modifier.height(Spacing.xs))
+        FlowRow(
+            horizontalArrangement = Arrangement.spacedBy(Spacing.xs),
+            verticalArrangement = Arrangement.spacedBy(Spacing.xs),
+        ) {
+            tags.forEach { tag ->
+                Text(
+                    text = tag,
+                    style = MaterialTheme.typography.labelSmall,
+                    modifier = Modifier
+                        .background(
+                            MaterialTheme.colorScheme.surfaceVariant,
+                            RoundedCornerShape(CornerRadius.chip),
+                        )
+                        .padding(horizontal = Spacing.sm, vertical = Spacing.xs),
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun FilesSection(
+    files: List<com.riox432.civitdeck.domain.model.ModelFile>,
+) {
+    Column(verticalArrangement = Arrangement.spacedBy(Spacing.xs)) {
+        Text("Files", style = MaterialTheme.typography.titleSmall)
+        files.forEach { file ->
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+            ) {
+                Text(
+                    text = file.name,
+                    style = MaterialTheme.typography.bodySmall,
+                    modifier = Modifier.weight(1f),
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                )
+                Text(
+                    text = FormatUtils.formatFileSize(file.sizeKB),
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun DescriptionSection(description: String) {
+    Column {
+        Text("Description", style = MaterialTheme.typography.titleSmall)
+        Spacer(modifier = Modifier.height(Spacing.xs))
+        Text(
+            text = description,
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+    }
+}

--- a/desktopApp/src/jvmMain/kotlin/com/riox432/civitdeck/ui/feed/DesktopFeedScreen.kt
+++ b/desktopApp/src/jvmMain/kotlin/com/riox432/civitdeck/ui/feed/DesktopFeedScreen.kt
@@ -120,7 +120,7 @@ private fun FeedEmptyView() {
         Column(horizontalAlignment = Alignment.CenterHorizontally) {
             Icon(
                 Icons.Default.RssFeed,
-                contentDescription = null,
+                contentDescription = "Empty feed",
                 modifier = Modifier.size(EMPTY_ICON_SIZE),
                 tint = MaterialTheme.colorScheme.onSurfaceVariant,
             )

--- a/desktopApp/src/jvmMain/kotlin/com/riox432/civitdeck/ui/plugin/DesktopPluginListScreen.kt
+++ b/desktopApp/src/jvmMain/kotlin/com/riox432/civitdeck/ui/plugin/DesktopPluginListScreen.kt
@@ -59,7 +59,7 @@ fun DesktopPluginListScreen(
                         Column(horizontalAlignment = Alignment.CenterHorizontally) {
                             Icon(
                                 Icons.Default.Extension,
-                                contentDescription = null,
+                                contentDescription = "No plugins",
                                 tint = MaterialTheme.colorScheme.onSurfaceVariant,
                             )
                             Text(
@@ -140,7 +140,7 @@ private fun DesktopPluginRow(
         ) {
             Icon(
                 Icons.Default.Extension,
-                contentDescription = null,
+                contentDescription = "Plugin",
                 tint = MaterialTheme.colorScheme.onPrimaryContainer,
                 modifier = Modifier.size(24.dp),
             )

--- a/desktopApp/src/jvmMain/kotlin/com/riox432/civitdeck/ui/prompts/DesktopPromptsScreen.kt
+++ b/desktopApp/src/jvmMain/kotlin/com/riox432/civitdeck/ui/prompts/DesktopPromptsScreen.kt
@@ -134,7 +134,7 @@ private fun PromptsList(
             Column(horizontalAlignment = Alignment.CenterHorizontally) {
                 Icon(
                     Icons.AutoMirrored.Filled.TextSnippet,
-                    contentDescription = null,
+                    contentDescription = "No prompts",
                     modifier = Modifier.size(EMPTY_ICON_SIZE),
                     tint = MaterialTheme.colorScheme.onSurfaceVariant,
                 )

--- a/desktopApp/src/jvmMain/kotlin/com/riox432/civitdeck/ui/qrcode/DesktopQRCodeScreen.kt
+++ b/desktopApp/src/jvmMain/kotlin/com/riox432/civitdeck/ui/qrcode/DesktopQRCodeScreen.kt
@@ -159,7 +159,7 @@ private fun QRGenerateSection(
                 modifier = Modifier.weight(1f),
             )
             Button(onClick = onGenerate) {
-                Icon(Icons.Default.QrCode, contentDescription = null)
+                Icon(Icons.Default.QrCode, contentDescription = "Generate QR code")
                 Spacer(modifier = Modifier.width(Spacing.xs))
                 Text("Generate")
             }
@@ -209,7 +209,7 @@ private fun QRScanSection(
         Text("Scan QR Code from Image", style = MaterialTheme.typography.titleSmall)
         Spacer(modifier = Modifier.height(Spacing.sm))
         OutlinedButton(onClick = onPickFile) {
-            Icon(Icons.Default.FileOpen, contentDescription = null)
+            Icon(Icons.Default.FileOpen, contentDescription = "Open file")
             Spacer(modifier = Modifier.width(Spacing.xs))
             Text("Open QR Code Image")
         }

--- a/desktopApp/src/jvmMain/kotlin/com/riox432/civitdeck/ui/settings/DesktopComfyUISection.kt
+++ b/desktopApp/src/jvmMain/kotlin/com/riox432/civitdeck/ui/settings/DesktopComfyUISection.kt
@@ -27,6 +27,7 @@ import com.riox432.civitdeck.feature.comfyui.presentation.ComfyUIGenerationViewM
 import com.riox432.civitdeck.feature.comfyui.presentation.ComfyUIHistoryViewModel
 import com.riox432.civitdeck.feature.comfyui.presentation.ComfyUISettingsViewModel
 import com.riox432.civitdeck.feature.comfyui.presentation.HistorySortOrder
+import com.riox432.civitdeck.domain.model.ComfyUIConnection
 import com.riox432.civitdeck.ui.theme.Spacing
 
 @Composable
@@ -34,7 +35,7 @@ fun ComfyUISettingsSection(viewModel: ComfyUISettingsViewModel) {
     val state by viewModel.uiState.collectAsState()
     var nameInput by remember { mutableStateOf("") }
     var hostInput by remember { mutableStateOf("127.0.0.1") }
-    var portInput by remember { mutableStateOf("8188") }
+    var portInput by remember { mutableStateOf(ComfyUIConnection.DEFAULT_COMFYUI_PORT.toString()) }
 
     SettingsCard(title = "ComfyUI Server") {
         ConnectionStatusBadge(
@@ -127,7 +128,7 @@ fun ComfyUISettingsSection(viewModel: ComfyUISettingsViewModel) {
                 viewModel.onSaveConnection(nameInput, hostInput, port)
                 nameInput = ""
                 hostInput = "127.0.0.1"
-                portInput = "8188"
+                portInput = ComfyUIConnection.DEFAULT_COMFYUI_PORT.toString()
             },
             enabled = nameInput.isNotBlank() && hostInput.isNotBlank(),
         ) {

--- a/desktopApp/src/jvmMain/kotlin/com/riox432/civitdeck/ui/settings/DesktopSDWebUISection.kt
+++ b/desktopApp/src/jvmMain/kotlin/com/riox432/civitdeck/ui/settings/DesktopSDWebUISection.kt
@@ -25,6 +25,7 @@ import androidx.compose.ui.Modifier
 import com.riox432.civitdeck.domain.model.SDWebUIConnectionStatus
 import com.riox432.civitdeck.feature.comfyui.presentation.SDWebUIGenerationViewModel
 import com.riox432.civitdeck.feature.comfyui.presentation.SDWebUISettingsViewModel
+import com.riox432.civitdeck.domain.model.SDWebUIConnection
 import com.riox432.civitdeck.ui.theme.Spacing
 
 @Composable
@@ -32,7 +33,7 @@ fun SDWebUISettingsSection(viewModel: SDWebUISettingsViewModel) {
     val state by viewModel.uiState.collectAsState()
     var nameInput by remember { mutableStateOf("") }
     var hostInput by remember { mutableStateOf("127.0.0.1") }
-    var portInput by remember { mutableStateOf("7860") }
+    var portInput by remember { mutableStateOf(SDWebUIConnection.DEFAULT_SDWEBUI_PORT.toString()) }
 
     SettingsCard(title = "SD WebUI Server") {
         ConnectionStatusBadge(
@@ -120,7 +121,7 @@ fun SDWebUISettingsSection(viewModel: SDWebUISettingsViewModel) {
                 viewModel.onSaveConnection(nameInput, hostInput, port)
                 nameInput = ""
                 hostInput = "127.0.0.1"
-                portInput = "7860"
+                portInput = SDWebUIConnection.DEFAULT_SDWEBUI_PORT.toString()
             },
             enabled = nameInput.isNotBlank() && hostInput.isNotBlank(),
         ) {

--- a/feature/feature-collections/src/commonMain/kotlin/com/riox432/civitdeck/feature/collections/presentation/CollectionDetailViewModel.kt
+++ b/feature/feature-collections/src/commonMain/kotlin/com/riox432/civitdeck/feature/collections/presentation/CollectionDetailViewModel.kt
@@ -7,10 +7,10 @@ import com.riox432.civitdeck.domain.model.FavoriteModelSummary
 import com.riox432.civitdeck.domain.model.ModelCollection
 import com.riox432.civitdeck.domain.model.ModelType
 import com.riox432.civitdeck.domain.usecase.ObserveCollectionsUseCase
+import com.riox432.civitdeck.domain.util.suspendRunCatching
 import com.riox432.civitdeck.feature.collections.domain.usecase.BulkMoveModelsUseCase
 import com.riox432.civitdeck.feature.collections.domain.usecase.BulkRemoveModelsUseCase
 import com.riox432.civitdeck.feature.collections.domain.usecase.ObserveCollectionModelsUseCase
-import com.riox432.civitdeck.domain.util.suspendRunCatching
 import com.riox432.civitdeck.util.Logger
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted

--- a/feature/feature-collections/src/commonMain/kotlin/com/riox432/civitdeck/feature/collections/presentation/CollectionsViewModel.kt
+++ b/feature/feature-collections/src/commonMain/kotlin/com/riox432/civitdeck/feature/collections/presentation/CollectionsViewModel.kt
@@ -5,9 +5,9 @@ import androidx.lifecycle.viewModelScope
 import com.riox432.civitdeck.domain.model.ModelCollection
 import com.riox432.civitdeck.domain.usecase.CreateCollectionUseCase
 import com.riox432.civitdeck.domain.usecase.ObserveCollectionsUseCase
+import com.riox432.civitdeck.domain.util.suspendRunCatching
 import com.riox432.civitdeck.feature.collections.domain.usecase.DeleteCollectionUseCase
 import com.riox432.civitdeck.feature.collections.domain.usecase.RenameCollectionUseCase
-import com.riox432.civitdeck.domain.util.suspendRunCatching
 import com.riox432.civitdeck.util.Logger
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow

--- a/feature/feature-comfyui/src/commonMain/kotlin/com/riox432/civitdeck/feature/comfyui/data/repository/ComfyUIGenerationRepositoryImpl.kt
+++ b/feature/feature-comfyui/src/commonMain/kotlin/com/riox432/civitdeck/feature/comfyui/data/repository/ComfyUIGenerationRepositoryImpl.kt
@@ -110,8 +110,8 @@ class ComfyUIGenerationRepositoryImpl(
         val loraChain = buildLoraChain(params.loraSelections)
         val finalModelNodeId = loraChain.lastOrNull()?.nodeId ?: "3"
         val finalClipNodeId = loraChain.lastOrNull()?.nodeId ?: "3"
-        val finalModelOutput = if (loraChain.isEmpty()) 0 else 0
-        val finalClipOutput = if (loraChain.isEmpty()) 1 else 1
+        val finalModelOutput = 0 // MODEL output index (same for CheckpointLoader and LoraLoader)
+        val finalClipOutput = 1 // CLIP output index (same for CheckpointLoader and LoraLoader)
 
         // Positive conditioning source
         val positiveCondId = if (params.controlNetEnabled && params.controlNetModel.isNotBlank()) "21" else "6"

--- a/feature/feature-comfyui/src/commonMain/kotlin/com/riox432/civitdeck/feature/comfyui/data/repository/ComfyUIRepositoryImpl.kt
+++ b/feature/feature-comfyui/src/commonMain/kotlin/com/riox432/civitdeck/feature/comfyui/data/repository/ComfyUIRepositoryImpl.kt
@@ -226,8 +226,8 @@ class ComfyUIRepositoryImpl(
         val loraChain = buildLoraChain(params.loraSelections)
         val finalModelNodeId = loraChain.lastOrNull()?.nodeId ?: "3"
         val finalClipNodeId = loraChain.lastOrNull()?.nodeId ?: "3"
-        val finalModelOutput = if (loraChain.isEmpty()) 0 else 0
-        val finalClipOutput = if (loraChain.isEmpty()) 1 else 1
+        val finalModelOutput = 0 // MODEL output index (same for CheckpointLoader and LoraLoader)
+        val finalClipOutput = 1 // CLIP output index (same for CheckpointLoader and LoraLoader)
 
         // Positive conditioning source
         val positiveCondId = if (params.controlNetEnabled && params.controlNetModel.isNotBlank()) "21" else "6"

--- a/feature/feature-comfyui/src/commonMain/kotlin/com/riox432/civitdeck/feature/comfyui/plugin/ComfyUIWorkflowPlugin.kt
+++ b/feature/feature-comfyui/src/commonMain/kotlin/com/riox432/civitdeck/feature/comfyui/plugin/ComfyUIWorkflowPlugin.kt
@@ -2,13 +2,13 @@ package com.riox432.civitdeck.feature.comfyui.plugin
 
 import com.riox432.civitdeck.domain.model.ComfyUIConnection
 import com.riox432.civitdeck.domain.repository.ComfyUIConnectionRepository
+import com.riox432.civitdeck.domain.util.suspendRunCatching
 import com.riox432.civitdeck.plugin.WorkflowEnginePlugin
 import com.riox432.civitdeck.plugin.WorkflowEngineStatus
 import com.riox432.civitdeck.plugin.capability.WorkflowCapability
 import com.riox432.civitdeck.plugin.model.PluginManifest
 import com.riox432.civitdeck.plugin.model.PluginState
 import com.riox432.civitdeck.plugin.model.PluginType
-import com.riox432.civitdeck.domain.util.suspendRunCatching
 import kotlinx.coroutines.flow.first
 
 /**

--- a/feature/feature-comfyui/src/commonMain/kotlin/com/riox432/civitdeck/feature/comfyui/presentation/ComfyUIHistoryViewModel.kt
+++ b/feature/feature-comfyui/src/commonMain/kotlin/com/riox432/civitdeck/feature/comfyui/presentation/ComfyUIHistoryViewModel.kt
@@ -14,8 +14,8 @@ import com.riox432.civitdeck.domain.usecase.ObserveDatasetCollectionsUseCase
 import com.riox432.civitdeck.domain.usecase.ObserveShareHashtagsUseCase
 import com.riox432.civitdeck.domain.usecase.RemoveShareHashtagUseCase
 import com.riox432.civitdeck.domain.usecase.ToggleShareHashtagUseCase
-import com.riox432.civitdeck.feature.comfyui.domain.usecase.FetchComfyUIHistoryUseCase
 import com.riox432.civitdeck.domain.util.suspendRunCatching
+import com.riox432.civitdeck.feature.comfyui.domain.usecase.FetchComfyUIHistoryUseCase
 import com.riox432.civitdeck.util.Logger
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted

--- a/feature/feature-comfyui/src/commonMain/kotlin/com/riox432/civitdeck/feature/comfyui/presentation/SDWebUIGenerationViewModel.kt
+++ b/feature/feature-comfyui/src/commonMain/kotlin/com/riox432/civitdeck/feature/comfyui/presentation/SDWebUIGenerationViewModel.kt
@@ -4,12 +4,12 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.riox432.civitdeck.domain.model.SDWebUIGenerationParams
 import com.riox432.civitdeck.domain.model.SDWebUIGenerationProgress
+import com.riox432.civitdeck.domain.util.suspendRunCatching
 import com.riox432.civitdeck.feature.comfyui.domain.usecase.FetchSDWebUIModelsUseCase
 import com.riox432.civitdeck.feature.comfyui.domain.usecase.FetchSDWebUISamplersUseCase
 import com.riox432.civitdeck.feature.comfyui.domain.usecase.FetchSDWebUIVaesUseCase
 import com.riox432.civitdeck.feature.comfyui.domain.usecase.GenerateSDWebUIImageUseCase
 import com.riox432.civitdeck.feature.comfyui.domain.usecase.InterruptSDWebUIGenerationUseCase
-import com.riox432.civitdeck.domain.util.suspendRunCatching
 import com.riox432.civitdeck.util.Logger
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow

--- a/feature/feature-detail/src/commonMain/kotlin/com/riox432/civitdeck/feature/detail/presentation/ModelDetailViewModel.kt
+++ b/feature/feature-detail/src/commonMain/kotlin/com/riox432/civitdeck/feature/detail/presentation/ModelDetailViewModel.kt
@@ -8,7 +8,9 @@ import com.riox432.civitdeck.domain.model.Model
 import com.riox432.civitdeck.domain.model.ModelCollection
 import com.riox432.civitdeck.domain.model.ModelDownload
 import com.riox432.civitdeck.domain.model.ModelFile
+import com.riox432.civitdeck.domain.model.ModelImage
 import com.riox432.civitdeck.domain.model.ModelNote
+import com.riox432.civitdeck.domain.model.ModelVersion
 import com.riox432.civitdeck.domain.model.NsfwFilterLevel
 import com.riox432.civitdeck.domain.model.PersonalTag
 import com.riox432.civitdeck.domain.model.RatingTotals
@@ -74,7 +76,7 @@ data class ModelDetailUiState(
     val reviewSubmitSuccess: Boolean = false,
 )
 
-@Suppress("LongParameterList")
+@Suppress("LongParameterList", "TooManyFunctions")
 class ModelDetailViewModel(
     private val modelId: Long,
     private val getModelDetailUseCase: GetModelDetailUseCase,
@@ -122,11 +124,7 @@ class ModelDetailViewModel(
     init {
         loadModel()
         observeFavorite()
-        observeNsfwFilter()
-        observePowerUserMode()
-        observeNote()
-        observePersonalTags()
-        observeDownloads()
+        startObservers()
         loadReviews()
     }
 
@@ -137,32 +135,14 @@ class ModelDetailViewModel(
 
     override fun onCleared() {
         super.onCleared()
-        if (viewStartTimeMs > 0L) {
-            val durationMs = currentTimeMillis() - viewStartTimeMs
-            viewStartTimeMs = 0L
-            viewModelScope.launch {
-                withContext(NonCancellable) {
-                    try {
-                        withTimeoutOrNull(END_VIEW_TIMEOUT) {
-                            trackModelViewUseCase.endView(modelId, durationMs)
-                        }
-                    } catch (e: Exception) {
-                        Logger.w(TAG, "End view tracking failed: ${e.message}")
-                    }
-                }
-            }
-        }
+        trackEndView()
     }
 
     fun onFavoriteToggle() {
         val model = _uiState.value.model ?: return
-        viewModelScope.launch {
-            suspendRunCatching {
-                toggleFavoriteUseCase(model)
-                trackModelViewUseCase.trackInteraction(modelId, InteractionType.FAVORITE)
-            }.onFailure { e ->
-                Logger.w(TAG, "Favorite toggle failed: ${e.message}")
-            }
+        launchCatching("Favorite toggle") {
+            toggleFavoriteUseCase(model)
+            trackModelViewUseCase.trackInteraction(modelId, InteractionType.FAVORITE)
         }
     }
 
@@ -170,16 +150,14 @@ class ModelDetailViewModel(
         loadModel()
     }
 
+    // region Notes & Tags
+
     fun saveNote(text: String) {
-        viewModelScope.launch {
-            suspendRunCatching {
-                if (text.isBlank()) {
-                    deleteModelNoteUseCase(modelId)
-                } else {
-                    saveModelNoteUseCase(modelId, text)
-                }
-            }.onFailure { e ->
-                Logger.w(TAG, "Note save failed: ${e.message}")
+        launchCatching("Note save") {
+            if (text.isBlank()) {
+                deleteModelNoteUseCase(modelId)
+            } else {
+                saveModelNoteUseCase(modelId, text)
             }
         }
     }
@@ -187,37 +165,105 @@ class ModelDetailViewModel(
     fun addTag(tag: String) {
         val trimmed = tag.trim().lowercase()
         if (trimmed.isBlank()) return
-        viewModelScope.launch {
-            suspendRunCatching { addPersonalTagUseCase(modelId, trimmed) }
-                .onFailure { e -> Logger.w(TAG, "Add tag failed: ${e.message}") }
-        }
+        launchCatching("Add tag") { addPersonalTagUseCase(modelId, trimmed) }
     }
 
     fun removeTag(tag: String) {
-        viewModelScope.launch {
-            suspendRunCatching { removePersonalTagUseCase(modelId, tag) }
-                .onFailure { e -> Logger.w(TAG, "Remove tag failed: ${e.message}") }
+        launchCatching("Remove tag") { removePersonalTagUseCase(modelId, tag) }
+    }
+
+    // endregion
+
+    // region Collections
+
+    fun toggleCollection(collectionId: Long) {
+        val model = _uiState.value.model ?: return
+        launchCatching("Collection toggle") {
+            if (collectionId in modelCollectionIds.value) {
+                removeModelFromCollectionUseCase(collectionId, model.id)
+            } else {
+                addModelToCollectionUseCase(collectionId, model)
+            }
         }
     }
+
+    fun createCollectionAndAdd(name: String) {
+        val model = _uiState.value.model ?: return
+        launchCatching("Create collection and add") {
+            val newId = createCollectionUseCase(name)
+            addModelToCollectionUseCase(newId, model)
+        }
+    }
+
+    // endregion
+
+    // region Downloads
+
+    fun downloadFile(file: ModelFile) {
+        val model = _uiState.value.model ?: return
+        val version = model.modelVersions.getOrNull(_uiState.value.selectedVersionIndex) ?: return
+        launchCatching("Download enqueue") {
+            val download = buildModelDownload(model, version, file)
+            val id = enqueueDownloadUseCase(download)
+            _downloadEnqueuedEvent.tryEmit(id)
+            trackModelViewUseCase.trackInteraction(modelId, InteractionType.DOWNLOAD)
+        }
+    }
+
+    fun cancelDownload(downloadId: Long) {
+        launchCatching("Cancel download") { cancelDownloadUseCase(downloadId) }
+    }
+
+    // endregion
+
+    // region Reviews
+
+    fun onReviewSortChanged(order: ReviewSortOrder) {
+        _uiState.update { it.copy(reviewSortOrder = order) }
+        loadReviews()
+    }
+
+    @Suppress("LongParameterList")
+    fun submitReview(
+        modelVersionId: Long,
+        rating: Int,
+        recommended: Boolean,
+        details: String?,
+    ) {
+        viewModelScope.launch {
+            _uiState.update { it.copy(isSubmittingReview = true) }
+            suspendRunCatching {
+                submitReviewUseCase(modelId, modelVersionId, rating, recommended, details)
+            }
+                .onSuccess {
+                    _uiState.update {
+                        it.copy(isSubmittingReview = false, reviewSubmitSuccess = true)
+                    }
+                    loadReviews()
+                }
+                .onFailure { e ->
+                    Logger.w(TAG, "Submit review failed: ${e.message}")
+                    _uiState.update { it.copy(isSubmittingReview = false) }
+                }
+        }
+    }
+
+    fun dismissReviewSuccess() {
+        _uiState.update { it.copy(reviewSubmitSuccess = false) }
+    }
+
+    // endregion
+
+    // region Private — Model loading & enrichment
 
     private fun loadModel() {
         viewModelScope.launch {
             _uiState.update { it.copy(isLoading = true, error = null) }
             suspendRunCatching { getModelDetailUseCase(modelId) }
                 .onSuccess { model ->
-                    _uiState.update {
-                        it.copy(model = model, isLoading = false)
-                    }
+                    _uiState.update { it.copy(model = model, isLoading = false) }
                     enrichCurrentVersion()
-                    trackModelViewUseCase(
-                        modelId = model.id,
-                        modelName = model.name,
-                        modelType = model.type.name,
-                        creatorName = model.creator?.username,
-                        thumbnailUrl = model.modelVersions.firstOrNull()
-                            ?.images?.firstOrNull()?.url,
-                        tags = model.tags,
-                    )
+                    trackModelView(model)
                     viewStartTimeMs = currentTimeMillis()
                 }
                 .onFailure { e ->
@@ -232,27 +278,10 @@ class ModelDetailViewModel(
         val state = _uiState.value
         val model = state.model ?: return
         val version = model.modelVersions.getOrNull(state.selectedVersionIndex) ?: return
-        var alreadyEnriched = false
-        enrichedVersionIds.update { ids ->
-            if (version.id in ids) {
-                alreadyEnriched = true
-                ids
-            } else {
-                ids + version.id
-            }
-        }
-        if (alreadyEnriched) return
+        if (!markVersionForEnrichment(version.id)) return
         viewModelScope.launch {
             suspendRunCatching { enrichModelImagesUseCase(version.id, version.images) }
-                .onSuccess { enriched ->
-                    _uiState.update { current ->
-                        val currentModel = current.model ?: return@update current
-                        val updatedVersions = currentModel.modelVersions.map { v ->
-                            if (v.id == version.id) v.copy(images = enriched) else v
-                        }
-                        current.copy(model = currentModel.copy(modelVersions = updatedVersions))
-                    }
-                }
+                .onSuccess { enriched -> applyEnrichedImages(version.id, enriched) }
                 .onFailure { e ->
                     Logger.w(TAG, "Enrich version images failed: ${e.message}")
                     enrichedVersionIds.update { it - version.id }
@@ -260,37 +289,49 @@ class ModelDetailViewModel(
         }
     }
 
+    /**
+     * Marks a version as being enriched. Returns true if enrichment should proceed
+     * (i.e., the version was not already enriched).
+     */
+    private fun markVersionForEnrichment(versionId: Long): Boolean {
+        var shouldEnrich = false
+        enrichedVersionIds.update { ids ->
+            if (versionId in ids) {
+                ids
+            } else {
+                shouldEnrich = true
+                ids + versionId
+            }
+        }
+        return shouldEnrich
+    }
+
+    private fun applyEnrichedImages(versionId: Long, enriched: List<ModelImage>) {
+        _uiState.update { current ->
+            val currentModel = current.model ?: return@update current
+            val updatedVersions = currentModel.modelVersions.map { v ->
+                if (v.id == versionId) v.copy(images = enriched) else v
+            }
+            current.copy(model = currentModel.copy(modelVersions = updatedVersions))
+        }
+    }
+
+    // endregion
+
+    // region Private — Observers
+
+    private fun startObservers() {
+        observeNsfwFilter()
+        observePowerUserMode()
+        observeNote()
+        observePersonalTags()
+        observeDownloads()
+    }
+
     private fun observeFavorite() {
         viewModelScope.launch {
             observeIsFavoriteUseCase(modelId).collect { isFavorite ->
                 _uiState.update { it.copy(isFavorite = isFavorite) }
-            }
-        }
-    }
-
-    fun toggleCollection(collectionId: Long) {
-        val model = _uiState.value.model ?: return
-        viewModelScope.launch {
-            suspendRunCatching {
-                if (collectionId in modelCollectionIds.value) {
-                    removeModelFromCollectionUseCase(collectionId, model.id)
-                } else {
-                    addModelToCollectionUseCase(collectionId, model)
-                }
-            }.onFailure { e ->
-                Logger.w(TAG, "Collection toggle failed: ${e.message}")
-            }
-        }
-    }
-
-    fun createCollectionAndAdd(name: String) {
-        val model = _uiState.value.model ?: return
-        viewModelScope.launch {
-            suspendRunCatching {
-                val newId = createCollectionUseCase(name)
-                addModelToCollectionUseCase(newId, model)
-            }.onFailure { e ->
-                Logger.w(TAG, "Create collection and add failed: ${e.message}")
             }
         }
     }
@@ -335,72 +376,9 @@ class ModelDetailViewModel(
         }
     }
 
-    fun downloadFile(file: ModelFile) {
-        val model = _uiState.value.model ?: return
-        val version = model.modelVersions.getOrNull(_uiState.value.selectedVersionIndex) ?: return
-        viewModelScope.launch {
-            suspendRunCatching {
-                val download = ModelDownload(
-                    modelId = model.id,
-                    modelName = model.name,
-                    versionId = version.id,
-                    versionName = version.name,
-                    fileId = file.id,
-                    fileName = file.name,
-                    fileUrl = file.downloadUrl,
-                    fileSizeBytes = (file.sizeKB * KB_TO_BYTES).toLong(),
-                    status = DownloadStatus.Pending,
-                    modelType = model.type.name,
-                )
-                val id = enqueueDownloadUseCase(download)
-                _downloadEnqueuedEvent.tryEmit(id)
-                trackModelViewUseCase.trackInteraction(modelId, InteractionType.DOWNLOAD)
-            }.onFailure { e ->
-                Logger.w(TAG, "Download enqueue failed: ${e.message}")
-            }
-        }
-    }
+    // endregion
 
-    fun cancelDownload(downloadId: Long) {
-        viewModelScope.launch {
-            suspendRunCatching { cancelDownloadUseCase(downloadId) }
-                .onFailure { e -> Logger.w(TAG, "Cancel download failed: ${e.message}") }
-        }
-    }
-
-    fun onReviewSortChanged(order: ReviewSortOrder) {
-        _uiState.update { it.copy(reviewSortOrder = order) }
-        loadReviews()
-    }
-
-    @Suppress("LongParameterList")
-    fun submitReview(
-        modelVersionId: Long,
-        rating: Int,
-        recommended: Boolean,
-        details: String?,
-    ) {
-        viewModelScope.launch {
-            _uiState.update { it.copy(isSubmittingReview = true) }
-            suspendRunCatching {
-                submitReviewUseCase(modelId, modelVersionId, rating, recommended, details)
-            }
-                .onSuccess {
-                    _uiState.update {
-                        it.copy(isSubmittingReview = false, reviewSubmitSuccess = true)
-                    }
-                    loadReviews()
-                }
-                .onFailure { e ->
-                    Logger.w(TAG, "Submit review failed: ${e.message}")
-                    _uiState.update { it.copy(isSubmittingReview = false) }
-                }
-        }
-    }
-
-    fun dismissReviewSuccess() {
-        _uiState.update { it.copy(reviewSubmitSuccess = false) }
-    }
+    // region Private — Reviews
 
     private fun loadReviews() {
         viewModelScope.launch {
@@ -435,6 +413,69 @@ class ModelDetailViewModel(
         ReviewSortOrder.HighestRated -> reviews.sortedByDescending { it.rating }
         ReviewSortOrder.LowestRated -> reviews.sortedBy { it.rating }
     }
+
+    // endregion
+
+    // region Private — Helpers
+
+    /**
+     * Common pattern: launch a coroutine, run [block] inside suspendRunCatching,
+     * and log failures with [operationName].
+     */
+    private fun launchCatching(operationName: String, block: suspend () -> Unit) {
+        viewModelScope.launch {
+            suspendRunCatching { block() }
+                .onFailure { e -> Logger.w(TAG, "$operationName failed: ${e.message}") }
+        }
+    }
+
+    private fun trackEndView() {
+        if (viewStartTimeMs <= 0L) return
+        val durationMs = currentTimeMillis() - viewStartTimeMs
+        viewStartTimeMs = 0L
+        viewModelScope.launch {
+            withContext(NonCancellable) {
+                try {
+                    withTimeoutOrNull(END_VIEW_TIMEOUT) {
+                        trackModelViewUseCase.endView(modelId, durationMs)
+                    }
+                } catch (e: Exception) {
+                    Logger.w(TAG, "End view tracking failed: ${e.message}")
+                }
+            }
+        }
+    }
+
+    private suspend fun trackModelView(model: Model) {
+        trackModelViewUseCase(
+            modelId = model.id,
+            modelName = model.name,
+            modelType = model.type.name,
+            creatorName = model.creator?.username,
+            thumbnailUrl = model.modelVersions.firstOrNull()
+                ?.images?.firstOrNull()?.url,
+            tags = model.tags,
+        )
+    }
+
+    private fun buildModelDownload(
+        model: Model,
+        version: ModelVersion,
+        file: ModelFile,
+    ): ModelDownload = ModelDownload(
+        modelId = model.id,
+        modelName = model.name,
+        versionId = version.id,
+        versionName = version.name,
+        fileId = file.id,
+        fileName = file.name,
+        fileUrl = file.downloadUrl,
+        fileSizeBytes = (file.sizeKB * KB_TO_BYTES).toLong(),
+        status = DownloadStatus.Pending,
+        modelType = model.type.name,
+    )
+
+    // endregion
 }
 
 private const val TAG = "ModelDetailViewModel"

--- a/feature/feature-externalserver/src/commonMain/kotlin/com/riox432/civitdeck/feature/externalserver/di/ExternalServerModule.kt
+++ b/feature/feature-externalserver/src/commonMain/kotlin/com/riox432/civitdeck/feature/externalserver/di/ExternalServerModule.kt
@@ -6,12 +6,12 @@ import com.riox432.civitdeck.feature.externalserver.domain.repository.ExternalSe
 import com.riox432.civitdeck.feature.externalserver.domain.repository.ExternalServerImagesRepository
 import com.riox432.civitdeck.feature.externalserver.domain.usecase.ActivateExternalServerConfigUseCase
 import com.riox432.civitdeck.feature.externalserver.domain.usecase.DeleteExternalServerConfigUseCase
+import com.riox432.civitdeck.feature.externalserver.domain.usecase.DeleteServerImagesUseCase
 import com.riox432.civitdeck.feature.externalserver.domain.usecase.ExecuteGenerationUseCase
 import com.riox432.civitdeck.feature.externalserver.domain.usecase.GetDependentChoicesUseCase
 import com.riox432.civitdeck.feature.externalserver.domain.usecase.GetExternalServerCapabilitiesUseCase
 import com.riox432.civitdeck.feature.externalserver.domain.usecase.GetExternalServerImagesUseCase
 import com.riox432.civitdeck.feature.externalserver.domain.usecase.GetGenerationOptionsUseCase
-import com.riox432.civitdeck.feature.externalserver.domain.usecase.DeleteServerImagesUseCase
 import com.riox432.civitdeck.feature.externalserver.domain.usecase.GetGenerationStatusUseCase
 import com.riox432.civitdeck.feature.externalserver.domain.usecase.ObserveActiveExternalServerConfigUseCase
 import com.riox432.civitdeck.feature.externalserver.domain.usecase.ObserveExternalServerConfigsUseCase

--- a/feature/feature-externalserver/src/commonMain/kotlin/com/riox432/civitdeck/feature/externalserver/plugin/ExternalServerWorkflowPlugin.kt
+++ b/feature/feature-externalserver/src/commonMain/kotlin/com/riox432/civitdeck/feature/externalserver/plugin/ExternalServerWorkflowPlugin.kt
@@ -1,6 +1,7 @@
 package com.riox432.civitdeck.feature.externalserver.plugin
 
 import com.riox432.civitdeck.domain.model.ExternalServerConfig
+import com.riox432.civitdeck.domain.util.suspendRunCatching
 import com.riox432.civitdeck.feature.externalserver.domain.repository.ExternalServerConfigRepository
 import com.riox432.civitdeck.feature.externalserver.domain.repository.ExternalServerImagesRepository
 import com.riox432.civitdeck.plugin.WorkflowEnginePlugin
@@ -9,7 +10,6 @@ import com.riox432.civitdeck.plugin.capability.WorkflowCapability
 import com.riox432.civitdeck.plugin.model.PluginManifest
 import com.riox432.civitdeck.plugin.model.PluginState
 import com.riox432.civitdeck.plugin.model.PluginType
-import com.riox432.civitdeck.domain.util.suspendRunCatching
 import kotlinx.coroutines.flow.first
 
 /**

--- a/feature/feature-externalserver/src/commonMain/kotlin/com/riox432/civitdeck/feature/externalserver/presentation/ExternalServerGalleryViewModel.kt
+++ b/feature/feature-externalserver/src/commonMain/kotlin/com/riox432/civitdeck/feature/externalserver/presentation/ExternalServerGalleryViewModel.kt
@@ -2,6 +2,7 @@ package com.riox432.civitdeck.feature.externalserver.presentation
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.riox432.civitdeck.domain.util.suspendRunCatching
 import com.riox432.civitdeck.feature.externalserver.domain.model.ExternalServerImageFilters
 import com.riox432.civitdeck.feature.externalserver.domain.model.GenerationChoice
 import com.riox432.civitdeck.feature.externalserver.domain.model.GenerationJob
@@ -16,7 +17,6 @@ import com.riox432.civitdeck.feature.externalserver.domain.usecase.GetExternalSe
 import com.riox432.civitdeck.feature.externalserver.domain.usecase.GetExternalServerImagesUseCase
 import com.riox432.civitdeck.feature.externalserver.domain.usecase.GetGenerationOptionsUseCase
 import com.riox432.civitdeck.feature.externalserver.domain.usecase.GetGenerationStatusUseCase
-import com.riox432.civitdeck.domain.util.suspendRunCatching
 import com.riox432.civitdeck.util.Logger
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay

--- a/feature/feature-search/src/commonMain/kotlin/com/riox432/civitdeck/feature/search/presentation/ModelSearchViewModel.kt
+++ b/feature/feature-search/src/commonMain/kotlin/com/riox432/civitdeck/feature/search/presentation/ModelSearchViewModel.kt
@@ -28,6 +28,7 @@ import com.riox432.civitdeck.domain.usecase.ObserveOwnedModelHashesUseCase
 import com.riox432.civitdeck.domain.usecase.ObserveQualityThresholdUseCase
 import com.riox432.civitdeck.domain.usecase.RemoveExcludedTagUseCase
 import com.riox432.civitdeck.domain.usecase.ToggleFavoriteUseCase
+import com.riox432.civitdeck.domain.util.suspendRunCatching
 import com.riox432.civitdeck.feature.search.domain.usecase.AddSearchHistoryUseCase
 import com.riox432.civitdeck.feature.search.domain.usecase.DeleteSavedSearchFilterUseCase
 import com.riox432.civitdeck.feature.search.domain.usecase.DeleteSearchHistoryItemUseCase
@@ -39,7 +40,7 @@ import com.riox432.civitdeck.feature.search.domain.usecase.MultiSourceSearchUseC
 import com.riox432.civitdeck.feature.search.domain.usecase.ObserveSavedSearchFiltersUseCase
 import com.riox432.civitdeck.feature.search.domain.usecase.ObserveSearchHistoryUseCase
 import com.riox432.civitdeck.feature.search.domain.usecase.SaveSearchFilterUseCase
-import com.riox432.civitdeck.domain.util.suspendRunCatching
+import com.riox432.civitdeck.util.Logger
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.Flow
@@ -223,7 +224,8 @@ class ModelSearchViewModel(
                 _uiState.update {
                     it.copy(recommendations = sections, isLoadingRecommendations = false)
                 }
-            } catch (@Suppress("TooGenericExceptionCaught") _: Exception) {
+            } catch (@Suppress("TooGenericExceptionCaught") e: Exception) {
+                Logger.w(TAG, "Failed to load recommendations: ${e.message}")
                 _uiState.update { it.copy(isLoadingRecommendations = false) }
             }
         }
@@ -255,19 +257,7 @@ class ModelSearchViewModel(
     }
 
     fun resetFilters() {
-        _uiState.update {
-            it.copy(
-                selectedType = null,
-                selectedSort = SortOrder.MostDownloaded,
-                selectedPeriod = TimePeriod.AllTime,
-                selectedBaseModels = emptySet(),
-                isFreshFindEnabled = false,
-                isQualityFilterEnabled = false,
-                includedTags = emptyList(),
-                selectedSources = setOf(ModelSource.CIVITAI),
-            )
-        }
-        _filterState.update {
+        updateFilter {
             it.copy(
                 selectedType = null,
                 selectedSort = SortOrder.MostDownloaded,
@@ -282,67 +272,57 @@ class ModelSearchViewModel(
     }
 
     fun onTypeSelected(type: ModelType?) {
-        _uiState.update { it.copy(selectedType = type) }
-        _filterState.update { it.copy(selectedType = type) }
+        updateFilter { it.copy(selectedType = type) }
     }
 
     fun onSortSelected(sort: SortOrder) {
-        _uiState.update { it.copy(selectedSort = sort) }
-        _filterState.update { it.copy(selectedSort = sort) }
+        updateFilter { it.copy(selectedSort = sort) }
     }
 
     fun onPeriodSelected(period: TimePeriod) {
-        _uiState.update { it.copy(selectedPeriod = period) }
-        _filterState.update { it.copy(selectedPeriod = period) }
+        updateFilter { it.copy(selectedPeriod = period) }
     }
 
     fun onBaseModelToggled(baseModel: BaseModel) {
-        val updater = { current: Set<BaseModel> ->
-            current.toMutableSet().apply {
+        updateFilter {
+            val updated = it.selectedBaseModels.toMutableSet().apply {
                 if (baseModel in this) remove(baseModel) else add(baseModel)
             }.toSet()
+            it.copy(selectedBaseModels = updated)
         }
-        _uiState.update { it.copy(selectedBaseModels = updater(it.selectedBaseModels)) }
-        _filterState.update { it.copy(selectedBaseModels = updater(it.selectedBaseModels)) }
     }
 
     fun onFreshFindToggled() {
-        _uiState.update { it.copy(isFreshFindEnabled = !it.isFreshFindEnabled) }
-        _filterState.update { it.copy(isFreshFindEnabled = !it.isFreshFindEnabled) }
+        updateFilter { it.copy(isFreshFindEnabled = !it.isFreshFindEnabled) }
     }
 
     fun onQualityFilterToggled() {
-        _uiState.update { it.copy(isQualityFilterEnabled = !it.isQualityFilterEnabled) }
-        _filterState.update { it.copy(isQualityFilterEnabled = !it.isQualityFilterEnabled) }
+        updateFilter { it.copy(isQualityFilterEnabled = !it.isQualityFilterEnabled) }
     }
 
     fun onAddIncludedTag(tag: String) {
         val trimmed = tag.trim().lowercase()
         if (trimmed.isBlank()) return
-        val current = _uiState.value.includedTags
+        val current = _filterState.value.includedTags
         if (trimmed in current) return
-        _uiState.update { it.copy(includedTags = it.includedTags + trimmed) }
-        _filterState.update { it.copy(includedTags = it.includedTags + trimmed) }
+        updateFilter { it.copy(includedTags = it.includedTags + trimmed) }
     }
 
     fun onRemoveIncludedTag(tag: String) {
-        _uiState.update { it.copy(includedTags = it.includedTags - tag) }
-        _filterState.update { it.copy(includedTags = it.includedTags - tag) }
+        updateFilter { it.copy(includedTags = it.includedTags - tag) }
     }
 
     fun toggleSource(source: ModelSource) {
-        val updater = { current: Set<ModelSource> ->
-            val updated = current.toMutableSet()
+        updateFilter {
+            val updated = it.selectedSources.toMutableSet()
             if (source in updated) {
                 // Don't allow deselecting all sources
                 if (updated.size > 1) updated.remove(source)
             } else {
                 updated.add(source)
             }
-            updated.toSet()
+            it.copy(selectedSources = updated.toSet())
         }
-        _uiState.update { it.copy(selectedSources = updater(it.selectedSources)) }
-        _filterState.update { it.copy(selectedSources = updater(it.selectedSources)) }
     }
 
     fun onAddExcludedTag(tag: String) {
@@ -390,21 +370,7 @@ class ModelSearchViewModel(
     }
 
     fun applyFilter(filter: SavedSearchFilter) {
-        _uiState.update {
-            it.copy(
-                query = filter.query,
-                selectedType = filter.selectedType,
-                selectedSort = filter.selectedSort,
-                selectedPeriod = filter.selectedPeriod,
-                selectedBaseModels = filter.selectedBaseModels,
-                nsfwFilterLevel = filter.nsfwFilterLevel,
-                isFreshFindEnabled = filter.isFreshFindEnabled,
-                includedTags = filter.includedTags,
-                excludedTags = filter.excludedTags,
-                selectedSources = filter.selectedSources,
-            )
-        }
-        _filterState.update {
+        updateFilter {
             it.copy(
                 query = filter.query,
                 selectedType = filter.selectedType,
@@ -435,12 +401,36 @@ class ModelSearchViewModel(
             val tags = getExcludedTagsUseCase()
             val hiddenIds = getHiddenModelIdsUseCase()
             _hiddenModelIds.value = hiddenIds
-            _uiState.update { it.copy(excludedTags = tags) }
-            _filterState.update { it.copy(excludedTags = tags) }
+            updateFilter { it.copy(excludedTags = tags) }
+        }
+    }
+
+    /**
+     * Updates both [_filterState] and [_uiState] in sync.
+     * The [transform] lambda is applied to [FilterState]; shared fields are then mirrored to [ModelSearchUiState].
+     */
+    private fun updateFilter(transform: (FilterState) -> FilterState) {
+        _filterState.update(transform)
+        val f = _filterState.value
+        _uiState.update {
+            it.copy(
+                query = f.query,
+                selectedType = f.selectedType,
+                selectedSort = f.selectedSort,
+                selectedPeriod = f.selectedPeriod,
+                selectedBaseModels = f.selectedBaseModels,
+                nsfwFilterLevel = f.nsfwFilterLevel,
+                isFreshFindEnabled = f.isFreshFindEnabled,
+                isQualityFilterEnabled = f.isQualityFilterEnabled,
+                excludedTags = f.excludedTags,
+                includedTags = f.includedTags,
+                selectedSources = f.selectedSources,
+            )
         }
     }
 
     companion object {
+        private const val TAG = "ModelSearchViewModel"
         private const val PAGE_SIZE = 20
     }
 }

--- a/shared/src/commonMain/kotlin/com/riox432/civitdeck/data/backup/BackupRepositoryImpl.kt
+++ b/shared/src/commonMain/kotlin/com/riox432/civitdeck/data/backup/BackupRepositoryImpl.kt
@@ -72,25 +72,53 @@ class BackupRepositoryImpl(
         encodeDefaults = true
     }
 
+    // region Public API
+
     override suspend fun createBackup(categories: Set<BackupCategory>): String {
         val backup = BackupDto(
             metadata = BackupMetadataDto(
                 createdAt = currentTimeMillis(),
                 categories = categories.map { it.name },
             ),
-            collections = exportCollections(categories),
-            collectionModels = exportCollectionModels(categories),
-            modelNotes = exportNotes(categories),
-            personalTags = exportTags(categories),
-            savedPrompts = exportPrompts(categories),
-            userPreferences = exportSettings(categories),
-            savedSearchFilters = exportSearchFilters(categories),
-            followedCreators = exportFollowedCreators(categories),
-            comfyUIConnections = exportComfyUIConnections(categories),
-            sdWebUIConnections = exportSDWebUIConnections(categories),
-            externalServerConfigs = exportExternalServers(categories),
-            hiddenModels = exportHiddenModels(categories),
-            excludedTags = exportExcludedTags(categories),
+            collections = exportIf(BackupCategory.COLLECTIONS, categories) {
+                collectionDaos.collectionDao.getAll().map { it.toDto() }
+            },
+            collectionModels = exportIf(BackupCategory.COLLECTIONS, categories) {
+                collectionDaos.collectionDao.getAllEntries().map { it.toDto() }
+            },
+            modelNotes = exportIf(BackupCategory.NOTES, categories) {
+                contentDaos.modelNoteDao.getAll().map { it.toDto() }
+            },
+            personalTags = exportIf(BackupCategory.TAGS, categories) {
+                contentDaos.personalTagDao.getAll().map { it.toDto() }
+            },
+            savedPrompts = exportIf(BackupCategory.PROMPTS, categories) {
+                contentDaos.savedPromptDao.getAllUserCreated().map { it.toDto() }
+            },
+            userPreferences = exportIf(BackupCategory.SETTINGS, categories) {
+                preferenceDaos.userPreferencesDao.getPreferences()?.toDto()
+            },
+            savedSearchFilters = exportIf(BackupCategory.SEARCH_FILTERS, categories) {
+                contentDaos.savedSearchFilterDao.getAll().map { it.toDto() }
+            },
+            followedCreators = exportIf(BackupCategory.FOLLOWED_CREATORS, categories) {
+                contentDaos.followedCreatorDao.getAll().map { it.toDto() }
+            },
+            comfyUIConnections = exportIf(BackupCategory.CONNECTIONS, categories) {
+                connectionDaos.comfyUIConnectionDao.getAll().map { it.toDto() }
+            },
+            sdWebUIConnections = exportIf(BackupCategory.CONNECTIONS, categories) {
+                connectionDaos.sdWebUIConnectionDao.getAll().map { it.toDto() }
+            },
+            externalServerConfigs = exportIf(BackupCategory.CONNECTIONS, categories) {
+                connectionDaos.externalServerConfigDao.getAll().map { it.toDto() }
+            },
+            hiddenModels = exportIf(BackupCategory.HIDDEN_MODELS, categories) {
+                preferenceDaos.hiddenModelDao.getAll().map { it.toDto() }
+            },
+            excludedTags = exportIf(BackupCategory.HIDDEN_MODELS, categories) {
+                preferenceDaos.excludedTagDao.getAll().map { it.toDto() }
+            },
         )
         return json.encodeToString(BackupDto.serializer(), backup)
     }
@@ -114,95 +142,37 @@ class BackupRepositoryImpl(
         }.toSet()
     }
 
-    // --- Export helpers ---
+    // endregion
 
-    private suspend fun exportCollections(categories: Set<BackupCategory>): List<CollectionDto>? =
-        exportIf(BackupCategory.COLLECTIONS in categories) {
-            collectionDaos.collectionDao.getAll().map { it.toDto() }
-        }
+    // region Export helper
 
-    private suspend fun exportCollectionModels(
+    private suspend fun <T> exportIf(
+        category: BackupCategory,
         categories: Set<BackupCategory>,
-    ): List<CollectionModelDto>? =
-        exportIf(BackupCategory.COLLECTIONS in categories) {
-            collectionDaos.collectionDao.getAllEntries().map { it.toDto() }
-        }
+        block: suspend () -> T,
+    ): T? = if (category in categories) block() else null
 
-    private suspend fun exportNotes(categories: Set<BackupCategory>): List<ModelNoteDto>? =
-        exportIf(BackupCategory.NOTES in categories) {
-            contentDaos.modelNoteDao.getAll().map { it.toDto() }
-        }
+    // endregion
 
-    private suspend fun exportTags(categories: Set<BackupCategory>): List<PersonalTagDto>? =
-        exportIf(BackupCategory.TAGS in categories) {
-            contentDaos.personalTagDao.getAll().map { it.toDto() }
-        }
+    // region Restore helpers
 
-    private suspend fun exportPrompts(categories: Set<BackupCategory>): List<SavedPromptDto>? =
-        exportIf(BackupCategory.PROMPTS in categories) {
-            contentDaos.savedPromptDao.getAllUserCreated().map { it.toDto() }
-        }
-
-    private suspend fun exportSettings(
+    /**
+     * Generic restore: checks category membership and null data, optionally clears
+     * existing rows on OVERWRITE, then bulk-inserts the mapped entities.
+     */
+    private suspend fun <D, E> restoreList(
+        data: List<D>?,
+        category: BackupCategory,
         categories: Set<BackupCategory>,
-    ): UserPreferencesDto? =
-        exportIf(BackupCategory.SETTINGS in categories) {
-            preferenceDaos.userPreferencesDao.getPreferences()?.toDto()
-        }
-
-    private suspend fun exportSearchFilters(
-        categories: Set<BackupCategory>,
-    ): List<SavedSearchFilterDto>? =
-        exportIf(BackupCategory.SEARCH_FILTERS in categories) {
-            contentDaos.savedSearchFilterDao.getAll().map { it.toDto() }
-        }
-
-    private suspend fun exportFollowedCreators(
-        categories: Set<BackupCategory>,
-    ): List<FollowedCreatorDto>? =
-        exportIf(BackupCategory.FOLLOWED_CREATORS in categories) {
-            contentDaos.followedCreatorDao.getAll().map { it.toDto() }
-        }
-
-    private suspend fun exportComfyUIConnections(
-        categories: Set<BackupCategory>,
-    ): List<ComfyUIConnectionDto>? =
-        exportIf(BackupCategory.CONNECTIONS in categories) {
-            connectionDaos.comfyUIConnectionDao.getAll().map { it.toDto() }
-        }
-
-    private suspend fun exportSDWebUIConnections(
-        categories: Set<BackupCategory>,
-    ): List<SDWebUIConnectionDto>? =
-        exportIf(BackupCategory.CONNECTIONS in categories) {
-            connectionDaos.sdWebUIConnectionDao.getAll().map { it.toDto() }
-        }
-
-    private suspend fun exportExternalServers(
-        categories: Set<BackupCategory>,
-    ): List<ExternalServerConfigDto>? =
-        exportIf(BackupCategory.CONNECTIONS in categories) {
-            connectionDaos.externalServerConfigDao.getAll().map { it.toDto() }
-        }
-
-    private suspend fun exportHiddenModels(
-        categories: Set<BackupCategory>,
-    ): List<HiddenModelDto>? =
-        exportIf(BackupCategory.HIDDEN_MODELS in categories) {
-            preferenceDaos.hiddenModelDao.getAll().map { it.toDto() }
-        }
-
-    private suspend fun exportExcludedTags(
-        categories: Set<BackupCategory>,
-    ): List<ExcludedTagDto>? =
-        exportIf(BackupCategory.HIDDEN_MODELS in categories) {
-            preferenceDaos.excludedTagDao.getAll().map { it.toDto() }
-        }
-
-    private suspend fun <T> exportIf(condition: Boolean, block: suspend () -> T): T? =
-        if (condition) block() else null
-
-    // --- Restore: category-group dispatchers ---
+        strategy: RestoreStrategy,
+        deleteAll: suspend () -> Unit,
+        insertAll: suspend (List<E>) -> Unit,
+        toEntity: (D) -> E,
+    ) {
+        if (category !in categories || data == null) return
+        if (strategy == RestoreStrategy.OVERWRITE) deleteAll()
+        insertAll(data.map(toEntity))
+    }
 
     private suspend fun restoreCollectionData(
         backup: BackupDto,
@@ -227,11 +197,51 @@ class BackupRepositoryImpl(
         strategy: RestoreStrategy,
         categories: Set<BackupCategory>,
     ) {
-        restoreNotes(backup, strategy, categories)
-        restoreTags(backup, strategy, categories)
-        restorePrompts(backup, strategy, categories)
-        restoreSearchFilters(backup, strategy, categories)
-        restoreFollowedCreators(backup, strategy, categories)
+        restoreList(
+            backup.modelNotes,
+            BackupCategory.NOTES,
+            categories,
+            strategy,
+            deleteAll = { contentDaos.modelNoteDao.deleteAll() },
+            insertAll = { contentDaos.modelNoteDao.insertAll(it) },
+            toEntity = { it.toEntity() },
+        )
+        restoreList(
+            backup.personalTags,
+            BackupCategory.TAGS,
+            categories,
+            strategy,
+            deleteAll = { contentDaos.personalTagDao.deleteAll() },
+            insertAll = { contentDaos.personalTagDao.insertAll(it) },
+            toEntity = { it.toEntity() },
+        )
+        restoreList(
+            backup.savedPrompts,
+            BackupCategory.PROMPTS,
+            categories,
+            strategy,
+            deleteAll = { contentDaos.savedPromptDao.deleteAllUserCreated() },
+            insertAll = { contentDaos.savedPromptDao.insertAll(it) },
+            toEntity = { it.toEntity() },
+        )
+        restoreList(
+            backup.savedSearchFilters,
+            BackupCategory.SEARCH_FILTERS,
+            categories,
+            strategy,
+            deleteAll = { contentDaos.savedSearchFilterDao.deleteAll() },
+            insertAll = { contentDaos.savedSearchFilterDao.insertAll(it) },
+            toEntity = { it.toEntity() },
+        )
+        restoreList(
+            backup.followedCreators,
+            BackupCategory.FOLLOWED_CREATORS,
+            categories,
+            strategy,
+            deleteAll = { contentDaos.followedCreatorDao.deleteAll() },
+            insertAll = { contentDaos.followedCreatorDao.insertAll(it) },
+            toEntity = { it.toEntity() },
+        )
     }
 
     private suspend fun restorePreferenceData(
@@ -244,7 +254,24 @@ class BackupRepositoryImpl(
             preferenceDaos.userPreferencesDao.upsert(backup.userPreferences.toEntity())
         }
         if (BackupCategory.HIDDEN_MODELS in categories) {
-            restoreHiddenModels(backup, strategy)
+            restoreList(
+                backup.hiddenModels,
+                BackupCategory.HIDDEN_MODELS,
+                categories,
+                strategy,
+                deleteAll = { preferenceDaos.hiddenModelDao.deleteAll() },
+                insertAll = { preferenceDaos.hiddenModelDao.insertAll(it) },
+                toEntity = { it.toEntity() },
+            )
+            restoreList(
+                backup.excludedTags,
+                BackupCategory.HIDDEN_MODELS,
+                categories,
+                strategy,
+                deleteAll = { preferenceDaos.excludedTagDao.deleteAll() },
+                insertAll = { preferenceDaos.excludedTagDao.insertAll(it) },
+                toEntity = { it.toEntity() },
+            )
         }
     }
 
@@ -272,69 +299,7 @@ class BackupRepositoryImpl(
         }
     }
 
-    // --- Restore: per-category helpers ---
-
-    private suspend fun restoreNotes(
-        backup: BackupDto,
-        strategy: RestoreStrategy,
-        categories: Set<BackupCategory>,
-    ) {
-        if (BackupCategory.NOTES !in categories || backup.modelNotes == null) return
-        if (strategy == RestoreStrategy.OVERWRITE) contentDaos.modelNoteDao.deleteAll()
-        contentDaos.modelNoteDao.insertAll(backup.modelNotes.map { it.toEntity() })
-    }
-
-    private suspend fun restoreTags(
-        backup: BackupDto,
-        strategy: RestoreStrategy,
-        categories: Set<BackupCategory>,
-    ) {
-        if (BackupCategory.TAGS !in categories || backup.personalTags == null) return
-        if (strategy == RestoreStrategy.OVERWRITE) contentDaos.personalTagDao.deleteAll()
-        contentDaos.personalTagDao.insertAll(backup.personalTags.map { it.toEntity() })
-    }
-
-    private suspend fun restorePrompts(
-        backup: BackupDto,
-        strategy: RestoreStrategy,
-        categories: Set<BackupCategory>,
-    ) {
-        if (BackupCategory.PROMPTS !in categories || backup.savedPrompts == null) return
-        if (strategy == RestoreStrategy.OVERWRITE) contentDaos.savedPromptDao.deleteAllUserCreated()
-        contentDaos.savedPromptDao.insertAll(backup.savedPrompts.map { it.toEntity() })
-    }
-
-    private suspend fun restoreSearchFilters(
-        backup: BackupDto,
-        strategy: RestoreStrategy,
-        categories: Set<BackupCategory>,
-    ) {
-        if (BackupCategory.SEARCH_FILTERS !in categories || backup.savedSearchFilters == null) return
-        if (strategy == RestoreStrategy.OVERWRITE) contentDaos.savedSearchFilterDao.deleteAll()
-        contentDaos.savedSearchFilterDao.insertAll(backup.savedSearchFilters.map { it.toEntity() })
-    }
-
-    private suspend fun restoreFollowedCreators(
-        backup: BackupDto,
-        strategy: RestoreStrategy,
-        categories: Set<BackupCategory>,
-    ) {
-        if (BackupCategory.FOLLOWED_CREATORS !in categories) return
-        if (backup.followedCreators == null) return
-        if (strategy == RestoreStrategy.OVERWRITE) contentDaos.followedCreatorDao.deleteAll()
-        contentDaos.followedCreatorDao.insertAll(backup.followedCreators.map { it.toEntity() })
-    }
-
-    private suspend fun restoreHiddenModels(backup: BackupDto, strategy: RestoreStrategy) {
-        backup.hiddenModels?.let { models ->
-            if (strategy == RestoreStrategy.OVERWRITE) preferenceDaos.hiddenModelDao.deleteAll()
-            preferenceDaos.hiddenModelDao.insertAll(models.map { it.toEntity() })
-        }
-        backup.excludedTags?.let { tags ->
-            if (strategy == RestoreStrategy.OVERWRITE) preferenceDaos.excludedTagDao.deleteAll()
-            preferenceDaos.excludedTagDao.insertAll(tags.map { it.toEntity() })
-        }
-    }
+    // endregion
 }
 
 // --- Entity -> DTO mappers ---

--- a/shared/src/commonMain/kotlin/com/riox432/civitdeck/usecase/ImportThemeUseCase.kt
+++ b/shared/src/commonMain/kotlin/com/riox432/civitdeck/usecase/ImportThemeUseCase.kt
@@ -7,9 +7,9 @@ import com.riox432.civitdeck.domain.model.InstalledPlugin
 import com.riox432.civitdeck.domain.model.InstalledPluginState
 import com.riox432.civitdeck.domain.model.InstalledPluginType
 import com.riox432.civitdeck.domain.repository.PluginRepository
+import com.riox432.civitdeck.domain.util.suspendRunCatching
 import com.riox432.civitdeck.plugin.PluginRegistry
 import com.riox432.civitdeck.plugin.capability.ThemeCapability
-import com.riox432.civitdeck.domain.util.suspendRunCatching
 import kotlinx.serialization.json.Json
 
 /**

--- a/shared/src/iosMain/kotlin/com/riox432/civitdeck/di/KoinHelper.kt
+++ b/shared/src/iosMain/kotlin/com/riox432/civitdeck/di/KoinHelper.kt
@@ -193,12 +193,12 @@ import com.riox432.civitdeck.feature.comfyui.domain.usecase.TestSDWebUIConnectio
 import com.riox432.civitdeck.feature.creator.domain.usecase.GetCreatorModelsUseCase
 import com.riox432.civitdeck.feature.externalserver.domain.usecase.ActivateExternalServerConfigUseCase
 import com.riox432.civitdeck.feature.externalserver.domain.usecase.DeleteExternalServerConfigUseCase
+import com.riox432.civitdeck.feature.externalserver.domain.usecase.DeleteServerImagesUseCase
 import com.riox432.civitdeck.feature.externalserver.domain.usecase.ExecuteGenerationUseCase
 import com.riox432.civitdeck.feature.externalserver.domain.usecase.GetDependentChoicesUseCase
 import com.riox432.civitdeck.feature.externalserver.domain.usecase.GetExternalServerCapabilitiesUseCase
 import com.riox432.civitdeck.feature.externalserver.domain.usecase.GetExternalServerImagesUseCase
 import com.riox432.civitdeck.feature.externalserver.domain.usecase.GetGenerationOptionsUseCase
-import com.riox432.civitdeck.feature.externalserver.domain.usecase.DeleteServerImagesUseCase
 import com.riox432.civitdeck.feature.externalserver.domain.usecase.GetGenerationStatusUseCase
 import com.riox432.civitdeck.feature.externalserver.domain.usecase.ObserveActiveExternalServerConfigUseCase
 import com.riox432.civitdeck.feature.externalserver.domain.usecase.ObserveExternalServerConfigsUseCase
@@ -237,61 +237,59 @@ import org.koin.mp.KoinPlatform.getKoin
 
 @Suppress("TooManyFunctions")
 object KoinHelper {
+
+    // region Search & Discovery
     fun getModelsUseCase(): GetModelsUseCase = getKoin().get()
     fun getMultiSourceSearchUseCase(): MultiSourceSearchUseCase = getKoin().get()
-    fun getCreatorModelsUseCase(): GetCreatorModelsUseCase = getKoin().get()
-    fun getModelDetailUseCase(): GetModelDetailUseCase = getKoin().get()
-    fun getImagesUseCase(): GetImagesUseCase = getKoin().get()
-    fun getToggleFavoriteUseCase(): ToggleFavoriteUseCase = getKoin().get()
-    fun getObserveFavoritesUseCase(): ObserveFavoritesUseCase = getKoin().get()
-    fun getObserveIsFavoriteUseCase(): ObserveIsFavoriteUseCase = getKoin().get()
-    fun getObserveNsfwFilterUseCase(): ObserveNsfwFilterUseCase = getKoin().get()
-    fun getSetNsfwFilterUseCase(): SetNsfwFilterUseCase = getKoin().get()
-    fun getObserveNsfwBlurSettingsUseCase(): ObserveNsfwBlurSettingsUseCase = getKoin().get()
-    fun getSetNsfwBlurSettingsUseCase(): SetNsfwBlurSettingsUseCase = getKoin().get()
-    fun getSavePromptUseCase(): SavePromptUseCase = getKoin().get()
-    fun getObserveSavedPromptsUseCase(): ObserveSavedPromptsUseCase = getKoin().get()
-    fun getDeleteSavedPromptUseCase(): DeleteSavedPromptUseCase = getKoin().get()
+    fun getDiscoveryModelsUseCase(): GetDiscoveryModelsUseCase = getKoin().get()
+    fun getRecommendationsUseCase(): GetRecommendationsUseCase = getKoin().get()
+    fun getEnrichModelImagesUseCase(): EnrichModelImagesUseCase = getKoin().get()
+    fun getSimilarModelsUseCase(): GetSimilarModelsUseCase = getKoin().get()
+    // endregion
+
+    // region Search History & Filters
     fun getObserveSearchHistoryUseCase(): ObserveSearchHistoryUseCase = getKoin().get()
     fun getAddSearchHistoryUseCase(): AddSearchHistoryUseCase = getKoin().get()
     fun getClearSearchHistoryUseCase(): ClearSearchHistoryUseCase = getKoin().get()
     fun getDeleteSearchHistoryItemUseCase(): DeleteSearchHistoryItemUseCase = getKoin().get()
-    fun getTrackModelViewUseCase(): TrackModelViewUseCase = getKoin().get()
-    fun getObserveRecentlyViewedUseCase(): ObserveRecentlyViewedUseCase = getKoin().get()
-    fun getRecommendationsUseCase(): GetRecommendationsUseCase = getKoin().get()
-    fun getViewedModelIdsUseCase(): GetViewedModelIdsUseCase = getKoin().get()
-    fun getExcludedTagsUseCase(): GetExcludedTagsUseCase = getKoin().get()
-    fun getAddExcludedTagUseCase(): AddExcludedTagUseCase = getKoin().get()
-    fun getRemoveExcludedTagUseCase(): RemoveExcludedTagUseCase = getKoin().get()
-    fun getHiddenModelIdsUseCase(): GetHiddenModelIdsUseCase = getKoin().get()
-    fun getHideModelUseCase(): HideModelUseCase = getKoin().get()
-    fun getUnhideModelUseCase(): UnhideModelUseCase = getKoin().get()
     fun getObserveSavedSearchFiltersUseCase(): ObserveSavedSearchFiltersUseCase = getKoin().get()
     fun getSaveSearchFilterUseCase(): SaveSearchFilterUseCase = getKoin().get()
     fun getDeleteSavedSearchFilterUseCase(): DeleteSavedSearchFilterUseCase = getKoin().get()
-    fun getObserveDefaultSortOrderUseCase(): ObserveDefaultSortOrderUseCase = getKoin().get()
-    fun getSetDefaultSortOrderUseCase(): SetDefaultSortOrderUseCase = getKoin().get()
-    fun getObserveDefaultTimePeriodUseCase(): ObserveDefaultTimePeriodUseCase = getKoin().get()
-    fun getSetDefaultTimePeriodUseCase(): SetDefaultTimePeriodUseCase = getKoin().get()
-    fun getObserveGridColumnsUseCase(): ObserveGridColumnsUseCase = getKoin().get()
-    fun getSetGridColumnsUseCase(): SetGridColumnsUseCase = getKoin().get()
-    fun getHiddenModelsUseCase(): GetHiddenModelsUseCase = getKoin().get()
+    fun getExcludedTagsUseCase(): GetExcludedTagsUseCase = getKoin().get()
+    fun getAddExcludedTagUseCase(): AddExcludedTagUseCase = getKoin().get()
+    fun getRemoveExcludedTagUseCase(): RemoveExcludedTagUseCase = getKoin().get()
+    // endregion
+
+    // region Model Detail & Creator
+    fun getModelDetailUseCase(): GetModelDetailUseCase = getKoin().get()
+    fun getCreatorModelsUseCase(): GetCreatorModelsUseCase = getKoin().get()
+    fun getImagesUseCase(): GetImagesUseCase = getKoin().get()
+    fun getModelLicenseUseCase(): GetModelLicenseUseCase = getKoin().get()
+    // endregion
+
+    // region Favorites
+    fun getToggleFavoriteUseCase(): ToggleFavoriteUseCase = getKoin().get()
+    fun getObserveFavoritesUseCase(): ObserveFavoritesUseCase = getKoin().get()
+    fun getObserveIsFavoriteUseCase(): ObserveIsFavoriteUseCase = getKoin().get()
+    // endregion
+
+    // region Browsing History
+    fun getTrackModelViewUseCase(): TrackModelViewUseCase = getKoin().get()
+    fun getObserveRecentlyViewedUseCase(): ObserveRecentlyViewedUseCase = getKoin().get()
+    fun getViewedModelIdsUseCase(): GetViewedModelIdsUseCase = getKoin().get()
     fun getClearBrowsingHistoryUseCase(): ClearBrowsingHistoryUseCase = getKoin().get()
     fun getDeleteBrowsingHistoryItemUseCase(): DeleteBrowsingHistoryItemUseCase = getKoin().get()
     fun getCleanupBrowsingHistoryUseCase(): CleanupBrowsingHistoryUseCase = getKoin().get()
-    fun getClearCacheUseCase(): ClearCacheUseCase = getKoin().get()
-    fun getObservePowerUserModeUseCase(): ObservePowerUserModeUseCase = getKoin().get()
-    fun getSetPowerUserModeUseCase(): SetPowerUserModeUseCase = getKoin().get()
-    fun getObserveCustomNavShortcutsUseCase(): ObserveCustomNavShortcutsUseCase = getKoin().get()
-    fun getSetCustomNavShortcutsUseCase(): SetCustomNavShortcutsUseCase = getKoin().get()
-    fun getEnrichModelImagesUseCase(): EnrichModelImagesUseCase = getKoin().get()
-    fun getDiscoveryModelsUseCase(): GetDiscoveryModelsUseCase = getKoin().get()
-    fun getObserveApiKeyUseCase(): ObserveApiKeyUseCase = getKoin().get()
-    fun getSetApiKeyUseCase(): SetApiKeyUseCase = getKoin().get()
-    fun getValidateApiKeyUseCase(): ValidateApiKeyUseCase = getKoin().get()
-    fun getApiKeyProvider(): ApiKeyProvider = getKoin().get()
+    // endregion
 
-    // Collection use cases
+    // region Hidden Models
+    fun getHiddenModelIdsUseCase(): GetHiddenModelIdsUseCase = getKoin().get()
+    fun getHideModelUseCase(): HideModelUseCase = getKoin().get()
+    fun getUnhideModelUseCase(): UnhideModelUseCase = getKoin().get()
+    fun getHiddenModelsUseCase(): GetHiddenModelsUseCase = getKoin().get()
+    // endregion
+
+    // region Collections
     fun getObserveCollectionsUseCase(): ObserveCollectionsUseCase = getKoin().get()
     fun getCreateCollectionUseCase(): CreateCollectionUseCase = getKoin().get()
     fun getRenameCollectionUseCase(): RenameCollectionUseCase = getKoin().get()
@@ -302,8 +300,9 @@ object KoinHelper {
     fun getObserveModelCollectionsUseCase(): ObserveModelCollectionsUseCase = getKoin().get()
     fun getBulkMoveModelsUseCase(): BulkMoveModelsUseCase = getKoin().get()
     fun getBulkRemoveModelsUseCase(): BulkRemoveModelsUseCase = getKoin().get()
+    // endregion
 
-    // Local model file use cases
+    // region Local Model Files
     fun getObserveModelDirectoriesUseCase(): ObserveModelDirectoriesUseCase = getKoin().get()
     fun getAddModelDirectoryUseCase(): AddModelDirectoryUseCase = getKoin().get()
     fun getRemoveModelDirectoryUseCase(): RemoveModelDirectoryUseCase = getKoin().get()
@@ -311,46 +310,80 @@ object KoinHelper {
     fun getScanModelDirectoriesUseCase(): ScanModelDirectoriesUseCase = getKoin().get()
     fun getVerifyModelHashUseCase(): VerifyModelHashUseCase = getKoin().get()
     fun getObserveOwnedModelHashesUseCase(): ObserveOwnedModelHashesUseCase = getKoin().get()
+    // endregion
 
-    // Prompt template use cases
+    // region Prompts & Templates
     fun getAutoSavePromptUseCase(): AutoSavePromptUseCase = getKoin().get()
     fun getToggleTemplateUseCase(): ToggleTemplateUseCase = getKoin().get()
     fun getSearchSavedPromptsUseCase(): SearchSavedPromptsUseCase = getKoin().get()
     fun getObserveTemplatesUseCase(): ObserveTemplatesUseCase = getKoin().get()
+    fun getSavePromptUseCase(): SavePromptUseCase = getKoin().get()
+    fun getObserveSavedPromptsUseCase(): ObserveSavedPromptsUseCase = getKoin().get()
+    fun getDeleteSavedPromptUseCase(): DeleteSavedPromptUseCase = getKoin().get()
+    // endregion
 
-    // Theme use cases
+    // region Theme & Display Settings
     fun getObserveAccentColorUseCase(): ObserveAccentColorUseCase = getKoin().get()
     fun getSetAccentColorUseCase(): SetAccentColorUseCase = getKoin().get()
     fun getObserveAmoledDarkModeUseCase(): ObserveAmoledDarkModeUseCase = getKoin().get()
     fun getSetAmoledDarkModeUseCase(): SetAmoledDarkModeUseCase = getKoin().get()
     fun getObserveThemeModeUseCase(): ObserveThemeModeUseCase = getKoin().get()
     fun getSetThemeModeUseCase(): SetThemeModeUseCase = getKoin().get()
+    fun getObserveDefaultSortOrderUseCase(): ObserveDefaultSortOrderUseCase = getKoin().get()
+    fun getSetDefaultSortOrderUseCase(): SetDefaultSortOrderUseCase = getKoin().get()
+    fun getObserveDefaultTimePeriodUseCase(): ObserveDefaultTimePeriodUseCase = getKoin().get()
+    fun getSetDefaultTimePeriodUseCase(): SetDefaultTimePeriodUseCase = getKoin().get()
+    fun getObserveGridColumnsUseCase(): ObserveGridColumnsUseCase = getKoin().get()
+    fun getSetGridColumnsUseCase(): SetGridColumnsUseCase = getKoin().get()
+    fun getObserveQualityThresholdUseCase(): ObserveQualityThresholdUseCase = getKoin().get()
+    fun getSetQualityThresholdUseCase(): SetQualityThresholdUseCase = getKoin().get()
+    fun getObservePowerUserModeUseCase(): ObservePowerUserModeUseCase = getKoin().get()
+    fun getSetPowerUserModeUseCase(): SetPowerUserModeUseCase = getKoin().get()
+    fun getObserveCustomNavShortcutsUseCase(): ObserveCustomNavShortcutsUseCase = getKoin().get()
+    fun getSetCustomNavShortcutsUseCase(): SetCustomNavShortcutsUseCase = getKoin().get()
+    fun getObserveSeenTutorialVersionUseCase(): ObserveSeenTutorialVersionUseCase = getKoin().get()
+    fun getSetSeenTutorialVersionUseCase(): SetSeenTutorialVersionUseCase = getKoin().get()
+    // endregion
 
-    // Notification use cases
+    // region NSFW & Content Filtering
+    fun getObserveNsfwFilterUseCase(): ObserveNsfwFilterUseCase = getKoin().get()
+    fun getSetNsfwFilterUseCase(): SetNsfwFilterUseCase = getKoin().get()
+    fun getObserveNsfwBlurSettingsUseCase(): ObserveNsfwBlurSettingsUseCase = getKoin().get()
+    fun getSetNsfwBlurSettingsUseCase(): SetNsfwBlurSettingsUseCase = getKoin().get()
+    // endregion
+
+    // region Authentication & API Key
+    fun getObserveApiKeyUseCase(): ObserveApiKeyUseCase = getKoin().get()
+    fun getSetApiKeyUseCase(): SetApiKeyUseCase = getKoin().get()
+    fun getValidateApiKeyUseCase(): ValidateApiKeyUseCase = getKoin().get()
+    fun getApiKeyProvider(): ApiKeyProvider = getKoin().get()
+    // endregion
+
+    // region Notifications & Model Updates
     fun getCheckModelUpdatesUseCase(): CheckModelUpdatesUseCase = getKoin().get()
     fun getObserveNotificationsEnabledUseCase(): ObserveNotificationsEnabledUseCase = getKoin().get()
     fun getSetNotificationsEnabledUseCase(): SetNotificationsEnabledUseCase = getKoin().get()
     fun getObservePollingIntervalUseCase(): ObservePollingIntervalUseCase = getKoin().get()
     fun getSetPollingIntervalUseCase(): SetPollingIntervalUseCase = getKoin().get()
+    fun getModelUpdateNotificationsUseCase(): GetModelUpdateNotificationsUseCase = getKoin().get()
+    fun getUnreadNotificationCountUseCase(): GetUnreadNotificationCountUseCase = getKoin().get()
+    fun getMarkNotificationReadUseCase(): MarkNotificationReadUseCase = getKoin().get()
+    fun getMarkAllNotificationsReadUseCase(): MarkAllNotificationsReadUseCase = getKoin().get()
+    fun getCheckAndStoreModelUpdatesUseCase(): CheckAndStoreModelUpdatesUseCase = getKoin().get()
+    // endregion
 
-    // Offline cache use cases
+    // region Offline Cache & Network
     fun getObserveNetworkStatusUseCase(): ObserveNetworkStatusUseCase = getKoin().get()
     fun getCacheInfoUseCase(): GetCacheInfoUseCase = getKoin().get()
     fun getEvictCacheUseCase(): EvictCacheUseCase = getKoin().get()
+    fun getClearCacheUseCase(): ClearCacheUseCase = getKoin().get()
     fun getObserveOfflineCacheEnabledUseCase(): ObserveOfflineCacheEnabledUseCase = getKoin().get()
     fun getSetOfflineCacheEnabledUseCase(): SetOfflineCacheEnabledUseCase = getKoin().get()
     fun getObserveCacheSizeLimitUseCase(): ObserveCacheSizeLimitUseCase = getKoin().get()
     fun getSetCacheSizeLimitUseCase(): SetCacheSizeLimitUseCase = getKoin().get()
+    // endregion
 
-    // Tutorial use cases
-    fun getObserveSeenTutorialVersionUseCase(): ObserveSeenTutorialVersionUseCase = getKoin().get()
-    fun getSetSeenTutorialVersionUseCase(): SetSeenTutorialVersionUseCase = getKoin().get()
-
-    // ComfyUI history use cases
-    fun getFetchComfyUIHistoryUseCase(): FetchComfyUIHistoryUseCase = getKoin().get()
-    fun getFetchComfyUIHistoryItemUseCase(): FetchComfyUIHistoryItemUseCase = getKoin().get()
-
-    // ComfyUI use cases
+    // region ComfyUI
     fun getObserveComfyUIConnectionsUseCase(): ObserveComfyUIConnectionsUseCase = getKoin().get()
     fun getObserveActiveComfyUIConnectionUseCase(): ObserveActiveComfyUIConnectionUseCase = getKoin().get()
     fun getSaveComfyUIConnectionUseCase(): SaveComfyUIConnectionUseCase = getKoin().get()
@@ -369,23 +402,26 @@ object KoinHelper {
     fun getFindMatchingLocalModelUseCase(): FindMatchingLocalModelUseCase = getKoin().get()
     fun getPopulateGenerationFromModelUseCase(): PopulateGenerationFromModelUseCase = getKoin().get()
     fun getSaveGeneratedImageUseCase(): SaveGeneratedImageUseCase = getKoin().get()
+    fun getFetchComfyUIHistoryUseCase(): FetchComfyUIHistoryUseCase = getKoin().get()
+    fun getFetchComfyUIHistoryItemUseCase(): FetchComfyUIHistoryItemUseCase = getKoin().get()
+    // endregion
 
-    // Workflow template use cases
+    // region ComfyUI Workflow Templates
     fun getGetWorkflowTemplatesUseCase(): GetWorkflowTemplatesUseCase = getKoin().get()
     fun getSaveWorkflowTemplateUseCase(): SaveWorkflowTemplateUseCase = getKoin().get()
     fun getDeleteWorkflowTemplateUseCase(): DeleteWorkflowTemplateUseCase = getKoin().get()
     fun getExportWorkflowTemplateUseCase(): ExportWorkflowTemplateUseCase = getKoin().get()
     fun getImportWorkflowTemplateUseCase(): ImportWorkflowTemplateUseCase = getKoin().get()
     fun getApplyWorkflowTemplateUseCase(): ApplyWorkflowTemplateUseCase = getKoin().get()
+    // endregion
 
-    // Settings ViewModels
-    fun createContentFilterSettingsViewModel(): ContentFilterSettingsViewModel = getKoin().get()
-    fun createDisplaySettingsViewModel(): DisplaySettingsViewModel = getKoin().get()
-    fun createAppBehaviorSettingsViewModel(): AppBehaviorSettingsViewModel = getKoin().get()
-    fun createAuthSettingsViewModel(): AuthSettingsViewModel = getKoin().get()
-    fun createStorageSettingsViewModel(): StorageSettingsViewModel = getKoin().get()
+    // region ComfyHub
+    fun getSearchComfyHubWorkflowsUseCase(): SearchComfyHubWorkflowsUseCase = getKoin().get()
+    fun getGetComfyHubWorkflowDetailUseCase(): GetComfyHubWorkflowDetailUseCase = getKoin().get()
+    fun getImportComfyHubWorkflowUseCase(): ImportComfyHubWorkflowUseCase = getKoin().get()
+    // endregion
 
-    // Civitai Link use cases
+    // region Civitai Link
     fun getObserveCivitaiLinkKeyUseCase(): ObserveCivitaiLinkKeyUseCase = getKoin().get()
     fun getSetCivitaiLinkKeyUseCase(): SetCivitaiLinkKeyUseCase = getKoin().get()
     fun getObserveCivitaiLinkStatusUseCase(): ObserveCivitaiLinkStatusUseCase = getKoin().get()
@@ -394,8 +430,9 @@ object KoinHelper {
     fun getDisconnectCivitaiLinkUseCase(): DisconnectCivitaiLinkUseCase = getKoin().get()
     fun getSendResourceToPCUseCase(): SendResourceToPCUseCase = getKoin().get()
     fun getCancelLinkActivityUseCase(): CancelLinkActivityUseCase = getKoin().get()
+    // endregion
 
-    // SD WebUI use cases
+    // region SD WebUI
     fun getObserveSDWebUIConnectionsUseCase(): ObserveSDWebUIConnectionsUseCase = getKoin().get()
     fun getObserveActiveSDWebUIConnectionUseCase(): ObserveActiveSDWebUIConnectionUseCase = getKoin().get()
     fun getSaveSDWebUIConnectionUseCase(): SaveSDWebUIConnectionUseCase = getKoin().get()
@@ -407,31 +444,9 @@ object KoinHelper {
     fun getFetchSDWebUIVaesUseCase(): FetchSDWebUIVaesUseCase = getKoin().get()
     fun getGenerateSDWebUIImageUseCase(): GenerateSDWebUIImageUseCase = getKoin().get()
     fun getInterruptSDWebUIGenerationUseCase(): InterruptSDWebUIGenerationUseCase = getKoin().get()
+    // endregion
 
-    // Dataset use cases
-    fun getObserveDatasetCollectionsUseCase(): ObserveDatasetCollectionsUseCase = getKoin().get()
-    fun getCreateDatasetCollectionUseCase(): CreateDatasetCollectionUseCase = getKoin().get()
-    fun getRenameDatasetCollectionUseCase(): RenameDatasetCollectionUseCase = getKoin().get()
-    fun getDeleteDatasetCollectionUseCase(): DeleteDatasetCollectionUseCase = getKoin().get()
-    fun getObserveDatasetImagesUseCase(): ObserveDatasetImagesUseCase = getKoin().get()
-    fun getAddImageToDatasetUseCase(): AddImageToDatasetUseCase = getKoin().get()
-    fun getRemoveImageFromDatasetUseCase(): RemoveImageFromDatasetUseCase = getKoin().get()
-    fun getBatchEditTagsUseCase(): BatchEditTagsUseCase = getKoin().get()
-    fun getEditCaptionUseCase(): EditCaptionUseCase = getKoin().get()
-    fun getGetTagSuggestionsUseCase(): GetTagSuggestionsUseCase = getKoin().get()
-    fun getUpdateTrainableUseCase(): UpdateTrainableUseCase = getKoin().get()
-    fun getGetNonTrainableImagesUseCase(): GetNonTrainableImagesUseCase = getKoin().get()
-    fun getGetModelLicenseUseCase(): GetModelLicenseUseCase = getKoin().get()
-    fun getDetectDuplicatesUseCase(): DetectDuplicatesUseCase = getKoin().get()
-    fun getFilterByResolutionUseCase(): FilterByResolutionUseCase = getKoin().get()
-    fun getMarkImageExcludedUseCase(): MarkImageExcludedUseCase = getKoin().get()
-    fun getStorePHashUseCase(): StorePHashUseCase = getKoin().get()
-    fun getStoreImageDimensionsUseCase(): StoreImageDimensionsUseCase = getKoin().get()
-    fun getExportDatasetUseCase(): ExportDatasetUseCase = getKoin().get()
-    fun getGetAvailableExportFormatsUseCase(): GetAvailableExportFormatsUseCase = getKoin().get()
-    fun getExportWithPluginUseCase(): ExportWithPluginUseCase = getKoin().get()
-
-    // External Server use cases
+    // region External Server
     fun getObserveExternalServerConfigsUseCase(): ObserveExternalServerConfigsUseCase = getKoin().get()
     fun getObserveActiveExternalServerConfigUseCase(): ObserveActiveExternalServerConfigUseCase = getKoin().get()
     fun getSaveExternalServerConfigUseCase(): SaveExternalServerConfigUseCase = getKoin().get()
@@ -445,8 +460,32 @@ object KoinHelper {
     fun getExecuteGenerationUseCase(): ExecuteGenerationUseCase = getKoin().get()
     fun getGetGenerationStatusUseCase(): GetGenerationStatusUseCase = getKoin().get()
     fun getDeleteServerImagesUseCase(): DeleteServerImagesUseCase = getKoin().get()
+    // endregion
 
-    // Model notes & personal tags use cases
+    // region Dataset
+    fun getObserveDatasetCollectionsUseCase(): ObserveDatasetCollectionsUseCase = getKoin().get()
+    fun getCreateDatasetCollectionUseCase(): CreateDatasetCollectionUseCase = getKoin().get()
+    fun getRenameDatasetCollectionUseCase(): RenameDatasetCollectionUseCase = getKoin().get()
+    fun getDeleteDatasetCollectionUseCase(): DeleteDatasetCollectionUseCase = getKoin().get()
+    fun getObserveDatasetImagesUseCase(): ObserveDatasetImagesUseCase = getKoin().get()
+    fun getAddImageToDatasetUseCase(): AddImageToDatasetUseCase = getKoin().get()
+    fun getRemoveImageFromDatasetUseCase(): RemoveImageFromDatasetUseCase = getKoin().get()
+    fun getBatchEditTagsUseCase(): BatchEditTagsUseCase = getKoin().get()
+    fun getEditCaptionUseCase(): EditCaptionUseCase = getKoin().get()
+    fun getGetTagSuggestionsUseCase(): GetTagSuggestionsUseCase = getKoin().get()
+    fun getUpdateTrainableUseCase(): UpdateTrainableUseCase = getKoin().get()
+    fun getGetNonTrainableImagesUseCase(): GetNonTrainableImagesUseCase = getKoin().get()
+    fun getDetectDuplicatesUseCase(): DetectDuplicatesUseCase = getKoin().get()
+    fun getFilterByResolutionUseCase(): FilterByResolutionUseCase = getKoin().get()
+    fun getMarkImageExcludedUseCase(): MarkImageExcludedUseCase = getKoin().get()
+    fun getStorePHashUseCase(): StorePHashUseCase = getKoin().get()
+    fun getStoreImageDimensionsUseCase(): StoreImageDimensionsUseCase = getKoin().get()
+    fun getExportDatasetUseCase(): ExportDatasetUseCase = getKoin().get()
+    fun getGetAvailableExportFormatsUseCase(): GetAvailableExportFormatsUseCase = getKoin().get()
+    fun getExportWithPluginUseCase(): ExportWithPluginUseCase = getKoin().get()
+    // endregion
+
+    // region Model Notes & Personal Tags
     fun getObserveModelNoteUseCase(): ObserveModelNoteUseCase = getKoin().get()
     fun getSaveModelNoteUseCase(): SaveModelNoteUseCase = getKoin().get()
     fun getDeleteModelNoteUseCase(): DeleteModelNoteUseCase = getKoin().get()
@@ -455,11 +494,13 @@ object KoinHelper {
     fun getRemovePersonalTagUseCase(): RemovePersonalTagUseCase = getKoin().get()
     fun getGetAllPersonalTagsUseCase(): GetAllPersonalTagsUseCase = getKoin().get()
     fun getSearchModelsByTagUseCase(): SearchModelsByTagUseCase = getKoin().get()
+    // endregion
 
-    // Analytics use cases
+    // region Analytics
     fun getBrowsingStatsUseCase(): GetBrowsingStatsUseCase = getKoin().get()
+    // endregion
 
-    // Creator follow use cases
+    // region Creator Follow & Feed
     fun getFollowCreatorUseCase(): FollowCreatorUseCase = getKoin().get()
     fun getUnfollowCreatorUseCase(): UnfollowCreatorUseCase = getKoin().get()
     fun getIsFollowingCreatorUseCase(): IsFollowingCreatorUseCase = getKoin().get()
@@ -467,13 +508,15 @@ object KoinHelper {
     fun getUnreadFeedCountUseCase(): GetUnreadFeedCountUseCase = getKoin().get()
     fun getMarkFeedReadUseCase(): MarkFeedReadUseCase = getKoin().get()
     fun getFollowedCreatorsUseCase(): GetFollowedCreatorsUseCase = getKoin().get()
+    // endregion
 
-    // Review use cases
+    // region Reviews
     fun getModelReviewsUseCase(): GetModelReviewsUseCase = getKoin().get()
     fun getRatingTotalsUseCase(): GetRatingTotalsUseCase = getKoin().get()
     fun getSubmitReviewUseCase(): SubmitReviewUseCase = getKoin().get()
+    // endregion
 
-    // Download
+    // region Downloads
     fun getModelDownloadRepository(): ModelDownloadRepository = getKoin().get()
     fun getEnqueueDownloadUseCase(): EnqueueDownloadUseCase = getKoin().get()
     fun getObserveDownloadsUseCase(): ObserveDownloadsUseCase = getKoin().get()
@@ -481,13 +524,15 @@ object KoinHelper {
     fun getCancelDownloadUseCase(): CancelDownloadUseCase = getKoin().get()
     fun getDeleteDownloadUseCase(): DeleteDownloadUseCase = getKoin().get()
     fun getClearCompletedDownloadsUseCase(): ClearCompletedDownloadsUseCase = getKoin().get()
+    // endregion
 
-    // Backup
+    // region Backup & Restore
     fun getCreateBackupUseCase(): CreateBackupUseCase = getKoin().get()
     fun getRestoreBackupUseCase(): RestoreBackupUseCase = getKoin().get()
     fun getParseBackupUseCase(): ParseBackupUseCase = getKoin().get()
+    // endregion
 
-    // Plugin management
+    // region Plugin Management
     fun getInstallPluginUseCase(): InstallPluginUseCase = getKoin().get()
     fun getUninstallPluginUseCase(): UninstallPluginUseCase = getKoin().get()
     fun getActivatePluginUseCase(): ActivatePluginUseCase = getKoin().get()
@@ -495,35 +540,27 @@ object KoinHelper {
     fun getObserveInstalledPluginsUseCase(): ObserveInstalledPluginsUseCase = getKoin().get()
     fun getGetPluginConfigUseCase(): GetPluginConfigUseCase = getKoin().get()
     fun getUpdatePluginConfigUseCase(): UpdatePluginConfigUseCase = getKoin().get()
+    // endregion
 
-    // Similarity use cases
-    fun getSimilarModelsUseCase(): GetSimilarModelsUseCase = getKoin().get()
-
-    // Quality threshold use cases
-    fun getObserveQualityThresholdUseCase(): ObserveQualityThresholdUseCase = getKoin().get()
-    fun getSetQualityThresholdUseCase(): SetQualityThresholdUseCase = getKoin().get()
-
-    // Theme plugin use cases
+    // region Theme Plugins
     fun getImportThemeUseCase(): ImportThemeUseCase = getKoin().get()
     fun getGetActiveThemeUseCase(): GetActiveThemeUseCase = getKoin().get()
     fun getObserveThemePluginsUseCase(): ObserveThemePluginsUseCase = getKoin().get()
     fun getActivateThemePluginUseCase(): ActivateThemePluginUseCase = getKoin().get()
+    // endregion
 
-    // Model update notification use cases
-    fun getModelUpdateNotificationsUseCase(): GetModelUpdateNotificationsUseCase = getKoin().get()
-    fun getUnreadNotificationCountUseCase(): GetUnreadNotificationCountUseCase = getKoin().get()
-    fun getMarkNotificationReadUseCase(): MarkNotificationReadUseCase = getKoin().get()
-    fun getMarkAllNotificationsReadUseCase(): MarkAllNotificationsReadUseCase = getKoin().get()
-    fun getCheckAndStoreModelUpdatesUseCase(): CheckAndStoreModelUpdatesUseCase = getKoin().get()
-
-    // ComfyHub use cases
-    fun getSearchComfyHubWorkflowsUseCase(): SearchComfyHubWorkflowsUseCase = getKoin().get()
-    fun getGetComfyHubWorkflowDetailUseCase(): GetComfyHubWorkflowDetailUseCase = getKoin().get()
-    fun getImportComfyHubWorkflowUseCase(): ImportComfyHubWorkflowUseCase = getKoin().get()
-
-    // Share hashtag use cases
+    // region Share Hashtags
     fun getObserveShareHashtagsUseCase(): ObserveShareHashtagsUseCase = getKoin().get()
     fun getAddShareHashtagUseCase(): AddShareHashtagUseCase = getKoin().get()
     fun getRemoveShareHashtagUseCase(): RemoveShareHashtagUseCase = getKoin().get()
     fun getToggleShareHashtagUseCase(): ToggleShareHashtagUseCase = getKoin().get()
+    // endregion
+
+    // region Settings ViewModels
+    fun createContentFilterSettingsViewModel(): ContentFilterSettingsViewModel = getKoin().get()
+    fun createDisplaySettingsViewModel(): DisplaySettingsViewModel = getKoin().get()
+    fun createAppBehaviorSettingsViewModel(): AppBehaviorSettingsViewModel = getKoin().get()
+    fun createAuthSettingsViewModel(): AuthSettingsViewModel = getKoin().get()
+    fun createStorageSettingsViewModel(): StorageSettingsViewModel = getKoin().get()
+    // endregion
 }


### PR DESCRIPTION
## Description

Addresses 15 codebase health issues found by `/audit` scan. 3 issues were closed as non-actionable (future cleanup dependent on minSdk/API level changes).

### Critical
- **#660** Fix dead conditional branches in ComfyUI LoRA chain output (`if (x) 0 else 0`)

### Architecture & Encapsulation
- **#661** Encapsulate MutableStateFlow in Dataset ViewModels (private backing fields + public StateFlow)
- **#662** Organize KoinHelper.kt with region markers for 233 getter methods
- **#664** Extract DesktopDetailScreen.kt (589→159 lines) into ImageGridPanel, ImageMetadataPanel, InfoPanel
- **#666** Extract helper methods in ModelDetailViewModel to reduce cognitive complexity
- **#667** Refactor BackupRepositoryImpl: generic `restoreList<D,E>()` helper, inline export calls (495→439 lines)

### Code Quality
- **#665** Add `updateFilter()` helper in ModelSearchViewModel to eliminate 10 duplicated state sync pairs
- **#670** Add Logger.w for silent exception catch in ModelSearchViewModel.loadRecommendations
- **#675** Replace redundant `!!` with `?.let` in DesktopDetailScreen
- **#669** Replace hardcoded port strings with `ComfyUIConnection.DEFAULT_COMFYUI_PORT` / `SDWebUIConnection.DEFAULT_SDWEBUI_PORT`

### UI & Accessibility
- **#663** Fix touch targets below 48dp (FilterChipComponents, ModelNotesSection, SwipeableCardLayout)
- **#668** Add contentDescription to 16 Desktop Icon components
- **#674** Add maxLines + ellipsis to TopAppBar username in CreatorProfileScreen

### Closed as non-actionable
- **#671** Design tokens already in use — false positive
- **#672** Deprecated API with @Suppress — not removable until minSdk 29+
- **#673** API 34+ deprecation — properly handled with version gate

## Verify
- [x] `./gradlew detekt` — PASS
- [x] `./gradlew :androidApp:assembleDebug` — PASS
- [x] `xcodebuild ... build` — PASS