### PR TITLE
#608 Port download queue and workflow templates to Desktop

### DIFF
--- a/desktopApp/src/jvmMain/kotlin/com/riox432/civitdeck/di/DesktopModule.kt
+++ b/desktopApp/src/jvmMain/kotlin/com/riox432/civitdeck/di/DesktopModule.kt
@@ -15,6 +15,8 @@ import com.riox432.civitdeck.ui.externalserver.ExternalServerSettingsViewModel
 import com.riox432.civitdeck.ui.creator.CreatorProfileViewModel
 import com.riox432.civitdeck.ui.prompts.SavedPromptsViewModel
 import com.riox432.civitdeck.ui.analytics.DesktopAnalyticsViewModel
+import com.riox432.civitdeck.ui.comfyui.template.DesktopWorkflowTemplateViewModel
+import com.riox432.civitdeck.ui.downloadqueue.DesktopDownloadQueueViewModel
 import com.riox432.civitdeck.ui.notificationcenter.DesktopNotificationCenterViewModel
 import com.riox432.civitdeck.ui.history.DesktopBrowsingHistoryViewModel
 import com.riox432.civitdeck.ui.backup.DesktopBackupViewModel
@@ -104,4 +106,12 @@ val desktopModule = module {
     // Creator & Prompts ViewModels (moved from feature modules)
     viewModel { params -> CreatorProfileViewModel(params.get(), get(), get(), get(), get()) }
     viewModel { SavedPromptsViewModel(get(), get(), get(), get(), get()) }
+    // Download Queue ViewModel
+    viewModel {
+        DesktopDownloadQueueViewModel(get(), get(), get(), get(), get(), get())
+    }
+    // Workflow Template ViewModel
+    viewModel {
+        DesktopWorkflowTemplateViewModel(get(), get(), get(), get(), get())
+    }
 }

--- a/desktopApp/src/jvmMain/kotlin/com/riox432/civitdeck/ui/CreateTabContent.kt
+++ b/desktopApp/src/jvmMain/kotlin/com/riox432/civitdeck/ui/CreateTabContent.kt
@@ -15,16 +15,22 @@ import androidx.compose.material3.IconButton
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import com.riox432.civitdeck.domain.model.WorkflowTemplate
 import com.riox432.civitdeck.ui.comfyui.ComfyUIGenerationViewModel
 import com.riox432.civitdeck.ui.comfyui.ComfyUIHistoryViewModel
 import com.riox432.civitdeck.ui.comfyui.ComfyUISettingsViewModel
 import com.riox432.civitdeck.ui.comfyui.SDWebUIGenerationViewModel
 import com.riox432.civitdeck.ui.comfyui.SDWebUISettingsViewModel
+import com.riox432.civitdeck.ui.comfyui.template.DesktopTemplateParameterScreen
+import com.riox432.civitdeck.ui.comfyui.template.DesktopWorkflowTemplateEditorScreen
+import com.riox432.civitdeck.ui.comfyui.template.DesktopWorkflowTemplateScreen
+import com.riox432.civitdeck.ui.comfyui.template.DesktopWorkflowTemplateViewModel
 import com.riox432.civitdeck.ui.externalserver.ExternalServerGalleryViewModel
 import com.riox432.civitdeck.ui.externalserver.ExternalServerSettingsViewModel
 import com.riox432.civitdeck.ui.create.DesktopCreateHubScreen
@@ -44,25 +50,70 @@ private enum class CreateSection(val title: String) {
     ExternalServer("External Server"),
 }
 
+/** Nested route for workflow template navigation within Create tab */
+private sealed class CreateRoute {
+    data object Hub : CreateRoute()
+    data class Section(val section: CreateSection) : CreateRoute()
+    data object WorkflowTemplates : CreateRoute()
+    data class WorkflowTemplateEditor(val template: WorkflowTemplate) : CreateRoute()
+    data class TemplateParameter(val template: WorkflowTemplate) : CreateRoute()
+}
+
 @Composable
 fun CreateTabContent(
     modifier: Modifier = Modifier,
 ) {
-    var activeSection by remember { mutableStateOf<CreateSection?>(null) }
+    var route by remember { mutableStateOf<CreateRoute>(CreateRoute.Hub) }
 
     Box(modifier = modifier.fillMaxSize()) {
-        val section = activeSection
-        if (section == null) {
-            DesktopCreateHubScreen(
-                onComfyUIClick = { activeSection = CreateSection.ComfyUI },
-                onSDWebUIClick = { activeSection = CreateSection.SDWebUI },
-                onExternalServerClick = { activeSection = CreateSection.ExternalServer },
-            )
-        } else {
-            CreateSectionDetail(
-                section = section,
-                onBack = { activeSection = null },
-            )
+        when (val currentRoute = route) {
+            is CreateRoute.Hub -> {
+                DesktopCreateHubScreen(
+                    onComfyUIClick = { route = CreateRoute.Section(CreateSection.ComfyUI) },
+                    onSDWebUIClick = { route = CreateRoute.Section(CreateSection.SDWebUI) },
+                    onExternalServerClick = { route = CreateRoute.Section(CreateSection.ExternalServer) },
+                    onWorkflowTemplatesClick = { route = CreateRoute.WorkflowTemplates },
+                )
+            }
+            is CreateRoute.Section -> {
+                CreateSectionDetail(
+                    section = currentRoute.section,
+                    onBack = { route = CreateRoute.Hub },
+                )
+            }
+            is CreateRoute.WorkflowTemplates -> {
+                val vm: DesktopWorkflowTemplateViewModel = koinViewModel()
+                DesktopWorkflowTemplateScreen(
+                    viewModel = vm,
+                    onBack = { route = CreateRoute.Hub },
+                    onCreateTemplate = {
+                        route = CreateRoute.WorkflowTemplateEditor(
+                            DesktopWorkflowTemplateViewModel.emptyTemplate(),
+                        )
+                    },
+                    onEditTemplate = { template ->
+                        route = CreateRoute.WorkflowTemplateEditor(template)
+                    },
+                    onSelectTemplate = { template ->
+                        route = CreateRoute.TemplateParameter(template)
+                    },
+                )
+            }
+            is CreateRoute.WorkflowTemplateEditor -> {
+                val vm: DesktopWorkflowTemplateViewModel = koinViewModel()
+                DesktopWorkflowTemplateEditorScreen(
+                    initialTemplate = currentRoute.template,
+                    viewModel = vm,
+                    onBack = { route = CreateRoute.WorkflowTemplates },
+                )
+            }
+            is CreateRoute.TemplateParameter -> {
+                DesktopTemplateParameterScreen(
+                    template = currentRoute.template,
+                    onBack = { route = CreateRoute.WorkflowTemplates },
+                    onApply = { /* Apply params to generation - handled by ComfyUI integration */ },
+                )
+            }
         }
     }
 }

--- a/desktopApp/src/jvmMain/kotlin/com/riox432/civitdeck/ui/DesktopNavigation.kt
+++ b/desktopApp/src/jvmMain/kotlin/com/riox432/civitdeck/ui/DesktopNavigation.kt
@@ -23,4 +23,12 @@ sealed class DesktopRoute {
     data object NotificationCenter : DesktopRoute()
     data object BrowsingHistory : DesktopRoute()
     data object QRCode : DesktopRoute()
+    data object DownloadQueue : DesktopRoute()
+    data object WorkflowTemplates : DesktopRoute()
+    data class WorkflowTemplateEditor(
+        val templateId: Long,
+    ) : DesktopRoute()
+    data class TemplateParameter(
+        val templateId: Long,
+    ) : DesktopRoute()
 }

--- a/desktopApp/src/jvmMain/kotlin/com/riox432/civitdeck/ui/SettingsTabContent.kt
+++ b/desktopApp/src/jvmMain/kotlin/com/riox432/civitdeck/ui/SettingsTabContent.kt
@@ -21,6 +21,8 @@ import com.riox432.civitdeck.ui.analytics.DesktopAnalyticsScreen
 import com.riox432.civitdeck.ui.analytics.DesktopAnalyticsViewModel
 import com.riox432.civitdeck.ui.backup.DesktopBackupScreen
 import com.riox432.civitdeck.ui.backup.DesktopBackupViewModel
+import com.riox432.civitdeck.ui.downloadqueue.DesktopDownloadQueueScreen
+import com.riox432.civitdeck.ui.downloadqueue.DesktopDownloadQueueViewModel
 import com.riox432.civitdeck.ui.history.DesktopBrowsingHistoryScreen
 import com.riox432.civitdeck.ui.history.DesktopBrowsingHistoryViewModel
 import com.riox432.civitdeck.ui.notificationcenter.DesktopNotificationCenterScreen
@@ -48,6 +50,7 @@ fun SettingsTabContent(
             onNavigateToAnalytics = { backstack.add(DesktopRoute.Analytics) },
             onNavigateToNotificationCenter = { backstack.add(DesktopRoute.NotificationCenter) },
             onNavigateToBrowsingHistory = { backstack.add(DesktopRoute.BrowsingHistory) },
+            onNavigateToDownloadQueue = { backstack.add(DesktopRoute.DownloadQueue) },
         )
 
         SettingsOverlayContent(backstack, currentRoute)
@@ -62,6 +65,7 @@ private fun SettingsMainContent(
     onNavigateToAnalytics: () -> Unit,
     onNavigateToNotificationCenter: () -> Unit,
     onNavigateToBrowsingHistory: () -> Unit,
+    onNavigateToDownloadQueue: () -> Unit,
 ) {
     Column(
         modifier = Modifier
@@ -89,6 +93,7 @@ private fun SettingsMainContent(
             onNavigateToAnalytics = onNavigateToAnalytics,
             onNavigateToNotificationCenter = onNavigateToNotificationCenter,
             onNavigateToBrowsingHistory = onNavigateToBrowsingHistory,
+            onNavigateToDownloadQueue = onNavigateToDownloadQueue,
         )
     }
 }
@@ -156,6 +161,13 @@ private fun SettingsOverlayContent(
                 onModelClick = { modelId ->
                     backstack.add(DesktopRoute.ModelDetail(modelId))
                 },
+            )
+        }
+        is DesktopRoute.DownloadQueue -> {
+            val vm: DesktopDownloadQueueViewModel = koinViewModel()
+            DesktopDownloadQueueScreen(
+                viewModel = vm,
+                onBack = { backstack.removeLastOrNull() },
             )
         }
         else -> { /* Settings main screen is shown */ }

--- a/desktopApp/src/jvmMain/kotlin/com/riox432/civitdeck/ui/comfyui/template/DesktopTemplateParameterScreen.kt
+++ b/desktopApp/src/jvmMain/kotlin/com/riox432/civitdeck/ui/comfyui/template/DesktopTemplateParameterScreen.kt
@@ -1,0 +1,258 @@
+@file:Suppress("TooManyFunctions")
+
+package com.riox432.civitdeck.ui.comfyui.template
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.Button
+import androidx.compose.material3.Card
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Slider
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateMapOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import com.riox432.civitdeck.domain.model.TemplateVariable
+import com.riox432.civitdeck.domain.model.TemplateVariableType
+import com.riox432.civitdeck.domain.model.WorkflowTemplate
+import com.riox432.civitdeck.ui.theme.Elevation
+import com.riox432.civitdeck.ui.theme.Spacing
+import kotlin.math.roundToInt
+
+@Composable
+fun DesktopTemplateParameterScreen(
+    template: WorkflowTemplate,
+    onBack: () -> Unit,
+    onApply: (Map<String, String>) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val values = remember {
+        mutableStateMapOf<String, String>().apply {
+            template.variables.forEach { v -> put(v.name, v.defaultValue) }
+        }
+    }
+
+    Surface(modifier = modifier.fillMaxSize()) {
+        Column {
+            ParameterToolbar(templateName = template.name, onBack = onBack)
+            LazyColumn(
+                modifier = Modifier.fillMaxSize(),
+                contentPadding = androidx.compose.foundation.layout.PaddingValues(Spacing.md),
+                verticalArrangement = Arrangement.spacedBy(Spacing.md),
+            ) {
+                if (template.description.isNotBlank()) {
+                    item {
+                        Text(
+                            template.description,
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                    }
+                }
+                items(template.variables, key = { it.name }) { variable ->
+                    ParameterInput(
+                        variable = variable,
+                        value = values[variable.name] ?: variable.defaultValue,
+                        onValueChange = { values[variable.name] = it },
+                    )
+                }
+                item {
+                    Button(
+                        onClick = { onApply(values.toMap()) },
+                        modifier = Modifier.fillMaxWidth(),
+                        enabled = template.variables
+                            .filter { it.required }
+                            .all { (values[it.name] ?: "").isNotBlank() },
+                    ) {
+                        Text("Generate")
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun ParameterToolbar(templateName: String, onBack: () -> Unit) {
+    Surface(tonalElevation = Elevation.xs) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = Spacing.md, vertical = Spacing.sm),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            IconButton(onClick = onBack) {
+                Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+            }
+            Text(
+                text = templateName,
+                style = MaterialTheme.typography.titleMedium,
+                modifier = Modifier.padding(start = Spacing.sm),
+            )
+        }
+    }
+}
+
+@Composable
+private fun ParameterInput(
+    variable: TemplateVariable,
+    value: String,
+    onValueChange: (String) -> Unit,
+) {
+    Card(modifier = Modifier.fillMaxWidth()) {
+        Column(
+            modifier = Modifier.padding(Spacing.md),
+            verticalArrangement = Arrangement.spacedBy(Spacing.xs),
+        ) {
+            Text(
+                variable.label.ifBlank { variable.name },
+                style = MaterialTheme.typography.titleSmall,
+            )
+            if (variable.description.isNotBlank()) {
+                Text(
+                    variable.description,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+            when (variable.type) {
+                TemplateVariableType.SLIDER -> SliderInput(variable, value, onValueChange)
+                TemplateVariableType.SELECT -> SelectInput(variable, value, onValueChange)
+                TemplateVariableType.NUMBER -> NumberInput(variable, value, onValueChange)
+                TemplateVariableType.TEXT -> TextInput(variable, value, onValueChange)
+            }
+        }
+    }
+}
+
+@Composable
+private fun SliderInput(
+    variable: TemplateVariable,
+    value: String,
+    onValueChange: (String) -> Unit,
+) {
+    val min = variable.min?.toFloat() ?: 0f
+    val max = variable.max?.toFloat() ?: 100f
+    val step = variable.step?.toFloat() ?: 1f
+    val current = value.toFloatOrNull()?.coerceIn(min, max) ?: min
+
+    Column {
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceBetween,
+        ) {
+            Text(formatSliderValue(min, step), style = MaterialTheme.typography.bodySmall)
+            Text(
+                formatSliderValue(current, step),
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.primary,
+            )
+            Text(formatSliderValue(max, step), style = MaterialTheme.typography.bodySmall)
+        }
+        val steps = if (step > 0f && max > min) {
+            ((max - min) / step).roundToInt() - 1
+        } else {
+            0
+        }
+        Slider(
+            value = current,
+            onValueChange = { onValueChange(formatSliderValue(it, step)) },
+            valueRange = min..max,
+            steps = steps.coerceAtLeast(0),
+        )
+    }
+}
+
+@Composable
+private fun SelectInput(
+    variable: TemplateVariable,
+    value: String,
+    onValueChange: (String) -> Unit,
+) {
+    var expanded by remember { mutableStateOf(false) }
+    Column {
+        TextButton(onClick = { expanded = true }) {
+            Text(value.ifBlank { "Select..." })
+        }
+        DropdownMenu(expanded = expanded, onDismissRequest = { expanded = false }) {
+            variable.options.forEach { option ->
+                DropdownMenuItem(
+                    text = { Text(option) },
+                    onClick = {
+                        onValueChange(option)
+                        expanded = false
+                    },
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun NumberInput(
+    variable: TemplateVariable,
+    value: String,
+    onValueChange: (String) -> Unit,
+) {
+    if (variable.min != null && variable.max != null) {
+        SliderInput(variable, value, onValueChange)
+    } else {
+        OutlinedTextField(
+            value = value,
+            onValueChange = onValueChange,
+            modifier = Modifier.fillMaxWidth(),
+            singleLine = true,
+        )
+    }
+}
+
+@Composable
+private fun TextInput(
+    variable: TemplateVariable,
+    value: String,
+    onValueChange: (String) -> Unit,
+) {
+    OutlinedTextField(
+        value = value,
+        onValueChange = onValueChange,
+        modifier = Modifier.fillMaxWidth(),
+        minLines = if (variable.name.contains("prompt")) 3 else 1,
+        maxLines = if (variable.name.contains("prompt")) 6 else 1,
+        placeholder = {
+            if (variable.required) Text("Required") else Text("Optional")
+        },
+    )
+}
+
+private fun formatSliderValue(value: Float, step: Float): String {
+    return if (step >= 1f) {
+        value.roundToInt().toString()
+    } else {
+        val decimals = when {
+            step >= 0.1f -> 1
+            step >= 0.01f -> 2
+            else -> 3
+        }
+        "%.${decimals}f".format(value)
+    }
+}

--- a/desktopApp/src/jvmMain/kotlin/com/riox432/civitdeck/ui/comfyui/template/DesktopWorkflowTemplateEditorScreen.kt
+++ b/desktopApp/src/jvmMain/kotlin/com/riox432/civitdeck/ui/comfyui/template/DesktopWorkflowTemplateEditorScreen.kt
@@ -1,0 +1,363 @@
+@file:Suppress("TooManyFunctions")
+
+package com.riox432.civitdeck.ui.comfyui.template
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material3.Card
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Switch
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import com.riox432.civitdeck.domain.model.TemplateVariable
+import com.riox432.civitdeck.domain.model.TemplateVariableType
+import com.riox432.civitdeck.domain.model.WorkflowTemplate
+import com.riox432.civitdeck.domain.model.WorkflowTemplateCategory
+import com.riox432.civitdeck.domain.model.WorkflowTemplateType
+import com.riox432.civitdeck.ui.theme.Elevation
+import com.riox432.civitdeck.ui.theme.Spacing
+
+@Composable
+fun DesktopWorkflowTemplateEditorScreen(
+    initialTemplate: WorkflowTemplate,
+    viewModel: DesktopWorkflowTemplateViewModel,
+    onBack: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    var name by remember { mutableStateOf(initialTemplate.name) }
+    var description by remember { mutableStateOf(initialTemplate.description) }
+    var type by remember { mutableStateOf(initialTemplate.type) }
+    var category by remember { mutableStateOf(initialTemplate.category) }
+    var variables by remember { mutableStateOf(initialTemplate.variables) }
+
+    Surface(modifier = modifier.fillMaxSize()) {
+        Column {
+            EditorToolbar(
+                isNew = initialTemplate.id == 0L,
+                onBack = onBack,
+                canSave = name.isNotBlank(),
+                onSave = {
+                    viewModel.onSaveTemplate(
+                        initialTemplate.copy(
+                            name = name.trim(),
+                            description = description.trim(),
+                            type = type,
+                            category = category,
+                            variables = variables,
+                        ),
+                    )
+                    onBack()
+                },
+            )
+            EditorContent(
+                name = name,
+                description = description,
+                type = type,
+                category = category,
+                variables = variables,
+                onNameChange = { name = it },
+                onDescriptionChange = { description = it },
+                onTypeChange = { newType ->
+                    type = newType
+                    variables = DesktopWorkflowTemplateViewModel.defaultVariablesFor(newType)
+                },
+                onCategoryChange = { category = it },
+                onVariablesChange = { variables = it },
+            )
+        }
+    }
+}
+
+@Composable
+private fun EditorToolbar(
+    isNew: Boolean,
+    onBack: () -> Unit,
+    canSave: Boolean,
+    onSave: () -> Unit,
+) {
+    Surface(tonalElevation = Elevation.xs) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = Spacing.md, vertical = Spacing.sm),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            IconButton(onClick = onBack) {
+                Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+            }
+            Text(
+                text = if (isNew) "Create Template" else "Edit Template",
+                style = MaterialTheme.typography.titleMedium,
+                modifier = Modifier.weight(1f).padding(start = Spacing.sm),
+            )
+            TextButton(onClick = onSave, enabled = canSave) { Text("Save") }
+        }
+    }
+}
+
+@Composable
+@Suppress("LongParameterList")
+private fun EditorContent(
+    name: String,
+    description: String,
+    type: WorkflowTemplateType,
+    category: WorkflowTemplateCategory,
+    variables: List<TemplateVariable>,
+    onNameChange: (String) -> Unit,
+    onDescriptionChange: (String) -> Unit,
+    onTypeChange: (WorkflowTemplateType) -> Unit,
+    onCategoryChange: (WorkflowTemplateCategory) -> Unit,
+    onVariablesChange: (List<TemplateVariable>) -> Unit,
+) {
+    LazyColumn(
+        modifier = Modifier.fillMaxSize(),
+        contentPadding = androidx.compose.foundation.layout.PaddingValues(Spacing.md),
+        verticalArrangement = Arrangement.spacedBy(Spacing.md),
+    ) {
+        item {
+            OutlinedTextField(
+                value = name,
+                onValueChange = onNameChange,
+                label = { Text("Template Name") },
+                modifier = Modifier.fillMaxWidth(),
+                singleLine = true,
+            )
+        }
+        item {
+            OutlinedTextField(
+                value = description,
+                onValueChange = onDescriptionChange,
+                label = { Text("Description") },
+                modifier = Modifier.fillMaxWidth(),
+                minLines = 2,
+                maxLines = 4,
+            )
+        }
+        item {
+            Row(horizontalArrangement = Arrangement.spacedBy(Spacing.md)) {
+                TypeSelector(type = type, onTypeChange = onTypeChange)
+                CategorySelector(category = category, onCategoryChange = onCategoryChange)
+            }
+        }
+        item {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Text(
+                    "Variables",
+                    style = MaterialTheme.typography.titleSmall,
+                    modifier = Modifier.weight(1f),
+                )
+                IconButton(
+                    onClick = {
+                        onVariablesChange(variables + newVariable(variables.size))
+                    },
+                ) {
+                    Icon(Icons.Default.Add, "Add variable")
+                }
+            }
+        }
+        itemsIndexed(variables, key = { _, v -> v.name }) { index, variable ->
+            VariableEditor(
+                variable = variable,
+                onUpdate = { updated ->
+                    onVariablesChange(
+                        variables.toMutableList().also { it[index] = updated },
+                    )
+                },
+                onDelete = {
+                    onVariablesChange(
+                        variables.toMutableList().also { it.removeAt(index) },
+                    )
+                },
+            )
+        }
+    }
+}
+
+private fun newVariable(size: Int) = TemplateVariable(
+    name = "var_${size + 1}",
+    type = TemplateVariableType.TEXT,
+    defaultValue = "",
+)
+
+@Composable
+private fun TypeSelector(
+    type: WorkflowTemplateType,
+    onTypeChange: (WorkflowTemplateType) -> Unit,
+) {
+    var expanded by remember { mutableStateOf(false) }
+    Column {
+        Text("Type", style = MaterialTheme.typography.labelMedium)
+        TextButton(onClick = { expanded = true }) { Text(typeLabel(type)) }
+        DropdownMenu(expanded = expanded, onDismissRequest = { expanded = false }) {
+            WorkflowTemplateType.entries.forEach { t ->
+                DropdownMenuItem(
+                    text = { Text(typeLabel(t)) },
+                    onClick = { onTypeChange(t); expanded = false },
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun CategorySelector(
+    category: WorkflowTemplateCategory,
+    onCategoryChange: (WorkflowTemplateCategory) -> Unit,
+) {
+    var expanded by remember { mutableStateOf(false) }
+    Column {
+        Text("Category", style = MaterialTheme.typography.labelMedium)
+        TextButton(onClick = { expanded = true }) { Text(categoryLabel(category)) }
+        DropdownMenu(expanded = expanded, onDismissRequest = { expanded = false }) {
+            WorkflowTemplateCategory.entries.forEach { c ->
+                DropdownMenuItem(
+                    text = { Text(categoryLabel(c)) },
+                    onClick = { onCategoryChange(c); expanded = false },
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun VariableEditor(
+    variable: TemplateVariable,
+    onUpdate: (TemplateVariable) -> Unit,
+    onDelete: () -> Unit,
+) {
+    Card(modifier = Modifier.fillMaxWidth()) {
+        Column(
+            modifier = Modifier.padding(Spacing.sm),
+            verticalArrangement = Arrangement.spacedBy(Spacing.xs),
+        ) {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                OutlinedTextField(
+                    value = variable.name,
+                    onValueChange = { onUpdate(variable.copy(name = it)) },
+                    label = { Text("Name") },
+                    modifier = Modifier.weight(1f),
+                    singleLine = true,
+                )
+                IconButton(onClick = onDelete) {
+                    Icon(
+                        Icons.Default.Delete, "Remove",
+                        tint = MaterialTheme.colorScheme.error,
+                    )
+                }
+            }
+            OutlinedTextField(
+                value = variable.label,
+                onValueChange = { onUpdate(variable.copy(label = it)) },
+                label = { Text("Display Label") },
+                modifier = Modifier.fillMaxWidth(),
+                singleLine = true,
+            )
+            VariableTypeAndDefault(variable = variable, onUpdate = onUpdate)
+            if (variable.type == TemplateVariableType.SLIDER) {
+                SliderRangeRow(variable = variable, onUpdate = onUpdate)
+            }
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Text(
+                    "Required",
+                    style = MaterialTheme.typography.bodySmall,
+                    modifier = Modifier.weight(1f),
+                )
+                Switch(
+                    checked = variable.required,
+                    onCheckedChange = { onUpdate(variable.copy(required = it)) },
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun VariableTypeAndDefault(
+    variable: TemplateVariable,
+    onUpdate: (TemplateVariable) -> Unit,
+) {
+    var typeMenuExpanded by remember { mutableStateOf(false) }
+    Row(
+        horizontalArrangement = Arrangement.spacedBy(Spacing.sm),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Column {
+            Text("Type", style = MaterialTheme.typography.labelSmall)
+            TextButton(onClick = { typeMenuExpanded = true }) { Text(variable.type.name) }
+            DropdownMenu(
+                expanded = typeMenuExpanded,
+                onDismissRequest = { typeMenuExpanded = false },
+            ) {
+                TemplateVariableType.entries.forEach { t ->
+                    DropdownMenuItem(
+                        text = { Text(t.name) },
+                        onClick = { onUpdate(variable.copy(type = t)); typeMenuExpanded = false },
+                    )
+                }
+            }
+        }
+        OutlinedTextField(
+            value = variable.defaultValue,
+            onValueChange = { onUpdate(variable.copy(defaultValue = it)) },
+            label = { Text("Default") },
+            modifier = Modifier.weight(1f),
+            singleLine = true,
+        )
+    }
+}
+
+@Composable
+private fun SliderRangeRow(
+    variable: TemplateVariable,
+    onUpdate: (TemplateVariable) -> Unit,
+) {
+    Row(
+        horizontalArrangement = Arrangement.spacedBy(Spacing.sm),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        OutlinedTextField(
+            value = variable.min?.toString() ?: "",
+            onValueChange = { onUpdate(variable.copy(min = it.toDoubleOrNull())) },
+            label = { Text("Min") },
+            modifier = Modifier.weight(1f),
+            singleLine = true,
+        )
+        OutlinedTextField(
+            value = variable.max?.toString() ?: "",
+            onValueChange = { onUpdate(variable.copy(max = it.toDoubleOrNull())) },
+            label = { Text("Max") },
+            modifier = Modifier.weight(1f),
+            singleLine = true,
+        )
+        OutlinedTextField(
+            value = variable.step?.toString() ?: "",
+            onValueChange = { onUpdate(variable.copy(step = it.toDoubleOrNull())) },
+            label = { Text("Step") },
+            modifier = Modifier.weight(1f),
+            singleLine = true,
+        )
+    }
+}

--- a/desktopApp/src/jvmMain/kotlin/com/riox432/civitdeck/ui/comfyui/template/DesktopWorkflowTemplateScreen.kt
+++ b/desktopApp/src/jvmMain/kotlin/com/riox432/civitdeck/ui/comfyui/template/DesktopWorkflowTemplateScreen.kt
@@ -1,0 +1,423 @@
+@file:Suppress("TooManyFunctions")
+
+package com.riox432.civitdeck.ui.comfyui.template
+
+import androidx.compose.foundation.horizontalScroll
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.ContentCopy
+import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material.icons.filled.Edit
+import androidx.compose.material.icons.filled.Search
+import androidx.compose.material.icons.filled.Upload
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Button
+import androidx.compose.material3.Card
+import androidx.compose.material3.FilterChip
+import androidx.compose.material3.FloatingActionButton
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import com.riox432.civitdeck.domain.model.WorkflowTemplate
+import com.riox432.civitdeck.domain.model.WorkflowTemplateCategory
+import com.riox432.civitdeck.domain.model.WorkflowTemplateType
+import com.riox432.civitdeck.ui.theme.Elevation
+import com.riox432.civitdeck.ui.theme.Spacing
+
+@Composable
+fun DesktopWorkflowTemplateScreen(
+    viewModel: DesktopWorkflowTemplateViewModel,
+    onBack: () -> Unit,
+    onCreateTemplate: () -> Unit,
+    onEditTemplate: (WorkflowTemplate) -> Unit,
+    onSelectTemplate: ((WorkflowTemplate) -> Unit)? = null,
+    modifier: Modifier = Modifier,
+) {
+    val state by viewModel.uiState.collectAsState()
+    val snackbarHostState = remember { SnackbarHostState() }
+    var showImportDialog by remember { mutableStateOf(false) }
+    var importText by remember { mutableStateOf("") }
+
+    LaunchedEffect(state.error) {
+        state.error?.let {
+            snackbarHostState.showSnackbar(it)
+            viewModel.dismissError()
+        }
+    }
+    LaunchedEffect(state.importError) {
+        state.importError?.let {
+            snackbarHostState.showSnackbar("Import failed: $it")
+            viewModel.onDismissImportError()
+        }
+    }
+
+    Surface(modifier = modifier.fillMaxSize()) {
+        Scaffold(
+            snackbarHost = { SnackbarHost(snackbarHostState) },
+            floatingActionButton = {
+                if (onSelectTemplate == null) {
+                    FloatingActionButton(onClick = onCreateTemplate) {
+                        Icon(Icons.Default.Add, "Create template")
+                    }
+                }
+            },
+        ) { padding ->
+            Column(modifier = Modifier.padding(padding).fillMaxSize()) {
+                TemplateToolbar(
+                    onBack = onBack,
+                    onImportClick = { showImportDialog = true },
+                    isPicker = onSelectTemplate != null,
+                )
+                TemplateSearchAndFilters(
+                    searchQuery = state.searchQuery,
+                    selectedCategory = state.selectedCategory,
+                    selectedType = state.selectedType,
+                    onSearchQueryChanged = viewModel::onSearchQueryChanged,
+                    onCategorySelected = viewModel::onCategorySelected,
+                    onTypeSelected = viewModel::onTypeSelected,
+                )
+                TemplateList(
+                    state = state,
+                    onSelectTemplate = onSelectTemplate,
+                    onEditTemplate = onEditTemplate,
+                    onExport = viewModel::onExportTemplate,
+                    onDelete = viewModel::onDeleteTemplate,
+                )
+            }
+        }
+    }
+
+    if (showImportDialog) {
+        ImportDialog(
+            text = importText,
+            onTextChange = { importText = it },
+            onConfirm = {
+                viewModel.onImportTemplate(importText)
+                importText = ""
+                showImportDialog = false
+            },
+            onDismiss = { showImportDialog = false },
+        )
+    }
+
+    state.exportedJson?.let { json ->
+        ExportDialog(json = json, onDismiss = viewModel::onDismissExport)
+    }
+}
+
+@Composable
+private fun TemplateToolbar(
+    onBack: () -> Unit,
+    onImportClick: () -> Unit,
+    isPicker: Boolean,
+) {
+    Surface(tonalElevation = Elevation.xs) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = Spacing.md, vertical = Spacing.sm),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            IconButton(onClick = onBack) {
+                Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+            }
+            Text(
+                text = if (isPicker) "Pick Template" else "Workflow Templates",
+                style = MaterialTheme.typography.titleMedium,
+                modifier = Modifier.weight(1f).padding(start = Spacing.sm),
+            )
+            IconButton(onClick = onImportClick) {
+                Icon(Icons.Default.Upload, "Import template")
+            }
+        }
+    }
+}
+
+@Composable
+@Suppress("LongParameterList")
+private fun TemplateSearchAndFilters(
+    searchQuery: String,
+    selectedCategory: WorkflowTemplateCategory?,
+    selectedType: WorkflowTemplateType?,
+    onSearchQueryChanged: (String) -> Unit,
+    onCategorySelected: (WorkflowTemplateCategory?) -> Unit,
+    onTypeSelected: (WorkflowTemplateType?) -> Unit,
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = Spacing.md, vertical = Spacing.sm),
+        verticalArrangement = Arrangement.spacedBy(Spacing.sm),
+    ) {
+        OutlinedTextField(
+            value = searchQuery,
+            onValueChange = onSearchQueryChanged,
+            placeholder = { Text("Search templates...") },
+            leadingIcon = { Icon(Icons.Default.Search, "Search") },
+            trailingIcon = if (searchQuery.isNotEmpty()) {
+                {
+                    IconButton(onClick = { onSearchQueryChanged("") }) {
+                        Icon(Icons.Default.Close, "Clear")
+                    }
+                }
+            } else {
+                null
+            },
+            singleLine = true,
+            modifier = Modifier.fillMaxWidth(),
+        )
+        CategoryFilterRow(selectedCategory, onCategorySelected)
+        TypeFilterRow(selectedType, onTypeSelected)
+    }
+}
+
+@Composable
+private fun CategoryFilterRow(
+    selectedCategory: WorkflowTemplateCategory?,
+    onCategorySelected: (WorkflowTemplateCategory?) -> Unit,
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .horizontalScroll(rememberScrollState()),
+        horizontalArrangement = Arrangement.spacedBy(Spacing.xs),
+    ) {
+        FilterChip(
+            selected = selectedCategory == null,
+            onClick = { onCategorySelected(null) },
+            label = { Text("All") },
+        )
+        WorkflowTemplateCategory.entries.forEach { category ->
+            FilterChip(
+                selected = selectedCategory == category,
+                onClick = {
+                    onCategorySelected(
+                        if (selectedCategory == category) null else category,
+                    )
+                },
+                label = { Text(categoryLabel(category)) },
+            )
+        }
+    }
+}
+
+@Composable
+private fun TypeFilterRow(
+    selectedType: WorkflowTemplateType?,
+    onTypeSelected: (WorkflowTemplateType?) -> Unit,
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .horizontalScroll(rememberScrollState()),
+        horizontalArrangement = Arrangement.spacedBy(Spacing.xs),
+    ) {
+        FilterChip(
+            selected = selectedType == null,
+            onClick = { onTypeSelected(null) },
+            label = { Text("All Types") },
+        )
+        WorkflowTemplateType.entries.forEach { type ->
+            FilterChip(
+                selected = selectedType == type,
+                onClick = {
+                    onTypeSelected(if (selectedType == type) null else type)
+                },
+                label = { Text(typeLabel(type)) },
+            )
+        }
+    }
+}
+
+@Composable
+@Suppress("LongParameterList")
+private fun TemplateList(
+    state: DesktopWorkflowTemplateUiState,
+    onSelectTemplate: ((WorkflowTemplate) -> Unit)?,
+    onEditTemplate: (WorkflowTemplate) -> Unit,
+    onExport: (WorkflowTemplate) -> Unit,
+    onDelete: (Long) -> Unit,
+) {
+    LazyColumn(
+        modifier = Modifier.fillMaxSize(),
+        contentPadding = androidx.compose.foundation.layout.PaddingValues(Spacing.md),
+        verticalArrangement = Arrangement.spacedBy(Spacing.sm),
+    ) {
+        when {
+            state.isLoading -> item {
+                Text("Loading...", style = MaterialTheme.typography.bodyMedium)
+            }
+            state.filteredTemplates.isEmpty() -> item {
+                Text(
+                    if (state.templates.isEmpty()) {
+                        "No templates yet. Create one with the + button."
+                    } else {
+                        "No templates match your filters."
+                    },
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+            else -> items(state.filteredTemplates, key = { it.id }) { template ->
+                TemplateCard(
+                    template = template,
+                    onSelect = onSelectTemplate?.let { cb -> { cb(template) } },
+                    onEdit = if (!template.isBuiltIn) { { onEditTemplate(template) } } else null,
+                    onDelete = if (!template.isBuiltIn) { { onDelete(template.id) } } else null,
+                    onExport = { onExport(template) },
+                )
+            }
+        }
+    }
+}
+
+@Composable
+@Suppress("LongParameterList")
+private fun TemplateCard(
+    template: WorkflowTemplate,
+    onSelect: (() -> Unit)?,
+    onEdit: (() -> Unit)?,
+    onDelete: (() -> Unit)?,
+    onExport: () -> Unit,
+) {
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+        onClick = onSelect ?: {},
+    ) {
+        Column(modifier = Modifier.padding(Spacing.md)) {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Column(modifier = Modifier.weight(1f)) {
+                    Text(template.name, style = MaterialTheme.typography.titleSmall)
+                    if (template.description.isNotBlank()) {
+                        Text(
+                            template.description,
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            maxLines = 2,
+                        )
+                    }
+                    Text(
+                        buildString {
+                            append(typeLabel(template.type))
+                            if (template.isBuiltIn) append(" \u2022 Built-in")
+                            append(" \u2022 ${categoryLabel(template.category)}")
+                            if (template.version > 1) append(" \u2022 v${template.version}")
+                        },
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                    if (template.variables.isNotEmpty()) {
+                        Text(
+                            "${template.variables.size} parameters",
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                    }
+                }
+                Row {
+                    IconButton(onClick = onExport) {
+                        Icon(Icons.Default.ContentCopy, "Export template")
+                    }
+                    onEdit?.let {
+                        IconButton(onClick = it) { Icon(Icons.Default.Edit, "Edit") }
+                    }
+                    onDelete?.let {
+                        IconButton(onClick = it) {
+                            Icon(
+                                Icons.Default.Delete, "Delete",
+                                tint = MaterialTheme.colorScheme.error,
+                            )
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun ImportDialog(
+    text: String,
+    onTextChange: (String) -> Unit,
+    onConfirm: () -> Unit,
+    onDismiss: () -> Unit,
+) {
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text("Import Template JSON") },
+        text = {
+            OutlinedTextField(
+                value = text,
+                onValueChange = onTextChange,
+                label = { Text("Paste template JSON") },
+                modifier = Modifier.fillMaxWidth(),
+                minLines = 5,
+                maxLines = 10,
+            )
+        },
+        confirmButton = { Button(onClick = onConfirm) { Text("Import") } },
+        dismissButton = { TextButton(onClick = onDismiss) { Text("Cancel") } },
+    )
+}
+
+@Composable
+private fun ExportDialog(json: String, onDismiss: () -> Unit) {
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text("Template JSON") },
+        text = {
+            OutlinedTextField(
+                value = json,
+                onValueChange = {},
+                readOnly = true,
+                modifier = Modifier.fillMaxWidth(),
+                minLines = 6,
+                maxLines = 12,
+            )
+        },
+        confirmButton = { Button(onClick = onDismiss) { Text("Done") } },
+    )
+}
+
+internal fun typeLabel(type: WorkflowTemplateType) = when (type) {
+    WorkflowTemplateType.TXT2IMG -> "txt2img"
+    WorkflowTemplateType.IMG2IMG -> "img2img"
+    WorkflowTemplateType.INPAINTING -> "Inpainting"
+    WorkflowTemplateType.UPSCALE -> "Upscale"
+    WorkflowTemplateType.LORA -> "LoRA"
+}
+
+internal fun categoryLabel(category: WorkflowTemplateCategory) = when (category) {
+    WorkflowTemplateCategory.GENERAL -> "General"
+    WorkflowTemplateCategory.ANIME -> "Anime"
+    WorkflowTemplateCategory.PHOTOREALISTIC -> "Photo"
+    WorkflowTemplateCategory.ARTISTIC -> "Artistic"
+    WorkflowTemplateCategory.UTILITY -> "Utility"
+}

--- a/desktopApp/src/jvmMain/kotlin/com/riox432/civitdeck/ui/comfyui/template/DesktopWorkflowTemplateViewModel.kt
+++ b/desktopApp/src/jvmMain/kotlin/com/riox432/civitdeck/ui/comfyui/template/DesktopWorkflowTemplateViewModel.kt
@@ -1,0 +1,229 @@
+package com.riox432.civitdeck.ui.comfyui.template
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.riox432.civitdeck.domain.model.TemplateVariable
+import com.riox432.civitdeck.domain.model.TemplateVariableType
+import com.riox432.civitdeck.domain.model.WorkflowTemplate
+import com.riox432.civitdeck.domain.model.WorkflowTemplateCategory
+import com.riox432.civitdeck.domain.model.WorkflowTemplateType
+import com.riox432.civitdeck.feature.comfyui.domain.usecase.DeleteWorkflowTemplateUseCase
+import com.riox432.civitdeck.feature.comfyui.domain.usecase.ExportWorkflowTemplateUseCase
+import com.riox432.civitdeck.feature.comfyui.domain.usecase.GetWorkflowTemplatesUseCase
+import com.riox432.civitdeck.feature.comfyui.domain.usecase.ImportWorkflowTemplateUseCase
+import com.riox432.civitdeck.feature.comfyui.domain.usecase.SaveWorkflowTemplateUseCase
+import com.riox432.civitdeck.util.Logger
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+
+data class DesktopWorkflowTemplateUiState(
+    val templates: List<WorkflowTemplate> = emptyList(),
+    val filteredTemplates: List<WorkflowTemplate> = emptyList(),
+    val isLoading: Boolean = true,
+    val error: String? = null,
+    val exportedJson: String? = null,
+    val importError: String? = null,
+    val searchQuery: String = "",
+    val selectedCategory: WorkflowTemplateCategory? = null,
+    val selectedType: WorkflowTemplateType? = null,
+)
+
+@Suppress("TooManyFunctions")
+class DesktopWorkflowTemplateViewModel(
+    private val getTemplates: GetWorkflowTemplatesUseCase,
+    private val saveTemplate: SaveWorkflowTemplateUseCase,
+    private val deleteTemplate: DeleteWorkflowTemplateUseCase,
+    private val exportTemplate: ExportWorkflowTemplateUseCase,
+    private val importTemplate: ImportWorkflowTemplateUseCase,
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow(DesktopWorkflowTemplateUiState())
+    val uiState: StateFlow<DesktopWorkflowTemplateUiState> = _uiState
+
+    init {
+        observeTemplates()
+    }
+
+    private fun observeTemplates() {
+        viewModelScope.launch {
+            getTemplates()
+                .catch { e ->
+                    _uiState.update { it.copy(isLoading = false, error = e.message) }
+                }
+                .collect { templates ->
+                    _uiState.update {
+                        it.copy(
+                            templates = templates,
+                            isLoading = false,
+                        ).applyFilters()
+                    }
+                }
+        }
+    }
+
+    fun onSearchQueryChanged(query: String) {
+        _uiState.update { it.copy(searchQuery = query).applyFilters() }
+    }
+
+    fun onCategorySelected(category: WorkflowTemplateCategory?) {
+        _uiState.update { it.copy(selectedCategory = category).applyFilters() }
+    }
+
+    fun onTypeSelected(type: WorkflowTemplateType?) {
+        _uiState.update { it.copy(selectedType = type).applyFilters() }
+    }
+
+    fun onDeleteTemplate(id: Long) {
+        viewModelScope.launch {
+            try {
+                deleteTemplate(id)
+            } catch (@Suppress("TooGenericExceptionCaught") e: Exception) {
+                Logger.e(TAG, "Failed to delete template $id: ${e.message}")
+                _uiState.update { it.copy(error = e.message) }
+            }
+        }
+    }
+
+    fun onExportTemplate(template: WorkflowTemplate) {
+        val json = exportTemplate(template)
+        _uiState.update { it.copy(exportedJson = json) }
+    }
+
+    fun onDismissExport() {
+        _uiState.update { it.copy(exportedJson = null) }
+    }
+
+    fun onImportTemplate(jsonString: String) {
+        viewModelScope.launch {
+            try {
+                importTemplate(jsonString)
+                _uiState.update { it.copy(importError = null) }
+            } catch (@Suppress("TooGenericExceptionCaught") e: Exception) {
+                Logger.e(TAG, "Failed to import template: ${e.message}")
+                _uiState.update { it.copy(importError = e.message) }
+            }
+        }
+    }
+
+    fun onDismissImportError() {
+        _uiState.update { it.copy(importError = null) }
+    }
+
+    fun onSaveTemplate(template: WorkflowTemplate) {
+        viewModelScope.launch {
+            try {
+                saveTemplate(template)
+            } catch (@Suppress("TooGenericExceptionCaught") e: Exception) {
+                Logger.e(TAG, "Failed to save template: ${e.message}")
+                _uiState.update { it.copy(error = e.message) }
+            }
+        }
+    }
+
+    fun dismissError() {
+        _uiState.update { it.copy(error = null) }
+    }
+
+    companion object {
+        private const val TAG = "DesktopWorkflowTemplateVM"
+
+        fun emptyTemplate(
+            type: WorkflowTemplateType = WorkflowTemplateType.TXT2IMG,
+        ): WorkflowTemplate =
+            WorkflowTemplate(
+                id = 0L,
+                name = "",
+                type = type,
+                variables = defaultVariablesFor(type),
+                isBuiltIn = false,
+                createdAt = 0L,
+            )
+
+        fun defaultVariablesFor(type: WorkflowTemplateType): List<TemplateVariable> =
+            when (type) {
+                WorkflowTemplateType.TXT2IMG -> txt2imgVars()
+                WorkflowTemplateType.IMG2IMG -> txt2imgVars() + denoiseVar()
+                WorkflowTemplateType.INPAINTING -> inpaintingVars()
+                WorkflowTemplateType.UPSCALE -> upscaleVars()
+                WorkflowTemplateType.LORA -> loraVars()
+            }
+
+        private fun txt2imgVars() = listOf(
+            promptVar(), negativePromptVar(), checkpointVar(),
+            stepsVar(), cfgVar(), widthVar(), heightVar(),
+        )
+
+        private fun inpaintingVars() = listOf(
+            promptVar(), negativePromptVar(), checkpointVar(),
+            stepsVar(), cfgVar(), denoiseVar(default = "1.0"),
+        )
+
+        private fun upscaleVars() = listOf(
+            TemplateVariable("input_image", "Input Image", "", TemplateVariableType.TEXT, ""),
+            TemplateVariable(
+                "upscale_factor", "Upscale Factor", "",
+                TemplateVariableType.SLIDER, "2", 1.0, 4.0, 0.5,
+            ),
+        )
+
+        private fun loraVars() = listOf(
+            promptVar(), negativePromptVar(), checkpointVar(),
+            TemplateVariable("lora_name", "LoRA Model", "", TemplateVariableType.TEXT, "", required = true),
+            TemplateVariable(
+                "lora_strength", "LoRA Strength", "",
+                TemplateVariableType.SLIDER, "0.8", 0.0, 2.0, 0.05,
+            ),
+            stepsVar(), cfgVar(), widthVar(), heightVar(),
+        )
+
+        private fun promptVar() = TemplateVariable(
+            "positive_prompt", "Prompt", "", TemplateVariableType.TEXT, "", required = true,
+        )
+
+        private fun negativePromptVar() = TemplateVariable(
+            "negative_prompt", "Negative Prompt", "", TemplateVariableType.TEXT, "", required = false,
+        )
+
+        private fun checkpointVar() = TemplateVariable(
+            "checkpoint", "Checkpoint", "", TemplateVariableType.TEXT, "", required = true,
+        )
+
+        private fun stepsVar() = TemplateVariable(
+            "steps", "Steps", "", TemplateVariableType.SLIDER, "20", 1.0, 150.0, 1.0,
+        )
+
+        private fun cfgVar() = TemplateVariable(
+            "cfg", "CFG Scale", "", TemplateVariableType.SLIDER, "7.0", 1.0, 30.0, 0.5,
+        )
+
+        private fun widthVar() = TemplateVariable(
+            "width", "Width", "", TemplateVariableType.SELECT, "512",
+            options = listOf("256", "384", "512", "640", "768", "832", "896", "1024", "1280"),
+        )
+
+        private fun heightVar() = TemplateVariable(
+            "height", "Height", "", TemplateVariableType.SELECT, "512",
+            options = listOf("256", "384", "512", "640", "768", "832", "896", "1024", "1280"),
+        )
+
+        private fun denoiseVar(default: String = "0.75") = TemplateVariable(
+            "denoise_strength", "Denoise Strength", "",
+            TemplateVariableType.SLIDER, default, 0.0, 1.0, 0.05,
+        )
+    }
+}
+
+private fun DesktopWorkflowTemplateUiState.applyFilters(): DesktopWorkflowTemplateUiState {
+    val filtered = templates.filter { template ->
+        val matchesSearch = searchQuery.isBlank() ||
+            template.name.contains(searchQuery, ignoreCase = true) ||
+            template.description.contains(searchQuery, ignoreCase = true)
+        val matchesCategory = selectedCategory == null || template.category == selectedCategory
+        val matchesType = selectedType == null || template.type == selectedType
+        matchesSearch && matchesCategory && matchesType
+    }
+    return copy(filteredTemplates = filtered)
+}

--- a/desktopApp/src/jvmMain/kotlin/com/riox432/civitdeck/ui/create/DesktopCreateHubScreen.kt
+++ b/desktopApp/src/jvmMain/kotlin/com/riox432/civitdeck/ui/create/DesktopCreateHubScreen.kt
@@ -15,6 +15,7 @@ import androidx.compose.material.icons.automirrored.filled.ArrowForward
 import androidx.compose.material.icons.filled.Brush
 import androidx.compose.material.icons.filled.Cloud
 import androidx.compose.material.icons.filled.Dns
+import androidx.compose.material.icons.filled.Description
 import androidx.compose.material3.Card
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
@@ -36,6 +37,7 @@ private val CREATE_ITEMS = listOf(
     CreateHubItem("ComfyUI", "Node-based generation workflow", Icons.Default.Brush),
     CreateHubItem("SD WebUI", "Stable Diffusion WebUI generation", Icons.Default.Cloud),
     CreateHubItem("External Server", "Custom server connection", Icons.Default.Dns),
+    CreateHubItem("Workflow Templates", "Manage and use workflow templates", Icons.Default.Description),
 )
 
 @Composable
@@ -43,9 +45,10 @@ fun DesktopCreateHubScreen(
     onComfyUIClick: () -> Unit,
     onSDWebUIClick: () -> Unit,
     onExternalServerClick: () -> Unit,
+    onWorkflowTemplatesClick: () -> Unit = {},
     modifier: Modifier = Modifier,
 ) {
-    val callbacks = listOf(onComfyUIClick, onSDWebUIClick, onExternalServerClick)
+    val callbacks = listOf(onComfyUIClick, onSDWebUIClick, onExternalServerClick, onWorkflowTemplatesClick)
 
     Column(
         modifier = modifier

--- a/desktopApp/src/jvmMain/kotlin/com/riox432/civitdeck/ui/downloadqueue/DesktopDownloadQueueScreen.kt
+++ b/desktopApp/src/jvmMain/kotlin/com/riox432/civitdeck/ui/downloadqueue/DesktopDownloadQueueScreen.kt
@@ -1,0 +1,416 @@
+@file:Suppress("TooManyFunctions")
+
+package com.riox432.civitdeck.ui.downloadqueue
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Cancel
+import androidx.compose.material.icons.filled.CheckCircle
+import androidx.compose.material.icons.filled.CloudDownload
+import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material.icons.filled.Pause
+import androidx.compose.material.icons.filled.PlayArrow
+import androidx.compose.material.icons.filled.Refresh
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.LinearProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import com.riox432.civitdeck.domain.model.DownloadStatus
+import com.riox432.civitdeck.domain.model.ModelDownload
+import com.riox432.civitdeck.domain.util.FormatUtils
+import com.riox432.civitdeck.ui.theme.Elevation
+import com.riox432.civitdeck.ui.theme.Spacing
+
+@Composable
+fun DesktopDownloadQueueScreen(
+    viewModel: DesktopDownloadQueueViewModel,
+    onBack: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val state by viewModel.uiState.collectAsState()
+
+    Surface(modifier = modifier.fillMaxSize()) {
+        Column {
+            DownloadQueueToolbar(onBack = onBack)
+            DownloadQueueBody(
+                state = state,
+                onPause = viewModel::pauseDownload,
+                onResume = viewModel::resumeDownload,
+                onCancel = viewModel::cancelDownload,
+                onRetry = viewModel::retryDownload,
+                onDelete = viewModel::deleteDownload,
+                onClearCompleted = viewModel::clearCompleted,
+            )
+        }
+    }
+}
+
+@Composable
+private fun DownloadQueueToolbar(onBack: () -> Unit) {
+    Surface(tonalElevation = Elevation.xs) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = Spacing.md, vertical = Spacing.sm),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            IconButton(onClick = onBack) {
+                Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+            }
+            Text(
+                text = "Download Queue",
+                style = MaterialTheme.typography.titleMedium,
+                modifier = Modifier.padding(start = Spacing.sm),
+            )
+        }
+    }
+}
+
+@Composable
+@Suppress("LongParameterList")
+private fun DownloadQueueBody(
+    state: DesktopDownloadQueueUiState,
+    onPause: (Long) -> Unit,
+    onResume: (Long) -> Unit,
+    onCancel: (Long) -> Unit,
+    onRetry: (Long) -> Unit,
+    onDelete: (Long) -> Unit,
+    onClearCompleted: () -> Unit,
+) {
+    val isEmpty = state.activeDownloads.isEmpty() &&
+        state.completedDownloads.isEmpty() &&
+        state.failedDownloads.isEmpty()
+
+    if (isEmpty && !state.isLoading) {
+        EmptyDownloadQueue()
+        return
+    }
+
+    LazyColumn(modifier = Modifier.fillMaxSize()) {
+        if (state.activeDownloads.isNotEmpty()) {
+            item { SectionHeader("Active") }
+            items(state.activeDownloads, key = { it.id }) { download ->
+                ActiveDownloadItem(download, onPause, onResume, onCancel)
+            }
+        }
+        if (state.failedDownloads.isNotEmpty()) {
+            item { SectionHeader("Failed") }
+            items(state.failedDownloads, key = { it.id }) { download ->
+                FailedDownloadItem(download, onRetry, onDelete)
+            }
+        }
+        if (state.completedDownloads.isNotEmpty()) {
+            item { CompletedSectionHeader(onClearCompleted) }
+            items(state.completedDownloads, key = { it.id }) { download ->
+                CompletedDownloadItem(download, onDelete)
+            }
+        }
+        if (state.totalStorageBytes > 0) {
+            item {
+                Text(
+                    text = "Total storage: ${FormatUtils.formatFileSize(state.totalStorageBytes / KB_DIVISOR)}",
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.padding(Spacing.md),
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun EmptyDownloadQueue() {
+    Column(
+        modifier = Modifier.fillMaxSize().padding(Spacing.xl),
+        verticalArrangement = Arrangement.Center,
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        Icon(
+            Icons.Default.CloudDownload,
+            contentDescription = null,
+            modifier = Modifier.size(EMPTY_ICON_SIZE),
+            tint = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        Text(
+            text = "No downloads",
+            style = MaterialTheme.typography.titleMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier.padding(top = Spacing.md),
+        )
+        Text(
+            text = "Downloads you start will appear here",
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+    }
+}
+
+@Composable
+private fun SectionHeader(title: String) {
+    Text(
+        text = title,
+        style = MaterialTheme.typography.titleSmall,
+        color = MaterialTheme.colorScheme.primary,
+        modifier = Modifier.padding(horizontal = Spacing.md, vertical = Spacing.sm),
+    )
+}
+
+@Composable
+private fun CompletedSectionHeader(onClearCompleted: () -> Unit) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = Spacing.md, vertical = Spacing.xs),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.SpaceBetween,
+    ) {
+        Text(
+            text = "Completed",
+            style = MaterialTheme.typography.titleSmall,
+            color = MaterialTheme.colorScheme.primary,
+        )
+        TextButton(onClick = onClearCompleted) {
+            Text("Clear All")
+        }
+    }
+}
+
+@Composable
+private fun ActiveDownloadItem(
+    download: ModelDownload,
+    onPause: (Long) -> Unit,
+    onResume: (Long) -> Unit,
+    onCancel: (Long) -> Unit,
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = Spacing.md, vertical = Spacing.sm),
+    ) {
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    text = download.modelName,
+                    style = MaterialTheme.typography.bodyMedium,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                )
+                Text(
+                    text = download.fileName,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                )
+            }
+            ActiveDownloadActions(download, onPause, onResume, onCancel)
+        }
+        DownloadProgressBar(download)
+    }
+}
+
+@Composable
+private fun ActiveDownloadActions(
+    download: ModelDownload,
+    onPause: (Long) -> Unit,
+    onResume: (Long) -> Unit,
+    onCancel: (Long) -> Unit,
+) {
+    Row(verticalAlignment = Alignment.CenterVertically) {
+        when (download.status) {
+            DownloadStatus.Downloading -> {
+                IconButton(onClick = { onPause(download.id) }) {
+                    Icon(
+                        Icons.Default.Pause,
+                        contentDescription = "Pause",
+                        tint = MaterialTheme.colorScheme.primary,
+                    )
+                }
+            }
+            DownloadStatus.Paused -> {
+                IconButton(onClick = { onResume(download.id) }) {
+                    Icon(
+                        Icons.Default.PlayArrow,
+                        contentDescription = "Resume",
+                        tint = MaterialTheme.colorScheme.primary,
+                    )
+                }
+            }
+            DownloadStatus.Pending -> {
+                CircularProgressIndicator(
+                    modifier = Modifier.size(INDICATOR_SIZE),
+                    strokeWidth = 2.dp,
+                )
+            }
+            else -> {}
+        }
+        IconButton(onClick = { onCancel(download.id) }) {
+            Icon(
+                Icons.Default.Cancel,
+                contentDescription = "Cancel",
+                tint = MaterialTheme.colorScheme.error,
+            )
+        }
+    }
+}
+
+@Composable
+private fun DownloadProgressBar(download: ModelDownload) {
+    val progress = if (download.fileSizeBytes > 0) {
+        download.downloadedBytes.toFloat() / download.fileSizeBytes
+    } else {
+        0f
+    }
+
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(Spacing.sm),
+        modifier = Modifier.padding(top = Spacing.xs),
+    ) {
+        if (download.status == DownloadStatus.Paused) {
+            Text(
+                text = "Paused",
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+        LinearProgressIndicator(
+            progress = { progress.coerceIn(0f, 1f) },
+            modifier = Modifier.weight(1f),
+        )
+        Text(
+            text = "${(progress * PERCENT_MAX).toInt()}%",
+            style = MaterialTheme.typography.labelSmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+    }
+}
+
+@Composable
+private fun FailedDownloadItem(
+    download: ModelDownload,
+    onRetry: (Long) -> Unit,
+    onDelete: (Long) -> Unit,
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = Spacing.md, vertical = Spacing.sm),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Column(modifier = Modifier.weight(1f)) {
+            Text(
+                text = download.modelName,
+                style = MaterialTheme.typography.bodyMedium,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+            )
+            Text(
+                text = download.errorMessage ?: download.status.name,
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.error,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+            )
+        }
+        IconButton(onClick = { onRetry(download.id) }) {
+            Icon(
+                Icons.Default.Refresh,
+                contentDescription = "Retry",
+                tint = MaterialTheme.colorScheme.primary,
+            )
+        }
+        IconButton(onClick = { onDelete(download.id) }) {
+            Icon(
+                Icons.Default.Delete,
+                contentDescription = "Delete",
+                tint = MaterialTheme.colorScheme.error,
+            )
+        }
+    }
+}
+
+@Composable
+private fun CompletedDownloadItem(
+    download: ModelDownload,
+    onDelete: (Long) -> Unit,
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = Spacing.md, vertical = Spacing.sm),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Column(modifier = Modifier.weight(1f)) {
+            Text(
+                text = download.modelName,
+                style = MaterialTheme.typography.bodyMedium,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+            )
+            Row(horizontalArrangement = Arrangement.spacedBy(Spacing.sm)) {
+                Text(
+                    text = FormatUtils.formatFileSize(download.fileSizeBytes / KB_DIVISOR),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+                HashBadge(download)
+            }
+        }
+        Icon(
+            Icons.Default.CheckCircle,
+            contentDescription = "Downloaded",
+            tint = MaterialTheme.colorScheme.primary,
+            modifier = Modifier.padding(Spacing.sm),
+        )
+        IconButton(onClick = { onDelete(download.id) }) {
+            Icon(
+                Icons.Default.Delete,
+                contentDescription = "Delete",
+                tint = MaterialTheme.colorScheme.error,
+            )
+        }
+    }
+}
+
+@Composable
+private fun HashBadge(download: ModelDownload) {
+    when (download.hashVerified) {
+        true -> Text(
+            text = "Verified",
+            style = MaterialTheme.typography.labelSmall,
+            color = MaterialTheme.colorScheme.primary,
+        )
+        false -> Text(
+            text = "Hash mismatch",
+            style = MaterialTheme.typography.labelSmall,
+            color = MaterialTheme.colorScheme.error,
+        )
+        null -> {}
+    }
+}
+
+private val INDICATOR_SIZE = 24.dp
+private val EMPTY_ICON_SIZE = 64.dp
+private const val PERCENT_MAX = 100
+private const val KB_DIVISOR = 1024.0

--- a/desktopApp/src/jvmMain/kotlin/com/riox432/civitdeck/ui/downloadqueue/DesktopDownloadQueueViewModel.kt
+++ b/desktopApp/src/jvmMain/kotlin/com/riox432/civitdeck/ui/downloadqueue/DesktopDownloadQueueViewModel.kt
@@ -1,0 +1,116 @@
+package com.riox432.civitdeck.ui.downloadqueue
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.riox432.civitdeck.domain.model.DownloadStatus
+import com.riox432.civitdeck.domain.model.ModelDownload
+import com.riox432.civitdeck.domain.usecase.CancelDownloadUseCase
+import com.riox432.civitdeck.domain.usecase.ClearCompletedDownloadsUseCase
+import com.riox432.civitdeck.domain.usecase.DeleteDownloadUseCase
+import com.riox432.civitdeck.domain.usecase.ObserveDownloadsUseCase
+import com.riox432.civitdeck.domain.usecase.PauseDownloadUseCase
+import com.riox432.civitdeck.domain.usecase.ResumeDownloadUseCase
+import com.riox432.civitdeck.util.Logger
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import kotlin.coroutines.cancellation.CancellationException
+
+data class DesktopDownloadQueueUiState(
+    val activeDownloads: List<ModelDownload> = emptyList(),
+    val completedDownloads: List<ModelDownload> = emptyList(),
+    val failedDownloads: List<ModelDownload> = emptyList(),
+    val isLoading: Boolean = true,
+    val totalStorageBytes: Long = 0,
+)
+
+class DesktopDownloadQueueViewModel(
+    observeDownloadsUseCase: ObserveDownloadsUseCase,
+    private val pauseDownloadUseCase: PauseDownloadUseCase,
+    private val resumeDownloadUseCase: ResumeDownloadUseCase,
+    private val cancelDownloadUseCase: CancelDownloadUseCase,
+    private val deleteDownloadUseCase: DeleteDownloadUseCase,
+    private val clearCompletedDownloadsUseCase: ClearCompletedDownloadsUseCase,
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow(DesktopDownloadQueueUiState())
+    val uiState: StateFlow<DesktopDownloadQueueUiState> = _uiState.asStateFlow()
+
+    init {
+        viewModelScope.launch {
+            observeDownloadsUseCase().collect { downloads ->
+                val active = downloads.filter {
+                    it.status in listOf(
+                        DownloadStatus.Pending,
+                        DownloadStatus.Downloading,
+                        DownloadStatus.Paused,
+                    )
+                }
+                val completed = downloads.filter { it.status == DownloadStatus.Completed }
+                val failed = downloads.filter {
+                    it.status in listOf(DownloadStatus.Failed, DownloadStatus.Cancelled)
+                }
+                val totalBytes = completed.sumOf { it.fileSizeBytes }
+                _uiState.update {
+                    it.copy(
+                        activeDownloads = active,
+                        completedDownloads = completed,
+                        failedDownloads = failed,
+                        isLoading = false,
+                        totalStorageBytes = totalBytes,
+                    )
+                }
+            }
+        }
+    }
+
+    fun pauseDownload(downloadId: Long) {
+        viewModelScope.launch {
+            safeCall("Pause") { pauseDownloadUseCase(downloadId) }
+        }
+    }
+
+    fun resumeDownload(downloadId: Long) {
+        viewModelScope.launch {
+            safeCall("Resume") { resumeDownloadUseCase(downloadId) }
+        }
+    }
+
+    fun cancelDownload(downloadId: Long) {
+        viewModelScope.launch {
+            safeCall("Cancel") { cancelDownloadUseCase(downloadId) }
+        }
+    }
+
+    fun retryDownload(downloadId: Long) {
+        viewModelScope.launch {
+            safeCall("Retry") { resumeDownloadUseCase(downloadId) }
+        }
+    }
+
+    fun deleteDownload(downloadId: Long) {
+        viewModelScope.launch {
+            safeCall("Delete") { deleteDownloadUseCase(downloadId) }
+        }
+    }
+
+    fun clearCompleted() {
+        viewModelScope.launch {
+            safeCall("ClearCompleted") { clearCompletedDownloadsUseCase() }
+        }
+    }
+
+    private suspend fun safeCall(tag: String, block: suspend () -> Unit) {
+        try {
+            block()
+        } catch (e: CancellationException) {
+            throw e
+        } catch (@Suppress("TooGenericExceptionCaught") e: Exception) {
+            Logger.w(TAG, "$tag failed: ${e.message}")
+        }
+    }
+}
+
+private const val TAG = "DesktopDownloadQueueVM"

--- a/desktopApp/src/jvmMain/kotlin/com/riox432/civitdeck/ui/settings/DesktopSettingsScreen.kt
+++ b/desktopApp/src/jvmMain/kotlin/com/riox432/civitdeck/ui/settings/DesktopSettingsScreen.kt
@@ -56,6 +56,7 @@ fun DesktopSettingsScreen(
     onNavigateToAnalytics: () -> Unit = {},
     onNavigateToNotificationCenter: () -> Unit = {},
     onNavigateToBrowsingHistory: () -> Unit = {},
+    onNavigateToDownloadQueue: () -> Unit = {},
     modifier: Modifier = Modifier,
 ) {
     Column(
@@ -70,6 +71,7 @@ fun DesktopSettingsScreen(
             onNavigateToAnalytics = onNavigateToAnalytics,
             onNavigateToNotificationCenter = onNavigateToNotificationCenter,
             onNavigateToBrowsingHistory = onNavigateToBrowsingHistory,
+            onNavigateToDownloadQueue = onNavigateToDownloadQueue,
         )
         DisplaySettingsSection(displaySettingsViewModel)
         ContentFilterSection(contentFilterSettingsViewModel)
@@ -88,6 +90,7 @@ private fun ToolsSection(
     onNavigateToAnalytics: () -> Unit,
     onNavigateToNotificationCenter: () -> Unit,
     onNavigateToBrowsingHistory: () -> Unit,
+    onNavigateToDownloadQueue: () -> Unit,
 ) {
     SettingsCard(title = "Tools") {
         Row(horizontalArrangement = Arrangement.spacedBy(Spacing.sm)) {
@@ -97,6 +100,7 @@ private fun ToolsSection(
             OutlinedButton(onClick = onNavigateToAnalytics) { Text("Analytics") }
             OutlinedButton(onClick = onNavigateToNotificationCenter) { Text("Notifications") }
             OutlinedButton(onClick = onNavigateToBrowsingHistory) { Text("History") }
+            OutlinedButton(onClick = onNavigateToDownloadQueue) { Text("Downloads") }
         }
     }
 }


### PR DESCRIPTION
## Summary
- Port **Download Queue** screen to Desktop (ViewModel + Screen with pause/resume/cancel/retry/delete/clear actions, no WorkManager dependency)
- Port **Workflow Template Library** to Desktop (list, search/filter, create, edit, import/export, delete)
- Port **Template Parameter Editor** to Desktop (slider, select, number, text inputs with generate button)
- Add "Downloads" tool entry in Settings, "Workflow Templates" entry in Create hub
- Register new Desktop ViewModels in Koin DI module
- Add new routes to DesktopNavigation sealed class

## Test plan
- [ ] Verify Desktop compiles and runs with `./gradlew :desktopApp:run`
- [ ] Navigate to Settings > Tools > Downloads — confirm Download Queue screen renders
- [ ] Navigate to Create > Workflow Templates — confirm template list, search, filters work
- [ ] Create/edit a workflow template — verify editor screen
- [ ] Select a template — verify parameter editor renders with correct input types
- [ ] Verify Android and iOS builds are unaffected

Closes #608