### PR TITLE
#603 Workflow template library with parameter editor

### DIFF
--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/comfyui/TemplateParameterScreen.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/comfyui/TemplateParameterScreen.kt
@@ -1,0 +1,246 @@
+@file:Suppress("TooManyFunctions")
+
+package com.riox432.civitdeck.ui.comfyui
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.Button
+import androidx.compose.material3.Card
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Slider
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateMapOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import com.riox432.civitdeck.domain.model.TemplateVariable
+import com.riox432.civitdeck.domain.model.TemplateVariableType
+import com.riox432.civitdeck.domain.model.WorkflowTemplate
+import com.riox432.civitdeck.ui.theme.Spacing
+import kotlin.math.roundToInt
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun TemplateParameterScreen(
+    template: WorkflowTemplate,
+    onBack: () -> Unit,
+    onApply: (Map<String, String>) -> Unit,
+) {
+    val values = remember {
+        mutableStateMapOf<String, String>().apply {
+            template.variables.forEach { v -> put(v.name, v.defaultValue) }
+        }
+    }
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text(template.name) },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, "Back")
+                    }
+                },
+            )
+        },
+    ) { padding ->
+        LazyColumn(
+            modifier = Modifier.padding(padding),
+            contentPadding = PaddingValues(Spacing.md),
+            verticalArrangement = Arrangement.spacedBy(Spacing.md),
+        ) {
+            if (template.description.isNotBlank()) {
+                item {
+                    Text(
+                        template.description,
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+            }
+            items(template.variables, key = { it.name }) { variable ->
+                ParameterInput(
+                    variable = variable,
+                    value = values[variable.name] ?: variable.defaultValue,
+                    onValueChange = { values[variable.name] = it },
+                )
+            }
+            item {
+                Button(
+                    onClick = { onApply(values.toMap()) },
+                    modifier = Modifier.fillMaxWidth(),
+                    enabled = template.variables
+                        .filter { it.required }
+                        .all { (values[it.name] ?: "").isNotBlank() },
+                ) {
+                    Text("Generate")
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun ParameterInput(
+    variable: TemplateVariable,
+    value: String,
+    onValueChange: (String) -> Unit,
+) {
+    Card(modifier = Modifier.fillMaxWidth()) {
+        Column(
+            modifier = Modifier.padding(Spacing.md),
+            verticalArrangement = Arrangement.spacedBy(Spacing.xs),
+        ) {
+            Text(
+                variable.label.ifBlank { variable.name },
+                style = MaterialTheme.typography.titleSmall,
+            )
+            if (variable.description.isNotBlank()) {
+                Text(
+                    variable.description,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+            when (variable.type) {
+                TemplateVariableType.SLIDER -> SliderInput(variable, value, onValueChange)
+                TemplateVariableType.SELECT -> SelectInput(variable, value, onValueChange)
+                TemplateVariableType.NUMBER -> NumberInput(variable, value, onValueChange)
+                TemplateVariableType.TEXT -> TextInput(variable, value, onValueChange)
+            }
+        }
+    }
+}
+
+@Composable
+private fun SliderInput(
+    variable: TemplateVariable,
+    value: String,
+    onValueChange: (String) -> Unit,
+) {
+    val min = variable.min?.toFloat() ?: 0f
+    val max = variable.max?.toFloat() ?: 100f
+    val step = variable.step?.toFloat() ?: 1f
+    val current = value.toFloatOrNull()?.coerceIn(min, max) ?: min
+
+    Column {
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceBetween,
+        ) {
+            Text(formatSliderValue(min, step), style = MaterialTheme.typography.bodySmall)
+            Text(
+                formatSliderValue(current, step),
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.primary,
+            )
+            Text(formatSliderValue(max, step), style = MaterialTheme.typography.bodySmall)
+        }
+        val steps = if (step > 0f && max > min) {
+            ((max - min) / step).roundToInt() - 1
+        } else {
+            0
+        }
+        Slider(
+            value = current,
+            onValueChange = { onValueChange(formatSliderValue(it, step)) },
+            valueRange = min..max,
+            steps = steps.coerceAtLeast(0),
+        )
+    }
+}
+
+@Composable
+private fun SelectInput(
+    variable: TemplateVariable,
+    value: String,
+    onValueChange: (String) -> Unit,
+) {
+    var expanded by remember { mutableStateOf(false) }
+    Column {
+        TextButton(onClick = { expanded = true }) {
+            Text(value.ifBlank { "Select..." })
+        }
+        DropdownMenu(expanded = expanded, onDismissRequest = { expanded = false }) {
+            variable.options.forEach { option ->
+                DropdownMenuItem(
+                    text = { Text(option) },
+                    onClick = {
+                        onValueChange(option)
+                        expanded = false
+                    },
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun NumberInput(
+    variable: TemplateVariable,
+    value: String,
+    onValueChange: (String) -> Unit,
+) {
+    // If has min/max, show as slider instead
+    if (variable.min != null && variable.max != null) {
+        SliderInput(variable, value, onValueChange)
+    } else {
+        OutlinedTextField(
+            value = value,
+            onValueChange = onValueChange,
+            modifier = Modifier.fillMaxWidth(),
+            singleLine = true,
+        )
+    }
+}
+
+@Composable
+private fun TextInput(
+    variable: TemplateVariable,
+    value: String,
+    onValueChange: (String) -> Unit,
+) {
+    OutlinedTextField(
+        value = value,
+        onValueChange = onValueChange,
+        modifier = Modifier.fillMaxWidth(),
+        minLines = if (variable.name.contains("prompt")) 3 else 1,
+        maxLines = if (variable.name.contains("prompt")) 6 else 1,
+        placeholder = {
+            if (variable.required) Text("Required") else Text("Optional")
+        },
+    )
+}
+
+private fun formatSliderValue(value: Float, step: Float): String {
+    return if (step >= 1f) {
+        value.roundToInt().toString()
+    } else {
+        val decimals = when {
+            step >= 0.1f -> 1
+            step >= 0.01f -> 2
+            else -> 3
+        }
+        "%.${decimals}f".format(value)
+    }
+}

--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/comfyui/WorkflowTemplateEditorScreen.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/comfyui/WorkflowTemplateEditorScreen.kt
@@ -38,6 +38,7 @@ import androidx.compose.ui.Modifier
 import com.riox432.civitdeck.domain.model.TemplateVariable
 import com.riox432.civitdeck.domain.model.TemplateVariableType
 import com.riox432.civitdeck.domain.model.WorkflowTemplate
+import com.riox432.civitdeck.domain.model.WorkflowTemplateCategory
 import com.riox432.civitdeck.domain.model.WorkflowTemplateType
 import com.riox432.civitdeck.ui.theme.Spacing
 
@@ -49,7 +50,9 @@ fun WorkflowTemplateEditorScreen(
     onBack: () -> Unit,
 ) {
     var name by rememberSaveable { mutableStateOf(initialTemplate.name) }
+    var description by rememberSaveable { mutableStateOf(initialTemplate.description) }
     var type by rememberSaveable { mutableStateOf(initialTemplate.type) }
+    var category by rememberSaveable { mutableStateOf(initialTemplate.category) }
     var variables by remember { mutableStateOf(initialTemplate.variables) }
 
     Scaffold(
@@ -60,7 +63,13 @@ fun WorkflowTemplateEditorScreen(
                 canSave = name.isNotBlank(),
                 onSave = {
                     viewModel.onSaveTemplate(
-                        initialTemplate.copy(name = name.trim(), type = type, variables = variables),
+                        initialTemplate.copy(
+                            name = name.trim(),
+                            description = description.trim(),
+                            type = type,
+                            category = category,
+                            variables = variables,
+                        ),
                     )
                     onBack()
                 },
@@ -70,13 +79,17 @@ fun WorkflowTemplateEditorScreen(
         EditorContent(
             modifier = Modifier.padding(padding),
             name = name,
+            description = description,
             type = type,
+            category = category,
             variables = variables,
             onNameChange = { name = it },
+            onDescriptionChange = { description = it },
             onTypeChange = { newType ->
                 type = newType
                 variables = WorkflowTemplateViewModel.defaultVariablesFor(newType)
             },
+            onCategoryChange = { category = it },
             onVariablesChange = { variables = it },
         )
     }
@@ -106,10 +119,14 @@ private fun EditorTopBar(
 private fun EditorContent(
     modifier: Modifier,
     name: String,
+    description: String,
     type: WorkflowTemplateType,
+    category: WorkflowTemplateCategory,
     variables: List<TemplateVariable>,
     onNameChange: (String) -> Unit,
+    onDescriptionChange: (String) -> Unit,
     onTypeChange: (WorkflowTemplateType) -> Unit,
+    onCategoryChange: (WorkflowTemplateCategory) -> Unit,
     onVariablesChange: (List<TemplateVariable>) -> Unit,
 ) {
     LazyColumn(
@@ -126,8 +143,27 @@ private fun EditorContent(
                 singleLine = true,
             )
         }
-        item { TypeSelector(type = type, onTypeChange = onTypeChange) }
-        item { VariablesHeader(onAdd = { onVariablesChange(variables + newVariable(variables.size)) }) }
+        item {
+            OutlinedTextField(
+                value = description,
+                onValueChange = onDescriptionChange,
+                label = { Text("Description") },
+                modifier = Modifier.fillMaxWidth(),
+                minLines = 2,
+                maxLines = 4,
+            )
+        }
+        item {
+            Row(
+                horizontalArrangement = Arrangement.spacedBy(Spacing.md),
+            ) {
+                TypeSelector(type = type, onTypeChange = onTypeChange)
+                CategorySelector(category = category, onCategoryChange = onCategoryChange)
+            }
+        }
+        item {
+            VariablesHeader(onAdd = { onVariablesChange(variables + newVariable(variables.size)) })
+        }
         itemsIndexed(variables, key = { _, variable -> variable.name }) { index, variable ->
             VariableEditor(
                 variable = variable,
@@ -177,21 +213,45 @@ private fun TypeSelector(type: WorkflowTemplateType, onTypeChange: (WorkflowTemp
 }
 
 @Composable
+private fun CategorySelector(
+    category: WorkflowTemplateCategory,
+    onCategoryChange: (WorkflowTemplateCategory) -> Unit,
+) {
+    var expanded by remember { mutableStateOf(false) }
+    Column {
+        Text("Category", style = MaterialTheme.typography.labelMedium)
+        TextButton(onClick = { expanded = true }) { Text(categoryLabel(category)) }
+        DropdownMenu(expanded = expanded, onDismissRequest = { expanded = false }) {
+            WorkflowTemplateCategory.entries.forEach { c ->
+                DropdownMenuItem(
+                    text = { Text(categoryLabel(c)) },
+                    onClick = {
+                        onCategoryChange(c)
+                        expanded = false
+                    },
+                )
+            }
+        }
+    }
+}
+
+@Composable
 private fun VariableEditor(
     variable: TemplateVariable,
     onUpdate: (TemplateVariable) -> Unit,
     onDelete: () -> Unit,
 ) {
-    var typeMenuExpanded by remember { mutableStateOf(false) }
     Card(modifier = Modifier.fillMaxWidth()) {
-        Column(modifier = Modifier.padding(Spacing.sm), verticalArrangement = Arrangement.spacedBy(Spacing.xs)) {
+        Column(
+            modifier = Modifier.padding(Spacing.sm),
+            verticalArrangement = Arrangement.spacedBy(Spacing.xs),
+        ) {
             VariableNameRow(variable = variable, onUpdate = onUpdate, onDelete = onDelete)
-            VariableTypeAndDefault(
-                variable = variable,
-                onUpdate = onUpdate,
-                typeMenuExpanded = typeMenuExpanded,
-                onTypeMenuExpand = { typeMenuExpanded = it },
-            )
+            VariableLabelRow(variable = variable, onUpdate = onUpdate)
+            VariableTypeAndDefault(variable = variable, onUpdate = onUpdate)
+            if (variable.type == TemplateVariableType.SLIDER) {
+                SliderRangeRow(variable = variable, onUpdate = onUpdate)
+            }
             Row(verticalAlignment = Alignment.CenterVertically) {
                 Text("Required", style = MaterialTheme.typography.bodySmall, modifier = Modifier.weight(1f))
                 Switch(checked = variable.required, onCheckedChange = { onUpdate(variable.copy(required = it)) })
@@ -221,26 +281,39 @@ private fun VariableNameRow(
 }
 
 @Composable
+private fun VariableLabelRow(
+    variable: TemplateVariable,
+    onUpdate: (TemplateVariable) -> Unit,
+) {
+    OutlinedTextField(
+        value = variable.label,
+        onValueChange = { onUpdate(variable.copy(label = it)) },
+        label = { Text("Display Label") },
+        modifier = Modifier.fillMaxWidth(),
+        singleLine = true,
+    )
+}
+
+@Composable
 private fun VariableTypeAndDefault(
     variable: TemplateVariable,
     onUpdate: (TemplateVariable) -> Unit,
-    typeMenuExpanded: Boolean,
-    onTypeMenuExpand: (Boolean) -> Unit,
 ) {
+    var typeMenuExpanded by remember { mutableStateOf(false) }
     Row(
         horizontalArrangement = Arrangement.spacedBy(Spacing.sm),
         verticalAlignment = Alignment.CenterVertically,
     ) {
         Column {
             Text("Type", style = MaterialTheme.typography.labelSmall)
-            TextButton(onClick = { onTypeMenuExpand(true) }) { Text(variable.type.name) }
-            DropdownMenu(expanded = typeMenuExpanded, onDismissRequest = { onTypeMenuExpand(false) }) {
+            TextButton(onClick = { typeMenuExpanded = true }) { Text(variable.type.name) }
+            DropdownMenu(expanded = typeMenuExpanded, onDismissRequest = { typeMenuExpanded = false }) {
                 TemplateVariableType.entries.forEach { t ->
                     DropdownMenuItem(
                         text = { Text(t.name) },
                         onClick = {
                             onUpdate(variable.copy(type = t))
-                            onTypeMenuExpand(false)
+                            typeMenuExpanded = false
                         },
                     )
                 }
@@ -256,9 +329,51 @@ private fun VariableTypeAndDefault(
     }
 }
 
+@Composable
+private fun SliderRangeRow(
+    variable: TemplateVariable,
+    onUpdate: (TemplateVariable) -> Unit,
+) {
+    Row(
+        horizontalArrangement = Arrangement.spacedBy(Spacing.sm),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        OutlinedTextField(
+            value = variable.min?.toString() ?: "",
+            onValueChange = { onUpdate(variable.copy(min = it.toDoubleOrNull())) },
+            label = { Text("Min") },
+            modifier = Modifier.weight(1f),
+            singleLine = true,
+        )
+        OutlinedTextField(
+            value = variable.max?.toString() ?: "",
+            onValueChange = { onUpdate(variable.copy(max = it.toDoubleOrNull())) },
+            label = { Text("Max") },
+            modifier = Modifier.weight(1f),
+            singleLine = true,
+        )
+        OutlinedTextField(
+            value = variable.step?.toString() ?: "",
+            onValueChange = { onUpdate(variable.copy(step = it.toDoubleOrNull())) },
+            label = { Text("Step") },
+            modifier = Modifier.weight(1f),
+            singleLine = true,
+        )
+    }
+}
+
 private fun typeLabel(type: WorkflowTemplateType) = when (type) {
     WorkflowTemplateType.TXT2IMG -> "txt2img"
     WorkflowTemplateType.IMG2IMG -> "img2img"
     WorkflowTemplateType.INPAINTING -> "Inpainting"
     WorkflowTemplateType.UPSCALE -> "Upscale"
+    WorkflowTemplateType.LORA -> "LoRA"
+}
+
+private fun categoryLabel(category: WorkflowTemplateCategory) = when (category) {
+    WorkflowTemplateCategory.GENERAL -> "General"
+    WorkflowTemplateCategory.ANIME -> "Anime"
+    WorkflowTemplateCategory.PHOTOREALISTIC -> "Photo"
+    WorkflowTemplateCategory.ARTISTIC -> "Artistic"
+    WorkflowTemplateCategory.UTILITY -> "Utility"
 }

--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/comfyui/WorkflowTemplateScreen.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/comfyui/WorkflowTemplateScreen.kt
@@ -2,6 +2,7 @@
 
 package com.riox432.civitdeck.ui.comfyui
 
+import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
@@ -9,24 +10,32 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyListScope
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.ContentCopy
 import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.Edit
+import androidx.compose.material.icons.filled.QrCode
+import androidx.compose.material.icons.filled.Search
 import androidx.compose.material.icons.filled.Upload
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
 import androidx.compose.material3.Card
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FilterChip
 import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SearchBar
+import androidx.compose.material3.SearchBarDefaults
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
@@ -42,9 +51,11 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.riox432.civitdeck.domain.model.WorkflowTemplate
+import com.riox432.civitdeck.domain.model.WorkflowTemplateCategory
 import com.riox432.civitdeck.domain.model.WorkflowTemplateType
 import com.riox432.civitdeck.ui.theme.Spacing
 
+@Suppress("LongParameterList")
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun WorkflowTemplateScreen(
@@ -53,6 +64,7 @@ fun WorkflowTemplateScreen(
     onCreateTemplate: () -> Unit,
     onEditTemplate: (WorkflowTemplate) -> Unit,
     onSelectTemplate: ((WorkflowTemplate) -> Unit)? = null,
+    onShareQR: ((String) -> Unit)? = null,
 ) {
     val state by viewModel.uiState.collectAsStateWithLifecycle()
     val snackbarHostState = remember { SnackbarHostState() }
@@ -70,6 +82,10 @@ fun WorkflowTemplateScreen(
         onSelectTemplate = onSelectTemplate,
         onExport = viewModel::onExportTemplate,
         onDelete = viewModel::onDeleteTemplate,
+        onSearchQueryChanged = viewModel::onSearchQueryChanged,
+        onCategorySelected = viewModel::onCategorySelected,
+        onTypeSelected = viewModel::onTypeSelected,
+        onShareQR = onShareQR,
         isPicker = onSelectTemplate != null,
     )
     if (showImportDialog) {
@@ -122,6 +138,10 @@ private fun TemplateScaffold(
     onSelectTemplate: ((WorkflowTemplate) -> Unit)?,
     onExport: (WorkflowTemplate) -> Unit,
     onDelete: (Long) -> Unit,
+    onSearchQueryChanged: (String) -> Unit,
+    onCategorySelected: (WorkflowTemplateCategory?) -> Unit,
+    onTypeSelected: (WorkflowTemplateType?) -> Unit,
+    onShareQR: ((String) -> Unit)?,
     isPicker: Boolean,
 ) {
     Scaffold(
@@ -149,49 +169,176 @@ private fun TemplateScaffold(
         },
         snackbarHost = { SnackbarHost(snackbarHostState) },
     ) { padding ->
-        TemplateList(
+        TemplateContent(
             modifier = Modifier.padding(padding),
             state = state,
             onSelectTemplate = onSelectTemplate,
             onEditTemplate = onEditTemplate,
             onExport = onExport,
             onDelete = onDelete,
+            onSearchQueryChanged = onSearchQueryChanged,
+            onCategorySelected = onCategorySelected,
+            onTypeSelected = onTypeSelected,
+            onShareQR = onShareQR,
         )
     }
 }
 
+@Suppress("LongParameterList")
 @Composable
-private fun TemplateList(
+private fun TemplateContent(
     modifier: Modifier,
     state: WorkflowTemplateUiState,
     onSelectTemplate: ((WorkflowTemplate) -> Unit)?,
     onEditTemplate: (WorkflowTemplate) -> Unit,
     onExport: (WorkflowTemplate) -> Unit,
     onDelete: (Long) -> Unit,
+    onSearchQueryChanged: (String) -> Unit,
+    onCategorySelected: (WorkflowTemplateCategory?) -> Unit,
+    onTypeSelected: (WorkflowTemplateType?) -> Unit,
+    onShareQR: ((String) -> Unit)?,
 ) {
     LazyColumn(
         modifier = modifier,
         contentPadding = PaddingValues(Spacing.md),
         verticalArrangement = Arrangement.spacedBy(Spacing.sm),
     ) {
-        when {
-            state.isLoading -> item { Text("Loading...", style = MaterialTheme.typography.bodyMedium) }
-            state.templates.isEmpty() -> item {
-                Text(
-                    "No templates yet. Create one with the + button.",
-                    style = MaterialTheme.typography.bodyMedium,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                )
-            }
-            else -> items(state.templates, key = { it.id }) { template ->
-                TemplateCard(
-                    template = template,
-                    onSelect = onSelectTemplate?.let { cb -> { cb(template) } },
-                    onEdit = if (!template.isBuiltIn) { { onEditTemplate(template) } } else null,
-                    onDelete = if (!template.isBuiltIn) { { onDelete(template.id) } } else null,
-                    onExport = { onExport(template) },
-                )
-            }
+        item {
+            TemplateSearchBar(query = state.searchQuery, onQueryChanged = onSearchQueryChanged)
+        }
+        item {
+            CategoryFilterRow(
+                selectedCategory = state.selectedCategory,
+                onCategorySelected = onCategorySelected,
+            )
+        }
+        item {
+            TypeFilterRow(selectedType = state.selectedType, onTypeSelected = onTypeSelected)
+        }
+        templateListItems(state, onSelectTemplate, onEditTemplate, onExport, onDelete, onShareQR)
+    }
+}
+
+@Suppress("LongParameterList")
+private fun LazyListScope.templateListItems(
+    state: WorkflowTemplateUiState,
+    onSelectTemplate: ((WorkflowTemplate) -> Unit)?,
+    onEditTemplate: (WorkflowTemplate) -> Unit,
+    onExport: (WorkflowTemplate) -> Unit,
+    onDelete: (Long) -> Unit,
+    onShareQR: ((String) -> Unit)?,
+) {
+    when {
+        state.isLoading -> item {
+            Text("Loading...", style = MaterialTheme.typography.bodyMedium)
+        }
+        state.filteredTemplates.isEmpty() -> item {
+            Text(
+                if (state.templates.isEmpty()) {
+                    "No templates yet. Create one with the + button."
+                } else {
+                    "No templates match your filters."
+                },
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+        else -> items(state.filteredTemplates, key = { it.id }) { template ->
+            TemplateCard(
+                template = template,
+                onSelect = onSelectTemplate?.let { cb -> { cb(template) } },
+                onEdit = if (!template.isBuiltIn) { { onEditTemplate(template) } } else null,
+                onDelete = if (!template.isBuiltIn) { { onDelete(template.id) } } else null,
+                onExport = { onExport(template) },
+                onShareQR = onShareQR,
+            )
+        }
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun TemplateSearchBar(
+    query: String,
+    onQueryChanged: (String) -> Unit,
+) {
+    SearchBar(
+        inputField = {
+            SearchBarDefaults.InputField(
+                query = query,
+                onQueryChange = onQueryChanged,
+                onSearch = {},
+                expanded = false,
+                onExpandedChange = {},
+                placeholder = { Text("Search templates...") },
+                leadingIcon = { Icon(Icons.Default.Search, "Search") },
+                trailingIcon = if (query.isNotEmpty()) {
+                    { IconButton(onClick = { onQueryChanged("") }) { Icon(Icons.Default.Close, "Clear") } }
+                } else {
+                    null
+                },
+            )
+        },
+        expanded = false,
+        onExpandedChange = {},
+        modifier = Modifier.fillMaxWidth(),
+    ) {}
+}
+
+@Composable
+private fun CategoryFilterRow(
+    selectedCategory: WorkflowTemplateCategory?,
+    onCategorySelected: (WorkflowTemplateCategory?) -> Unit,
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .horizontalScroll(rememberScrollState()),
+        horizontalArrangement = Arrangement.spacedBy(Spacing.xs),
+    ) {
+        FilterChip(
+            selected = selectedCategory == null,
+            onClick = { onCategorySelected(null) },
+            label = { Text("All") },
+        )
+        WorkflowTemplateCategory.entries.forEach { category ->
+            FilterChip(
+                selected = selectedCategory == category,
+                onClick = {
+                    onCategorySelected(
+                        if (selectedCategory == category) null else category,
+                    )
+                },
+                label = { Text(categoryLabel(category)) },
+            )
+        }
+    }
+}
+
+@Composable
+private fun TypeFilterRow(
+    selectedType: WorkflowTemplateType?,
+    onTypeSelected: (WorkflowTemplateType?) -> Unit,
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .horizontalScroll(rememberScrollState()),
+        horizontalArrangement = Arrangement.spacedBy(Spacing.xs),
+    ) {
+        FilterChip(
+            selected = selectedType == null,
+            onClick = { onTypeSelected(null) },
+            label = { Text("All Types") },
+        )
+        WorkflowTemplateType.entries.forEach { type ->
+            FilterChip(
+                selected = selectedType == type,
+                onClick = {
+                    onTypeSelected(if (selectedType == type) null else type)
+                },
+                label = { Text(typeLabel(type)) },
+            )
         }
     }
 }
@@ -240,6 +387,7 @@ private fun ExportDialog(json: String, onDismiss: () -> Unit) {
     )
 }
 
+@Suppress("LongParameterList")
 @Composable
 private fun TemplateCard(
     template: WorkflowTemplate,
@@ -247,6 +395,7 @@ private fun TemplateCard(
     onEdit: (() -> Unit)?,
     onDelete: (() -> Unit)?,
     onExport: () -> Unit,
+    onShareQR: ((String) -> Unit)?,
 ) {
     Card(
         modifier = Modifier.fillMaxWidth(),
@@ -255,17 +404,13 @@ private fun TemplateCard(
         Column(modifier = Modifier.padding(Spacing.md)) {
             Row(verticalAlignment = Alignment.CenterVertically) {
                 TemplateCardInfo(template = template, modifier = Modifier.weight(1f))
-                IconButton(onClick = onExport) {
-                    Icon(Icons.Default.ContentCopy, "Export template")
-                }
-                onEdit?.let {
-                    IconButton(onClick = it) { Icon(Icons.Default.Edit, "Edit template") }
-                }
-                onDelete?.let {
-                    IconButton(onClick = it) {
-                        Icon(Icons.Default.Delete, "Delete template", tint = MaterialTheme.colorScheme.error)
-                    }
-                }
+                TemplateCardActions(
+                    template = template,
+                    onExport = onExport,
+                    onEdit = onEdit,
+                    onDelete = onDelete,
+                    onShareQR = onShareQR,
+                )
             }
         }
     }
@@ -275,18 +420,62 @@ private fun TemplateCard(
 private fun TemplateCardInfo(template: WorkflowTemplate, modifier: Modifier) {
     Column(modifier = modifier) {
         Text(template.name, style = MaterialTheme.typography.titleSmall)
+        if (template.description.isNotBlank()) {
+            Text(
+                template.description,
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                maxLines = 2,
+            )
+        }
         Text(
-            "${typeLabel(template.type)}${if (template.isBuiltIn) " • Built-in" else ""}",
+            buildString {
+                append(typeLabel(template.type))
+                if (template.isBuiltIn) append(" \u2022 Built-in")
+                append(" \u2022 ${categoryLabel(template.category)}")
+                if (template.version > 1) append(" \u2022 v${template.version}")
+            },
             style = MaterialTheme.typography.bodySmall,
             color = MaterialTheme.colorScheme.onSurfaceVariant,
         )
         if (template.variables.isNotEmpty()) {
             Text(
-                "Variables: ${template.variables.joinToString(", ") { it.name }}",
+                "${template.variables.size} parameters",
                 style = MaterialTheme.typography.bodySmall,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
-                maxLines = 2,
             )
+        }
+    }
+}
+
+@Composable
+private fun TemplateCardActions(
+    template: WorkflowTemplate,
+    onExport: () -> Unit,
+    onEdit: (() -> Unit)?,
+    onDelete: (() -> Unit)?,
+    onShareQR: ((String) -> Unit)?,
+) {
+    Row {
+        onShareQR?.let { share ->
+            IconButton(onClick = { share(template.name) }) {
+                Icon(Icons.Default.QrCode, "Share QR code")
+            }
+        }
+        IconButton(onClick = onExport) {
+            Icon(Icons.Default.ContentCopy, "Export template")
+        }
+        onEdit?.let {
+            IconButton(onClick = it) { Icon(Icons.Default.Edit, "Edit template") }
+        }
+        onDelete?.let {
+            IconButton(onClick = it) {
+                Icon(
+                    Icons.Default.Delete,
+                    "Delete template",
+                    tint = MaterialTheme.colorScheme.error,
+                )
+            }
         }
     }
 }
@@ -296,4 +485,13 @@ private fun typeLabel(type: WorkflowTemplateType) = when (type) {
     WorkflowTemplateType.IMG2IMG -> "img2img"
     WorkflowTemplateType.INPAINTING -> "Inpainting"
     WorkflowTemplateType.UPSCALE -> "Upscale"
+    WorkflowTemplateType.LORA -> "LoRA"
+}
+
+private fun categoryLabel(category: WorkflowTemplateCategory) = when (category) {
+    WorkflowTemplateCategory.GENERAL -> "General"
+    WorkflowTemplateCategory.ANIME -> "Anime"
+    WorkflowTemplateCategory.PHOTOREALISTIC -> "Photo"
+    WorkflowTemplateCategory.ARTISTIC -> "Artistic"
+    WorkflowTemplateCategory.UTILITY -> "Utility"
 }

--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/comfyui/WorkflowTemplateViewModel.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/comfyui/WorkflowTemplateViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.viewModelScope
 import com.riox432.civitdeck.domain.model.TemplateVariable
 import com.riox432.civitdeck.domain.model.TemplateVariableType
 import com.riox432.civitdeck.domain.model.WorkflowTemplate
+import com.riox432.civitdeck.domain.model.WorkflowTemplateCategory
 import com.riox432.civitdeck.domain.model.WorkflowTemplateType
 import com.riox432.civitdeck.feature.comfyui.domain.usecase.DeleteWorkflowTemplateUseCase
 import com.riox432.civitdeck.feature.comfyui.domain.usecase.ExportWorkflowTemplateUseCase
@@ -20,10 +21,14 @@ import kotlinx.coroutines.launch
 
 data class WorkflowTemplateUiState(
     val templates: List<WorkflowTemplate> = emptyList(),
+    val filteredTemplates: List<WorkflowTemplate> = emptyList(),
     val isLoading: Boolean = true,
     val error: String? = null,
     val exportedJson: String? = null,
     val importError: String? = null,
+    val searchQuery: String = "",
+    val selectedCategory: WorkflowTemplateCategory? = null,
+    val selectedType: WorkflowTemplateType? = null,
 )
 
 @Suppress("TooManyFunctions")
@@ -49,9 +54,26 @@ class WorkflowTemplateViewModel(
                     _uiState.update { it.copy(isLoading = false, error = e.message) }
                 }
                 .collect { templates ->
-                    _uiState.update { it.copy(templates = templates, isLoading = false) }
+                    _uiState.update {
+                        it.copy(
+                            templates = templates,
+                            isLoading = false,
+                        ).applyFilters()
+                    }
                 }
         }
+    }
+
+    fun onSearchQueryChanged(query: String) {
+        _uiState.update { it.copy(searchQuery = query).applyFilters() }
+    }
+
+    fun onCategorySelected(category: WorkflowTemplateCategory?) {
+        _uiState.update { it.copy(selectedCategory = category).applyFilters() }
+    }
+
+    fun onTypeSelected(type: WorkflowTemplateType?) {
+        _uiState.update { it.copy(selectedType = type).applyFilters() }
     }
 
     fun onDeleteTemplate(id: Long) {
@@ -108,7 +130,9 @@ class WorkflowTemplateViewModel(
     companion object {
         private const val TAG = "WorkflowTemplateVM"
 
-        fun emptyTemplate(type: WorkflowTemplateType = WorkflowTemplateType.TXT2IMG): WorkflowTemplate =
+        fun emptyTemplate(
+            type: WorkflowTemplateType = WorkflowTemplateType.TXT2IMG,
+        ): WorkflowTemplate =
             WorkflowTemplate(
                 id = 0L,
                 name = "",
@@ -118,38 +142,158 @@ class WorkflowTemplateViewModel(
                 createdAt = 0L,
             )
 
-        fun defaultVariablesFor(type: WorkflowTemplateType): List<TemplateVariable> = when (type) {
-            WorkflowTemplateType.TXT2IMG -> listOf(
-                TemplateVariable("positive_prompt", TemplateVariableType.TEXT, "", required = true),
-                TemplateVariable("negative_prompt", TemplateVariableType.TEXT, "", required = false),
-                TemplateVariable("checkpoint", TemplateVariableType.TEXT, "", required = true),
-                TemplateVariable("steps", TemplateVariableType.NUMBER, "20", required = false),
-                TemplateVariable("cfg", TemplateVariableType.NUMBER, "7.0", required = false),
-                TemplateVariable("width", TemplateVariableType.NUMBER, "512", required = false),
-                TemplateVariable("height", TemplateVariableType.NUMBER, "512", required = false),
-            )
-            WorkflowTemplateType.IMG2IMG -> listOf(
-                TemplateVariable("positive_prompt", TemplateVariableType.TEXT, "", required = true),
-                TemplateVariable("negative_prompt", TemplateVariableType.TEXT, "", required = false),
-                TemplateVariable("checkpoint", TemplateVariableType.TEXT, "", required = true),
-                TemplateVariable("steps", TemplateVariableType.NUMBER, "20", required = false),
-                TemplateVariable("cfg", TemplateVariableType.NUMBER, "7.0", required = false),
-                TemplateVariable("width", TemplateVariableType.NUMBER, "512", required = false),
-                TemplateVariable("height", TemplateVariableType.NUMBER, "512", required = false),
-                TemplateVariable("denoise_strength", TemplateVariableType.NUMBER, "0.75", required = false),
-            )
-            WorkflowTemplateType.INPAINTING -> listOf(
-                TemplateVariable("positive_prompt", TemplateVariableType.TEXT, "", required = true),
-                TemplateVariable("negative_prompt", TemplateVariableType.TEXT, "", required = false),
-                TemplateVariable("checkpoint", TemplateVariableType.TEXT, "", required = true),
-                TemplateVariable("steps", TemplateVariableType.NUMBER, "20", required = false),
-                TemplateVariable("cfg", TemplateVariableType.NUMBER, "7.0", required = false),
-                TemplateVariable("denoise_strength", TemplateVariableType.NUMBER, "1.0", required = false),
-            )
-            WorkflowTemplateType.UPSCALE -> listOf(
-                TemplateVariable("input_image", TemplateVariableType.TEXT, "", required = true),
-                TemplateVariable("upscale_factor", TemplateVariableType.NUMBER, "2", required = false),
-            )
-        }
+        @Suppress("LongMethod")
+        fun defaultVariablesFor(type: WorkflowTemplateType): List<TemplateVariable> =
+            when (type) {
+                WorkflowTemplateType.TXT2IMG -> txt2imgVariables()
+                WorkflowTemplateType.IMG2IMG -> img2imgVariables()
+                WorkflowTemplateType.INPAINTING -> inpaintingVariables()
+                WorkflowTemplateType.UPSCALE -> upscaleVariables()
+                WorkflowTemplateType.LORA -> loraVariables()
+            }
+
+        private fun txt2imgVariables() = listOf(
+            promptVariable(),
+            negativePromptVariable(),
+            checkpointVariable(),
+            stepsVariable(),
+            cfgVariable(),
+            widthVariable(),
+            heightVariable(),
+        )
+
+        private fun img2imgVariables() = txt2imgVariables() + denoiseVariable()
+
+        private fun inpaintingVariables() = listOf(
+            promptVariable(),
+            negativePromptVariable(),
+            checkpointVariable(),
+            stepsVariable(),
+            cfgVariable(),
+            denoiseVariable(default = "1.0"),
+        )
+
+        private fun upscaleVariables() = listOf(
+            TemplateVariable(
+                name = "input_image",
+                label = "Input Image",
+                type = TemplateVariableType.TEXT,
+                defaultValue = "",
+                required = true,
+            ),
+            TemplateVariable(
+                name = "upscale_factor",
+                label = "Upscale Factor",
+                type = TemplateVariableType.SLIDER,
+                defaultValue = "2",
+                min = 1.0,
+                max = 4.0,
+                step = 0.5,
+            ),
+        )
+
+        private fun loraVariables() = listOf(
+            promptVariable(), negativePromptVariable(), checkpointVariable(),
+            TemplateVariable(
+                name = "lora_name",
+                label = "LoRA Model",
+                type = TemplateVariableType.TEXT,
+                defaultValue = "",
+                required = true,
+            ),
+            TemplateVariable(
+                name = "lora_strength",
+                label = "LoRA Strength",
+                type = TemplateVariableType.SLIDER,
+                defaultValue = "0.8",
+                min = 0.0,
+                max = 2.0,
+                step = 0.05,
+            ),
+            stepsVariable(), cfgVariable(), widthVariable(), heightVariable(),
+        )
+
+        private fun promptVariable() = TemplateVariable(
+            name = "positive_prompt",
+            label = "Prompt",
+            type = TemplateVariableType.TEXT,
+            defaultValue = "",
+            required = true,
+        )
+
+        private fun negativePromptVariable() = TemplateVariable(
+            name = "negative_prompt",
+            label = "Negative Prompt",
+            type = TemplateVariableType.TEXT,
+            defaultValue = "",
+            required = false,
+        )
+
+        private fun checkpointVariable() = TemplateVariable(
+            name = "checkpoint",
+            label = "Checkpoint",
+            type = TemplateVariableType.TEXT,
+            defaultValue = "",
+            required = true,
+        )
+
+        private fun stepsVariable() = TemplateVariable(
+            name = "steps",
+            label = "Steps",
+            type = TemplateVariableType.SLIDER,
+            defaultValue = "20",
+            min = 1.0,
+            max = 150.0,
+            step = 1.0,
+        )
+
+        private fun cfgVariable() = TemplateVariable(
+            name = "cfg",
+            label = "CFG Scale",
+            type = TemplateVariableType.SLIDER,
+            defaultValue = "7.0",
+            min = 1.0,
+            max = 30.0,
+            step = 0.5,
+        )
+
+        private fun widthVariable() = TemplateVariable(
+            name = "width",
+            label = "Width",
+            type = TemplateVariableType.SELECT,
+            defaultValue = "512",
+            options = listOf("256", "384", "512", "640", "768", "832", "896", "1024", "1280"),
+        )
+
+        private fun heightVariable() = TemplateVariable(
+            name = "height",
+            label = "Height",
+            type = TemplateVariableType.SELECT,
+            defaultValue = "512",
+            options = listOf("256", "384", "512", "640", "768", "832", "896", "1024", "1280"),
+        )
+
+        private fun denoiseVariable(default: String = "0.75") = TemplateVariable(
+            name = "denoise_strength",
+            label = "Denoise Strength",
+            type = TemplateVariableType.SLIDER,
+            defaultValue = default,
+            min = 0.0,
+            max = 1.0,
+            step = 0.05,
+        )
     }
+}
+
+private fun WorkflowTemplateUiState.applyFilters(): WorkflowTemplateUiState {
+    val filtered = templates.filter { template ->
+        val matchesSearch = searchQuery.isBlank() ||
+            template.name.contains(searchQuery, ignoreCase = true) ||
+            template.description.contains(searchQuery, ignoreCase = true)
+        val matchesCategory = selectedCategory == null ||
+            template.category == selectedCategory
+        val matchesType = selectedType == null || template.type == selectedType
+        matchesSearch && matchesCategory && matchesType
+    }
+    return copy(filteredTemplates = filtered)
 }

--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/navigation/CreateNavEntries.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/navigation/CreateNavEntries.kt
@@ -24,6 +24,7 @@ import com.riox432.civitdeck.ui.comfyui.SDWebUIGenerationScreen
 import com.riox432.civitdeck.ui.comfyui.SDWebUIGenerationViewModel
 import com.riox432.civitdeck.ui.comfyui.SDWebUISettingsScreen
 import com.riox432.civitdeck.ui.comfyui.SDWebUISettingsViewModel
+import com.riox432.civitdeck.ui.comfyui.TemplateParameterScreen
 import com.riox432.civitdeck.ui.comfyui.WorkflowTemplateEditorScreen
 import com.riox432.civitdeck.ui.comfyui.WorkflowTemplateScreen
 import com.riox432.civitdeck.ui.comfyui.WorkflowTemplateViewModel
@@ -118,6 +119,7 @@ private fun EntryProviderScope<Any>.workflowTemplateEntries(backStack: MutableLi
             onBack = { backStack.removeLastOrNull() },
             onCreateTemplate = { backStack.add(WorkflowTemplateEditorRoute(templateId = 0L)) },
             onEditTemplate = { template -> backStack.add(WorkflowTemplateEditorRoute(templateId = template.id)) },
+            onSelectTemplate = { template -> backStack.add(TemplateParameterRoute(templateId = template.id)) },
         )
     }
     entry<WorkflowTemplatePickerRoute> {
@@ -142,6 +144,19 @@ private fun EntryProviderScope<Any>.workflowTemplateEntries(backStack: MutableLi
             initialTemplate = template,
             viewModel = viewModel,
             onBack = { backStack.removeLastOrNull() },
+        )
+    }
+    entry<TemplateParameterRoute> { key ->
+        val viewModel: WorkflowTemplateViewModel = koinViewModel()
+        val template = viewModel.uiState.value.templates.find { it.id == key.templateId }
+            ?: WorkflowTemplateViewModel.emptyTemplate()
+        TemplateParameterScreen(
+            template = template,
+            onBack = { backStack.removeLastOrNull() },
+            onApply = {
+                // Applied template values will be forwarded to ComfyUI generation
+                backStack.removeLastOrNull()
+            },
         )
     }
 }

--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/navigation/NavRoutes.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/navigation/NavRoutes.kt
@@ -53,6 +53,8 @@ data class WorkflowTemplateEditorRoute(val templateId: Long)
 
 data object WorkflowTemplatePickerRoute
 
+data class TemplateParameterRoute(val templateId: Long)
+
 data object SDWebUISettingsRoute
 
 data object SDWebUIGenerationRoute

--- a/core/core-database/schemas/com.riox432.civitdeck.data.local.CivitDeckDatabase/41.json
+++ b/core/core-database/schemas/com.riox432.civitdeck.data.local.CivitDeckDatabase/41.json
@@ -1,0 +1,1916 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 41,
+    "identityHash": "4c805ed7c28dc705582a8e10b425a528",
+    "entities": [
+      {
+        "tableName": "collections",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL, `isDefault` INTEGER NOT NULL, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isDefault",
+            "columnName": "isDefault",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "collection_model_entries",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`collectionId` INTEGER NOT NULL, `modelId` INTEGER NOT NULL, `name` TEXT NOT NULL, `type` TEXT NOT NULL, `nsfw` INTEGER NOT NULL, `thumbnailUrl` TEXT, `creatorName` TEXT, `downloadCount` INTEGER NOT NULL, `favoriteCount` INTEGER NOT NULL, `rating` REAL NOT NULL, `addedAt` INTEGER NOT NULL, PRIMARY KEY(`collectionId`, `modelId`), FOREIGN KEY(`collectionId`) REFERENCES `collections`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "collectionId",
+            "columnName": "collectionId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "modelId",
+            "columnName": "modelId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "nsfw",
+            "columnName": "nsfw",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "thumbnailUrl",
+            "columnName": "thumbnailUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "creatorName",
+            "columnName": "creatorName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "downloadCount",
+            "columnName": "downloadCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "favoriteCount",
+            "columnName": "favoriteCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "rating",
+            "columnName": "rating",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "addedAt",
+            "columnName": "addedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "collectionId",
+            "modelId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_collection_model_entries_modelId",
+            "unique": false,
+            "columnNames": [
+              "modelId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_collection_model_entries_modelId` ON `${TABLE_NAME}` (`modelId`)"
+          },
+          {
+            "name": "index_collection_model_entries_collectionId",
+            "unique": false,
+            "columnNames": [
+              "collectionId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_collection_model_entries_collectionId` ON `${TABLE_NAME}` (`collectionId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "collections",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "collectionId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "cached_api_responses",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`cacheKey` TEXT NOT NULL, `responseJson` TEXT NOT NULL, `cachedAt` INTEGER NOT NULL, `isOfflinePinned` INTEGER NOT NULL, PRIMARY KEY(`cacheKey`))",
+        "fields": [
+          {
+            "fieldPath": "cacheKey",
+            "columnName": "cacheKey",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "responseJson",
+            "columnName": "responseJson",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cachedAt",
+            "columnName": "cachedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isOfflinePinned",
+            "columnName": "isOfflinePinned",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "cacheKey"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_cached_api_responses_cachedAt",
+            "unique": false,
+            "columnNames": [
+              "cachedAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_cached_api_responses_cachedAt` ON `${TABLE_NAME}` (`cachedAt`)"
+          }
+        ]
+      },
+      {
+        "tableName": "user_preferences",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `nsfwFilterLevel` TEXT NOT NULL, `defaultSortOrder` TEXT NOT NULL, `defaultTimePeriod` TEXT NOT NULL, `gridColumns` INTEGER NOT NULL, `apiKey` TEXT, `powerUserMode` INTEGER NOT NULL, `notificationsEnabled` INTEGER NOT NULL, `pollingIntervalMinutes` INTEGER NOT NULL, `nsfwBlurSoft` INTEGER NOT NULL, `nsfwBlurMature` INTEGER NOT NULL, `nsfwBlurExplicit` INTEGER NOT NULL, `offlineCacheEnabled` INTEGER NOT NULL, `cacheSizeLimitMb` INTEGER NOT NULL, `accentColor` TEXT NOT NULL, `amoledDarkMode` INTEGER NOT NULL, `seenTutorialVersion` INTEGER NOT NULL, `civitaiLinkKey` TEXT, `themeMode` TEXT NOT NULL, `customNavShortcuts` TEXT NOT NULL, `feedQualityThreshold` INTEGER NOT NULL, `autoUpdateCheckEnabled` INTEGER NOT NULL, `lastUpdateCheckTimestamp` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "nsfwFilterLevel",
+            "columnName": "nsfwFilterLevel",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "defaultSortOrder",
+            "columnName": "defaultSortOrder",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "defaultTimePeriod",
+            "columnName": "defaultTimePeriod",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "gridColumns",
+            "columnName": "gridColumns",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "apiKey",
+            "columnName": "apiKey",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "powerUserMode",
+            "columnName": "powerUserMode",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "notificationsEnabled",
+            "columnName": "notificationsEnabled",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "pollingIntervalMinutes",
+            "columnName": "pollingIntervalMinutes",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "nsfwBlurSoft",
+            "columnName": "nsfwBlurSoft",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "nsfwBlurMature",
+            "columnName": "nsfwBlurMature",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "nsfwBlurExplicit",
+            "columnName": "nsfwBlurExplicit",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "offlineCacheEnabled",
+            "columnName": "offlineCacheEnabled",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cacheSizeLimitMb",
+            "columnName": "cacheSizeLimitMb",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "accentColor",
+            "columnName": "accentColor",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "amoledDarkMode",
+            "columnName": "amoledDarkMode",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "seenTutorialVersion",
+            "columnName": "seenTutorialVersion",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "civitaiLinkKey",
+            "columnName": "civitaiLinkKey",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "themeMode",
+            "columnName": "themeMode",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "customNavShortcuts",
+            "columnName": "customNavShortcuts",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "feedQualityThreshold",
+            "columnName": "feedQualityThreshold",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "autoUpdateCheckEnabled",
+            "columnName": "autoUpdateCheckEnabled",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastUpdateCheckTimestamp",
+            "columnName": "lastUpdateCheckTimestamp",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "saved_prompts",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `prompt` TEXT NOT NULL, `negativePrompt` TEXT, `sampler` TEXT, `steps` INTEGER, `cfgScale` REAL, `seed` INTEGER, `modelName` TEXT, `size` TEXT, `sourceImageUrl` TEXT, `savedAt` INTEGER NOT NULL, `isTemplate` INTEGER NOT NULL DEFAULT 0, `templateName` TEXT, `autoSaved` INTEGER NOT NULL DEFAULT 0, `templateVariables` TEXT, `templateType` TEXT, `templateMetadata` TEXT)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "prompt",
+            "columnName": "prompt",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "negativePrompt",
+            "columnName": "negativePrompt",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "sampler",
+            "columnName": "sampler",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "steps",
+            "columnName": "steps",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "cfgScale",
+            "columnName": "cfgScale",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "seed",
+            "columnName": "seed",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "modelName",
+            "columnName": "modelName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "size",
+            "columnName": "size",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "sourceImageUrl",
+            "columnName": "sourceImageUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "savedAt",
+            "columnName": "savedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isTemplate",
+            "columnName": "isTemplate",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "templateName",
+            "columnName": "templateName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "autoSaved",
+            "columnName": "autoSaved",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "templateVariables",
+            "columnName": "templateVariables",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "templateType",
+            "columnName": "templateType",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "templateMetadata",
+            "columnName": "templateMetadata",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "search_history",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `query` TEXT NOT NULL, `searchedAt` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "query",
+            "columnName": "query",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "searchedAt",
+            "columnName": "searchedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "browsing_history",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `modelId` INTEGER NOT NULL, `modelName` TEXT NOT NULL, `modelType` TEXT NOT NULL, `creatorName` TEXT, `thumbnailUrl` TEXT, `tags` TEXT NOT NULL, `viewedAt` INTEGER NOT NULL, `durationMs` INTEGER, `interactionType` TEXT)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "modelId",
+            "columnName": "modelId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "modelName",
+            "columnName": "modelName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "modelType",
+            "columnName": "modelType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "creatorName",
+            "columnName": "creatorName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "thumbnailUrl",
+            "columnName": "thumbnailUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "tags",
+            "columnName": "tags",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "viewedAt",
+            "columnName": "viewedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "durationMs",
+            "columnName": "durationMs",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "interactionType",
+            "columnName": "interactionType",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_browsing_history_modelId",
+            "unique": false,
+            "columnNames": [
+              "modelId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_browsing_history_modelId` ON `${TABLE_NAME}` (`modelId`)"
+          },
+          {
+            "name": "index_browsing_history_viewedAt",
+            "unique": false,
+            "columnNames": [
+              "viewedAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_browsing_history_viewedAt` ON `${TABLE_NAME}` (`viewedAt`)"
+          }
+        ]
+      },
+      {
+        "tableName": "excluded_tags",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`tag` TEXT NOT NULL, `addedAt` INTEGER NOT NULL, PRIMARY KEY(`tag`))",
+        "fields": [
+          {
+            "fieldPath": "tag",
+            "columnName": "tag",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "addedAt",
+            "columnName": "addedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "tag"
+          ]
+        }
+      },
+      {
+        "tableName": "hidden_models",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`modelId` INTEGER NOT NULL, `modelName` TEXT NOT NULL, `hiddenAt` INTEGER NOT NULL, PRIMARY KEY(`modelId`))",
+        "fields": [
+          {
+            "fieldPath": "modelId",
+            "columnName": "modelId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "modelName",
+            "columnName": "modelName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "hiddenAt",
+            "columnName": "hiddenAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "modelId"
+          ]
+        }
+      },
+      {
+        "tableName": "model_directories",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `path` TEXT NOT NULL, `label` TEXT, `lastScannedAt` INTEGER, `isEnabled` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "path",
+            "columnName": "path",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "label",
+            "columnName": "label",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "lastScannedAt",
+            "columnName": "lastScannedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "isEnabled",
+            "columnName": "isEnabled",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "local_model_files",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `directoryId` INTEGER NOT NULL, `filePath` TEXT NOT NULL, `fileName` TEXT NOT NULL, `sha256Hash` TEXT NOT NULL, `sizeBytes` INTEGER NOT NULL, `scannedAt` INTEGER NOT NULL, `matchedModelId` INTEGER, `matchedModelName` TEXT, `matchedVersionId` INTEGER, `matchedVersionName` TEXT, `latestVersionId` INTEGER, `hasUpdate` INTEGER NOT NULL, FOREIGN KEY(`directoryId`) REFERENCES `model_directories`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "directoryId",
+            "columnName": "directoryId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "filePath",
+            "columnName": "filePath",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fileName",
+            "columnName": "fileName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sha256Hash",
+            "columnName": "sha256Hash",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sizeBytes",
+            "columnName": "sizeBytes",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "scannedAt",
+            "columnName": "scannedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "matchedModelId",
+            "columnName": "matchedModelId",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "matchedModelName",
+            "columnName": "matchedModelName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "matchedVersionId",
+            "columnName": "matchedVersionId",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "matchedVersionName",
+            "columnName": "matchedVersionName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "latestVersionId",
+            "columnName": "latestVersionId",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "hasUpdate",
+            "columnName": "hasUpdate",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_local_model_files_directoryId",
+            "unique": false,
+            "columnNames": [
+              "directoryId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_local_model_files_directoryId` ON `${TABLE_NAME}` (`directoryId`)"
+          },
+          {
+            "name": "index_local_model_files_sha256Hash",
+            "unique": false,
+            "columnNames": [
+              "sha256Hash"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_local_model_files_sha256Hash` ON `${TABLE_NAME}` (`sha256Hash`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "model_directories",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "directoryId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "model_version_checkpoints",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`modelId` INTEGER NOT NULL, `lastKnownVersionId` INTEGER NOT NULL, `lastCheckedAt` INTEGER NOT NULL, PRIMARY KEY(`modelId`))",
+        "fields": [
+          {
+            "fieldPath": "modelId",
+            "columnName": "modelId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastKnownVersionId",
+            "columnName": "lastKnownVersionId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastCheckedAt",
+            "columnName": "lastCheckedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "modelId"
+          ]
+        }
+      },
+      {
+        "tableName": "comfyui_connections",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL, `hostname` TEXT NOT NULL, `port` INTEGER NOT NULL, `isActive` INTEGER NOT NULL, `lastTestedAt` INTEGER, `lastTestSuccess` INTEGER, `createdAt` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "hostname",
+            "columnName": "hostname",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "port",
+            "columnName": "port",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isActive",
+            "columnName": "isActive",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastTestedAt",
+            "columnName": "lastTestedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "lastTestSuccess",
+            "columnName": "lastTestSuccess",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "sdwebui_connections",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL, `hostname` TEXT NOT NULL, `port` INTEGER NOT NULL, `isActive` INTEGER NOT NULL, `lastTestedAt` INTEGER, `lastTestSuccess` INTEGER, `createdAt` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "hostname",
+            "columnName": "hostname",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "port",
+            "columnName": "port",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isActive",
+            "columnName": "isActive",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastTestedAt",
+            "columnName": "lastTestedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "lastTestSuccess",
+            "columnName": "lastTestSuccess",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "dataset_collections",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL, `description` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "dataset_images",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `datasetId` INTEGER NOT NULL, `imageUrl` TEXT NOT NULL, `sourceType` TEXT NOT NULL, `trainable` INTEGER NOT NULL, `addedAt` INTEGER NOT NULL, `licenseNote` TEXT, `pHash` TEXT, `excluded` INTEGER NOT NULL, `width` INTEGER, `height` INTEGER, FOREIGN KEY(`datasetId`) REFERENCES `dataset_collections`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "datasetId",
+            "columnName": "datasetId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "imageUrl",
+            "columnName": "imageUrl",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceType",
+            "columnName": "sourceType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "trainable",
+            "columnName": "trainable",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "addedAt",
+            "columnName": "addedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "licenseNote",
+            "columnName": "licenseNote",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "pHash",
+            "columnName": "pHash",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "excluded",
+            "columnName": "excluded",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "width",
+            "columnName": "width",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "height",
+            "columnName": "height",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_dataset_images_datasetId",
+            "unique": false,
+            "columnNames": [
+              "datasetId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_dataset_images_datasetId` ON `${TABLE_NAME}` (`datasetId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "dataset_collections",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "datasetId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "image_tags",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `datasetImageId` INTEGER NOT NULL, `tag` TEXT NOT NULL, FOREIGN KEY(`datasetImageId`) REFERENCES `dataset_images`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "datasetImageId",
+            "columnName": "datasetImageId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "tag",
+            "columnName": "tag",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_image_tags_datasetImageId",
+            "unique": false,
+            "columnNames": [
+              "datasetImageId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_image_tags_datasetImageId` ON `${TABLE_NAME}` (`datasetImageId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "dataset_images",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "datasetImageId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "captions",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`datasetImageId` INTEGER NOT NULL, `text` TEXT NOT NULL, PRIMARY KEY(`datasetImageId`), FOREIGN KEY(`datasetImageId`) REFERENCES `dataset_images`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "datasetImageId",
+            "columnName": "datasetImageId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "text",
+            "columnName": "text",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "datasetImageId"
+          ]
+        },
+        "foreignKeys": [
+          {
+            "table": "dataset_images",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "datasetImageId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "saved_search_filters",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL, `query` TEXT NOT NULL, `selectedType` TEXT, `selectedSort` TEXT NOT NULL, `selectedPeriod` TEXT NOT NULL, `selectedBaseModels` TEXT NOT NULL, `nsfwFilterLevel` TEXT NOT NULL, `isFreshFindEnabled` INTEGER NOT NULL, `excludedTags` TEXT NOT NULL, `includedTags` TEXT NOT NULL, `selectedSources` TEXT NOT NULL, `savedAt` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "query",
+            "columnName": "query",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "selectedType",
+            "columnName": "selectedType",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "selectedSort",
+            "columnName": "selectedSort",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "selectedPeriod",
+            "columnName": "selectedPeriod",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "selectedBaseModels",
+            "columnName": "selectedBaseModels",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "nsfwFilterLevel",
+            "columnName": "nsfwFilterLevel",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isFreshFindEnabled",
+            "columnName": "isFreshFindEnabled",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "excludedTags",
+            "columnName": "excludedTags",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "includedTags",
+            "columnName": "includedTags",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "selectedSources",
+            "columnName": "selectedSources",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "savedAt",
+            "columnName": "savedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "external_server_configs",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL, `baseUrl` TEXT NOT NULL, `apiKey` TEXT NOT NULL, `isActive` INTEGER NOT NULL, `lastTestedAt` INTEGER, `lastTestSuccess` INTEGER, `createdAt` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "baseUrl",
+            "columnName": "baseUrl",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "apiKey",
+            "columnName": "apiKey",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isActive",
+            "columnName": "isActive",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastTestedAt",
+            "columnName": "lastTestedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "lastTestSuccess",
+            "columnName": "lastTestSuccess",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "model_notes",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `modelId` INTEGER NOT NULL, `noteText` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "modelId",
+            "columnName": "modelId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "noteText",
+            "columnName": "noteText",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_model_notes_modelId",
+            "unique": false,
+            "columnNames": [
+              "modelId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_model_notes_modelId` ON `${TABLE_NAME}` (`modelId`)"
+          }
+        ]
+      },
+      {
+        "tableName": "personal_tags",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `modelId` INTEGER NOT NULL, `tag` TEXT NOT NULL, `addedAt` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "modelId",
+            "columnName": "modelId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "tag",
+            "columnName": "tag",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "addedAt",
+            "columnName": "addedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_personal_tags_modelId",
+            "unique": false,
+            "columnNames": [
+              "modelId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_personal_tags_modelId` ON `${TABLE_NAME}` (`modelId`)"
+          },
+          {
+            "name": "index_personal_tags_tag",
+            "unique": false,
+            "columnNames": [
+              "tag"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_personal_tags_tag` ON `${TABLE_NAME}` (`tag`)"
+          }
+        ]
+      },
+      {
+        "tableName": "followed_creators",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`username` TEXT NOT NULL, `displayName` TEXT NOT NULL, `avatarUrl` TEXT, `followedAt` INTEGER NOT NULL, `lastCheckedAt` INTEGER NOT NULL, PRIMARY KEY(`username`))",
+        "fields": [
+          {
+            "fieldPath": "username",
+            "columnName": "username",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayName",
+            "columnName": "displayName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "avatarUrl",
+            "columnName": "avatarUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "followedAt",
+            "columnName": "followedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastCheckedAt",
+            "columnName": "lastCheckedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "username"
+          ]
+        }
+      },
+      {
+        "tableName": "feed_cache",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`modelId` INTEGER NOT NULL, `creatorUsername` TEXT NOT NULL, `title` TEXT NOT NULL, `thumbnailUrl` TEXT, `type` TEXT NOT NULL, `publishedAt` TEXT NOT NULL, `cachedAt` INTEGER NOT NULL, `downloadCount` INTEGER NOT NULL, `favoriteCount` INTEGER NOT NULL, `commentCount` INTEGER NOT NULL, `ratingCount` INTEGER NOT NULL, `rating` REAL NOT NULL, PRIMARY KEY(`modelId`))",
+        "fields": [
+          {
+            "fieldPath": "modelId",
+            "columnName": "modelId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "creatorUsername",
+            "columnName": "creatorUsername",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "thumbnailUrl",
+            "columnName": "thumbnailUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "publishedAt",
+            "columnName": "publishedAt",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cachedAt",
+            "columnName": "cachedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "downloadCount",
+            "columnName": "downloadCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "favoriteCount",
+            "columnName": "favoriteCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "commentCount",
+            "columnName": "commentCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ratingCount",
+            "columnName": "ratingCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "rating",
+            "columnName": "rating",
+            "affinity": "REAL",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "modelId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_feed_cache_creatorUsername",
+            "unique": false,
+            "columnNames": [
+              "creatorUsername"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_feed_cache_creatorUsername` ON `${TABLE_NAME}` (`creatorUsername`)"
+          },
+          {
+            "name": "index_feed_cache_publishedAt",
+            "unique": false,
+            "columnNames": [
+              "publishedAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_feed_cache_publishedAt` ON `${TABLE_NAME}` (`publishedAt`)"
+          }
+        ]
+      },
+      {
+        "tableName": "model_downloads",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `modelId` INTEGER NOT NULL, `modelName` TEXT NOT NULL, `versionId` INTEGER NOT NULL, `versionName` TEXT NOT NULL, `fileId` INTEGER NOT NULL, `fileName` TEXT NOT NULL, `fileUrl` TEXT NOT NULL, `fileSizeBytes` INTEGER NOT NULL, `downloadedBytes` INTEGER NOT NULL, `status` TEXT NOT NULL, `modelType` TEXT NOT NULL, `destinationPath` TEXT, `errorMessage` TEXT, `expectedSha256` TEXT, `hashVerified` INTEGER, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "modelId",
+            "columnName": "modelId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "modelName",
+            "columnName": "modelName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "versionId",
+            "columnName": "versionId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "versionName",
+            "columnName": "versionName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fileId",
+            "columnName": "fileId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fileName",
+            "columnName": "fileName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fileUrl",
+            "columnName": "fileUrl",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fileSizeBytes",
+            "columnName": "fileSizeBytes",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "downloadedBytes",
+            "columnName": "downloadedBytes",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "modelType",
+            "columnName": "modelType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "destinationPath",
+            "columnName": "destinationPath",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "errorMessage",
+            "columnName": "errorMessage",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "expectedSha256",
+            "columnName": "expectedSha256",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "hashVerified",
+            "columnName": "hashVerified",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_model_downloads_modelId",
+            "unique": false,
+            "columnNames": [
+              "modelId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_model_downloads_modelId` ON `${TABLE_NAME}` (`modelId`)"
+          },
+          {
+            "name": "index_model_downloads_status",
+            "unique": false,
+            "columnNames": [
+              "status"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_model_downloads_status` ON `${TABLE_NAME}` (`status`)"
+          },
+          {
+            "name": "index_model_downloads_createdAt",
+            "unique": false,
+            "columnNames": [
+              "createdAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_model_downloads_createdAt` ON `${TABLE_NAME}` (`createdAt`)"
+          }
+        ]
+      },
+      {
+        "tableName": "plugins",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `name` TEXT NOT NULL, `version` TEXT NOT NULL, `author` TEXT NOT NULL, `description` TEXT NOT NULL, `pluginType` TEXT NOT NULL, `capabilities` TEXT NOT NULL, `minAppVersion` TEXT NOT NULL, `state` TEXT NOT NULL, `configJson` TEXT NOT NULL, `installedAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "version",
+            "columnName": "version",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "author",
+            "columnName": "author",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "pluginType",
+            "columnName": "pluginType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "capabilities",
+            "columnName": "capabilities",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "minAppVersion",
+            "columnName": "minAppVersion",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "state",
+            "columnName": "state",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "configJson",
+            "columnName": "configJson",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "installedAt",
+            "columnName": "installedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "share_hashtags",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`tag` TEXT NOT NULL, `isEnabled` INTEGER NOT NULL, `isCustom` INTEGER NOT NULL, `addedAt` INTEGER NOT NULL, PRIMARY KEY(`tag`))",
+        "fields": [
+          {
+            "fieldPath": "tag",
+            "columnName": "tag",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isEnabled",
+            "columnName": "isEnabled",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isCustom",
+            "columnName": "isCustom",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "addedAt",
+            "columnName": "addedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "tag"
+          ]
+        }
+      },
+      {
+        "tableName": "model_update_notifications",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `modelId` INTEGER NOT NULL, `modelName` TEXT NOT NULL, `newVersionName` TEXT NOT NULL, `newVersionId` INTEGER NOT NULL, `source` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, `isRead` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "modelId",
+            "columnName": "modelId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "modelName",
+            "columnName": "modelName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "newVersionName",
+            "columnName": "newVersionName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "newVersionId",
+            "columnName": "newVersionId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "source",
+            "columnName": "source",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isRead",
+            "columnName": "isRead",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_model_update_notifications_createdAt",
+            "unique": false,
+            "columnNames": [
+              "createdAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_model_update_notifications_createdAt` ON `${TABLE_NAME}` (`createdAt`)"
+          },
+          {
+            "name": "index_model_update_notifications_isRead",
+            "unique": false,
+            "columnNames": [
+              "isRead"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_model_update_notifications_isRead` ON `${TABLE_NAME}` (`isRead`)"
+          }
+        ]
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '4c805ed7c28dc705582a8e10b425a528')"
+    ]
+  }
+}

--- a/core/core-database/src/commonMain/kotlin/com/riox432/civitdeck/data/local/CivitDeckDatabase.kt
+++ b/core/core-database/src/commonMain/kotlin/com/riox432/civitdeck/data/local/CivitDeckDatabase.kt
@@ -90,6 +90,7 @@ import com.riox432.civitdeck.data.local.migrations.MIGRATION_37_38
 import com.riox432.civitdeck.data.local.migrations.MIGRATION_38_39
 import com.riox432.civitdeck.data.local.migrations.MIGRATION_39_40
 import com.riox432.civitdeck.data.local.migrations.MIGRATION_3_4
+import com.riox432.civitdeck.data.local.migrations.MIGRATION_40_41
 import com.riox432.civitdeck.data.local.migrations.MIGRATION_4_5
 import com.riox432.civitdeck.data.local.migrations.MIGRATION_5_6
 import com.riox432.civitdeck.data.local.migrations.MIGRATION_6_7
@@ -131,7 +132,7 @@ import kotlinx.coroutines.IO
         ShareHashtagEntity::class,
         ModelUpdateNotificationEntity::class,
     ],
-    version = 40,
+    version = 41,
 )
 @ConstructedBy(CivitDeckDatabaseConstructor::class)
 abstract class CivitDeckDatabase : RoomDatabase() {
@@ -206,6 +207,7 @@ fun getRoomDatabase(builder: RoomDatabase.Builder<CivitDeckDatabase>): CivitDeck
             MIGRATION_37_38,
             MIGRATION_38_39,
             MIGRATION_39_40,
+            MIGRATION_40_41,
         )
         .fallbackToDestructiveMigrationOnDowngrade(dropAllTables = true)
         .addCallback(defaultCollectionCallback)

--- a/core/core-database/src/commonMain/kotlin/com/riox432/civitdeck/data/local/entity/SavedPromptEntity.kt
+++ b/core/core-database/src/commonMain/kotlin/com/riox432/civitdeck/data/local/entity/SavedPromptEntity.kt
@@ -22,4 +22,5 @@ data class SavedPromptEntity(
     @ColumnInfo(defaultValue = "0") val autoSaved: Boolean = false,
     val templateVariables: String? = null,
     val templateType: String? = null,
+    val templateMetadata: String? = null,
 )

--- a/core/core-database/src/commonMain/kotlin/com/riox432/civitdeck/data/local/migrations/Migration40to41.kt
+++ b/core/core-database/src/commonMain/kotlin/com/riox432/civitdeck/data/local/migrations/Migration40to41.kt
@@ -1,0 +1,14 @@
+package com.riox432.civitdeck.data.local.migrations
+
+import androidx.room.migration.Migration
+import androidx.sqlite.SQLiteConnection
+import androidx.sqlite.execSQL
+
+@Suppress("MatchingDeclarationName")
+val MIGRATION_40_41 = object : Migration(40, 41) {
+    override fun migrate(connection: SQLiteConnection) {
+        connection.execSQL(
+            "ALTER TABLE saved_prompts ADD COLUMN templateMetadata TEXT DEFAULT NULL",
+        )
+    }
+}

--- a/core/core-database/src/commonMain/kotlin/com/riox432/civitdeck/data/local/migrations/SeedData.kt
+++ b/core/core-database/src/commonMain/kotlin/com/riox432/civitdeck/data/local/migrations/SeedData.kt
@@ -1,3 +1,5 @@
+@file:Suppress("MaxLineLength")
+
 package com.riox432.civitdeck.data.local.migrations
 
 import androidx.room.RoomDatabase
@@ -24,35 +26,72 @@ internal val defaultCollectionCallback = object : RoomDatabase.Callback() {
 private fun seedBuiltInTemplates(connection: SQLiteConnection) {
     // INSERT OR IGNORE guarantees idempotency: rows with the same negative IDs are silently
     // skipped if they already exist, so this function is safe to call on every app open.
+    // Use UPDATE for existing rows to migrate to new format with metadata and slider types.
+
     // id=-1 → TXT2IMG built-in template
-    connection.execSQL(
-        """INSERT OR IGNORE INTO saved_prompts
-            (id, prompt, negativePrompt, sampler, steps, cfgScale, seed, modelName, size,
-             sourceImageUrl, savedAt, isTemplate, templateName, autoSaved, templateVariables, templateType)
-           VALUES (-1, '{positive_prompt}', '{negative_prompt}', 'euler', 20, 7.0, -1,
-                   '{checkpoint}', '{width}x{height}', NULL, 0, 1, 'txt2img Default', 0,
-                   '[{"name":"positive_prompt","type":"TEXT","defaultValue":"","options":[],"required":true},{"name":"negative_prompt","type":"TEXT","defaultValue":"","options":[],"required":false},{"name":"checkpoint","type":"TEXT","defaultValue":"","options":[],"required":true},{"name":"steps","type":"NUMBER","defaultValue":"20","options":[],"required":false},{"name":"cfg","type":"NUMBER","defaultValue":"7.0","options":[],"required":false},{"name":"width","type":"NUMBER","defaultValue":"512","options":[],"required":false},{"name":"height","type":"NUMBER","defaultValue":"512","options":[],"required":false}]',
-                   'TXT2IMG')""",
+    upsertBuiltInTemplate(
+        connection,
+        id = -1,
+        name = "txt2img Default",
+        type = "TXT2IMG",
+        variables = TXT2IMG_VARS,
+        metadata = """{"description":"Standard text-to-image generation","category":"GENERAL","version":2,"author":"CivitDeck"}""",
     )
     // id=-2 → IMG2IMG built-in template
-    connection.execSQL(
-        """INSERT OR IGNORE INTO saved_prompts
-            (id, prompt, negativePrompt, sampler, steps, cfgScale, seed, modelName, size,
-             sourceImageUrl, savedAt, isTemplate, templateName, autoSaved, templateVariables, templateType)
-           VALUES (-2, '{positive_prompt}', '{negative_prompt}', 'euler', 20, 7.0, -1,
-                   '{checkpoint}', '{width}x{height}', NULL, 0, 1, 'img2img Default', 0,
-                   '[{"name":"positive_prompt","type":"TEXT","defaultValue":"","options":[],"required":true},{"name":"negative_prompt","type":"TEXT","defaultValue":"","options":[],"required":false},{"name":"checkpoint","type":"TEXT","defaultValue":"","options":[],"required":true},{"name":"steps","type":"NUMBER","defaultValue":"20","options":[],"required":false},{"name":"cfg","type":"NUMBER","defaultValue":"7.0","options":[],"required":false},{"name":"width","type":"NUMBER","defaultValue":"512","options":[],"required":false},{"name":"height","type":"NUMBER","defaultValue":"512","options":[],"required":false},{"name":"denoise_strength","type":"NUMBER","defaultValue":"0.75","options":[],"required":false}]',
-                   'IMG2IMG')""",
+    upsertBuiltInTemplate(
+        connection,
+        id = -2,
+        name = "img2img Default",
+        type = "IMG2IMG",
+        variables = IMG2IMG_VARS,
+        metadata = """{"description":"Image-to-image with denoising control","category":"GENERAL","version":2,"author":"CivitDeck"}""",
     )
     // id=-3 → UPSCALE built-in template
+    upsertBuiltInTemplate(
+        connection,
+        id = -3,
+        name = "Upscale Default",
+        type = "UPSCALE",
+        variables = UPSCALE_VARS,
+        metadata = """{"description":"Upscale images with adjustable factor","category":"UTILITY","version":2,"author":"CivitDeck"}""",
+    )
+    // id=-4 → INPAINTING built-in template
+    upsertBuiltInTemplate(
+        connection,
+        id = -4,
+        name = "Inpainting Default",
+        type = "INPAINTING",
+        variables = INPAINTING_VARS,
+        metadata = """{"description":"Fill masked areas with AI-generated content","category":"GENERAL","version":1,"author":"CivitDeck"}""",
+    )
+    // id=-5 → LORA built-in template
+    upsertBuiltInTemplate(
+        connection,
+        id = -5,
+        name = "LoRA Default",
+        type = "LORA",
+        variables = LORA_VARS,
+        metadata = """{"description":"Generate with LoRA model injection and strength control","category":"GENERAL","version":1,"author":"CivitDeck"}""",
+    )
+}
+
+private fun upsertBuiltInTemplate(
+    connection: SQLiteConnection,
+    id: Int,
+    name: String,
+    type: String,
+    variables: String,
+    metadata: String,
+) {
     connection.execSQL(
-        """INSERT OR IGNORE INTO saved_prompts
+        """INSERT OR REPLACE INTO saved_prompts
             (id, prompt, negativePrompt, sampler, steps, cfgScale, seed, modelName, size,
-             sourceImageUrl, savedAt, isTemplate, templateName, autoSaved, templateVariables, templateType)
-           VALUES (-3, '{input_image}', NULL, 'euler', 20, 7.0, -1,
-                   NULL, '512x512', NULL, 0, 1, 'Upscale Default', 0,
-                   '[{"name":"input_image","type":"TEXT","defaultValue":"","options":[],"required":true},{"name":"upscale_factor","type":"NUMBER","defaultValue":"2","options":[],"required":false}]',
-                   'UPSCALE')""",
+             sourceImageUrl, savedAt, isTemplate, templateName, autoSaved, templateVariables, templateType, templateMetadata)
+           VALUES ($id, '', NULL, 'euler', 20, 7.0, -1,
+                   NULL, '512x512', NULL, 0, 1, '$name', 0,
+                   '$variables',
+                   '$type',
+                   '$metadata')""",
     )
 }
 
@@ -67,3 +106,20 @@ private fun seedDefaultHashtags(connection: SQLiteConnection) {
     // Remove legacy Japanese presets that were added in earlier builds
     connection.execSQL("DELETE FROM share_hashtags WHERE tag IN ('#AIイラスト', '#AI画像生成') AND isCustom = 0")
 }
+
+// -- Variable JSON constants --
+
+private const val TXT2IMG_VARS =
+    """[{"name":"positive_prompt","label":"Prompt","type":"TEXT","defaultValue":"","required":true},{"name":"negative_prompt","label":"Negative Prompt","type":"TEXT","defaultValue":"","required":false},{"name":"checkpoint","label":"Checkpoint","type":"TEXT","defaultValue":"","required":true},{"name":"steps","label":"Steps","type":"SLIDER","defaultValue":"20","min":1.0,"max":150.0,"step":1.0,"required":false},{"name":"cfg","label":"CFG Scale","type":"SLIDER","defaultValue":"7.0","min":1.0,"max":30.0,"step":0.5,"required":false},{"name":"width","label":"Width","type":"SELECT","defaultValue":"512","options":["256","384","512","640","768","832","896","1024","1280"],"required":false},{"name":"height","label":"Height","type":"SELECT","defaultValue":"512","options":["256","384","512","640","768","832","896","1024","1280"],"required":false}]"""
+
+private const val IMG2IMG_VARS =
+    """[{"name":"positive_prompt","label":"Prompt","type":"TEXT","defaultValue":"","required":true},{"name":"negative_prompt","label":"Negative Prompt","type":"TEXT","defaultValue":"","required":false},{"name":"checkpoint","label":"Checkpoint","type":"TEXT","defaultValue":"","required":true},{"name":"steps","label":"Steps","type":"SLIDER","defaultValue":"20","min":1.0,"max":150.0,"step":1.0,"required":false},{"name":"cfg","label":"CFG Scale","type":"SLIDER","defaultValue":"7.0","min":1.0,"max":30.0,"step":0.5,"required":false},{"name":"width","label":"Width","type":"SELECT","defaultValue":"512","options":["256","384","512","640","768","832","896","1024","1280"],"required":false},{"name":"height","label":"Height","type":"SELECT","defaultValue":"512","options":["256","384","512","640","768","832","896","1024","1280"],"required":false},{"name":"denoise_strength","label":"Denoise Strength","type":"SLIDER","defaultValue":"0.75","min":0.0,"max":1.0,"step":0.05,"required":false}]"""
+
+private const val UPSCALE_VARS =
+    """[{"name":"input_image","label":"Input Image","type":"TEXT","defaultValue":"","required":true},{"name":"upscale_factor","label":"Upscale Factor","type":"SLIDER","defaultValue":"2","min":1.0,"max":4.0,"step":0.5,"required":false}]"""
+
+private const val INPAINTING_VARS =
+    """[{"name":"positive_prompt","label":"Prompt","type":"TEXT","defaultValue":"","required":true},{"name":"negative_prompt","label":"Negative Prompt","type":"TEXT","defaultValue":"","required":false},{"name":"checkpoint","label":"Checkpoint","type":"TEXT","defaultValue":"","required":true},{"name":"steps","label":"Steps","type":"SLIDER","defaultValue":"20","min":1.0,"max":150.0,"step":1.0,"required":false},{"name":"cfg","label":"CFG Scale","type":"SLIDER","defaultValue":"7.0","min":1.0,"max":30.0,"step":0.5,"required":false},{"name":"denoise_strength","label":"Denoise Strength","type":"SLIDER","defaultValue":"1.0","min":0.0,"max":1.0,"step":0.05,"required":false}]"""
+
+private const val LORA_VARS =
+    """[{"name":"positive_prompt","label":"Prompt","type":"TEXT","defaultValue":"","required":true},{"name":"negative_prompt","label":"Negative Prompt","type":"TEXT","defaultValue":"","required":false},{"name":"checkpoint","label":"Checkpoint","type":"TEXT","defaultValue":"","required":true},{"name":"lora_name","label":"LoRA Model","type":"TEXT","defaultValue":"","required":true},{"name":"lora_strength","label":"LoRA Strength","type":"SLIDER","defaultValue":"0.8","min":0.0,"max":2.0,"step":0.05,"required":false},{"name":"steps","label":"Steps","type":"SLIDER","defaultValue":"20","min":1.0,"max":150.0,"step":1.0,"required":false},{"name":"cfg","label":"CFG Scale","type":"SLIDER","defaultValue":"7.0","min":1.0,"max":30.0,"step":0.5,"required":false},{"name":"width","label":"Width","type":"SELECT","defaultValue":"512","options":["256","384","512","640","768","832","896","1024","1280"],"required":false},{"name":"height","label":"Height","type":"SELECT","defaultValue":"512","options":["256","384","512","640","768","832","896","1024","1280"],"required":false}]"""

--- a/core/core-domain/src/commonMain/kotlin/com/riox432/civitdeck/domain/model/SavedPrompt.kt
+++ b/core/core-domain/src/commonMain/kotlin/com/riox432/civitdeck/domain/model/SavedPrompt.kt
@@ -17,4 +17,5 @@ data class SavedPrompt(
     val autoSaved: Boolean = false,
     val templateVariables: String? = null,
     val templateType: String? = null,
+    val templateMetadata: String? = null,
 )

--- a/core/core-domain/src/commonMain/kotlin/com/riox432/civitdeck/domain/model/WorkflowTemplate.kt
+++ b/core/core-domain/src/commonMain/kotlin/com/riox432/civitdeck/domain/model/WorkflowTemplate.kt
@@ -3,9 +3,13 @@ package com.riox432.civitdeck.domain.model
 data class WorkflowTemplate(
     val id: Long,
     val name: String,
+    val description: String = "",
     val type: WorkflowTemplateType,
+    val category: WorkflowTemplateCategory = WorkflowTemplateCategory.GENERAL,
     val variables: List<TemplateVariable>,
     val isBuiltIn: Boolean,
+    val version: Int = 1,
+    val author: String = "",
     val createdAt: Long,
 )
 
@@ -14,12 +18,26 @@ enum class WorkflowTemplateType {
     IMG2IMG,
     INPAINTING,
     UPSCALE,
+    LORA,
+}
+
+enum class WorkflowTemplateCategory {
+    GENERAL,
+    ANIME,
+    PHOTOREALISTIC,
+    ARTISTIC,
+    UTILITY,
 }
 
 data class TemplateVariable(
     val name: String,
+    val label: String = "",
+    val description: String = "",
     val type: TemplateVariableType,
     val defaultValue: String,
+    val min: Double? = null,
+    val max: Double? = null,
+    val step: Double? = null,
     val options: List<String> = emptyList(),
     val required: Boolean = true,
 )
@@ -28,4 +46,5 @@ enum class TemplateVariableType {
     TEXT,
     NUMBER,
     SELECT,
+    SLIDER,
 }

--- a/feature/feature-comfyui/src/commonMain/kotlin/com/riox432/civitdeck/feature/comfyui/domain/usecase/WorkflowTemplateUseCases.kt
+++ b/feature/feature-comfyui/src/commonMain/kotlin/com/riox432/civitdeck/feature/comfyui/domain/usecase/WorkflowTemplateUseCases.kt
@@ -1,3 +1,5 @@
+@file:Suppress("TooManyFunctions")
+
 package com.riox432.civitdeck.feature.comfyui.domain.usecase
 
 import com.riox432.civitdeck.domain.model.ComfyUIGenerationParams
@@ -5,6 +7,7 @@ import com.riox432.civitdeck.domain.model.SavedPrompt
 import com.riox432.civitdeck.domain.model.TemplateVariable
 import com.riox432.civitdeck.domain.model.TemplateVariableType
 import com.riox432.civitdeck.domain.model.WorkflowTemplate
+import com.riox432.civitdeck.domain.model.WorkflowTemplateCategory
 import com.riox432.civitdeck.domain.model.WorkflowTemplateType
 import com.riox432.civitdeck.domain.repository.SavedPromptRepository
 import com.riox432.civitdeck.domain.util.currentTimeMillis
@@ -23,25 +26,64 @@ private val templateJson = Json {
 @kotlinx.serialization.Serializable
 private data class TemplateVariableDto(
     val name: String,
+    val label: String = "",
+    val description: String = "",
     val type: String,
     val defaultValue: String,
+    val min: Double? = null,
+    val max: Double? = null,
+    val step: Double? = null,
     val options: List<String> = emptyList(),
     val required: Boolean = true,
 )
 
+@kotlinx.serialization.Serializable
+private data class TemplateMetadataDto(
+    val description: String = "",
+    val category: String = "GENERAL",
+    val version: Int = 1,
+    val author: String = "",
+)
+
 // -- Mappers --
 
+private fun TemplateVariable.toDto() = TemplateVariableDto(
+    name = name,
+    label = label,
+    description = description,
+    type = type.name,
+    defaultValue = defaultValue,
+    min = min,
+    max = max,
+    step = step,
+    options = options,
+    required = required,
+)
+
+private fun TemplateVariableDto.toModel() = TemplateVariable(
+    name = name,
+    label = label,
+    description = description,
+    type = try { TemplateVariableType.valueOf(type) } catch (_: IllegalArgumentException) {
+        TemplateVariableType.TEXT
+    },
+    defaultValue = defaultValue,
+    min = min,
+    max = max,
+    step = step,
+    options = options,
+    required = required,
+)
+
 private fun WorkflowTemplate.toSavedPrompt(): SavedPrompt {
-    val variablesJson = templateJson.encodeToString(
-        variables.map {
-            TemplateVariableDto(
-                name = it.name,
-                type = it.type.name,
-                defaultValue = it.defaultValue,
-                options = it.options,
-                required = it.required,
-            )
-        },
+    val variablesJson = templateJson.encodeToString(variables.map { it.toDto() })
+    val metadataJson = templateJson.encodeToString(
+        TemplateMetadataDto(
+            description = description,
+            category = category.name,
+            version = version,
+            author = author,
+        ),
     )
     return SavedPrompt(
         id = if (id <= 0L) 0L else id,
@@ -60,6 +102,7 @@ private fun WorkflowTemplate.toSavedPrompt(): SavedPrompt {
         autoSaved = false,
         templateVariables = variablesJson,
         templateType = type.name,
+        templateMetadata = metadataJson,
     )
 }
 
@@ -70,27 +113,30 @@ private fun SavedPrompt.toWorkflowTemplate(): WorkflowTemplate? {
         return null
     }
     val vars = try {
-        val dtos = templateJson.decodeFromString<List<TemplateVariableDto>>(templateVariables ?: "[]")
-        dtos.map {
-            TemplateVariable(
-                name = it.name,
-                type = try { TemplateVariableType.valueOf(it.type) } catch (_: IllegalArgumentException) {
-                    TemplateVariableType.TEXT
-                },
-                defaultValue = it.defaultValue,
-                options = it.options,
-                required = it.required,
-            )
-        }
+        templateJson.decodeFromString<List<TemplateVariableDto>>(templateVariables ?: "[]")
+            .map { it.toModel() }
     } catch (@Suppress("TooGenericExceptionCaught") _: Exception) {
         emptyList()
+    }
+    val metadata = try {
+        templateJson.decodeFromString<TemplateMetadataDto>(templateMetadata ?: "{}")
+    } catch (@Suppress("TooGenericExceptionCaught") _: Exception) {
+        TemplateMetadataDto()
     }
     return WorkflowTemplate(
         id = id,
         name = templateName ?: "Unnamed",
+        description = metadata.description,
         type = type,
+        category = try {
+            WorkflowTemplateCategory.valueOf(metadata.category)
+        } catch (_: IllegalArgumentException) {
+            WorkflowTemplateCategory.GENERAL
+        },
         variables = vars,
         isBuiltIn = id < 0L,
+        version = metadata.version,
+        author = metadata.author,
         createdAt = savedAt,
     )
 }
@@ -124,23 +170,23 @@ class ExportWorkflowTemplateUseCase {
     @kotlinx.serialization.Serializable
     private data class ExportDto(
         val name: String,
+        val description: String = "",
         val type: String,
+        val category: String = "GENERAL",
+        val version: Int = 1,
+        val author: String = "",
         val variables: List<TemplateVariableDto>,
     )
 
     operator fun invoke(template: WorkflowTemplate): String {
         val dto = ExportDto(
             name = template.name,
+            description = template.description,
             type = template.type.name,
-            variables = template.variables.map {
-                TemplateVariableDto(
-                    name = it.name,
-                    type = it.type.name,
-                    defaultValue = it.defaultValue,
-                    options = it.options,
-                    required = it.required,
-                )
-            },
+            category = template.category.name,
+            version = template.version,
+            author = template.author,
+            variables = template.variables.map { it.toDto() },
         )
         return Json { prettyPrint = true }.encodeToString(dto)
     }
@@ -150,7 +196,11 @@ class ImportWorkflowTemplateUseCase(private val repository: SavedPromptRepositor
     @kotlinx.serialization.Serializable
     private data class ImportDto(
         val name: String,
+        val description: String = "",
         val type: String,
+        val category: String = "GENERAL",
+        val version: Int = 1,
+        val author: String = "",
         val variables: List<TemplateVariableDto>,
     )
 
@@ -167,23 +217,21 @@ class ImportWorkflowTemplateUseCase(private val repository: SavedPromptRepositor
         } catch (_: IllegalArgumentException) {
             error("Unknown template type: ${dto.type}")
         }
-        val variables = dto.variables.map {
-            TemplateVariable(
-                name = it.name,
-                type = try { TemplateVariableType.valueOf(it.type) } catch (_: IllegalArgumentException) {
-                    TemplateVariableType.TEXT
-                },
-                defaultValue = it.defaultValue,
-                options = it.options,
-                required = it.required,
-            )
+        val category = try {
+            WorkflowTemplateCategory.valueOf(dto.category)
+        } catch (_: IllegalArgumentException) {
+            WorkflowTemplateCategory.GENERAL
         }
         val template = WorkflowTemplate(
             id = 0L,
             name = dto.name,
+            description = dto.description,
             type = type,
-            variables = variables,
+            category = category,
+            variables = dto.variables.map { it.toModel() },
             isBuiltIn = false,
+            version = dto.version,
+            author = dto.author,
             createdAt = currentTimeMillis(),
         )
         repository.saveTemplate(template.toSavedPrompt())

--- a/feature/feature-prompts/src/commonMain/kotlin/com/riox432/civitdeck/feature/prompts/data/repository/SavedPromptRepositoryImpl.kt
+++ b/feature/feature-prompts/src/commonMain/kotlin/com/riox432/civitdeck/feature/prompts/data/repository/SavedPromptRepositoryImpl.kt
@@ -63,6 +63,7 @@ class SavedPromptRepositoryImpl(
         autoSaved = autoSaved,
         templateVariables = templateVariables,
         templateType = templateType,
+        templateMetadata = templateMetadata,
     )
 
     private fun ImageGenerationMeta.toEntity(
@@ -99,5 +100,6 @@ class SavedPromptRepositoryImpl(
         autoSaved = autoSaved,
         templateVariables = templateVariables,
         templateType = templateType,
+        templateMetadata = templateMetadata,
     )
 }

--- a/iosApp/iosApp.xcodeproj/project.pbxproj
+++ b/iosApp/iosApp.xcodeproj/project.pbxproj
@@ -120,6 +120,7 @@
 		CDWT01012F200001000CD001 /* WorkflowTemplateView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDWT01002F200001000CD001 /* WorkflowTemplateView.swift */; };
 		CDWT02012F200002000CD001 /* WorkflowTemplateEditorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDWT02002F200002000CD001 /* WorkflowTemplateEditorView.swift */; };
 		CDWT03012F200003000CD001 /* WorkflowTemplateViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDWT03002F200003000CD001 /* WorkflowTemplateViewModel.swift */; };
+		CDTP04012F200004000CD001 /* TemplateParameterView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDTP04002F200004000CD001 /* TemplateParameterView.swift */; };
 		CDSD01012F780001000CD001 /* SDWebUISettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDSD01002F780001000CD001 /* SDWebUISettingsView.swift */; };
 		CDSD02012F780002000CD001 /* SDWebUISettingsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDSD02002F780002000CD001 /* SDWebUISettingsViewModel.swift */; };
 		CDSD03012F780003000CD001 /* SDWebUIGenerationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDSD03002F780003000CD001 /* SDWebUIGenerationView.swift */; };
@@ -294,6 +295,7 @@
 		CDWT01002F200001000CD001 /* WorkflowTemplateView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkflowTemplateView.swift; sourceTree = "<group>"; };
 		CDWT02002F200002000CD001 /* WorkflowTemplateEditorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkflowTemplateEditorView.swift; sourceTree = "<group>"; };
 		CDWT03002F200003000CD001 /* WorkflowTemplateViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkflowTemplateViewModel.swift; sourceTree = "<group>"; };
+		CDTP04002F200004000CD001 /* TemplateParameterView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TemplateParameterView.swift; sourceTree = "<group>"; };
 		CDSD01002F780001000CD001 /* SDWebUISettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SDWebUISettingsView.swift; sourceTree = "<group>"; };
 		CDSD02002F780002000CD001 /* SDWebUISettingsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SDWebUISettingsViewModel.swift; sourceTree = "<group>"; };
 		CDSD03002F780003000CD001 /* SDWebUIGenerationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SDWebUIGenerationView.swift; sourceTree = "<group>"; };
@@ -806,6 +808,7 @@
 				CDWT01002F200001000CD001 /* WorkflowTemplateView.swift */,
 				CDWT02002F200002000CD001 /* WorkflowTemplateEditorView.swift */,
 				CDWT03002F200003000CD001 /* WorkflowTemplateViewModel.swift */,
+				CDTP04002F200004000CD001 /* TemplateParameterView.swift */,
 				CDSD01002F780001000CD001 /* SDWebUISettingsView.swift */,
 				CDSD02002F780002000CD001 /* SDWebUISettingsViewModel.swift */,
 				CDSD03002F780003000CD001 /* SDWebUIGenerationView.swift */,
@@ -1057,6 +1060,7 @@
 				CDWT01012F200001000CD001 /* WorkflowTemplateView.swift in Sources */,
 				CDWT02012F200002000CD001 /* WorkflowTemplateEditorView.swift in Sources */,
 				CDWT03012F200003000CD001 /* WorkflowTemplateViewModel.swift in Sources */,
+				CDTP04012F200004000CD001 /* TemplateParameterView.swift in Sources */,
 				CDSD01012F780001000CD001 /* SDWebUISettingsView.swift in Sources */,
 				CDSD02012F780002000CD001 /* SDWebUISettingsViewModel.swift in Sources */,
 				CDSD03012F780003000CD001 /* SDWebUIGenerationView.swift in Sources */,

--- a/iosApp/iosApp/Features/ComfyUI/TemplateParameterView.swift
+++ b/iosApp/iosApp/Features/ComfyUI/TemplateParameterView.swift
@@ -1,0 +1,181 @@
+import SwiftUI
+import Shared
+
+struct TemplateParameterView: View {
+    let template: WorkflowTemplate
+    let onApply: ([String: String]) -> Void
+    @State private var values: [String: String]
+    @Environment(\.dismiss) private var dismiss
+
+    init(template: WorkflowTemplate, onApply: @escaping ([String: String]) -> Void) {
+        self.template = template
+        self.onApply = onApply
+        var initial: [String: String] = [:]
+        for variable in template.variables {
+            initial[variable.name] = variable.defaultValue
+        }
+        _values = State(initialValue: initial)
+    }
+
+    var body: some View {
+        List {
+            if !template.description_.isEmpty {
+                Section {
+                    Text(template.description_)
+                        .font(.civitBodyMedium)
+                        .foregroundColor(.civitOnSurfaceVariant)
+                }
+            }
+            Section("Parameters") {
+                ForEach(template.variables, id: \.name) { variable in
+                    parameterInput(variable: variable)
+                }
+            }
+            Section {
+                Button {
+                    onApply(values)
+                    dismiss()
+                } label: {
+                    Text("Generate")
+                        .frame(maxWidth: .infinity)
+                        .font(.civitBodyMedium)
+                }
+                .disabled(!allRequiredFilled)
+            }
+        }
+        .navigationTitle(template.name)
+        .navigationBarTitleDisplayMode(.inline)
+        .toolbar {
+            ToolbarItem(placement: .cancellationAction) {
+                Button("Cancel") { dismiss() }
+            }
+        }
+    }
+
+    private var allRequiredFilled: Bool {
+        template.variables
+            .filter { $0.required }
+            .allSatisfy { !(values[$0.name] ?? "").isEmpty }
+    }
+
+    @ViewBuilder
+    private func parameterInput(variable: TemplateVariable) -> some View {
+        VStack(alignment: .leading, spacing: Spacing.xs) {
+            Text(variable.label.isEmpty ? variable.name : variable.label)
+                .font(.civitBodySmall)
+                .fontWeight(.semibold)
+            if !variable.description_.isEmpty {
+                Text(variable.description_)
+                    .font(.civitLabelSmall)
+                    .foregroundColor(.civitOnSurfaceVariant)
+            }
+            switch variable.type {
+            case .slider:
+                sliderInput(variable: variable)
+            case .select:
+                selectInput(variable: variable)
+            case .number:
+                numberInput(variable: variable)
+            default:
+                textInput(variable: variable)
+            }
+        }
+        .padding(.vertical, Spacing.xs)
+    }
+
+    private func sliderInput(variable: TemplateVariable) -> some View {
+        let minVal = variable.min?.doubleValue ?? 0
+        let maxVal = variable.max?.doubleValue ?? 100
+        let stepVal = variable.step?.doubleValue ?? 1
+        let current = Binding<Double>(
+            get: {
+                let val = Double(values[variable.name] ?? variable.defaultValue) ?? minVal
+                return Swift.min(Swift.max(val, minVal), maxVal)
+            },
+            set: { newValue in
+                values[variable.name] = formatSliderValue(newValue, step: stepVal)
+            }
+        )
+        return VStack {
+            HStack {
+                Text(formatSliderValue(minVal, step: stepVal))
+                    .font(.civitLabelSmall)
+                    .foregroundColor(.civitOnSurfaceVariant)
+                Spacer()
+                Text(formatSliderValue(current.wrappedValue, step: stepVal))
+                    .font(.civitBodyMedium)
+                    .foregroundColor(.civitPrimary)
+                Spacer()
+                Text(formatSliderValue(maxVal, step: stepVal))
+                    .font(.civitLabelSmall)
+                    .foregroundColor(.civitOnSurfaceVariant)
+            }
+            Slider(
+                value: current,
+                in: minVal...maxVal,
+                step: stepVal
+            )
+        }
+    }
+
+    private func selectInput(variable: TemplateVariable) -> some View {
+        let options = variable.options as? [String] ?? []
+        return Picker(
+            variable.label.isEmpty ? variable.name : variable.label,
+            selection: Binding(
+                get: { values[variable.name] ?? variable.defaultValue },
+                set: { values[variable.name] = $0 }
+            )
+        ) {
+            ForEach(options, id: \.self) { option in
+                Text(option).tag(option)
+            }
+        }
+        .pickerStyle(.menu)
+    }
+
+    private func numberInput(variable: TemplateVariable) -> some View {
+        // If has min/max, render as slider
+        if variable.min != nil && variable.max != nil {
+            return AnyView(sliderInput(variable: variable))
+        } else {
+            return AnyView(
+                TextField(
+                    variable.required ? "Required" : "Optional",
+                    text: Binding(
+                        get: { values[variable.name] ?? "" },
+                        set: { values[variable.name] = $0 }
+                    )
+                )
+                .keyboardType(.decimalPad)
+                .textFieldStyle(.roundedBorder)
+            )
+        }
+    }
+
+    private func textInput(variable: TemplateVariable) -> some View {
+        let isPrompt = variable.name.contains("prompt")
+        return TextField(
+            variable.required ? "Required" : "Optional",
+            text: Binding(
+                get: { values[variable.name] ?? "" },
+                set: { values[variable.name] = $0 }
+            ),
+            axis: isPrompt ? .vertical : .horizontal
+        )
+        .lineLimit(isPrompt ? 3...6 : 1...1)
+        .textFieldStyle(.roundedBorder)
+    }
+
+    private func formatSliderValue(_ value: Double, step: Double) -> String {
+        if step >= 1 {
+            return String(Int(value.rounded()))
+        } else if step >= 0.1 {
+            return String(format: "%.1f", value)
+        } else if step >= 0.01 {
+            return String(format: "%.2f", value)
+        } else {
+            return String(format: "%.3f", value)
+        }
+    }
+}

--- a/iosApp/iosApp/Features/ComfyUI/WorkflowTemplateEditorView.swift
+++ b/iosApp/iosApp/Features/ComfyUI/WorkflowTemplateEditorView.swift
@@ -6,7 +6,9 @@ struct WorkflowTemplateEditorView: View {
     let viewModel: WorkflowTemplateViewModel
 
     @State private var name: String
+    @State private var templateDescription: String
     @State private var templateType: WorkflowTemplateType
+    @State private var templateCategory: WorkflowTemplateCategory
     @State private var variables: [TemplateVariableSwift]
     @Environment(\.dismiss) private var dismiss
 
@@ -14,7 +16,9 @@ struct WorkflowTemplateEditorView: View {
         self.initialTemplate = initialTemplate
         self.viewModel = viewModel
         _name = State(initialValue: initialTemplate.name)
+        _templateDescription = State(initialValue: initialTemplate.description_)
         _templateType = State(initialValue: initialTemplate.type)
+        _templateCategory = State(initialValue: initialTemplate.category)
         _variables = State(initialValue: initialTemplate.variables.map {
             TemplateVariableSwift(from: $0)
         })
@@ -25,10 +29,14 @@ struct WorkflowTemplateEditorView: View {
             Section("Name") {
                 TextField("Template name", text: $name)
             }
-            Section("Type") {
+            Section("Description") {
+                TextField("Template description", text: $templateDescription, axis: .vertical)
+                    .lineLimit(2...4)
+            }
+            Section("Type & Category") {
                 Picker("Type", selection: $templateType) {
-                    ForEach(WorkflowTemplateType.allCases, id: \.self) { t in
-                        Text(typeLabel(t)).tag(t)
+                    ForEach(WorkflowTemplateType.allCases, id: \.self) { type in
+                        Text(typeLabel(type)).tag(type)
                     }
                 }
                 .pickerStyle(.menu)
@@ -36,6 +44,12 @@ struct WorkflowTemplateEditorView: View {
                     variables = WorkflowTemplateViewModel.defaultVariables(for: newType)
                         .map { TemplateVariableSwift(from: $0) }
                 }
+                Picker("Category", selection: $templateCategory) {
+                    ForEach(WorkflowTemplateCategory.allCases, id: \.self) { category in
+                        Text(categoryLabel(category)).tag(category)
+                    }
+                }
+                .pickerStyle(.menu)
             }
             Section {
                 ForEach($variables) { $variable in
@@ -69,9 +83,13 @@ struct WorkflowTemplateEditorView: View {
                     let updated = WorkflowTemplate(
                         id: initialTemplate.id,
                         name: name.trimmingCharacters(in: .whitespaces),
+                        description: templateDescription.trimmingCharacters(in: .whitespaces),
                         type: templateType,
+                        category: templateCategory,
                         variables: variables.map { $0.toKotlin() },
                         isBuiltIn: false,
+                        version: initialTemplate.version,
+                        author: initialTemplate.author,
                         createdAt: initialTemplate.createdAt
                     )
                     viewModel.onSaveTemplate(updated)
@@ -90,10 +108,12 @@ private struct VariableEditorRow: View {
         VStack(alignment: .leading, spacing: Spacing.xs) {
             TextField("Variable name", text: $variable.name)
                 .font(.civitBodySmall)
+            TextField("Display label", text: $variable.label)
+                .font(.civitBodySmall)
             HStack {
                 Picker("Type", selection: $variable.type) {
-                    ForEach(TemplateVariableTypeSwift.allCases, id: \.self) { t in
-                        Text(t.rawValue).tag(t)
+                    ForEach(TemplateVariableTypeSwift.allCases, id: \.self) { type in
+                        Text(type.rawValue).tag(type)
                     }
                 }
                 .pickerStyle(.menu)
@@ -101,6 +121,31 @@ private struct VariableEditorRow: View {
                 TextField("Default", text: $variable.defaultValue)
                     .font(.civitBodySmall)
                     .textFieldStyle(.roundedBorder)
+            }
+            if variable.type == .slider {
+                HStack(spacing: Spacing.sm) {
+                    TextField("Min", text: Binding(
+                        get: { variable.min.map { String($0) } ?? "" },
+                        set: { variable.min = Double($0) }
+                    ))
+                    .font(.civitBodySmall)
+                    .textFieldStyle(.roundedBorder)
+                    .frame(maxWidth: 80)
+                    TextField("Max", text: Binding(
+                        get: { variable.max.map { String($0) } ?? "" },
+                        set: { variable.max = Double($0) }
+                    ))
+                    .font(.civitBodySmall)
+                    .textFieldStyle(.roundedBorder)
+                    .frame(maxWidth: 80)
+                    TextField("Step", text: Binding(
+                        get: { variable.step.map { String($0) } ?? "" },
+                        set: { variable.step = Double($0) }
+                    ))
+                    .font(.civitBodySmall)
+                    .textFieldStyle(.roundedBorder)
+                    .frame(maxWidth: 80)
+                }
             }
             Toggle("Required", isOn: $variable.required)
                 .font(.civitBodySmall)
@@ -114,25 +159,55 @@ private struct VariableEditorRow: View {
 struct TemplateVariableSwift: Identifiable {
     let id = UUID()
     var name: String
+    var label: String
+    var description: String
     var type: TemplateVariableTypeSwift
     var defaultValue: String
+    var min: Double?
+    var max: Double?
+    var step: Double?
+    var options: [String]
     var required: Bool
 
-    init(name: String, type: TemplateVariableTypeSwift, defaultValue: String, required: Bool) {
+    init(
+        name: String,
+        type: TemplateVariableTypeSwift,
+        defaultValue: String,
+        required: Bool,
+        label: String = "",
+        description: String = "",
+        min: Double? = nil,
+        max: Double? = nil,
+        step: Double? = nil,
+        options: [String] = []
+    ) {
         self.name = name
+        self.label = label
+        self.description = description
         self.type = type
         self.defaultValue = defaultValue
+        self.min = min
+        self.max = max
+        self.step = step
+        self.options = options
         self.required = required
     }
 
     init(from kotlin: TemplateVariable) {
         self.name = kotlin.name
+        self.label = kotlin.label
+        self.description = kotlin.description_
         self.defaultValue = kotlin.defaultValue
+        self.min = kotlin.min?.doubleValue
+        self.max = kotlin.max?.doubleValue
+        self.step = kotlin.step?.doubleValue
+        self.options = kotlin.options as? [String] ?? []
         self.required = kotlin.required
         switch kotlin.type {
         case .text: self.type = .text
         case .number: self.type = .number
         case .select: self.type = .select
+        case .slider: self.type = .slider
         default: self.type = .text
         }
     }
@@ -140,9 +215,14 @@ struct TemplateVariableSwift: Identifiable {
     func toKotlin() -> TemplateVariable {
         TemplateVariable(
             name: name,
+            label: label,
+            description: description,
             type: type.toKotlin(),
             defaultValue: defaultValue,
-            options: [],
+            min: min.map { KotlinDouble(double: $0) },
+            max: max.map { KotlinDouble(double: $0) },
+            step: step.map { KotlinDouble(double: $0) },
+            options: options,
             required: required
         )
     }
@@ -152,12 +232,14 @@ enum TemplateVariableTypeSwift: String, CaseIterable {
     case text = "TEXT"
     case number = "NUMBER"
     case select = "SELECT"
+    case slider = "SLIDER"
 
     func toKotlin() -> TemplateVariableType {
         switch self {
         case .text: return .text
         case .number: return .number
         case .select: return .select
+        case .slider: return .slider
         }
     }
 }
@@ -168,6 +250,18 @@ private func typeLabel(_ type: WorkflowTemplateType) -> String {
     case .img2Img: return "img2img"
     case .inpainting: return "Inpainting"
     case .upscale: return "Upscale"
+    case .lora: return "LoRA"
     default: return type.name
+    }
+}
+
+private func categoryLabel(_ category: WorkflowTemplateCategory) -> String {
+    switch category {
+    case .general: return "General"
+    case .anime: return "Anime"
+    case .photorealistic: return "Photo"
+    case .artistic: return "Artistic"
+    case .utility: return "Utility"
+    default: return category.name
     }
 }

--- a/iosApp/iosApp/Features/ComfyUI/WorkflowTemplateView.swift
+++ b/iosApp/iosApp/Features/ComfyUI/WorkflowTemplateView.swift
@@ -12,6 +12,7 @@ struct WorkflowTemplateView: View {
     @State private var importText = ""
     @State private var showCreateEditor = false
     @State private var editingTemplate: WorkflowTemplate?
+    @State private var parameterTemplate: WorkflowTemplate?
     @Environment(\.dismiss) private var dismiss
 
     init(isPicker: Bool = false, onSelect: ((WorkflowTemplate) -> Void)? = nil) {
@@ -20,26 +21,10 @@ struct WorkflowTemplateView: View {
     }
 
     var body: some View {
-        List {
-            if viewModel.isLoading {
-                ProgressView()
-            } else if viewModel.templates.isEmpty {
-                Text("No templates yet. Tap + to create one.")
-                    .font(.civitBodyMedium)
-                    .foregroundColor(.civitOnSurfaceVariant)
-            } else {
-                ForEach(viewModel.templates, id: \.id) { template in
-                    TemplateRow(
-                        template: template,
-                        isPicker: isPicker,
-                        onSelect: onSelect != nil ? { onSelect?(template); dismiss() } : nil,
-                        onExport: { viewModel.onExportTemplate(template) },
-                        onDelete: template.isBuiltIn ? nil : {
-                            viewModel.onDeleteTemplate(id: template.id)
-                        }
-                    )
-                }
-            }
+        VStack(spacing: 0) {
+            searchBar
+            filterSection
+            templateList
         }
         .navigationTitle(isPicker ? "Pick Template" : "Workflow Templates")
         .navigationBarTitleDisplayMode(.inline)
@@ -61,9 +46,7 @@ struct WorkflowTemplateView: View {
                 }
             }
         }
-        .sheet(isPresented: $showImportSheet) {
-            importSheet
-        }
+        .sheet(isPresented: $showImportSheet) { importSheet }
         .sheet(isPresented: $showCreateEditor) {
             NavigationStack {
                 WorkflowTemplateEditorView(
@@ -75,6 +58,13 @@ struct WorkflowTemplateView: View {
         .sheet(item: $editingTemplate) { template in
             NavigationStack {
                 WorkflowTemplateEditorView(initialTemplate: template, viewModel: viewModel)
+            }
+        }
+        .sheet(item: $parameterTemplate) { template in
+            NavigationStack {
+                TemplateParameterView(template: template) { _ in
+                    parameterTemplate = nil
+                }
             }
         }
         .alert("Export Template", isPresented: .init(
@@ -95,6 +85,118 @@ struct WorkflowTemplateView: View {
         } message: {
             if let err = viewModel.importError {
                 Text(err)
+            }
+        }
+    }
+
+    private var searchBar: some View {
+        HStack {
+            Image(systemName: "magnifyingglass")
+                .foregroundColor(.civitOnSurfaceVariant)
+            TextField("Search templates...", text: $viewModel.searchQuery)
+                .font(.civitBodyMedium)
+            if !viewModel.searchQuery.isEmpty {
+                Button {
+                    viewModel.searchQuery = ""
+                } label: {
+                    Image(systemName: "xmark.circle.fill")
+                        .foregroundColor(.civitOnSurfaceVariant)
+                }
+            }
+        }
+        .padding(.horizontal, Spacing.md)
+        .padding(.vertical, Spacing.sm)
+    }
+
+    private var filterSection: some View {
+        VStack(spacing: Spacing.xs) {
+            categoryFilterRow
+            typeFilterRow
+        }
+        .padding(.horizontal, Spacing.md)
+        .padding(.bottom, Spacing.sm)
+    }
+
+    private var categoryFilterRow: some View {
+        ScrollView(.horizontal, showsIndicators: false) {
+            HStack(spacing: Spacing.xs) {
+                chipButton(title: "All", isSelected: viewModel.selectedCategory == nil) {
+                    viewModel.selectedCategory = nil
+                }
+                ForEach(WorkflowTemplateCategory.allCases, id: \.self) { category in
+                    chipButton(
+                        title: categoryLabel(category),
+                        isSelected: viewModel.selectedCategory == category
+                    ) {
+                        viewModel.selectedCategory = viewModel.selectedCategory == category ? nil : category
+                    }
+                }
+            }
+        }
+    }
+
+    private var typeFilterRow: some View {
+        ScrollView(.horizontal, showsIndicators: false) {
+            HStack(spacing: Spacing.xs) {
+                chipButton(title: "All Types", isSelected: viewModel.selectedType == nil) {
+                    viewModel.selectedType = nil
+                }
+                ForEach(WorkflowTemplateType.allCases, id: \.self) { type in
+                    chipButton(
+                        title: typeLabel(type),
+                        isSelected: viewModel.selectedType == type
+                    ) {
+                        viewModel.selectedType = viewModel.selectedType == type ? nil : type
+                    }
+                }
+            }
+        }
+    }
+
+    private func chipButton(title: String, isSelected: Bool, action: @escaping () -> Void) -> some View {
+        Button(action: action) {
+            Text(title)
+                .font(.civitBodySmall)
+                .padding(.horizontal, Spacing.sm)
+                .padding(.vertical, Spacing.xs)
+                .background(isSelected ? Color.civitPrimary.opacity(0.15) : Color.clear)
+                .foregroundColor(isSelected ? .civitPrimary : .civitOnSurfaceVariant)
+                .cornerRadius(CornerRadius.image)
+                .overlay(
+                    RoundedRectangle(cornerRadius: CornerRadius.image)
+                        .stroke(isSelected ? Color.civitPrimary : Color.civitOnSurfaceVariant.opacity(0.3))
+                )
+        }
+        .buttonStyle(.plain)
+    }
+
+    private var templateList: some View {
+        List {
+            if viewModel.isLoading {
+                ProgressView()
+            } else if viewModel.filteredTemplates.isEmpty {
+                Text(
+                    viewModel.templates.isEmpty
+                        ? "No templates yet. Tap + to create one."
+                        : "No templates match your filters."
+                )
+                .font(.civitBodyMedium)
+                .foregroundColor(.civitOnSurfaceVariant)
+            } else {
+                ForEach(viewModel.filteredTemplates, id: \.id) { template in
+                    TemplateRow(
+                        template: template,
+                        isPicker: isPicker,
+                        onSelect: isPicker
+                            ? { onSelect?(template); dismiss() }
+                            : { parameterTemplate = template },
+                        onExport: { viewModel.onExportTemplate(template) },
+                        onEdit: template.isBuiltIn ? nil : { editingTemplate = template },
+                        onDelete: template.isBuiltIn ? nil : {
+                            viewModel.onDeleteTemplate(id: template.id)
+                        }
+                    )
+                }
             }
         }
     }
@@ -135,6 +237,7 @@ private struct TemplateRow: View {
     let isPicker: Bool
     var onSelect: (() -> Void)?
     var onExport: () -> Void
+    var onEdit: (() -> Void)?
     var onDelete: (() -> Void)?
     @Environment(\.civitTheme) private var theme
 
@@ -143,14 +246,19 @@ private struct TemplateRow: View {
             VStack(alignment: .leading, spacing: Spacing.xs) {
                 Text(template.name)
                     .font(.civitBodyMedium)
-                Text("\(typeLabel(template.type))\(template.isBuiltIn ? " · Built-in" : "")")
-                    .font(.civitBodySmall)
-                    .foregroundColor(.civitOnSurfaceVariant)
-                if !template.variables.isEmpty {
-                    Text("Variables: \(template.variables.map { $0.name }.joined(separator: ", "))")
+                if !template.description_.isEmpty {
+                    Text(template.description_)
                         .font(.civitBodySmall)
                         .foregroundColor(.civitOnSurfaceVariant)
                         .lineLimit(2)
+                }
+                Text(templateMetaText(template))
+                    .font(.civitBodySmall)
+                    .foregroundColor(.civitOnSurfaceVariant)
+                if !template.variables.isEmpty {
+                    Text("\(template.variables.count) parameters")
+                        .font(.civitBodySmall)
+                        .foregroundColor(.civitOnSurfaceVariant)
                 }
             }
             Spacer()
@@ -162,7 +270,13 @@ private struct TemplateRow: View {
                 .buttonStyle(.plain)
             } else {
                 Menu {
+                    if let select = onSelect {
+                        Button("Use Template", action: select)
+                    }
                     Button("Export JSON", action: onExport)
+                    if let edit = onEdit {
+                        Button("Edit", action: edit)
+                    }
                     if let del = onDelete {
                         Button("Delete", role: .destructive, action: del)
                     }
@@ -174,7 +288,17 @@ private struct TemplateRow: View {
             }
         }
         .contentShape(Rectangle())
-        .onTapGesture { if isPicker { onSelect?() } }
+        .onTapGesture {
+            if isPicker { onSelect?() } else { onSelect?() }
+        }
+    }
+
+    private func templateMetaText(_ template: WorkflowTemplate) -> String {
+        var parts = [typeLabel(template.type)]
+        if template.isBuiltIn { parts.append("Built-in") }
+        parts.append(categoryLabel(template.category))
+        if template.version > 1 { parts.append("v\(template.version)") }
+        return parts.joined(separator: " \u{2022} ")
     }
 }
 
@@ -184,7 +308,19 @@ private func typeLabel(_ type: WorkflowTemplateType) -> String {
     case .img2Img: return "img2img"
     case .inpainting: return "Inpainting"
     case .upscale: return "Upscale"
+    case .lora: return "LoRA"
     default: return type.name
+    }
+}
+
+private func categoryLabel(_ category: WorkflowTemplateCategory) -> String {
+    switch category {
+    case .general: return "General"
+    case .anime: return "Anime"
+    case .photorealistic: return "Photo"
+    case .artistic: return "Artistic"
+    case .utility: return "Utility"
+    default: return category.name
     }
 }
 

--- a/iosApp/iosApp/Features/ComfyUI/WorkflowTemplateViewModel.swift
+++ b/iosApp/iosApp/Features/ComfyUI/WorkflowTemplateViewModel.swift
@@ -4,10 +4,20 @@ import Shared
 @MainActor
 class WorkflowTemplateViewModel: ObservableObject {
     @Published var templates: [WorkflowTemplate] = []
+    @Published var filteredTemplates: [WorkflowTemplate] = []
     @Published var isLoading = true
     @Published var error: String?
     @Published var exportedJson: String?
     @Published var importError: String?
+    @Published var searchQuery = "" {
+        didSet { applyFilters() }
+    }
+    @Published var selectedCategory: WorkflowTemplateCategory? {
+        didSet { applyFilters() }
+    }
+    @Published var selectedType: WorkflowTemplateType? {
+        didSet { applyFilters() }
+    }
 
     private let getTemplates = KoinHelper.shared.getGetWorkflowTemplatesUseCase()
     private let saveTemplate = KoinHelper.shared.getSaveWorkflowTemplateUseCase()
@@ -32,11 +42,23 @@ class WorkflowTemplateViewModel: ObservableObject {
                     guard !Task.isCancelled else { return }
                     templates = list as? [WorkflowTemplate] ?? []
                     isLoading = false
+                    applyFilters()
                 }
             } catch {
                 isLoading = false
                 self.error = error.localizedDescription
             }
+        }
+    }
+
+    private func applyFilters() {
+        filteredTemplates = templates.filter { template in
+            let matchesSearch = searchQuery.isEmpty
+                || template.name.localizedCaseInsensitiveContains(searchQuery)
+                || template.description_.localizedCaseInsensitiveContains(searchQuery)
+            let matchesCategory = selectedCategory == nil || template.category == selectedCategory
+            let matchesType = selectedType == nil || template.type == selectedType
+            return matchesSearch && matchesCategory && matchesType
         }
     }
 
@@ -89,62 +111,144 @@ class WorkflowTemplateViewModel: ObservableObject {
 
     // MARK: - Factory helpers
 
-    static func emptyTemplate(type: WorkflowTemplateType = WorkflowTemplateType.txt2Img) -> WorkflowTemplate {
+    static func emptyTemplate(
+        type: WorkflowTemplateType = WorkflowTemplateType.txt2Img
+    ) -> WorkflowTemplate {
         WorkflowTemplate(
             id: 0,
             name: "",
+            description: "",
             type: type,
+            category: .general,
             variables: defaultVariables(for: type),
             isBuiltIn: false,
+            version: 1,
+            author: "",
             createdAt: 0
         )
     }
 
+    // swiftlint:disable function_body_length
     static func defaultVariables(for type: WorkflowTemplateType) -> [TemplateVariable] {
         switch type {
         case .txt2Img:
-            return [
-                TemplateVariable(name: "positive_prompt", type: .text, defaultValue: "", options: [], required: true),
-                TemplateVariable(name: "negative_prompt", type: .text, defaultValue: "", options: [], required: false),
-                TemplateVariable(name: "checkpoint", type: .text, defaultValue: "", options: [], required: true),
-                TemplateVariable(name: "steps", type: .number, defaultValue: "20", options: [], required: false),
-                TemplateVariable(name: "cfg", type: .number, defaultValue: "7.0", options: [], required: false),
-                TemplateVariable(name: "width", type: .number, defaultValue: "512", options: [], required: false),
-                TemplateVariable(name: "height", type: .number, defaultValue: "512", options: [], required: false),
-            ]
+            return txt2imgVariables()
         case .img2Img:
-            return [
-                TemplateVariable(name: "positive_prompt", type: .text, defaultValue: "", options: [], required: true),
-                TemplateVariable(name: "negative_prompt", type: .text, defaultValue: "", options: [], required: false),
-                TemplateVariable(name: "checkpoint", type: .text, defaultValue: "", options: [], required: true),
-                TemplateVariable(name: "steps", type: .number, defaultValue: "20", options: [], required: false),
-                TemplateVariable(name: "cfg", type: .number, defaultValue: "7.0", options: [], required: false),
-                TemplateVariable(name: "width", type: .number, defaultValue: "512", options: [], required: false),
-                TemplateVariable(name: "height", type: .number, defaultValue: "512", options: [], required: false),
-                TemplateVariable(
-                    name: "denoise_strength", type: .number, defaultValue: "0.75", options: [], required: false
-                ),
-            ]
+            return txt2imgVariables() + [denoiseVariable()]
         case .inpainting:
             return [
-                TemplateVariable(name: "positive_prompt", type: .text, defaultValue: "", options: [], required: true),
-                TemplateVariable(name: "negative_prompt", type: .text, defaultValue: "", options: [], required: false),
-                TemplateVariable(name: "checkpoint", type: .text, defaultValue: "", options: [], required: true),
-                TemplateVariable(name: "steps", type: .number, defaultValue: "20", options: [], required: false),
-                TemplateVariable(name: "cfg", type: .number, defaultValue: "7.0", options: [], required: false),
-                TemplateVariable(
-                    name: "denoise_strength", type: .number, defaultValue: "1.0", options: [], required: false
-                ),
+                promptVariable(), negativePromptVariable(), checkpointVariable(),
+                stepsVariable(), cfgVariable(), denoiseVariable(default: "1.0"),
             ]
         case .upscale:
             return [
-                TemplateVariable(name: "input_image", type: .text, defaultValue: "", options: [], required: true),
                 TemplateVariable(
-                    name: "upscale_factor", type: .number, defaultValue: "2", options: [], required: false
+                    name: "input_image", label: "Input Image", description: "",
+                    type: .text, defaultValue: "", min: nil, max: nil, step: nil,
+                    options: [], required: true
                 ),
+                TemplateVariable(
+                    name: "upscale_factor", label: "Upscale Factor", description: "",
+                    type: .slider, defaultValue: "2",
+                    min: 1.0, max: 4.0, step: 0.5,
+                    options: [], required: false
+                ),
+            ]
+        case .lora:
+            return [
+                promptVariable(), negativePromptVariable(), checkpointVariable(),
+                TemplateVariable(
+                    name: "lora_name", label: "LoRA Model", description: "",
+                    type: .text, defaultValue: "", min: nil, max: nil, step: nil,
+                    options: [], required: true
+                ),
+                TemplateVariable(
+                    name: "lora_strength", label: "LoRA Strength", description: "",
+                    type: .slider, defaultValue: "0.8",
+                    min: 0.0, max: 2.0, step: 0.05,
+                    options: [], required: false
+                ),
+                stepsVariable(), cfgVariable(), widthVariable(), heightVariable(),
             ]
         default:
             return []
         }
+    }
+    // swiftlint:enable function_body_length
+
+    // MARK: - Variable builders
+
+    private static func promptVariable() -> TemplateVariable {
+        TemplateVariable(
+            name: "positive_prompt", label: "Prompt", description: "",
+            type: .text, defaultValue: "", min: nil, max: nil, step: nil,
+            options: [], required: true
+        )
+    }
+
+    private static func negativePromptVariable() -> TemplateVariable {
+        TemplateVariable(
+            name: "negative_prompt", label: "Negative Prompt", description: "",
+            type: .text, defaultValue: "", min: nil, max: nil, step: nil,
+            options: [], required: false
+        )
+    }
+
+    private static func checkpointVariable() -> TemplateVariable {
+        TemplateVariable(
+            name: "checkpoint", label: "Checkpoint", description: "",
+            type: .text, defaultValue: "", min: nil, max: nil, step: nil,
+            options: [], required: true
+        )
+    }
+
+    private static func stepsVariable() -> TemplateVariable {
+        TemplateVariable(
+            name: "steps", label: "Steps", description: "",
+            type: .slider, defaultValue: "20",
+            min: 1.0, max: 150.0, step: 1.0,
+            options: [], required: false
+        )
+    }
+
+    private static func cfgVariable() -> TemplateVariable {
+        TemplateVariable(
+            name: "cfg", label: "CFG Scale", description: "",
+            type: .slider, defaultValue: "7.0",
+            min: 1.0, max: 30.0, step: 0.5,
+            options: [], required: false
+        )
+    }
+
+    private static func widthVariable() -> TemplateVariable {
+        TemplateVariable(
+            name: "width", label: "Width", description: "",
+            type: .select, defaultValue: "512", min: nil, max: nil, step: nil,
+            options: ["256", "384", "512", "640", "768", "832", "896", "1024", "1280"],
+            required: false
+        )
+    }
+
+    private static func heightVariable() -> TemplateVariable {
+        TemplateVariable(
+            name: "height", label: "Height", description: "",
+            type: .select, defaultValue: "512", min: nil, max: nil, step: nil,
+            options: ["256", "384", "512", "640", "768", "832", "896", "1024", "1280"],
+            required: false
+        )
+    }
+
+    private static func denoiseVariable(default value: String = "0.75") -> TemplateVariable {
+        TemplateVariable(
+            name: "denoise_strength", label: "Denoise Strength", description: "",
+            type: .slider, defaultValue: value,
+            min: 0.0, max: 1.0, step: 0.05,
+            options: [], required: false
+        )
+    }
+
+    private static func txt2imgVariables() -> [TemplateVariable] {
+        [promptVariable(), negativePromptVariable(), checkpointVariable(),
+         stepsVariable(), cfgVariable(), widthVariable(), heightVariable()]
     }
 }

--- a/iosApp/iosApp/SharedTypeAliases.swift
+++ b/iosApp/iosApp/SharedTypeAliases.swift
@@ -295,6 +295,7 @@ typealias ComfyUIGeneratedImage = Core_domainComfyUIGeneratedImage
 typealias ComfyUIGenerationMeta = Core_domainComfyUIGenerationMeta
 typealias WorkflowTemplate = Core_domainWorkflowTemplate
 typealias WorkflowTemplateType = Core_domainWorkflowTemplateType
+typealias WorkflowTemplateCategory = Core_domainWorkflowTemplateCategory
 typealias TemplateVariable = Core_domainTemplateVariable
 typealias TemplateVariableType = Core_domainTemplateVariableType
 typealias GetWorkflowTemplatesUseCase = Feature_comfyuiGetWorkflowTemplatesUseCase

--- a/shared/src/commonMain/kotlin/com/riox432/civitdeck/data/backup/BackupDto.kt
+++ b/shared/src/commonMain/kotlin/com/riox432/civitdeck/data/backup/BackupDto.kt
@@ -84,6 +84,7 @@ data class SavedPromptDto(
     val autoSaved: Boolean = false,
     val templateVariables: String? = null,
     val templateType: String? = null,
+    val templateMetadata: String? = null,
 )
 
 @Serializable

--- a/shared/src/commonMain/kotlin/com/riox432/civitdeck/data/backup/BackupRepositoryImpl.kt
+++ b/shared/src/commonMain/kotlin/com/riox432/civitdeck/data/backup/BackupRepositoryImpl.kt
@@ -318,7 +318,7 @@ private fun PersonalTagEntity.toDto() = PersonalTagDto(modelId, tag, addedAt)
 private fun SavedPromptEntity.toDto() = SavedPromptDto(
     prompt, negativePrompt, sampler, steps, cfgScale, seed,
     modelName, size, sourceImageUrl, savedAt, isTemplate,
-    templateName, autoSaved, templateVariables, templateType,
+    templateName, autoSaved, templateVariables, templateType, templateMetadata,
 )
 
 private fun UserPreferencesEntity.toDto() = UserPreferencesDto(
@@ -398,6 +398,7 @@ private fun SavedPromptDto.toEntity() = SavedPromptEntity(
     size = size, sourceImageUrl = sourceImageUrl, savedAt = savedAt,
     isTemplate = isTemplate, templateName = templateName, autoSaved = autoSaved,
     templateVariables = templateVariables, templateType = templateType,
+    templateMetadata = templateMetadata,
 )
 
 private fun UserPreferencesDto.toEntity() = UserPreferencesEntity(


### PR DESCRIPTION
## Description

Add a curated workflow template library with parameter sliders/dropdowns for common generation tasks, replacing the need for a mobile node editor.

**Key changes:**
- Enhanced domain model: `WorkflowTemplate` now has description, category, version, author fields; `TemplateVariable` gains label, description, min/max/step for sliders; new `SLIDER` variable type and `LORA` template type; `WorkflowTemplateCategory` enum (General, Anime, Photo, Artistic, Utility)
- 5 curated built-in templates (txt2img, img2img, inpainting, upscale, LoRA) with slider controls for steps/CFG/denoise and dropdown selects for dimensions
- Template browser with search bar, category filter chips, and type filter chips (Android + iOS)
- Parameter editor screen with sliders, dropdowns, and multi-line text inputs for prompt fields (Android `TemplateParameterScreen` + iOS `TemplateParameterView`)
- Template editor updated with description, category selector, slider range config (min/max/step)
- DB migration v41 for `templateMetadata` column; seed data uses `INSERT OR REPLACE` to upgrade existing built-in templates to new format
- Export/Import JSON updated to include all new fields (description, category, version, author, slider ranges)

## Related Issues

Closes #603

## Screenshots / Video

<!-- Template browser with search and filters, parameter screen with sliders -->

## Test Plan

- [x] `./gradlew :androidApp:detekt` passes
- [x] `./gradlew :androidApp:assembleDebug` passes
- [x] iOS Simulator build passes
- [x] iOS Device build passes
- [ ] Verify built-in templates appear on fresh install
- [ ] Verify slider controls work for steps, CFG, denoise strength
- [ ] Verify category/type filter chips filter templates correctly
- [ ] Verify search filters templates by name and description
- [ ] Verify export/import preserves all new fields
- [ ] Verify user-created templates with slider variables save correctly

## Review Checklist

- [x] Code follows project architecture (Clean Architecture + MVVM)
- [x] Shared logic is in `commonMain`, platform-specific code only when necessary
- [x] No unnecessary dependencies added
- [ ] Tests added/updated as needed

## Breaking Changes

None