### PR TITLE
Real-time WebSocket generation preview for ComfyUI

### DIFF
--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/CivitDeckApplication.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/CivitDeckApplication.kt
@@ -168,7 +168,7 @@ val androidModule = module {
     viewModel { GestureTutorialViewModel(get(), get()) }
     viewModel { SwipeDiscoveryViewModel(get(), get()) }
     viewModel { ComfyUISettingsViewModel(get(), get(), get(), get(), get(), get()) }
-    viewModel { ComfyUIGenerationViewModel(get(), get(), get(), get(), get(), get(), get(), get(), get()) }
+    viewModel { ComfyUIGenerationViewModel(get(), get(), get(), get(), get(), get(), get(), get(), get(), get()) }
     viewModel { ComfyUIHistoryViewModel(get(), get(), get(), get(), get(), get(), get(), get(), get()) }
     viewModel { ComfyUIQueueViewModel(get(), get()) }
     viewModel { WorkflowTemplateViewModel(get(), get(), get(), get(), get()) }

--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/comfyui/ComfyUIGenerationScreen.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/comfyui/ComfyUIGenerationScreen.kt
@@ -97,7 +97,7 @@ fun ComfyUIGenerationScreen(
             item { LoraSection(state, viewModel) }
             item { ControlNetSection(state, viewModel) }
             item { CustomWorkflowSection(state, viewModel) }
-            item { GenerateButton(state, viewModel::onGenerate) }
+            item { GenerateButton(state, viewModel::onGenerate, viewModel::onInterrupt) }
             item { GenerationStatusSection(state) }
             val result = state.result
             if (result?.imageUrls?.isNotEmpty() == true) {

--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/comfyui/ComfyUIGenerationViewModel.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/comfyui/ComfyUIGenerationViewModel.kt
@@ -13,6 +13,7 @@ import com.riox432.civitdeck.feature.comfyui.domain.usecase.FetchComfyUICheckpoi
 import com.riox432.civitdeck.feature.comfyui.domain.usecase.FetchComfyUIControlNetsUseCase
 import com.riox432.civitdeck.feature.comfyui.domain.usecase.FetchComfyUILorasUseCase
 import com.riox432.civitdeck.feature.comfyui.domain.usecase.ImportWorkflowUseCase
+import com.riox432.civitdeck.feature.comfyui.domain.usecase.InterruptComfyUIGenerationUseCase
 import com.riox432.civitdeck.feature.comfyui.domain.usecase.ObserveGenerationProgressUseCase
 import com.riox432.civitdeck.feature.comfyui.domain.usecase.PollComfyUIResultUseCase
 import com.riox432.civitdeck.feature.comfyui.domain.usecase.SubmitComfyUIGenerationUseCase
@@ -59,6 +60,9 @@ data class GenerationUiState(
     val result: GenerationResult? = null,
     val error: String? = null,
     val imageSaveSuccess: Boolean? = null,
+    /** Latest preview image bytes from WebSocket during generation. */
+    val previewImageBytes: ByteArray? = null,
+    val currentNodeName: String = "",
 ) {
     /** Progress fraction in [0f, 1f]. Returns 0 when totalSteps is unknown. */
     val progressFraction: Float
@@ -74,6 +78,7 @@ class ComfyUIGenerationViewModel(
     private val submitGeneration: SubmitComfyUIGenerationUseCase,
     private val pollResult: PollComfyUIResultUseCase,
     private val observeProgress: ObserveGenerationProgressUseCase,
+    private val interruptGeneration: InterruptComfyUIGenerationUseCase,
     private val saveImage: SaveGeneratedImageUseCase,
     private val repository: ComfyUIConnectionRepository,
 ) : ViewModel() {
@@ -272,6 +277,8 @@ class ComfyUIGenerationViewModel(
                 result = null,
                 currentStep = 0,
                 totalSteps = 0,
+                previewImageBytes = null,
+                currentNodeName = "",
             )
         }
         launchWithErrorHandling(
@@ -302,6 +309,24 @@ class ComfyUIGenerationViewModel(
         _uiState.update { it.copy(imageSaveSuccess = null) }
     }
 
+    fun onInterrupt() {
+        progressJob?.cancel()
+        launchWithErrorHandling(
+            tag = "Interrupt failed",
+            onError = { e -> _uiState.update { it.copy(error = e.message) } },
+        ) {
+            interruptGeneration()
+            _uiState.update {
+                it.copy(
+                    generationStatus = GenerationStatus.Idle,
+                    currentStep = 0,
+                    totalSteps = 0,
+                    previewImageBytes = null,
+                )
+            }
+        }
+    }
+
     private fun buildParams(state: GenerationUiState) = ComfyUIGenerationParams(
         checkpoint = state.selectedCheckpoint,
         prompt = state.prompt,
@@ -325,8 +350,24 @@ class ComfyUIGenerationViewModel(
             observeProgress(promptId, connection.hostname, connection.port)
                 .catch { pollForResult(promptId) }
                 .collect { progress ->
-                    _uiState.update {
-                        it.copy(currentStep = progress.currentStep, totalSteps = progress.totalSteps)
+                    _uiState.update { state ->
+                        state.copy(
+                            currentStep = if (progress.currentStep > 0) {
+                                progress.currentStep
+                            } else {
+                                state.currentStep
+                            },
+                            totalSteps = if (progress.totalSteps > 0) {
+                                progress.totalSteps
+                            } else {
+                                state.totalSteps
+                            },
+                            previewImageBytes = progress.previewImageBytes
+                                ?: state.previewImageBytes,
+                            currentNodeName = progress.currentNode.ifEmpty {
+                                state.currentNodeName
+                            },
+                        )
                     }
                 }
             // WebSocket flow completed: fetch final result

--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/comfyui/ComfyUIResultSection.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/comfyui/ComfyUIResultSection.kt
@@ -1,7 +1,10 @@
 package com.riox432.civitdeck.ui.comfyui
 
+import android.graphics.BitmapFactory
+import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
@@ -10,7 +13,9 @@ import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.lazy.grid.items
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Download
+import androidx.compose.material.icons.filled.Stop
 import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Card
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Icon
@@ -19,8 +24,10 @@ import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.stringResource
 import com.riox432.civitdeck.R
@@ -29,18 +36,39 @@ import com.riox432.civitdeck.ui.components.CivitAsyncImage
 import com.riox432.civitdeck.ui.theme.Spacing
 
 @Composable
-internal fun GenerateButton(state: GenerationUiState, onGenerate: () -> Unit) {
+internal fun GenerateButton(
+    state: GenerationUiState,
+    onGenerate: () -> Unit,
+    onInterrupt: () -> Unit,
+) {
     val isGenerating = state.generationStatus == GenerationStatus.Submitting ||
         state.generationStatus == GenerationStatus.Running
-    Button(
-        onClick = onGenerate,
-        enabled = !isGenerating && state.selectedCheckpoint.isNotBlank() && state.prompt.isNotBlank(),
+    val canGenerate = state.customWorkflowJson != null ||
+        (state.selectedCheckpoint.isNotBlank() && state.prompt.isNotBlank())
+    Row(
         modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.spacedBy(Spacing.sm),
     ) {
-        if (isGenerating) {
-            CircularProgressIndicator(modifier = Modifier.padding(end = Spacing.sm))
+        Button(
+            onClick = onGenerate,
+            enabled = !isGenerating && canGenerate,
+            modifier = Modifier.weight(1f),
+        ) {
+            if (isGenerating) {
+                CircularProgressIndicator(modifier = Modifier.padding(end = Spacing.sm))
+            }
+            Text(if (isGenerating) "Generating..." else "Generate")
         }
-        Text(if (isGenerating) "Generating..." else "Generate")
+        if (isGenerating) {
+            Button(
+                onClick = onInterrupt,
+                colors = ButtonDefaults.buttonColors(
+                    containerColor = MaterialTheme.colorScheme.error,
+                ),
+            ) {
+                Icon(Icons.Default.Stop, contentDescription = "Stop generation")
+            }
+        }
     }
 }
 
@@ -68,7 +96,7 @@ internal fun GenerationStatusSection(state: GenerationUiState) {
 
 @Composable
 private fun GenerationProgressSection(state: GenerationUiState) {
-    Column(verticalArrangement = Arrangement.spacedBy(Spacing.xs)) {
+    Column(verticalArrangement = Arrangement.spacedBy(Spacing.sm)) {
         if (state.totalSteps > 0) {
             LinearProgressIndicator(
                 progress = { state.progressFraction },
@@ -82,6 +110,33 @@ private fun GenerationProgressSection(state: GenerationUiState) {
             LinearProgressIndicator(modifier = Modifier.fillMaxWidth())
             Text("Generating...", style = MaterialTheme.typography.bodySmall)
         }
+        if (state.currentNodeName.isNotEmpty()) {
+            Text(
+                "Node: ${state.currentNodeName}",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+        PreviewImageView(state.previewImageBytes)
+    }
+}
+
+@Composable
+private fun PreviewImageView(imageBytes: ByteArray?) {
+    if (imageBytes == null) return
+    val bitmap = remember(imageBytes) {
+        BitmapFactory.decodeByteArray(imageBytes, 0, imageBytes.size)
+            ?.asImageBitmap()
+    } ?: return
+    Card(modifier = Modifier.fillMaxWidth()) {
+        Image(
+            bitmap = bitmap,
+            contentDescription = "Generation preview",
+            contentScale = ContentScale.Fit,
+            modifier = Modifier
+                .fillMaxWidth()
+                .aspectRatio(1f),
+        )
     }
 }
 

--- a/core/core-domain/src/commonMain/kotlin/com/riox432/civitdeck/domain/model/GenerationProgress.kt
+++ b/core/core-domain/src/commonMain/kotlin/com/riox432/civitdeck/domain/model/GenerationProgress.kt
@@ -8,8 +8,35 @@ data class GenerationProgress(
     val currentStep: Int,
     val totalSteps: Int,
     val currentNode: String = "",
+    /** Preview image bytes from WebSocket binary frames (JPEG/PNG). Null when no preview available. */
+    val previewImageBytes: ByteArray? = null,
 ) {
     /** Progress fraction in [0.0, 1.0]. Returns 0 when totalSteps is unknown. */
     val fraction: Float
         get() = if (totalSteps > 0) currentStep.toFloat() / totalSteps.toFloat() else 0f
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is GenerationProgress) return false
+        return promptId == other.promptId &&
+            currentStep == other.currentStep &&
+            totalSteps == other.totalSteps &&
+            currentNode == other.currentNode &&
+            previewImageBytes.contentEquals(other.previewImageBytes)
+    }
+
+    override fun hashCode(): Int {
+        var result = promptId.hashCode()
+        result = 31 * result + currentStep
+        result = 31 * result + totalSteps
+        result = 31 * result + currentNode.hashCode()
+        result = 31 * result + (previewImageBytes?.contentHashCode() ?: 0)
+        return result
+    }
+}
+
+private fun ByteArray?.contentEquals(other: ByteArray?): Boolean {
+    if (this === other) return true
+    if (this == null || other == null) return this == other
+    return this.contentEquals(other)
 }

--- a/core/core-domain/src/commonMain/kotlin/com/riox432/civitdeck/domain/repository/ComfyUIGenerationRepository.kt
+++ b/core/core-domain/src/commonMain/kotlin/com/riox432/civitdeck/domain/repository/ComfyUIGenerationRepository.kt
@@ -13,4 +13,5 @@ interface ComfyUIGenerationRepository {
     suspend fun pollGenerationResult(promptId: String): GenerationResult
     fun observeGenerationProgress(promptId: String, host: String, port: Int): Flow<GenerationProgress>
     fun getImageUrl(filename: String, subfolder: String = "", type: String = "output"): String
+    suspend fun interruptGeneration()
 }

--- a/core/core-network/src/commonMain/kotlin/com/riox432/civitdeck/data/api/comfyui/ComfyUIApi.kt
+++ b/core/core-network/src/commonMain/kotlin/com/riox432/civitdeck/data/api/comfyui/ComfyUIApi.kt
@@ -123,6 +123,23 @@ class ComfyUIApi(
     }
 
     /**
+     * Interrupt the currently running generation: POST /interrupt
+     * @throws CancellationException if coroutine is cancelled
+     * @throws Exception on network failure
+     */
+    suspend fun interrupt() {
+        val url = baseUrl
+        try {
+            client.post("$url/interrupt")
+        } catch (e: CancellationException) {
+            throw e
+        } catch (@Suppress("TooGenericExceptionCaught") e: Exception) {
+            Logger.e(TAG, "interrupt failed: ${e.message}", e)
+            throw e
+        }
+    }
+
+    /**
      * Delete (cancel) queued prompts: POST /queue with {"delete": [...promptIds]}
      * @throws CancellationException if coroutine is cancelled
      * @throws Exception on network failure

--- a/core/core-network/src/commonMain/kotlin/com/riox432/civitdeck/data/api/comfyui/ComfyUIWebSocketApi.kt
+++ b/core/core-network/src/commonMain/kotlin/com/riox432/civitdeck/data/api/comfyui/ComfyUIWebSocketApi.kt
@@ -15,6 +15,7 @@ import kotlinx.serialization.json.decodeFromJsonElement
 private const val MAX_RETRIES = 5
 private const val BASE_DELAY_MS = 1_000L
 private const val MAX_DELAY_MS = 16_000L
+private const val BINARY_HEADER_SIZE = 8
 
 /**
  * Manages a ComfyUI WebSocket connection and emits typed [ComfyUIWebSocketMessage] events.
@@ -79,9 +80,24 @@ class ComfyUIWebSocketApi(
     }
 
     private fun Frame.toRelevantMessage(promptId: String): ComfyUIWebSocketMessage? {
-        if (this !is Frame.Text) return null
-        val msg = parseMessage(readText()) ?: return null
-        return if (isRelevant(msg, promptId)) msg else null
+        return when (this) {
+            is Frame.Text -> {
+                val msg = parseMessage(readText()) ?: return null
+                if (isRelevant(msg, promptId)) msg else null
+            }
+            is Frame.Binary -> parseBinaryPreview(data)
+            else -> null
+        }
+    }
+
+    /**
+     * ComfyUI sends preview images as binary frames.
+     * Format: first 8 bytes are a header (event type + format), remaining bytes are image data.
+     */
+    private fun parseBinaryPreview(data: ByteArray): ComfyUIWebSocketMessage? {
+        if (data.size <= BINARY_HEADER_SIZE) return null
+        val imageBytes = data.copyOfRange(BINARY_HEADER_SIZE, data.size)
+        return ComfyUIWebSocketMessage.PreviewImage(imageBytes)
     }
 
     private fun isTerminal(msg: ComfyUIWebSocketMessage): Boolean =
@@ -139,6 +155,7 @@ class ComfyUIWebSocketApi(
         is ComfyUIWebSocketMessage.Executed -> msg.promptId == promptId
         is ComfyUIWebSocketMessage.ExecutionSuccess -> msg.promptId == promptId
         is ComfyUIWebSocketMessage.ExecutionError -> msg.promptId == promptId
+        is ComfyUIWebSocketMessage.PreviewImage -> true
         is ComfyUIWebSocketMessage.Unknown -> false
     }
 }

--- a/core/core-network/src/commonMain/kotlin/com/riox432/civitdeck/data/api/comfyui/ComfyUIWebSocketDto.kt
+++ b/core/core-network/src/commonMain/kotlin/com/riox432/civitdeck/data/api/comfyui/ComfyUIWebSocketDto.kt
@@ -30,6 +30,13 @@ sealed class ComfyUIWebSocketMessage {
     data class Executed(val promptId: String, val node: String) : ComfyUIWebSocketMessage()
     data class ExecutionSuccess(val promptId: String) : ComfyUIWebSocketMessage()
     data class ExecutionError(val promptId: String, val exceptionMessage: String) : ComfyUIWebSocketMessage()
+
+    /** Binary preview image data sent during sampling (e.g. from SaveImageWebsocket node). */
+    data class PreviewImage(val imageBytes: ByteArray) : ComfyUIWebSocketMessage() {
+        override fun equals(other: Any?): Boolean =
+            other is PreviewImage && imageBytes.contentEquals(other.imageBytes)
+        override fun hashCode(): Int = imageBytes.contentHashCode()
+    }
     data class Unknown(val type: String) : ComfyUIWebSocketMessage()
 }
 

--- a/desktopApp/src/jvmMain/kotlin/com/riox432/civitdeck/di/DesktopModule.kt
+++ b/desktopApp/src/jvmMain/kotlin/com/riox432/civitdeck/di/DesktopModule.kt
@@ -63,7 +63,7 @@ val desktopModule = module {
         ComfyUISettingsViewModel(get(), get(), get(), get(), get(), get())
     }
     viewModel {
-        ComfyUIGenerationViewModel(get(), get(), get(), get(), get(), get(), get(), get(), get())
+        ComfyUIGenerationViewModel(get(), get(), get(), get(), get(), get(), get(), get(), get(), get())
     }
     viewModel {
         ComfyUIHistoryViewModel(get(), get(), get(), get(), get(), get(), get(), get(), get())

--- a/desktopApp/src/jvmMain/kotlin/com/riox432/civitdeck/ui/comfyui/ComfyUIGenerationViewModel.kt
+++ b/desktopApp/src/jvmMain/kotlin/com/riox432/civitdeck/ui/comfyui/ComfyUIGenerationViewModel.kt
@@ -13,6 +13,7 @@ import com.riox432.civitdeck.feature.comfyui.domain.usecase.FetchComfyUICheckpoi
 import com.riox432.civitdeck.feature.comfyui.domain.usecase.FetchComfyUIControlNetsUseCase
 import com.riox432.civitdeck.feature.comfyui.domain.usecase.FetchComfyUILorasUseCase
 import com.riox432.civitdeck.feature.comfyui.domain.usecase.ImportWorkflowUseCase
+import com.riox432.civitdeck.feature.comfyui.domain.usecase.InterruptComfyUIGenerationUseCase
 import com.riox432.civitdeck.feature.comfyui.domain.usecase.ObserveGenerationProgressUseCase
 import com.riox432.civitdeck.feature.comfyui.domain.usecase.PollComfyUIResultUseCase
 import com.riox432.civitdeck.feature.comfyui.domain.usecase.SubmitComfyUIGenerationUseCase
@@ -59,6 +60,8 @@ data class GenerationUiState(
     val result: GenerationResult? = null,
     val error: String? = null,
     val imageSaveSuccess: Boolean? = null,
+    val previewImageBytes: ByteArray? = null,
+    val currentNodeName: String = "",
 ) {
     /** Progress fraction in [0f, 1f]. Returns 0 when totalSteps is unknown. */
     val progressFraction: Float
@@ -74,6 +77,7 @@ class ComfyUIGenerationViewModel(
     private val submitGeneration: SubmitComfyUIGenerationUseCase,
     private val pollResult: PollComfyUIResultUseCase,
     private val observeProgress: ObserveGenerationProgressUseCase,
+    private val interruptGeneration: InterruptComfyUIGenerationUseCase,
     private val saveImage: SaveGeneratedImageUseCase,
     private val repository: ComfyUIConnectionRepository,
 ) : ViewModel() {
@@ -272,6 +276,8 @@ class ComfyUIGenerationViewModel(
                 result = null,
                 currentStep = 0,
                 totalSteps = 0,
+                previewImageBytes = null,
+                currentNodeName = "",
             )
         }
         launchWithErrorHandling(
@@ -302,6 +308,24 @@ class ComfyUIGenerationViewModel(
         _uiState.update { it.copy(imageSaveSuccess = null) }
     }
 
+    fun onInterrupt() {
+        progressJob?.cancel()
+        launchWithErrorHandling(
+            tag = "Interrupt failed",
+            onError = { e -> _uiState.update { it.copy(error = e.message) } },
+        ) {
+            interruptGeneration()
+            _uiState.update {
+                it.copy(
+                    generationStatus = GenerationStatus.Idle,
+                    currentStep = 0,
+                    totalSteps = 0,
+                    previewImageBytes = null,
+                )
+            }
+        }
+    }
+
     private fun buildParams(state: GenerationUiState) = ComfyUIGenerationParams(
         checkpoint = state.selectedCheckpoint,
         prompt = state.prompt,
@@ -325,8 +349,24 @@ class ComfyUIGenerationViewModel(
             observeProgress(promptId, connection.hostname, connection.port)
                 .catch { pollForResult(promptId) }
                 .collect { progress ->
-                    _uiState.update {
-                        it.copy(currentStep = progress.currentStep, totalSteps = progress.totalSteps)
+                    _uiState.update { state ->
+                        state.copy(
+                            currentStep = if (progress.currentStep > 0) {
+                                progress.currentStep
+                            } else {
+                                state.currentStep
+                            },
+                            totalSteps = if (progress.totalSteps > 0) {
+                                progress.totalSteps
+                            } else {
+                                state.totalSteps
+                            },
+                            previewImageBytes = progress.previewImageBytes
+                                ?: state.previewImageBytes,
+                            currentNodeName = progress.currentNode.ifEmpty {
+                                state.currentNodeName
+                            },
+                        )
                     }
                 }
             // WebSocket flow completed: fetch final result

--- a/feature/feature-comfyui/src/commonMain/kotlin/com/riox432/civitdeck/feature/comfyui/data/repository/ComfyUIGenerationRepositoryImpl.kt
+++ b/feature/feature-comfyui/src/commonMain/kotlin/com/riox432/civitdeck/feature/comfyui/data/repository/ComfyUIGenerationRepositoryImpl.kt
@@ -85,9 +85,20 @@ class ComfyUIGenerationRepositoryImpl(
                     totalSteps = msg.max,
                     currentNode = msg.node,
                 )
+                is ComfyUIWebSocketMessage.PreviewImage -> GenerationProgress(
+                    promptId = promptId,
+                    currentStep = 0,
+                    totalSteps = 0,
+                    previewImageBytes = msg.imageBytes,
+                )
                 else -> null
             }
         }
+    }
+
+    override suspend fun interruptGeneration() {
+        ensureApiConfigured()
+        api.interrupt()
     }
 
     override fun getImageUrl(filename: String, subfolder: String, type: String): String {

--- a/feature/feature-comfyui/src/commonMain/kotlin/com/riox432/civitdeck/feature/comfyui/data/repository/ComfyUIRepositoryImpl.kt
+++ b/feature/feature-comfyui/src/commonMain/kotlin/com/riox432/civitdeck/feature/comfyui/data/repository/ComfyUIRepositoryImpl.kt
@@ -146,6 +146,12 @@ class ComfyUIRepositoryImpl(
                     totalSteps = msg.max,
                     currentNode = msg.node,
                 )
+                is ComfyUIWebSocketMessage.PreviewImage -> GenerationProgress(
+                    promptId = promptId,
+                    currentStep = 0,
+                    totalSteps = 0,
+                    previewImageBytes = msg.imageBytes,
+                )
                 else -> null
             }
         }
@@ -153,6 +159,11 @@ class ComfyUIRepositoryImpl(
 
     override fun getImageUrl(filename: String, subfolder: String, type: String): String {
         return api.getImageUrl(ComfyUIOutputImage(filename, subfolder, type))
+    }
+
+    override suspend fun interruptGeneration() {
+        ensureApiConfigured()
+        api.interrupt()
     }
 
     override fun observeQueue(intervalMs: Long): Flow<List<QueueJob>> = flow {

--- a/feature/feature-comfyui/src/commonMain/kotlin/com/riox432/civitdeck/feature/comfyui/di/ComfyUIModule.kt
+++ b/feature/feature-comfyui/src/commonMain/kotlin/com/riox432/civitdeck/feature/comfyui/di/ComfyUIModule.kt
@@ -43,6 +43,7 @@ import com.riox432.civitdeck.feature.comfyui.domain.usecase.GetWorkflowTemplates
 import com.riox432.civitdeck.feature.comfyui.domain.usecase.ImportComfyHubWorkflowUseCase
 import com.riox432.civitdeck.feature.comfyui.domain.usecase.ImportWorkflowTemplateUseCase
 import com.riox432.civitdeck.feature.comfyui.domain.usecase.ImportWorkflowUseCase
+import com.riox432.civitdeck.feature.comfyui.domain.usecase.InterruptComfyUIGenerationUseCase
 import com.riox432.civitdeck.feature.comfyui.domain.usecase.InterruptSDWebUIGenerationUseCase
 import com.riox432.civitdeck.feature.comfyui.domain.usecase.ObserveActiveComfyUIConnectionUseCase
 import com.riox432.civitdeck.feature.comfyui.domain.usecase.ObserveActiveSDWebUIConnectionUseCase
@@ -90,6 +91,7 @@ val comfyuiModule = module {
     factory { ObserveGenerationProgressUseCase(get()) }
     factory { ObserveComfyUIQueueUseCase(get()) }
     factory { CancelComfyUIJobUseCase(get()) }
+    factory { InterruptComfyUIGenerationUseCase(get()) }
     factory { FindMatchingLocalModelUseCase(get()) }
     factory { PopulateGenerationFromModelUseCase() }
     factory { SaveGeneratedImageUseCase(get(named("comfyui")), get()) }

--- a/feature/feature-comfyui/src/commonMain/kotlin/com/riox432/civitdeck/feature/comfyui/domain/usecase/ComfyUIUseCases.kt
+++ b/feature/feature-comfyui/src/commonMain/kotlin/com/riox432/civitdeck/feature/comfyui/domain/usecase/ComfyUIUseCases.kt
@@ -91,6 +91,10 @@ class PollComfyUIResultUseCase(private val repository: ComfyUIGenerationReposito
         repository.pollGenerationResult(promptId)
 }
 
+class InterruptComfyUIGenerationUseCase(private val repository: ComfyUIGenerationRepository) {
+    suspend operator fun invoke() = repository.interruptGeneration()
+}
+
 // -- History --
 
 class FetchComfyUIHistoryUseCase(private val repository: ComfyUIHistoryRepository) {

--- a/iosApp/iosApp/Features/ComfyUI/ComfyUIGenerationView.swift
+++ b/iosApp/iosApp/Features/ComfyUI/ComfyUIGenerationView.swift
@@ -226,17 +226,28 @@ struct ComfyUIGenerationView: View {
             || viewModel.generationStatus == .running
         let canGenerate = viewModel.customWorkflowJson != nil
             || (!viewModel.selectedCheckpoint.isEmpty && !viewModel.prompt.isEmpty)
-        return Button(action: viewModel.onGenerate) {
-            HStack {
-                if isGenerating {
-                    ProgressView().tint(theme.onPrimary)
+        return HStack(spacing: Spacing.sm) {
+            Button(action: viewModel.onGenerate) {
+                HStack {
+                    if isGenerating {
+                        ProgressView().tint(theme.onPrimary)
+                    }
+                    Text(isGenerating ? "Generating..." : "Generate")
                 }
-                Text(isGenerating ? "Generating..." : "Generate")
+                .frame(maxWidth: .infinity)
             }
-            .frame(maxWidth: .infinity)
+            .buttonStyle(.borderedProminent)
+            .disabled(isGenerating || !canGenerate)
+
+            if isGenerating {
+                Button(action: viewModel.onInterrupt) {
+                    Image(systemName: "stop.fill")
+                        .accessibilityLabel("Stop generation")
+                }
+                .buttonStyle(.borderedProminent)
+                .tint(.civitError)
+            }
         }
-        .buttonStyle(.borderedProminent)
-        .disabled(isGenerating || !canGenerate)
     }
 
     @ViewBuilder
@@ -259,7 +270,7 @@ struct ComfyUIGenerationView: View {
 
     @ViewBuilder
     private var generationProgressSection: some View {
-        VStack(spacing: Spacing.xs) {
+        VStack(spacing: Spacing.sm) {
             if viewModel.totalSteps > 0 {
                 ProgressView(value: viewModel.progressFraction)
                     .progressViewStyle(.linear)
@@ -268,6 +279,19 @@ struct ComfyUIGenerationView: View {
             } else {
                 ProgressView()
                 Text("Generating...").font(.civitBodySmall)
+            }
+            if !viewModel.currentNodeName.isEmpty {
+                Text("Node: \(viewModel.currentNodeName)")
+                    .font(.civitBodySmall)
+                    .foregroundColor(.civitOnSurfaceVariant)
+            }
+            if let preview = viewModel.previewImage {
+                Image(uiImage: preview)
+                    .resizable()
+                    .aspectRatio(contentMode: .fit)
+                    .frame(maxWidth: .infinity)
+                    .clipShape(RoundedRectangle(cornerRadius: CornerRadius.image))
+                    .accessibilityLabel("Generation preview")
             }
         }
     }

--- a/iosApp/iosApp/Features/ComfyUI/ComfyUIGenerationViewModel.swift
+++ b/iosApp/iosApp/Features/ComfyUI/ComfyUIGenerationViewModel.swift
@@ -1,5 +1,6 @@
 import Foundation
 import Shared
+import UIKit
 
 @MainActor
 class ComfyUIGenerationViewModel: ObservableObject {
@@ -32,6 +33,9 @@ class ComfyUIGenerationViewModel: ObservableObject {
     @Published var resultImageUrls: [String] = []
     @Published var error: String?
     @Published var imageSaveSuccess: Bool?
+    // Preview
+    @Published var previewImage: UIImage?
+    @Published var currentNodeName: String = ""
 
     var progressFraction: Float {
         guard totalSteps > 0 else { return 0 }
@@ -44,6 +48,9 @@ class ComfyUIGenerationViewModel: ObservableObject {
     private let importWorkflowUseCase = KoinHelper.shared.getImportWorkflowUseCase()
     private let submitGeneration = KoinHelper.shared.getSubmitComfyUIGenerationUseCase()
     private let pollResult = KoinHelper.shared.getPollComfyUIResultUseCase()
+    private let observeProgressUseCase = KoinHelper.shared.getObserveGenerationProgressUseCase()
+    private let interruptGenerationUseCase = KoinHelper.shared.getInterruptComfyUIGenerationUseCase()
+    private let connectionRepository = KoinHelper.shared.getComfyUIConnectionRepository()
     private let saveImageUseCase = KoinHelper.shared.getSaveGeneratedImageUseCase()
     private var progressTask: Task<Void, Never>?
 
@@ -136,37 +143,41 @@ class ComfyUIGenerationViewModel: ObservableObject {
         resultImageUrls = []
         currentStep = 0
         totalSteps = 0
+        previewImage = nil
+        currentNodeName = ""
 
         Task {
             do {
-                let w = Int32(width) ?? 512
-                let h = Int32(height) ?? 512
-                let s = Int64(seed) ?? -1
-                let kLoras = loraSelections.map {
-                    LoraSelection(name: $0.name, strengthModel: $0.strengthModel, strengthClip: $0.strengthClip)
-                }
-                let params = ComfyUIGenerationParams(
-                    checkpoint: selectedCheckpoint,
-                    prompt: prompt,
-                    negativePrompt: negativePrompt,
-                    steps: Int32(steps),
-                    cfgScale: cfgScale,
-                    seed: s,
-                    width: w,
-                    height: h,
-                    samplerName: "euler",
-                    scheduler: "normal",
-                    loraSelections: kLoras,
-                    controlNetEnabled: controlNetEnabled,
-                    controlNetModel: selectedControlNet,
-                    controlNetStrength: Float(controlNetStrength),
-                    customWorkflowJson: customWorkflowJson
-                )
+                let params = buildParams()
                 let promptId = try await submitGeneration.invoke(params: params)
                 generationStatus = .running
-                await pollForResult(promptId: promptId)
+                let connection = try await connectionRepository.getActiveConnection()
+                if let conn = connection {
+                    await startWebSocketProgress(
+                        promptId: promptId,
+                        host: conn.hostname,
+                        port: conn.port
+                    )
+                } else {
+                    await pollForResult(promptId: promptId)
+                }
             } catch {
                 generationStatus = .error
+                self.error = error.localizedDescription
+            }
+        }
+    }
+
+    func onInterrupt() {
+        progressTask?.cancel()
+        Task {
+            do {
+                try await interruptGenerationUseCase.invoke()
+                generationStatus = .idle
+                currentStep = 0
+                totalSteps = 0
+                previewImage = nil
+            } catch {
                 self.error = error.localizedDescription
             }
         }
@@ -180,6 +191,81 @@ class ComfyUIGenerationViewModel: ObservableObject {
             } catch {
                 imageSaveSuccess = false
             }
+        }
+    }
+
+    private func buildParams() -> ComfyUIGenerationParams {
+        let w = Int32(width) ?? 512
+        let h = Int32(height) ?? 512
+        let s = Int64(seed) ?? -1
+        let kLoras = loraSelections.map {
+            LoraSelection(name: $0.name, strengthModel: $0.strengthModel, strengthClip: $0.strengthClip)
+        }
+        return ComfyUIGenerationParams(
+            checkpoint: selectedCheckpoint,
+            prompt: prompt,
+            negativePrompt: negativePrompt,
+            steps: Int32(steps),
+            cfgScale: cfgScale,
+            seed: s,
+            width: w,
+            height: h,
+            samplerName: "euler",
+            scheduler: "normal",
+            loraSelections: kLoras,
+            controlNetEnabled: controlNetEnabled,
+            controlNetModel: selectedControlNet,
+            controlNetStrength: Float(controlNetStrength),
+            customWorkflowJson: customWorkflowJson
+        )
+    }
+
+    private func startWebSocketProgress(promptId: String, host: String, port: Int32) async {
+        // Collect progress from WebSocket flow via SKIE async sequence
+        do {
+            for try await progress in observeProgressUseCase.invoke(
+                promptId: promptId,
+                host: host,
+                port: port
+            ) {
+                if progress.currentStep > 0 {
+                    currentStep = Int(progress.currentStep)
+                }
+                if progress.totalSteps > 0 {
+                    totalSteps = Int(progress.totalSteps)
+                }
+                if !progress.currentNode.isEmpty {
+                    currentNodeName = progress.currentNode
+                }
+                if let bytes = progress.previewImageBytes {
+                    let data = kotlinByteArrayToData(bytes)
+                    if let image = UIImage(data: data) {
+                        previewImage = image
+                    }
+                }
+            }
+            // WebSocket flow completed: fetch final result
+            await fetchFinalResult(promptId: promptId)
+        } catch {
+            // WebSocket failed: fall back to polling
+            await pollForResult(promptId: promptId)
+        }
+    }
+
+    private func fetchFinalResult(promptId: String) async {
+        do {
+            let result = try await pollResult.invoke(promptId: promptId)
+            let status = result.status
+            if status == .completed {
+                resultImageUrls = result.imageUrls
+                generationStatus = .completed
+            } else {
+                self.error = result.error ?? "Generation failed"
+                generationStatus = .error
+            }
+        } catch {
+            self.error = error.localizedDescription
+            generationStatus = .error
         }
     }
 
@@ -207,6 +293,16 @@ class ComfyUIGenerationViewModel: ObservableObject {
         self.error = "Generation timed out"
         generationStatus = .error
     }
+}
+
+/// Convert Kotlin ByteArray to Swift Data
+private func kotlinByteArrayToData(_ byteArray: KotlinByteArray) -> Data {
+    let size = byteArray.size
+    var bytes = [UInt8](repeating: 0, count: Int(size))
+    for i in 0..<size {
+        bytes[Int(i)] = UInt8(bitPattern: byteArray.get(index: i))
+    }
+    return Data(bytes)
 }
 
 struct LoraSelectionSwift: Identifiable {

--- a/shared/src/commonTest/kotlin/com/riox432/civitdeck/domain/usecase/ComfyUIUseCasesTest.kt
+++ b/shared/src/commonTest/kotlin/com/riox432/civitdeck/domain/usecase/ComfyUIUseCasesTest.kt
@@ -70,6 +70,7 @@ class ComfyUIUseCasesTest {
         override fun observeQueue(intervalMs: Long): Flow<List<QueueJob>> =
             kotlinx.coroutines.flow.flowOf(emptyList())
         override suspend fun cancelJob(promptId: String) {}
+        override suspend fun interruptGeneration() {}
     }
 
     private val repo = FakeComfyUIRepository()

--- a/shared/src/iosMain/kotlin/com/riox432/civitdeck/di/KoinHelper.kt
+++ b/shared/src/iosMain/kotlin/com/riox432/civitdeck/di/KoinHelper.kt
@@ -2,6 +2,7 @@ package com.riox432.civitdeck.di
 
 import com.riox432.civitdeck.data.api.ApiKeyProvider
 import com.riox432.civitdeck.data.image.SaveGeneratedImageUseCase
+import com.riox432.civitdeck.domain.repository.ComfyUIConnectionRepository
 import com.riox432.civitdeck.domain.repository.ModelDownloadRepository
 import com.riox432.civitdeck.domain.usecase.ActivatePluginUseCase
 import com.riox432.civitdeck.domain.usecase.AddExcludedTagUseCase
@@ -171,6 +172,7 @@ import com.riox432.civitdeck.feature.comfyui.domain.usecase.GetWorkflowTemplates
 import com.riox432.civitdeck.feature.comfyui.domain.usecase.ImportComfyHubWorkflowUseCase
 import com.riox432.civitdeck.feature.comfyui.domain.usecase.ImportWorkflowTemplateUseCase
 import com.riox432.civitdeck.feature.comfyui.domain.usecase.ImportWorkflowUseCase
+import com.riox432.civitdeck.feature.comfyui.domain.usecase.InterruptComfyUIGenerationUseCase
 import com.riox432.civitdeck.feature.comfyui.domain.usecase.InterruptSDWebUIGenerationUseCase
 import com.riox432.civitdeck.feature.comfyui.domain.usecase.ObserveActiveComfyUIConnectionUseCase
 import com.riox432.civitdeck.feature.comfyui.domain.usecase.ObserveActiveSDWebUIConnectionUseCase
@@ -399,6 +401,8 @@ object KoinHelper {
     fun getObserveGenerationProgressUseCase(): ObserveGenerationProgressUseCase = getKoin().get()
     fun getObserveComfyUIQueueUseCase(): ObserveComfyUIQueueUseCase = getKoin().get()
     fun getCancelComfyUIJobUseCase(): CancelComfyUIJobUseCase = getKoin().get()
+    fun getInterruptComfyUIGenerationUseCase(): InterruptComfyUIGenerationUseCase = getKoin().get()
+    fun getComfyUIConnectionRepository(): ComfyUIConnectionRepository = getKoin().get()
     fun getFindMatchingLocalModelUseCase(): FindMatchingLocalModelUseCase = getKoin().get()
     fun getPopulateGenerationFromModelUseCase(): PopulateGenerationFromModelUseCase = getKoin().get()
     fun getSaveGeneratedImageUseCase(): SaveGeneratedImageUseCase = getKoin().get()


### PR DESCRIPTION
## Summary
- Add real-time step-by-step preview images during ComfyUI generation via WebSocket binary frames
- Add interrupt/cancel button to stop running generation from mobile/desktop
- iOS ViewModel now uses WebSocket progress (was polling-only) with fallback to polling on failure
- All three platforms (Android, iOS, Desktop) updated with preview image display and node name tracking

## Changes
- **core-network**: WebSocket API handles binary frames (8-byte header + image data) as `PreviewImage` messages; ComfyUI API gains `interrupt()` endpoint
- **core-domain**: `GenerationProgress` extended with `previewImageBytes` field; `ComfyUIGenerationRepository` gains `interruptGeneration()`
- **feature-comfyui**: Both repository impls emit preview images; new `InterruptComfyUIGenerationUseCase`; Koin module updated
- **Android**: Generation screen shows real-time preview image, current node name, and stop button during generation
- **iOS**: Generation view shows preview image and stop button; VM upgraded from polling-only to WebSocket progress with polling fallback
- **Desktop**: VM updated with interrupt support and preview image handling

## Test plan
- [ ] Start a ComfyUI generation with a workflow that includes `SaveImageWebsocket` node — verify step-by-step preview images appear
- [ ] Verify progress bar shows `Step X / Y` during generation
- [ ] Tap the stop button during generation — verify it interrupts the running job
- [ ] Test with no WebSocket available — verify fallback to polling still works
- [ ] Test network disconnect during generation — verify reconnection or graceful fallback

Closes #601