### PR TITLE
#605 Add image quality auto-curation filter

### DIFF
--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/search/FilterChipComponents.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/search/FilterChipComponents.kt
@@ -80,6 +80,7 @@ internal fun ModelType.displayLabel(): String = when (this) {
 internal fun SortOrder.displayLabel(): String = when (this) {
     SortOrder.HighestRated -> "Highest Rated"
     SortOrder.MostDownloaded -> "Most Downloaded"
+    SortOrder.Quality -> "Quality Score"
     else -> name
 }
 

--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/search/ModelPagingSource.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/search/ModelPagingSource.kt
@@ -170,6 +170,7 @@ internal class ModelPagingSource(
         SortOrder.MostDownloaded -> model.stats.downloadCount.toDouble()
         SortOrder.HighestRated -> model.stats.rating
         SortOrder.Newest -> model.id.toDouble()
+        SortOrder.Quality -> QualityScoreCalculator.calculate(model.stats).toDouble()
     }
 
     companion object {

--- a/core/core-database/schemas/com.riox432.civitdeck.data.local.CivitDeckDatabase/42.json
+++ b/core/core-database/schemas/com.riox432.civitdeck.data.local.CivitDeckDatabase/42.json
@@ -1,0 +1,1964 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 42,
+    "identityHash": "15ba40f06920e6555f073ccda0b0cca1",
+    "entities": [
+      {
+        "tableName": "collections",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL, `isDefault` INTEGER NOT NULL, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isDefault",
+            "columnName": "isDefault",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "collection_model_entries",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`collectionId` INTEGER NOT NULL, `modelId` INTEGER NOT NULL, `name` TEXT NOT NULL, `type` TEXT NOT NULL, `nsfw` INTEGER NOT NULL, `thumbnailUrl` TEXT, `creatorName` TEXT, `downloadCount` INTEGER NOT NULL, `favoriteCount` INTEGER NOT NULL, `rating` REAL NOT NULL, `addedAt` INTEGER NOT NULL, PRIMARY KEY(`collectionId`, `modelId`), FOREIGN KEY(`collectionId`) REFERENCES `collections`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "collectionId",
+            "columnName": "collectionId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "modelId",
+            "columnName": "modelId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "nsfw",
+            "columnName": "nsfw",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "thumbnailUrl",
+            "columnName": "thumbnailUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "creatorName",
+            "columnName": "creatorName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "downloadCount",
+            "columnName": "downloadCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "favoriteCount",
+            "columnName": "favoriteCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "rating",
+            "columnName": "rating",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "addedAt",
+            "columnName": "addedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "collectionId",
+            "modelId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_collection_model_entries_modelId",
+            "unique": false,
+            "columnNames": [
+              "modelId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_collection_model_entries_modelId` ON `${TABLE_NAME}` (`modelId`)"
+          },
+          {
+            "name": "index_collection_model_entries_collectionId",
+            "unique": false,
+            "columnNames": [
+              "collectionId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_collection_model_entries_collectionId` ON `${TABLE_NAME}` (`collectionId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "collections",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "collectionId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "cached_api_responses",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`cacheKey` TEXT NOT NULL, `responseJson` TEXT NOT NULL, `cachedAt` INTEGER NOT NULL, `isOfflinePinned` INTEGER NOT NULL, PRIMARY KEY(`cacheKey`))",
+        "fields": [
+          {
+            "fieldPath": "cacheKey",
+            "columnName": "cacheKey",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "responseJson",
+            "columnName": "responseJson",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cachedAt",
+            "columnName": "cachedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isOfflinePinned",
+            "columnName": "isOfflinePinned",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "cacheKey"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_cached_api_responses_cachedAt",
+            "unique": false,
+            "columnNames": [
+              "cachedAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_cached_api_responses_cachedAt` ON `${TABLE_NAME}` (`cachedAt`)"
+          }
+        ]
+      },
+      {
+        "tableName": "user_preferences",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `nsfwFilterLevel` TEXT NOT NULL, `defaultSortOrder` TEXT NOT NULL, `defaultTimePeriod` TEXT NOT NULL, `gridColumns` INTEGER NOT NULL, `apiKey` TEXT, `powerUserMode` INTEGER NOT NULL, `notificationsEnabled` INTEGER NOT NULL, `pollingIntervalMinutes` INTEGER NOT NULL, `nsfwBlurSoft` INTEGER NOT NULL, `nsfwBlurMature` INTEGER NOT NULL, `nsfwBlurExplicit` INTEGER NOT NULL, `offlineCacheEnabled` INTEGER NOT NULL, `cacheSizeLimitMb` INTEGER NOT NULL, `accentColor` TEXT NOT NULL, `amoledDarkMode` INTEGER NOT NULL, `seenTutorialVersion` INTEGER NOT NULL, `civitaiLinkKey` TEXT, `themeMode` TEXT NOT NULL, `customNavShortcuts` TEXT NOT NULL, `feedQualityThreshold` INTEGER NOT NULL, `autoUpdateCheckEnabled` INTEGER NOT NULL, `lastUpdateCheckTimestamp` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "nsfwFilterLevel",
+            "columnName": "nsfwFilterLevel",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "defaultSortOrder",
+            "columnName": "defaultSortOrder",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "defaultTimePeriod",
+            "columnName": "defaultTimePeriod",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "gridColumns",
+            "columnName": "gridColumns",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "apiKey",
+            "columnName": "apiKey",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "powerUserMode",
+            "columnName": "powerUserMode",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "notificationsEnabled",
+            "columnName": "notificationsEnabled",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "pollingIntervalMinutes",
+            "columnName": "pollingIntervalMinutes",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "nsfwBlurSoft",
+            "columnName": "nsfwBlurSoft",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "nsfwBlurMature",
+            "columnName": "nsfwBlurMature",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "nsfwBlurExplicit",
+            "columnName": "nsfwBlurExplicit",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "offlineCacheEnabled",
+            "columnName": "offlineCacheEnabled",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cacheSizeLimitMb",
+            "columnName": "cacheSizeLimitMb",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "accentColor",
+            "columnName": "accentColor",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "amoledDarkMode",
+            "columnName": "amoledDarkMode",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "seenTutorialVersion",
+            "columnName": "seenTutorialVersion",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "civitaiLinkKey",
+            "columnName": "civitaiLinkKey",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "themeMode",
+            "columnName": "themeMode",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "customNavShortcuts",
+            "columnName": "customNavShortcuts",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "feedQualityThreshold",
+            "columnName": "feedQualityThreshold",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "autoUpdateCheckEnabled",
+            "columnName": "autoUpdateCheckEnabled",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastUpdateCheckTimestamp",
+            "columnName": "lastUpdateCheckTimestamp",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "saved_prompts",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `prompt` TEXT NOT NULL, `negativePrompt` TEXT, `sampler` TEXT, `steps` INTEGER, `cfgScale` REAL, `seed` INTEGER, `modelName` TEXT, `size` TEXT, `sourceImageUrl` TEXT, `savedAt` INTEGER NOT NULL, `isTemplate` INTEGER NOT NULL DEFAULT 0, `templateName` TEXT, `autoSaved` INTEGER NOT NULL DEFAULT 0, `templateVariables` TEXT, `templateType` TEXT, `templateMetadata` TEXT)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "prompt",
+            "columnName": "prompt",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "negativePrompt",
+            "columnName": "negativePrompt",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "sampler",
+            "columnName": "sampler",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "steps",
+            "columnName": "steps",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "cfgScale",
+            "columnName": "cfgScale",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "seed",
+            "columnName": "seed",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "modelName",
+            "columnName": "modelName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "size",
+            "columnName": "size",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "sourceImageUrl",
+            "columnName": "sourceImageUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "savedAt",
+            "columnName": "savedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isTemplate",
+            "columnName": "isTemplate",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "templateName",
+            "columnName": "templateName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "autoSaved",
+            "columnName": "autoSaved",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "templateVariables",
+            "columnName": "templateVariables",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "templateType",
+            "columnName": "templateType",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "templateMetadata",
+            "columnName": "templateMetadata",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "search_history",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `query` TEXT NOT NULL, `searchedAt` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "query",
+            "columnName": "query",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "searchedAt",
+            "columnName": "searchedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "browsing_history",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `modelId` INTEGER NOT NULL, `modelName` TEXT NOT NULL, `modelType` TEXT NOT NULL, `creatorName` TEXT, `thumbnailUrl` TEXT, `tags` TEXT NOT NULL, `viewedAt` INTEGER NOT NULL, `durationMs` INTEGER, `interactionType` TEXT)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "modelId",
+            "columnName": "modelId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "modelName",
+            "columnName": "modelName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "modelType",
+            "columnName": "modelType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "creatorName",
+            "columnName": "creatorName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "thumbnailUrl",
+            "columnName": "thumbnailUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "tags",
+            "columnName": "tags",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "viewedAt",
+            "columnName": "viewedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "durationMs",
+            "columnName": "durationMs",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "interactionType",
+            "columnName": "interactionType",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_browsing_history_modelId",
+            "unique": false,
+            "columnNames": [
+              "modelId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_browsing_history_modelId` ON `${TABLE_NAME}` (`modelId`)"
+          },
+          {
+            "name": "index_browsing_history_viewedAt",
+            "unique": false,
+            "columnNames": [
+              "viewedAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_browsing_history_viewedAt` ON `${TABLE_NAME}` (`viewedAt`)"
+          }
+        ]
+      },
+      {
+        "tableName": "excluded_tags",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`tag` TEXT NOT NULL, `addedAt` INTEGER NOT NULL, PRIMARY KEY(`tag`))",
+        "fields": [
+          {
+            "fieldPath": "tag",
+            "columnName": "tag",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "addedAt",
+            "columnName": "addedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "tag"
+          ]
+        }
+      },
+      {
+        "tableName": "hidden_models",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`modelId` INTEGER NOT NULL, `modelName` TEXT NOT NULL, `hiddenAt` INTEGER NOT NULL, PRIMARY KEY(`modelId`))",
+        "fields": [
+          {
+            "fieldPath": "modelId",
+            "columnName": "modelId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "modelName",
+            "columnName": "modelName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "hiddenAt",
+            "columnName": "hiddenAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "modelId"
+          ]
+        }
+      },
+      {
+        "tableName": "model_directories",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `path` TEXT NOT NULL, `label` TEXT, `lastScannedAt` INTEGER, `isEnabled` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "path",
+            "columnName": "path",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "label",
+            "columnName": "label",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "lastScannedAt",
+            "columnName": "lastScannedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "isEnabled",
+            "columnName": "isEnabled",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "local_model_files",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `directoryId` INTEGER NOT NULL, `filePath` TEXT NOT NULL, `fileName` TEXT NOT NULL, `sha256Hash` TEXT NOT NULL, `sizeBytes` INTEGER NOT NULL, `scannedAt` INTEGER NOT NULL, `matchedModelId` INTEGER, `matchedModelName` TEXT, `matchedVersionId` INTEGER, `matchedVersionName` TEXT, `latestVersionId` INTEGER, `hasUpdate` INTEGER NOT NULL, FOREIGN KEY(`directoryId`) REFERENCES `model_directories`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "directoryId",
+            "columnName": "directoryId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "filePath",
+            "columnName": "filePath",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fileName",
+            "columnName": "fileName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sha256Hash",
+            "columnName": "sha256Hash",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sizeBytes",
+            "columnName": "sizeBytes",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "scannedAt",
+            "columnName": "scannedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "matchedModelId",
+            "columnName": "matchedModelId",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "matchedModelName",
+            "columnName": "matchedModelName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "matchedVersionId",
+            "columnName": "matchedVersionId",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "matchedVersionName",
+            "columnName": "matchedVersionName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "latestVersionId",
+            "columnName": "latestVersionId",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "hasUpdate",
+            "columnName": "hasUpdate",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_local_model_files_directoryId",
+            "unique": false,
+            "columnNames": [
+              "directoryId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_local_model_files_directoryId` ON `${TABLE_NAME}` (`directoryId`)"
+          },
+          {
+            "name": "index_local_model_files_sha256Hash",
+            "unique": false,
+            "columnNames": [
+              "sha256Hash"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_local_model_files_sha256Hash` ON `${TABLE_NAME}` (`sha256Hash`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "model_directories",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "directoryId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "model_version_checkpoints",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`modelId` INTEGER NOT NULL, `lastKnownVersionId` INTEGER NOT NULL, `lastCheckedAt` INTEGER NOT NULL, PRIMARY KEY(`modelId`))",
+        "fields": [
+          {
+            "fieldPath": "modelId",
+            "columnName": "modelId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastKnownVersionId",
+            "columnName": "lastKnownVersionId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastCheckedAt",
+            "columnName": "lastCheckedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "modelId"
+          ]
+        }
+      },
+      {
+        "tableName": "comfyui_connections",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL, `hostname` TEXT NOT NULL, `port` INTEGER NOT NULL, `isActive` INTEGER NOT NULL, `lastTestedAt` INTEGER, `lastTestSuccess` INTEGER, `createdAt` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "hostname",
+            "columnName": "hostname",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "port",
+            "columnName": "port",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isActive",
+            "columnName": "isActive",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastTestedAt",
+            "columnName": "lastTestedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "lastTestSuccess",
+            "columnName": "lastTestSuccess",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "sdwebui_connections",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL, `hostname` TEXT NOT NULL, `port` INTEGER NOT NULL, `isActive` INTEGER NOT NULL, `lastTestedAt` INTEGER, `lastTestSuccess` INTEGER, `createdAt` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "hostname",
+            "columnName": "hostname",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "port",
+            "columnName": "port",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isActive",
+            "columnName": "isActive",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastTestedAt",
+            "columnName": "lastTestedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "lastTestSuccess",
+            "columnName": "lastTestSuccess",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "dataset_collections",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL, `description` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "dataset_images",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `datasetId` INTEGER NOT NULL, `imageUrl` TEXT NOT NULL, `sourceType` TEXT NOT NULL, `trainable` INTEGER NOT NULL, `addedAt` INTEGER NOT NULL, `licenseNote` TEXT, `pHash` TEXT, `excluded` INTEGER NOT NULL, `width` INTEGER, `height` INTEGER, FOREIGN KEY(`datasetId`) REFERENCES `dataset_collections`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "datasetId",
+            "columnName": "datasetId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "imageUrl",
+            "columnName": "imageUrl",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceType",
+            "columnName": "sourceType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "trainable",
+            "columnName": "trainable",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "addedAt",
+            "columnName": "addedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "licenseNote",
+            "columnName": "licenseNote",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "pHash",
+            "columnName": "pHash",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "excluded",
+            "columnName": "excluded",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "width",
+            "columnName": "width",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "height",
+            "columnName": "height",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_dataset_images_datasetId",
+            "unique": false,
+            "columnNames": [
+              "datasetId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_dataset_images_datasetId` ON `${TABLE_NAME}` (`datasetId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "dataset_collections",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "datasetId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "image_tags",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `datasetImageId` INTEGER NOT NULL, `tag` TEXT NOT NULL, FOREIGN KEY(`datasetImageId`) REFERENCES `dataset_images`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "datasetImageId",
+            "columnName": "datasetImageId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "tag",
+            "columnName": "tag",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_image_tags_datasetImageId",
+            "unique": false,
+            "columnNames": [
+              "datasetImageId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_image_tags_datasetImageId` ON `${TABLE_NAME}` (`datasetImageId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "dataset_images",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "datasetImageId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "captions",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`datasetImageId` INTEGER NOT NULL, `text` TEXT NOT NULL, PRIMARY KEY(`datasetImageId`), FOREIGN KEY(`datasetImageId`) REFERENCES `dataset_images`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "datasetImageId",
+            "columnName": "datasetImageId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "text",
+            "columnName": "text",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "datasetImageId"
+          ]
+        },
+        "foreignKeys": [
+          {
+            "table": "dataset_images",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "datasetImageId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "saved_search_filters",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL, `query` TEXT NOT NULL, `selectedType` TEXT, `selectedSort` TEXT NOT NULL, `selectedPeriod` TEXT NOT NULL, `selectedBaseModels` TEXT NOT NULL, `nsfwFilterLevel` TEXT NOT NULL, `isFreshFindEnabled` INTEGER NOT NULL, `excludedTags` TEXT NOT NULL, `includedTags` TEXT NOT NULL, `selectedSources` TEXT NOT NULL, `savedAt` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "query",
+            "columnName": "query",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "selectedType",
+            "columnName": "selectedType",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "selectedSort",
+            "columnName": "selectedSort",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "selectedPeriod",
+            "columnName": "selectedPeriod",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "selectedBaseModels",
+            "columnName": "selectedBaseModels",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "nsfwFilterLevel",
+            "columnName": "nsfwFilterLevel",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isFreshFindEnabled",
+            "columnName": "isFreshFindEnabled",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "excludedTags",
+            "columnName": "excludedTags",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "includedTags",
+            "columnName": "includedTags",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "selectedSources",
+            "columnName": "selectedSources",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "savedAt",
+            "columnName": "savedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "external_server_configs",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL, `baseUrl` TEXT NOT NULL, `apiKey` TEXT NOT NULL, `isActive` INTEGER NOT NULL, `lastTestedAt` INTEGER, `lastTestSuccess` INTEGER, `createdAt` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "baseUrl",
+            "columnName": "baseUrl",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "apiKey",
+            "columnName": "apiKey",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isActive",
+            "columnName": "isActive",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastTestedAt",
+            "columnName": "lastTestedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "lastTestSuccess",
+            "columnName": "lastTestSuccess",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "model_notes",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `modelId` INTEGER NOT NULL, `noteText` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "modelId",
+            "columnName": "modelId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "noteText",
+            "columnName": "noteText",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_model_notes_modelId",
+            "unique": false,
+            "columnNames": [
+              "modelId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_model_notes_modelId` ON `${TABLE_NAME}` (`modelId`)"
+          }
+        ]
+      },
+      {
+        "tableName": "personal_tags",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `modelId` INTEGER NOT NULL, `tag` TEXT NOT NULL, `addedAt` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "modelId",
+            "columnName": "modelId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "tag",
+            "columnName": "tag",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "addedAt",
+            "columnName": "addedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_personal_tags_modelId",
+            "unique": false,
+            "columnNames": [
+              "modelId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_personal_tags_modelId` ON `${TABLE_NAME}` (`modelId`)"
+          },
+          {
+            "name": "index_personal_tags_tag",
+            "unique": false,
+            "columnNames": [
+              "tag"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_personal_tags_tag` ON `${TABLE_NAME}` (`tag`)"
+          }
+        ]
+      },
+      {
+        "tableName": "followed_creators",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`username` TEXT NOT NULL, `displayName` TEXT NOT NULL, `avatarUrl` TEXT, `followedAt` INTEGER NOT NULL, `lastCheckedAt` INTEGER NOT NULL, PRIMARY KEY(`username`))",
+        "fields": [
+          {
+            "fieldPath": "username",
+            "columnName": "username",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayName",
+            "columnName": "displayName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "avatarUrl",
+            "columnName": "avatarUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "followedAt",
+            "columnName": "followedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastCheckedAt",
+            "columnName": "lastCheckedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "username"
+          ]
+        }
+      },
+      {
+        "tableName": "feed_cache",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`modelId` INTEGER NOT NULL, `creatorUsername` TEXT NOT NULL, `title` TEXT NOT NULL, `thumbnailUrl` TEXT, `type` TEXT NOT NULL, `publishedAt` TEXT NOT NULL, `cachedAt` INTEGER NOT NULL, `downloadCount` INTEGER NOT NULL, `favoriteCount` INTEGER NOT NULL, `commentCount` INTEGER NOT NULL, `ratingCount` INTEGER NOT NULL, `rating` REAL NOT NULL, PRIMARY KEY(`modelId`))",
+        "fields": [
+          {
+            "fieldPath": "modelId",
+            "columnName": "modelId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "creatorUsername",
+            "columnName": "creatorUsername",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "thumbnailUrl",
+            "columnName": "thumbnailUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "publishedAt",
+            "columnName": "publishedAt",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cachedAt",
+            "columnName": "cachedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "downloadCount",
+            "columnName": "downloadCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "favoriteCount",
+            "columnName": "favoriteCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "commentCount",
+            "columnName": "commentCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ratingCount",
+            "columnName": "ratingCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "rating",
+            "columnName": "rating",
+            "affinity": "REAL",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "modelId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_feed_cache_creatorUsername",
+            "unique": false,
+            "columnNames": [
+              "creatorUsername"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_feed_cache_creatorUsername` ON `${TABLE_NAME}` (`creatorUsername`)"
+          },
+          {
+            "name": "index_feed_cache_publishedAt",
+            "unique": false,
+            "columnNames": [
+              "publishedAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_feed_cache_publishedAt` ON `${TABLE_NAME}` (`publishedAt`)"
+          }
+        ]
+      },
+      {
+        "tableName": "model_downloads",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `modelId` INTEGER NOT NULL, `modelName` TEXT NOT NULL, `versionId` INTEGER NOT NULL, `versionName` TEXT NOT NULL, `fileId` INTEGER NOT NULL, `fileName` TEXT NOT NULL, `fileUrl` TEXT NOT NULL, `fileSizeBytes` INTEGER NOT NULL, `downloadedBytes` INTEGER NOT NULL, `status` TEXT NOT NULL, `modelType` TEXT NOT NULL, `destinationPath` TEXT, `errorMessage` TEXT, `expectedSha256` TEXT, `hashVerified` INTEGER, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "modelId",
+            "columnName": "modelId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "modelName",
+            "columnName": "modelName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "versionId",
+            "columnName": "versionId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "versionName",
+            "columnName": "versionName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fileId",
+            "columnName": "fileId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fileName",
+            "columnName": "fileName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fileUrl",
+            "columnName": "fileUrl",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fileSizeBytes",
+            "columnName": "fileSizeBytes",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "downloadedBytes",
+            "columnName": "downloadedBytes",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "modelType",
+            "columnName": "modelType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "destinationPath",
+            "columnName": "destinationPath",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "errorMessage",
+            "columnName": "errorMessage",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "expectedSha256",
+            "columnName": "expectedSha256",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "hashVerified",
+            "columnName": "hashVerified",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_model_downloads_modelId",
+            "unique": false,
+            "columnNames": [
+              "modelId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_model_downloads_modelId` ON `${TABLE_NAME}` (`modelId`)"
+          },
+          {
+            "name": "index_model_downloads_status",
+            "unique": false,
+            "columnNames": [
+              "status"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_model_downloads_status` ON `${TABLE_NAME}` (`status`)"
+          },
+          {
+            "name": "index_model_downloads_createdAt",
+            "unique": false,
+            "columnNames": [
+              "createdAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_model_downloads_createdAt` ON `${TABLE_NAME}` (`createdAt`)"
+          }
+        ]
+      },
+      {
+        "tableName": "plugins",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `name` TEXT NOT NULL, `version` TEXT NOT NULL, `author` TEXT NOT NULL, `description` TEXT NOT NULL, `pluginType` TEXT NOT NULL, `capabilities` TEXT NOT NULL, `minAppVersion` TEXT NOT NULL, `state` TEXT NOT NULL, `configJson` TEXT NOT NULL, `installedAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "version",
+            "columnName": "version",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "author",
+            "columnName": "author",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "pluginType",
+            "columnName": "pluginType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "capabilities",
+            "columnName": "capabilities",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "minAppVersion",
+            "columnName": "minAppVersion",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "state",
+            "columnName": "state",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "configJson",
+            "columnName": "configJson",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "installedAt",
+            "columnName": "installedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "share_hashtags",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`tag` TEXT NOT NULL, `isEnabled` INTEGER NOT NULL, `isCustom` INTEGER NOT NULL, `addedAt` INTEGER NOT NULL, PRIMARY KEY(`tag`))",
+        "fields": [
+          {
+            "fieldPath": "tag",
+            "columnName": "tag",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isEnabled",
+            "columnName": "isEnabled",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isCustom",
+            "columnName": "isCustom",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "addedAt",
+            "columnName": "addedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "tag"
+          ]
+        }
+      },
+      {
+        "tableName": "model_update_notifications",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `modelId` INTEGER NOT NULL, `modelName` TEXT NOT NULL, `newVersionName` TEXT NOT NULL, `newVersionId` INTEGER NOT NULL, `source` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, `isRead` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "modelId",
+            "columnName": "modelId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "modelName",
+            "columnName": "modelName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "newVersionName",
+            "columnName": "newVersionName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "newVersionId",
+            "columnName": "newVersionId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "source",
+            "columnName": "source",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isRead",
+            "columnName": "isRead",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_model_update_notifications_createdAt",
+            "unique": false,
+            "columnNames": [
+              "createdAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_model_update_notifications_createdAt` ON `${TABLE_NAME}` (`createdAt`)"
+          },
+          {
+            "name": "index_model_update_notifications_isRead",
+            "unique": false,
+            "columnNames": [
+              "isRead"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_model_update_notifications_isRead` ON `${TABLE_NAME}` (`isRead`)"
+          }
+        ]
+      },
+      {
+        "tableName": "quality_score_cache",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`modelId` INTEGER NOT NULL, `score` INTEGER NOT NULL, `downloadCount` INTEGER NOT NULL, `favoriteCount` INTEGER NOT NULL, `ratingCount` INTEGER NOT NULL, `cachedAt` INTEGER NOT NULL, PRIMARY KEY(`modelId`))",
+        "fields": [
+          {
+            "fieldPath": "modelId",
+            "columnName": "modelId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "score",
+            "columnName": "score",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "downloadCount",
+            "columnName": "downloadCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "favoriteCount",
+            "columnName": "favoriteCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ratingCount",
+            "columnName": "ratingCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cachedAt",
+            "columnName": "cachedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "modelId"
+          ]
+        }
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '15ba40f06920e6555f073ccda0b0cca1')"
+    ]
+  }
+}

--- a/core/core-database/src/commonMain/kotlin/com/riox432/civitdeck/data/local/CivitDeckDatabase.kt
+++ b/core/core-database/src/commonMain/kotlin/com/riox432/civitdeck/data/local/CivitDeckDatabase.kt
@@ -23,6 +23,7 @@ import com.riox432.civitdeck.data.local.dao.ModelUpdateNotificationDao
 import com.riox432.civitdeck.data.local.dao.ModelVersionCheckpointDao
 import com.riox432.civitdeck.data.local.dao.PersonalTagDao
 import com.riox432.civitdeck.data.local.dao.PluginDao
+import com.riox432.civitdeck.data.local.dao.QualityScoreCacheDao
 import com.riox432.civitdeck.data.local.dao.SDWebUIConnectionDao
 import com.riox432.civitdeck.data.local.dao.SavedPromptDao
 import com.riox432.civitdeck.data.local.dao.SavedSearchFilterDao
@@ -51,6 +52,7 @@ import com.riox432.civitdeck.data.local.entity.ModelUpdateNotificationEntity
 import com.riox432.civitdeck.data.local.entity.ModelVersionCheckpointEntity
 import com.riox432.civitdeck.data.local.entity.PersonalTagEntity
 import com.riox432.civitdeck.data.local.entity.PluginEntity
+import com.riox432.civitdeck.data.local.entity.QualityScoreCacheEntity
 import com.riox432.civitdeck.data.local.entity.SDWebUIConnectionEntity
 import com.riox432.civitdeck.data.local.entity.SavedPromptEntity
 import com.riox432.civitdeck.data.local.entity.SavedSearchFilterEntity
@@ -91,6 +93,7 @@ import com.riox432.civitdeck.data.local.migrations.MIGRATION_38_39
 import com.riox432.civitdeck.data.local.migrations.MIGRATION_39_40
 import com.riox432.civitdeck.data.local.migrations.MIGRATION_3_4
 import com.riox432.civitdeck.data.local.migrations.MIGRATION_40_41
+import com.riox432.civitdeck.data.local.migrations.MIGRATION_41_42
 import com.riox432.civitdeck.data.local.migrations.MIGRATION_4_5
 import com.riox432.civitdeck.data.local.migrations.MIGRATION_5_6
 import com.riox432.civitdeck.data.local.migrations.MIGRATION_6_7
@@ -131,8 +134,9 @@ import kotlinx.coroutines.IO
         PluginEntity::class,
         ShareHashtagEntity::class,
         ModelUpdateNotificationEntity::class,
+        QualityScoreCacheEntity::class,
     ],
-    version = 41,
+    version = 42,
 )
 @ConstructedBy(CivitDeckDatabaseConstructor::class)
 abstract class CivitDeckDatabase : RoomDatabase() {
@@ -160,6 +164,7 @@ abstract class CivitDeckDatabase : RoomDatabase() {
     abstract fun pluginDao(): PluginDao
     abstract fun shareHashtagDao(): ShareHashtagDao
     abstract fun modelUpdateNotificationDao(): ModelUpdateNotificationDao
+    abstract fun qualityScoreCacheDao(): QualityScoreCacheDao
 }
 
 @Suppress("NO_ACTUAL_FOR_EXPECT")
@@ -208,6 +213,7 @@ fun getRoomDatabase(builder: RoomDatabase.Builder<CivitDeckDatabase>): CivitDeck
             MIGRATION_38_39,
             MIGRATION_39_40,
             MIGRATION_40_41,
+            MIGRATION_41_42,
         )
         .fallbackToDestructiveMigrationOnDowngrade(dropAllTables = true)
         .addCallback(defaultCollectionCallback)

--- a/core/core-database/src/commonMain/kotlin/com/riox432/civitdeck/data/local/dao/QualityScoreCacheDao.kt
+++ b/core/core-database/src/commonMain/kotlin/com/riox432/civitdeck/data/local/dao/QualityScoreCacheDao.kt
@@ -1,0 +1,27 @@
+package com.riox432.civitdeck.data.local.dao
+
+import androidx.room.Dao
+import androidx.room.Query
+import androidx.room.Upsert
+import com.riox432.civitdeck.data.local.entity.QualityScoreCacheEntity
+
+@Dao
+interface QualityScoreCacheDao {
+    @Query("SELECT * FROM quality_score_cache WHERE modelId = :modelId")
+    suspend fun getByModelId(modelId: Long): QualityScoreCacheEntity?
+
+    @Query("SELECT * FROM quality_score_cache WHERE modelId IN (:modelIds)")
+    suspend fun getByModelIds(modelIds: List<Long>): List<QualityScoreCacheEntity>
+
+    @Upsert
+    suspend fun upsert(entity: QualityScoreCacheEntity)
+
+    @Upsert
+    suspend fun upsertAll(entities: List<QualityScoreCacheEntity>)
+
+    @Query("DELETE FROM quality_score_cache WHERE cachedAt < :before")
+    suspend fun deleteOlderThan(before: Long)
+
+    @Query("DELETE FROM quality_score_cache")
+    suspend fun deleteAll()
+}

--- a/core/core-database/src/commonMain/kotlin/com/riox432/civitdeck/data/local/entity/QualityScoreCacheEntity.kt
+++ b/core/core-database/src/commonMain/kotlin/com/riox432/civitdeck/data/local/entity/QualityScoreCacheEntity.kt
@@ -1,0 +1,18 @@
+package com.riox432.civitdeck.data.local.entity
+
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+
+/**
+ * Caches computed quality scores for models to avoid re-calculation on each render.
+ * Scores are refreshed when model stats change (TTL-based eviction).
+ */
+@Entity(tableName = "quality_score_cache")
+data class QualityScoreCacheEntity(
+    @PrimaryKey val modelId: Long,
+    val score: Int,
+    val downloadCount: Int,
+    val favoriteCount: Int,
+    val ratingCount: Int,
+    val cachedAt: Long,
+)

--- a/core/core-database/src/commonMain/kotlin/com/riox432/civitdeck/data/local/migrations/Migration41to42.kt
+++ b/core/core-database/src/commonMain/kotlin/com/riox432/civitdeck/data/local/migrations/Migration41to42.kt
@@ -1,0 +1,22 @@
+package com.riox432.civitdeck.data.local.migrations
+
+import androidx.room.migration.Migration
+import androidx.sqlite.SQLiteConnection
+import androidx.sqlite.execSQL
+
+val MIGRATION_41_42 = object : Migration(41, 42) {
+    override fun migrate(connection: SQLiteConnection) {
+        connection.execSQL(
+            """
+            CREATE TABLE IF NOT EXISTS quality_score_cache (
+                modelId INTEGER NOT NULL PRIMARY KEY,
+                score INTEGER NOT NULL,
+                downloadCount INTEGER NOT NULL,
+                favoriteCount INTEGER NOT NULL,
+                ratingCount INTEGER NOT NULL,
+                cachedAt INTEGER NOT NULL
+            )
+            """.trimIndent(),
+        )
+    }
+}

--- a/core/core-database/src/commonMain/kotlin/com/riox432/civitdeck/di/DatabaseModule.kt
+++ b/core/core-database/src/commonMain/kotlin/com/riox432/civitdeck/di/DatabaseModule.kt
@@ -50,6 +50,7 @@ val databaseModule = module {
     single { get<CivitDeckDatabase>().pluginDao() }
     single { get<CivitDeckDatabase>().shareHashtagDao() }
     single { get<CivitDeckDatabase>().modelUpdateNotificationDao() }
+    single { get<CivitDeckDatabase>().qualityScoreCacheDao() }
 
     // Data Sources
     single { LocalCacheDataSource(get()) }

--- a/core/core-domain/src/commonMain/kotlin/com/riox432/civitdeck/domain/model/SortOrder.kt
+++ b/core/core-domain/src/commonMain/kotlin/com/riox432/civitdeck/domain/model/SortOrder.kt
@@ -4,4 +4,5 @@ enum class SortOrder {
     HighestRated,
     MostDownloaded,
     Newest,
+    Quality,
 }

--- a/desktopApp/src/jvmMain/kotlin/com/riox432/civitdeck/di/DesktopModule.kt
+++ b/desktopApp/src/jvmMain/kotlin/com/riox432/civitdeck/di/DesktopModule.kt
@@ -32,7 +32,7 @@ val desktopModule = module {
     single<AppVersionProvider> { DesktopAppVersionProvider() }
     viewModel { DesktopUpdateViewModel(get(), get(), get()) }
     viewModel {
-        DesktopSearchViewModel(get(), get(), get(), get())
+        DesktopSearchViewModel(get(), get(), get(), get(), get())
     }
     viewModel { params ->
         ModelDetailViewModel(

--- a/desktopApp/src/jvmMain/kotlin/com/riox432/civitdeck/ui/search/DesktopFilterBar.kt
+++ b/desktopApp/src/jvmMain/kotlin/com/riox432/civitdeck/ui/search/DesktopFilterBar.kt
@@ -133,6 +133,7 @@ private fun ModelType.displayLabel(): String = when (this) {
 private fun SortOrder.displayLabel(): String = when (this) {
     SortOrder.HighestRated -> "Highest Rated"
     SortOrder.MostDownloaded -> "Most Downloaded"
+    SortOrder.Quality -> "Quality Score"
     else -> name
 }
 

--- a/desktopApp/src/jvmMain/kotlin/com/riox432/civitdeck/ui/search/DesktopSearchViewModel.kt
+++ b/desktopApp/src/jvmMain/kotlin/com/riox432/civitdeck/ui/search/DesktopSearchViewModel.kt
@@ -10,6 +10,8 @@ import com.riox432.civitdeck.domain.model.SortOrder
 import com.riox432.civitdeck.domain.model.TimePeriod
 import com.riox432.civitdeck.domain.usecase.ObserveDefaultSortOrderUseCase
 import com.riox432.civitdeck.domain.usecase.ObserveDefaultTimePeriodUseCase
+import com.riox432.civitdeck.domain.usecase.ObserveQualityThresholdUseCase
+import com.riox432.civitdeck.domain.usecase.QualityScoreCalculator
 import com.riox432.civitdeck.domain.util.LoadResult
 import com.riox432.civitdeck.domain.util.PaginatedLoader
 import com.riox432.civitdeck.feature.search.domain.usecase.GetModelsUseCase
@@ -42,9 +44,11 @@ class DesktopSearchViewModel(
     private val multiSourceSearchUseCase: MultiSourceSearchUseCase,
     private val observeDefaultSortOrderUseCase: ObserveDefaultSortOrderUseCase,
     private val observeDefaultTimePeriodUseCase: ObserveDefaultTimePeriodUseCase,
+    private val observeQualityThresholdUseCase: ObserveQualityThresholdUseCase,
 ) : ViewModel() {
 
     private var multiSourcePage: Int = 1
+    private var qualityThreshold: Int = 0
 
     private val _uiState = MutableStateFlow(DesktopSearchUiState())
     val uiState: StateFlow<DesktopSearchUiState> = _uiState.asStateFlow()
@@ -73,6 +77,9 @@ class DesktopSearchViewModel(
             val period = observeDefaultTimePeriodUseCase().first()
             _uiState.update { it.copy(selectedSort = sort, selectedPeriod = period) }
             paginatedLoader.loadFirst()
+        }
+        viewModelScope.launch {
+            observeQualityThresholdUseCase().collect { qualityThreshold = it }
         }
     }
 
@@ -138,11 +145,23 @@ class DesktopSearchViewModel(
     private suspend fun loadPage(cursor: String?, limit: Int): LoadResult<Model> {
         val state = _uiState.value
         val isCivitaiOnly = state.selectedSources == setOf(ModelSource.CIVITAI)
-        return if (isCivitaiOnly) {
+        val raw = if (isCivitaiOnly) {
             loadCivitaiPage(state, cursor, limit)
         } else {
             loadMultiSourcePage(state, cursor, limit)
         }
+        val filtered = applyQualityFilter(raw.items, state)
+        val sorted = if (state.selectedSort == SortOrder.Quality) {
+            filtered.sortedByDescending { QualityScoreCalculator.calculate(it.stats) }
+        } else {
+            filtered
+        }
+        return LoadResult(items = sorted, nextCursor = raw.nextCursor)
+    }
+
+    private fun applyQualityFilter(models: List<Model>, state: DesktopSearchUiState): List<Model> {
+        if (!state.isQualityFilterEnabled || qualityThreshold <= 0) return models
+        return models.filter { QualityScoreCalculator.calculate(it.stats) >= qualityThreshold }
     }
 
     private suspend fun loadCivitaiPage(

--- a/feature/feature-gallery/src/commonMain/kotlin/com/riox432/civitdeck/feature/gallery/data/repository/ImageRepositoryImpl.kt
+++ b/feature/feature-gallery/src/commonMain/kotlin/com/riox432/civitdeck/feature/gallery/data/repository/ImageRepositoryImpl.kt
@@ -38,6 +38,7 @@ class ImageRepositoryImpl(
                     SortOrder.HighestRated -> "Most Reactions"
                     SortOrder.MostDownloaded -> "Most Comments"
                     SortOrder.Newest -> "Newest"
+                    SortOrder.Quality -> "Most Reactions"
                 }
             },
             period?.name,
@@ -55,6 +56,7 @@ class ImageRepositoryImpl(
                         SortOrder.HighestRated -> "Most Reactions"
                         SortOrder.MostDownloaded -> "Most Comments"
                         SortOrder.Newest -> "Newest"
+                        SortOrder.Quality -> "Most Reactions"
                     }
                 },
                 period = period?.name,

--- a/feature/feature-search/src/commonMain/kotlin/com/riox432/civitdeck/feature/search/di/SearchModule.kt
+++ b/feature/feature-search/src/commonMain/kotlin/com/riox432/civitdeck/feature/search/di/SearchModule.kt
@@ -34,7 +34,7 @@ val searchModule = module {
     factory { GetModelsUseCase(get()) }
     factory { MultiSourceSearchUseCase(get(), get(), get()) }
     factory { GetDiscoveryModelsUseCase(get()) }
-    factory { GetRecommendationsUseCase(get(), get(), get(), get()) }
+    factory { GetRecommendationsUseCase(get(), get(), get(), get(), get()) }
     factory { ObserveSearchHistoryUseCase(get()) }
     factory { AddSearchHistoryUseCase(get()) }
     factory { DeleteSearchHistoryItemUseCase(get()) }

--- a/feature/feature-search/src/commonMain/kotlin/com/riox432/civitdeck/feature/search/domain/usecase/GetRecommendationsUseCase.kt
+++ b/feature/feature-search/src/commonMain/kotlin/com/riox432/civitdeck/feature/search/domain/usecase/GetRecommendationsUseCase.kt
@@ -1,5 +1,6 @@
 package com.riox432.civitdeck.feature.search.domain.usecase
 
+import com.riox432.civitdeck.domain.model.Model
 import com.riox432.civitdeck.domain.model.ModelType
 import com.riox432.civitdeck.domain.model.NsfwFilterLevel
 import com.riox432.civitdeck.domain.model.RecommendationSection
@@ -7,10 +8,12 @@ import com.riox432.civitdeck.domain.model.RecommendationSectionType
 import com.riox432.civitdeck.domain.model.SortOrder
 import com.riox432.civitdeck.domain.model.TimePeriod
 import com.riox432.civitdeck.domain.model.filterNsfwImages
+import com.riox432.civitdeck.domain.repository.AppBehaviorPreferencesRepository
 import com.riox432.civitdeck.domain.repository.BrowsingHistoryRepository
 import com.riox432.civitdeck.domain.repository.ContentFilterPreferencesRepository
 import com.riox432.civitdeck.domain.repository.FavoriteRepository
 import com.riox432.civitdeck.domain.repository.ModelRepository
+import com.riox432.civitdeck.domain.usecase.QualityScoreCalculator
 import kotlinx.coroutines.flow.first
 
 class GetRecommendationsUseCase(
@@ -18,12 +21,14 @@ class GetRecommendationsUseCase(
     private val favoriteRepository: FavoriteRepository,
     private val browsingHistoryRepository: BrowsingHistoryRepository,
     private val userPreferencesRepository: ContentFilterPreferencesRepository,
+    private val appBehaviorRepository: AppBehaviorPreferencesRepository,
 ) {
     @Suppress("LongMethod")
     suspend operator fun invoke(): List<RecommendationSection> {
         val sections = mutableListOf<RecommendationSection>()
         val seenIds = mutableSetOf<Long>()
         val nsfwLevel = userPreferencesRepository.observeNsfwFilterLevel().first()
+        val qualityThreshold = appBehaviorRepository.observeFeedQualityThreshold().first()
 
         val favIds = favoriteRepository.getAllFavoriteIds()
         seenIds.addAll(favIds)
@@ -34,28 +39,28 @@ class GetRecommendationsUseCase(
         val favTypes = favoriteRepository.getFavoriteTypeCounts()
 
         // Affinity-based "Recommended for You" section
-        val affinitySection = buildAffinitySection(seenIds, nsfwLevel, favTypes)
+        val affinitySection = buildAffinitySection(seenIds, nsfwLevel, favTypes, qualityThreshold)
         if (affinitySection != null) sections.add(affinitySection)
 
-        val typeSections = buildTypeSections(seenIds, nsfwLevel, favTypes)
+        val typeSections = buildTypeSections(seenIds, nsfwLevel, favTypes, qualityThreshold)
         sections.addAll(typeSections)
 
-        val tagSections = buildTagSections(seenIds, nsfwLevel)
+        val tagSections = buildTagSections(seenIds, nsfwLevel, qualityThreshold)
         sections.addAll(tagSections)
 
-        val creatorSection = buildCreatorSection(seenIds, nsfwLevel)
+        val creatorSection = buildCreatorSection(seenIds, nsfwLevel, qualityThreshold)
         if (creatorSection != null) sections.add(creatorSection)
 
         // Trending velocity section — models gaining traction fast
-        val trendingSection = buildTrendingVelocitySection(seenIds, nsfwLevel)
+        val trendingSection = buildTrendingVelocitySection(seenIds, nsfwLevel, qualityThreshold)
         if (trendingSection != null) sections.add(trendingSection)
 
         // Diversity: inject exploration section if too homogeneous
-        val explorationSection = buildExplorationSection(seenIds, nsfwLevel, sections)
+        val explorationSection = buildExplorationSection(seenIds, nsfwLevel, sections, qualityThreshold)
         if (explorationSection != null) sections.add(explorationSection)
 
         if (sections.isEmpty()) {
-            val fallback = buildTrendingFallback(seenIds, nsfwLevel)
+            val fallback = buildTrendingFallback(seenIds, nsfwLevel, qualityThreshold)
             if (fallback != null) sections.add(fallback)
         }
 
@@ -70,6 +75,7 @@ class GetRecommendationsUseCase(
         seenIds: Set<Long>,
         nsfwLevel: NsfwFilterLevel,
         favTypes: Map<String, Int>,
+        qualityThreshold: Int,
     ): RecommendationSection? {
         val weightedTags = browsingHistoryRepository.getWeightedTags()
         val topTag = weightedTags.entries.maxByOrNull { it.value }?.key ?: return null
@@ -92,6 +98,7 @@ class GetRecommendationsUseCase(
             type = topType,
             tag = topTag,
             sectionType = RecommendationSectionType.PERSONALIZED,
+            qualityThreshold = qualityThreshold,
         )
     }
 
@@ -99,6 +106,7 @@ class GetRecommendationsUseCase(
         seenIds: Set<Long>,
         nsfwLevel: NsfwFilterLevel,
         favTypes: Map<String, Int>,
+        qualityThreshold: Int,
     ): List<RecommendationSection> {
         val weightedTypes = browsingHistoryRepository.getWeightedTypes()
         val merged = mutableMapOf<String, Double>()
@@ -121,6 +129,7 @@ class GetRecommendationsUseCase(
                 seenIds = seenIds,
                 nsfwLevel = nsfwLevel,
                 type = modelType,
+                qualityThreshold = qualityThreshold,
             )
         }
     }
@@ -128,6 +137,7 @@ class GetRecommendationsUseCase(
     private suspend fun buildTagSections(
         seenIds: Set<Long>,
         nsfwLevel: NsfwFilterLevel,
+        qualityThreshold: Int,
     ): List<RecommendationSection> {
         val weightedTags = browsingHistoryRepository.getWeightedTags()
         val topTags = weightedTags.entries
@@ -142,6 +152,7 @@ class GetRecommendationsUseCase(
                 seenIds = seenIds,
                 nsfwLevel = nsfwLevel,
                 tag = tag,
+                qualityThreshold = qualityThreshold,
             )
         }
     }
@@ -149,6 +160,7 @@ class GetRecommendationsUseCase(
     private suspend fun buildCreatorSection(
         seenIds: Set<Long>,
         nsfwLevel: NsfwFilterLevel,
+        qualityThreshold: Int,
     ): RecommendationSection? {
         val weightedCreators = browsingHistoryRepository.getWeightedCreators()
         val topCreator = weightedCreators.entries
@@ -160,6 +172,7 @@ class GetRecommendationsUseCase(
             seenIds = seenIds,
             nsfwLevel = nsfwLevel,
             username = topCreator,
+            qualityThreshold = qualityThreshold,
         )
     }
 
@@ -170,6 +183,7 @@ class GetRecommendationsUseCase(
     private suspend fun buildTrendingVelocitySection(
         seenIds: Set<Long>,
         nsfwLevel: NsfwFilterLevel,
+        qualityThreshold: Int,
     ): RecommendationSection? {
         val nsfw = if (nsfwLevel == NsfwFilterLevel.Off) false else null
         val result = modelRepository.getModels(
@@ -181,6 +195,7 @@ class GetRecommendationsUseCase(
         val filtered = result.items
             .filterNot { it.id in seenIds }
             .filterNsfwImages(nsfwLevel)
+            .filterByQuality(qualityThreshold)
             .take(SECTION_SIZE)
         if (filtered.isEmpty()) return null
 
@@ -200,6 +215,7 @@ class GetRecommendationsUseCase(
         seenIds: Set<Long>,
         nsfwLevel: NsfwFilterLevel,
         existingSections: List<RecommendationSection>,
+        qualityThreshold: Int,
     ): RecommendationSection? {
         if (existingSections.size < MIN_SECTIONS_FOR_EXPLORATION) return null
 
@@ -222,6 +238,7 @@ class GetRecommendationsUseCase(
             sort = SortOrder.MostDownloaded,
             period = TimePeriod.Week,
             sectionType = RecommendationSectionType.EXPLORATION,
+            qualityThreshold = qualityThreshold,
         )
     }
 
@@ -236,6 +253,7 @@ class GetRecommendationsUseCase(
         sort: SortOrder? = SortOrder.HighestRated,
         period: TimePeriod? = TimePeriod.Month,
         sectionType: RecommendationSectionType = RecommendationSectionType.PERSONALIZED,
+        qualityThreshold: Int = 0,
     ): RecommendationSection? {
         val nsfw = if (nsfwLevel == NsfwFilterLevel.Off) false else null
         val result = modelRepository.getModels(
@@ -250,6 +268,7 @@ class GetRecommendationsUseCase(
         val filtered = result.items
             .filterNot { it.id in seenIds }
             .filterNsfwImages(nsfwLevel)
+            .filterByQuality(qualityThreshold)
             .take(SECTION_SIZE)
         if (filtered.isEmpty()) return null
 
@@ -264,6 +283,7 @@ class GetRecommendationsUseCase(
     private suspend fun buildTrendingFallback(
         seenIds: Set<Long>,
         nsfwLevel: NsfwFilterLevel,
+        qualityThreshold: Int,
     ): RecommendationSection? {
         val nsfw = if (nsfwLevel == NsfwFilterLevel.Off) false else null
         val result = modelRepository.getModels(
@@ -275,6 +295,7 @@ class GetRecommendationsUseCase(
         val filtered = result.items
             .filterNot { it.id in seenIds }
             .filterNsfwImages(nsfwLevel)
+            .filterByQuality(qualityThreshold)
             .take(SECTION_SIZE)
         if (filtered.isEmpty()) return null
 
@@ -284,6 +305,15 @@ class GetRecommendationsUseCase(
             models = filtered,
             sectionType = RecommendationSectionType.TRENDING,
         )
+    }
+
+    /**
+     * Filters models below the quality threshold.
+     * Threshold of 0 means no filtering (disabled).
+     */
+    private fun List<Model>.filterByQuality(threshold: Int): List<Model> {
+        if (threshold <= 0) return this
+        return filter { QualityScoreCalculator.calculate(it.stats) >= threshold }
     }
 
     companion object {

--- a/iosApp/iosApp/Features/Gallery/ImageGalleryScreen.swift
+++ b/iosApp/iosApp/Features/Gallery/ImageGalleryScreen.swift
@@ -230,6 +230,8 @@ struct ImageGalleryScreen: View {
         case .highestRated: return "Highest Rated"
         case .mostDownloaded: return "Most Downloaded"
         case .newest: return "Newest"
+        case .quality: return "Quality Score"
+        default: return sort.name
         }
     }
 
@@ -246,5 +248,5 @@ struct ImageGalleryScreen: View {
 
 // MARK: - Filter Options
 
-private let sortOptions: [CivitSortOrder] = [.highestRated, .mostDownloaded, .newest]
+private let sortOptions: [CivitSortOrder] = [.highestRated, .mostDownloaded, .newest, .quality]
 private let periodOptions: [TimePeriod] = [.allTime, .year, .month, .week, .day]

--- a/iosApp/iosApp/Features/Search/ModelSearchViewModel.swift
+++ b/iosApp/iosApp/Features/Search/ModelSearchViewModel.swift
@@ -333,6 +333,7 @@ private extension ModelSearchViewModel {
         case .mostDownloaded: return Double(model.stats.downloadCount)
         case .highestRated: return model.stats.rating
         case .newest: return Double(model.id)
+        case .quality: return Double(FeedQualityScoreHelper.calculate(stats: model.stats))
         default: return Double(model.id)
         }
     }

--- a/iosApp/iosApp/Features/Search/SearchFilterConstants.swift
+++ b/iosApp/iosApp/Features/Search/SearchFilterConstants.swift
@@ -3,7 +3,7 @@ import Shared
 
 enum SearchFilter {
     static let baseModelOptions: [BaseModel] = [.sd15, .sdxl10, .pony, .flux1D, .flux1S, .sd21, .svd]
-    static let sortOptions: [CivitSortOrder] = [.mostDownloaded, .highestRated, .newest]
+    static let sortOptions: [CivitSortOrder] = [.mostDownloaded, .highestRated, .newest, .quality]
     static let periodOptions: [TimePeriod] = [.allTime, .year, .month, .week, .day]
 
     static let modelTypeOptions: [ModelType] = [
@@ -18,6 +18,8 @@ enum SearchFilter {
         case .highestRated: return "Highest Rated"
         case .mostDownloaded: return "Most Downloaded"
         case .newest: return "Newest"
+        case .quality: return "Quality Score"
+        default: return sort.name
         }
     }
 

--- a/shared/src/commonMain/kotlin/com/riox432/civitdeck/data/repository/ModelRepositoryImpl.kt
+++ b/shared/src/commonMain/kotlin/com/riox432/civitdeck/data/repository/ModelRepositoryImpl.kt
@@ -187,6 +187,8 @@ private fun SortOrder.toApiParam(): String = when (this) {
     SortOrder.HighestRated -> "Highest Rated"
     SortOrder.MostDownloaded -> "Most Downloaded"
     SortOrder.Newest -> "Newest"
+    // Quality sort is client-side only; fetch by Highest Rated as closest proxy
+    SortOrder.Quality -> "Highest Rated"
 }
 
 private fun TimePeriod.toApiParam(): String = when (this) {

--- a/shared/src/commonTest/kotlin/com/riox432/civitdeck/domain/usecase/GetRecommendationsUseCaseTest.kt
+++ b/shared/src/commonTest/kotlin/com/riox432/civitdeck/domain/usecase/GetRecommendationsUseCaseTest.kt
@@ -12,6 +12,9 @@ import com.riox432.civitdeck.domain.model.NsfwBlurSettings
 import com.riox432.civitdeck.domain.model.PaginatedResult
 import com.riox432.civitdeck.domain.model.SortOrder
 import com.riox432.civitdeck.domain.model.TimePeriod
+import com.riox432.civitdeck.domain.model.NavShortcut
+import com.riox432.civitdeck.domain.model.PollingInterval
+import com.riox432.civitdeck.domain.repository.AppBehaviorPreferencesRepository
 import com.riox432.civitdeck.domain.repository.BrowsingHistoryRepository
 import com.riox432.civitdeck.domain.repository.ContentFilterPreferencesRepository
 import com.riox432.civitdeck.domain.repository.FavoriteRepository
@@ -116,6 +119,23 @@ class GetRecommendationsUseCaseTest {
         override suspend fun setNsfwBlurSettings(settings: NsfwBlurSettings) = error("not used")
     }
 
+    private class FakeAppBehaviorRepository(
+        private val qualityThreshold: Int = 0,
+    ) : AppBehaviorPreferencesRepository {
+        override fun observePowerUserMode(): Flow<Boolean> = flowOf(false)
+        override suspend fun setPowerUserMode(enabled: Boolean) = Unit
+        override fun observeNotificationsEnabled(): Flow<Boolean> = flowOf(false)
+        override suspend fun setNotificationsEnabled(enabled: Boolean) = Unit
+        override fun observePollingInterval(): Flow<PollingInterval> = flowOf(PollingInterval.Off)
+        override suspend fun setPollingInterval(interval: PollingInterval) = Unit
+        override fun observeSeenTutorialVersion(): Flow<Int> = flowOf(0)
+        override suspend fun setSeenTutorialVersion(version: Int) = Unit
+        override fun observeCustomNavShortcuts(): Flow<List<NavShortcut>> = flowOf(emptyList())
+        override suspend fun setCustomNavShortcuts(items: List<NavShortcut>) = Unit
+        override fun observeFeedQualityThreshold(): Flow<Int> = flowOf(qualityThreshold)
+        override suspend fun setFeedQualityThreshold(threshold: Int) = Unit
+    }
+
     @Test
     fun returns_type_section_when_favorites_have_types() = runTest {
         val models = (1L..10L).map { testModel(id = it, type = ModelType.LORA) }
@@ -126,7 +146,7 @@ class GetRecommendationsUseCaseTest {
         val browsingRepo = FakeBrowsingHistoryRepository()
         val prefsRepo = FakeUserPreferencesRepository()
 
-        val useCase = GetRecommendationsUseCase(modelRepo, favRepo, browsingRepo, prefsRepo)
+        val useCase = GetRecommendationsUseCase(modelRepo, favRepo, browsingRepo, prefsRepo, FakeAppBehaviorRepository())
         val sections = useCase()
 
         assertTrue(sections.isNotEmpty())
@@ -144,7 +164,7 @@ class GetRecommendationsUseCaseTest {
         val browsingRepo = FakeBrowsingHistoryRepository(recentTags = mapOf("anime" to 10))
         val prefsRepo = FakeUserPreferencesRepository()
 
-        val useCase = GetRecommendationsUseCase(modelRepo, favRepo, browsingRepo, prefsRepo)
+        val useCase = GetRecommendationsUseCase(modelRepo, favRepo, browsingRepo, prefsRepo, FakeAppBehaviorRepository())
         val sections = useCase()
 
         assertTrue(sections.any { it.title.contains("anime") })
@@ -160,7 +180,7 @@ class GetRecommendationsUseCaseTest {
         val browsingRepo = FakeBrowsingHistoryRepository()
         val prefsRepo = FakeUserPreferencesRepository()
 
-        val useCase = GetRecommendationsUseCase(modelRepo, favRepo, browsingRepo, prefsRepo)
+        val useCase = GetRecommendationsUseCase(modelRepo, favRepo, browsingRepo, prefsRepo, FakeAppBehaviorRepository())
         val sections = useCase()
 
         assertTrue(sections.isNotEmpty())
@@ -178,7 +198,7 @@ class GetRecommendationsUseCaseTest {
         val browsingRepo = FakeBrowsingHistoryRepository(recentModelIds = listOf(3L, 4L))
         val prefsRepo = FakeUserPreferencesRepository()
 
-        val useCase = GetRecommendationsUseCase(modelRepo, favRepo, browsingRepo, prefsRepo)
+        val useCase = GetRecommendationsUseCase(modelRepo, favRepo, browsingRepo, prefsRepo, FakeAppBehaviorRepository())
         val sections = useCase()
 
         assertTrue(sections.isNotEmpty())
@@ -198,7 +218,7 @@ class GetRecommendationsUseCaseTest {
         val browsingRepo = FakeBrowsingHistoryRepository()
         val prefsRepo = FakeUserPreferencesRepository()
 
-        val useCase = GetRecommendationsUseCase(modelRepo, favRepo, browsingRepo, prefsRepo)
+        val useCase = GetRecommendationsUseCase(modelRepo, favRepo, browsingRepo, prefsRepo, FakeAppBehaviorRepository())
         val sections = useCase()
 
         assertTrue(sections.isEmpty())
@@ -218,7 +238,7 @@ class GetRecommendationsUseCaseTest {
         )
         val prefsRepo = FakeUserPreferencesRepository()
 
-        val useCase = GetRecommendationsUseCase(modelRepo, favRepo, browsingRepo, prefsRepo)
+        val useCase = GetRecommendationsUseCase(modelRepo, favRepo, browsingRepo, prefsRepo, FakeAppBehaviorRepository())
         val sections = useCase()
 
         assertTrue(sections.isNotEmpty())
@@ -235,7 +255,7 @@ class GetRecommendationsUseCaseTest {
         val browsingRepo = FakeBrowsingHistoryRepository()
         val prefsRepo = FakeUserPreferencesRepository()
 
-        val useCase = GetRecommendationsUseCase(modelRepo, favRepo, browsingRepo, prefsRepo)
+        val useCase = GetRecommendationsUseCase(modelRepo, favRepo, browsingRepo, prefsRepo, FakeAppBehaviorRepository())
         val sections = useCase()
 
         assertTrue(sections.isNotEmpty())
@@ -255,7 +275,7 @@ class GetRecommendationsUseCaseTest {
         )
         val prefsRepo = FakeUserPreferencesRepository()
 
-        val useCase = GetRecommendationsUseCase(modelRepo, favRepo, browsingRepo, prefsRepo)
+        val useCase = GetRecommendationsUseCase(modelRepo, favRepo, browsingRepo, prefsRepo, FakeAppBehaviorRepository())
         val sections = useCase()
 
         assertTrue(sections.any { it.title == "Recommended for You" })
@@ -276,7 +296,7 @@ class GetRecommendationsUseCaseTest {
         )
         val prefsRepo = FakeUserPreferencesRepository()
 
-        val useCase = GetRecommendationsUseCase(modelRepo, favRepo, browsingRepo, prefsRepo)
+        val useCase = GetRecommendationsUseCase(modelRepo, favRepo, browsingRepo, prefsRepo, FakeAppBehaviorRepository())
         val sections = useCase()
 
         assertTrue(sections.size <= 6)


### PR DESCRIPTION
## Description

Closes #605

Implements automatic image quality assessment to filter low-quality results from search and discovery feeds using CivitAI metadata (stats.rating, download count, favorite count, comment count) as proxy quality signals.

### Changes

**Domain layer:**
- Add `Quality` sort option to `SortOrder` enum — client-side scoring via `QualityScoreCalculator`
- Quality sort maps to `HighestRated` server-side as closest proxy, then re-sorts client-side by computed quality score

**Quality filtering in recommendations:**
- `GetRecommendationsUseCase` now reads the feed quality threshold from `AppBehaviorPreferencesRepository`
- All recommendation sections (affinity, type, tag, creator, trending, exploration, fallback) filter models below the threshold

**Database (v41 → v42):**
- New `quality_score_cache` table with `QualityScoreCacheEntity` and `QualityScoreCacheDao`
- Caches computed quality scores with stat fingerprints for offline access and TTL-based eviction

**Android:**
- `ModelPagingSource` handles `Quality` sort in `sortValueOf()`
- `FilterChipComponents` displays "Quality Score" label

**iOS:**
- `ModelSearchViewModel.sortValueOf()` handles `.quality` case using `FeedQualityScoreHelper`
- `SearchFilterConstants` and `ImageGalleryScreen` include `.quality` sort option with label

**Desktop:**
- `DesktopSearchViewModel` observes quality threshold and applies filtering + re-sorting
- `DesktopFilterBar` displays "Quality Score" label
- Updated DI registration for new constructor parameter

**Tests:**
- Updated `GetRecommendationsUseCaseTest` with `FakeAppBehaviorRepository`