### PR TITLE
#712 Background embedding indexer — auto-embed on browse/favorite

### DIFF
--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/CivitDeckApplication.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/CivitDeckApplication.kt
@@ -116,7 +116,7 @@ val androidModule = module {
     viewModel { params ->
         ModelDetailViewModel(
             params.get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get(),
-            get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get(),
+            get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get(),
         )
     }
     viewModel { params -> DuplicateReviewViewModel(params.get(), get(), get()) }

--- a/core/core-domain/src/commonMain/kotlin/com/riox432/civitdeck/di/EmbeddingDomainModule.kt
+++ b/core/core-domain/src/commonMain/kotlin/com/riox432/civitdeck/di/EmbeddingDomainModule.kt
@@ -2,11 +2,13 @@ package com.riox432.civitdeck.di
 
 import com.riox432.civitdeck.domain.ml.ImageEmbeddingModel
 import com.riox432.civitdeck.domain.usecase.EmbedImageUseCase
+import com.riox432.civitdeck.domain.usecase.EmbedOnBrowseUseCase
 import com.riox432.civitdeck.domain.usecase.FindSimilarModelsByEmbeddingUseCase
 import org.koin.dsl.module
 
 val embeddingDomainModule = module {
     single { ImageEmbeddingModel() }
     factory { EmbedImageUseCase(get()) }
+    factory { EmbedOnBrowseUseCase(get(), get(), get()) }
     factory { FindSimilarModelsByEmbeddingUseCase(get()) }
 }

--- a/core/core-domain/src/commonMain/kotlin/com/riox432/civitdeck/domain/repository/ThumbnailDownloader.kt
+++ b/core/core-domain/src/commonMain/kotlin/com/riox432/civitdeck/domain/repository/ThumbnailDownloader.kt
@@ -1,0 +1,12 @@
+package com.riox432.civitdeck.domain.repository
+
+/**
+ * Downloads raw image bytes from a URL.
+ *
+ * Extracted as an interface so the domain layer stays free of Ktor / HTTP
+ * dependencies. The implementation lives in `:core:core-network`.
+ */
+fun interface ThumbnailDownloader {
+    /** Returns the raw JPEG/PNG bytes for [url], or throws on network failure. */
+    suspend fun download(url: String): ByteArray
+}

--- a/core/core-domain/src/commonMain/kotlin/com/riox432/civitdeck/domain/usecase/EmbedOnBrowseUseCase.kt
+++ b/core/core-domain/src/commonMain/kotlin/com/riox432/civitdeck/domain/usecase/EmbedOnBrowseUseCase.kt
@@ -1,0 +1,50 @@
+package com.riox432.civitdeck.domain.usecase
+
+import com.riox432.civitdeck.domain.model.ModelEmbedding
+import com.riox432.civitdeck.domain.repository.ModelEmbeddingRepository
+import com.riox432.civitdeck.domain.repository.ThumbnailDownloader
+
+/**
+ * Automatically embeds a model's thumbnail image when the user browses or favorites it.
+ *
+ * The embedding is produced by [EmbedImageUseCase] (which delegates to the platform
+ * [ImageEmbeddingModel][com.riox432.civitdeck.domain.ml.ImageEmbeddingModel]) and cached
+ * via [ModelEmbeddingRepository] so that "Find Similar" can use it later.
+ *
+ * Short-circuits silently when:
+ * - an embedding is already cached for this model
+ * - the on-device embedder is unavailable (e.g. Desktop)
+ *
+ * Callers should wrap invocations in `runCatching` — this use case must never block UI.
+ */
+class EmbedOnBrowseUseCase(
+    private val embeddingRepository: ModelEmbeddingRepository,
+    private val embedImage: EmbedImageUseCase,
+    private val downloader: ThumbnailDownloader,
+) {
+    /**
+     * Downloads the thumbnail at [thumbnailUrl], embeds it, and caches the result
+     * for [modelId]. No-op if the embedding is already cached or the embedder is
+     * unavailable on this platform.
+     */
+    suspend operator fun invoke(modelId: Long, thumbnailUrl: String) {
+        if (!embedImage.isAvailable) return
+        if (embeddingRepository.get(modelId) != null) return
+
+        val imageBytes = downloader.download(thumbnailUrl)
+        val vector = embedImage(imageBytes)
+        embeddingRepository.cache(
+            ModelEmbedding(
+                modelId = modelId,
+                embeddingModel = EMBEDDING_MODEL_ID,
+                vector = vector,
+                cachedAt = 0L, // repository fills in current time when cachedAt <= 0
+            ),
+        )
+    }
+
+    private companion object {
+        /** Matches the SigLIP-2 base model used across all platforms. */
+        private const val EMBEDDING_MODEL_ID = "siglip2-base-p16-224"
+    }
+}

--- a/core/core-network/src/commonMain/kotlin/com/riox432/civitdeck/data/api/ThumbnailDownloaderImpl.kt
+++ b/core/core-network/src/commonMain/kotlin/com/riox432/civitdeck/data/api/ThumbnailDownloaderImpl.kt
@@ -1,0 +1,21 @@
+package com.riox432.civitdeck.data.api
+
+import com.riox432.civitdeck.domain.repository.ThumbnailDownloader
+import io.ktor.client.HttpClient
+import io.ktor.client.request.get
+import io.ktor.client.statement.readRawBytes
+
+/**
+ * Ktor-backed implementation of [ThumbnailDownloader].
+ *
+ * Uses the existing CivitAI [HttpClient] for connection pooling and retry policy.
+ * The response is read as raw bytes without JSON deserialization, so the
+ * `ContentNegotiation` plugin is not invoked.
+ */
+class ThumbnailDownloaderImpl(
+    private val client: HttpClient,
+) : ThumbnailDownloader {
+
+    override suspend fun download(url: String): ByteArray =
+        client.get(url).readRawBytes()
+}

--- a/core/core-network/src/commonMain/kotlin/com/riox432/civitdeck/di/NetworkModule.kt
+++ b/core/core-network/src/commonMain/kotlin/com/riox432/civitdeck/di/NetworkModule.kt
@@ -3,6 +3,8 @@ package com.riox432.civitdeck.di
 import com.riox432.civitdeck.data.api.ApiKeyProvider
 import com.riox432.civitdeck.data.api.CivitAiApi
 import com.riox432.civitdeck.data.api.GitHubReleaseApi
+import com.riox432.civitdeck.data.api.ThumbnailDownloaderImpl
+import com.riox432.civitdeck.domain.repository.ThumbnailDownloader
 import com.riox432.civitdeck.data.api.civitailink.CivitaiLinkApi
 import com.riox432.civitdeck.data.api.comfyhub.ComfyHubApi
 import com.riox432.civitdeck.data.api.comfyui.ComfyUIApi
@@ -36,6 +38,9 @@ val networkModule = module {
             encodeDefaults = true
         }
     }
+
+    // Thumbnail downloader (used by background embedding indexer)
+    single<ThumbnailDownloader> { ThumbnailDownloaderImpl(get()) }
 
     // GitHub Releases
     single { GitHubReleaseApi(get()) }

--- a/feature/feature-detail/src/commonMain/kotlin/com/riox432/civitdeck/feature/detail/di/DetailModule.kt
+++ b/feature/feature-detail/src/commonMain/kotlin/com/riox432/civitdeck/feature/detail/di/DetailModule.kt
@@ -8,7 +8,7 @@ val detailModule = module {
     viewModel { params ->
         ModelDetailViewModel(
             params.get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get(),
-            get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get(),
+            get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get(),
         )
     }
 }

--- a/feature/feature-detail/src/commonMain/kotlin/com/riox432/civitdeck/feature/detail/presentation/ModelDetailViewModel.kt
+++ b/feature/feature-detail/src/commonMain/kotlin/com/riox432/civitdeck/feature/detail/presentation/ModelDetailViewModel.kt
@@ -17,6 +17,7 @@ import com.riox432.civitdeck.domain.model.RatingTotals
 import com.riox432.civitdeck.domain.model.ResourceReview
 import com.riox432.civitdeck.domain.model.ReviewSortOrder
 import com.riox432.civitdeck.domain.usecase.AddModelToCollectionUseCase
+import com.riox432.civitdeck.domain.usecase.EmbedOnBrowseUseCase
 import com.riox432.civitdeck.domain.usecase.AddPersonalTagUseCase
 import com.riox432.civitdeck.domain.usecase.CancelDownloadUseCase
 import com.riox432.civitdeck.domain.usecase.CreateCollectionUseCase
@@ -103,6 +104,7 @@ class ModelDetailViewModel(
     private val getModelReviewsUseCase: GetModelReviewsUseCase,
     private val getRatingTotalsUseCase: GetRatingTotalsUseCase,
     private val submitReviewUseCase: SubmitReviewUseCase,
+    private val embedOnBrowseUseCase: EmbedOnBrowseUseCase,
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow(ModelDetailUiState())
@@ -144,6 +146,7 @@ class ModelDetailViewModel(
             toggleFavoriteUseCase(model)
             trackModelViewUseCase.trackInteraction(modelId, InteractionType.FAVORITE)
         }
+        triggerBackgroundEmbed(model)
     }
 
     fun retry() {
@@ -264,6 +267,7 @@ class ModelDetailViewModel(
                     _uiState.update { it.copy(model = model, isLoading = false) }
                     enrichCurrentVersion()
                     trackModelView(model)
+                    triggerBackgroundEmbed(model)
                     viewStartTimeMs = currentTimeMillis()
                 }
                 .onFailure { e ->
@@ -426,6 +430,19 @@ class ModelDetailViewModel(
         viewModelScope.launch {
             suspendRunCatching { block() }
                 .onFailure { e -> Logger.w(TAG, "$operationName failed: ${e.message}") }
+        }
+    }
+
+    /**
+     * Fire-and-forget background embed of the model's first thumbnail.
+     * Silent on failure — never blocks or surfaces errors to the user.
+     */
+    private fun triggerBackgroundEmbed(model: Model) {
+        val url = model.modelVersions.firstOrNull()
+            ?.images?.firstOrNull()?.url ?: return
+        viewModelScope.launch {
+            suspendRunCatching { embedOnBrowseUseCase(model.id, url) }
+                .onFailure { e -> Logger.d(TAG, "Background embed skipped: ${e.message}") }
         }
     }
 

--- a/shared/src/iosMain/kotlin/com/riox432/civitdeck/di/KoinHelper.kt
+++ b/shared/src/iosMain/kotlin/com/riox432/civitdeck/di/KoinHelper.kt
@@ -35,6 +35,7 @@ import com.riox432.civitdeck.domain.usecase.DeleteModelNoteUseCase
 import com.riox432.civitdeck.domain.usecase.DetectDuplicatesUseCase
 import com.riox432.civitdeck.domain.usecase.EditCaptionUseCase
 import com.riox432.civitdeck.domain.usecase.EmbedImageUseCase
+import com.riox432.civitdeck.domain.usecase.EmbedOnBrowseUseCase
 import com.riox432.civitdeck.domain.usecase.EnqueueDownloadUseCase
 import com.riox432.civitdeck.domain.usecase.EnrichModelImagesUseCase
 import com.riox432.civitdeck.domain.usecase.EvictCacheUseCase
@@ -276,6 +277,7 @@ object KoinHelper {
     // region Image Embedding (#700)
     fun getImageEmbeddingModel(): ImageEmbeddingModel = getKoin().get()
     fun getEmbedImageUseCase(): EmbedImageUseCase = getKoin().get()
+    fun getEmbedOnBrowseUseCase(): EmbedOnBrowseUseCase = getKoin().get()
     fun getFindSimilarModelsByEmbeddingUseCase(): FindSimilarModelsByEmbeddingUseCase = getKoin().get()
     fun getModelEmbeddingRepository(): ModelEmbeddingRepository = getKoin().get()
 


### PR DESCRIPTION
## Description

Closes #712

Automatically embeds model thumbnail images as users browse or favorite them, building up the local embedding index that powers Find Similar (#702).

### Changes:
- **`ThumbnailDownloader`** (core-domain): New `fun interface` for downloading raw image bytes from URL. Keeps domain free of Ktor dependency.
- **`ThumbnailDownloaderImpl`** (core-network): Ktor-backed implementation using the existing CivitAI HttpClient.
- **`EmbedOnBrowseUseCase`** (core-domain): Orchestrates download → embed → cache. Short-circuits when embedding is already cached or embedder is unavailable (Desktop).
- **`ModelDetailViewModel`** (feature-detail): Triggers background embed on model load and favorite toggle. Fire-and-forget with `viewModelScope.launch` + `suspendRunCatching` — never blocks UI.
- **DI**: Registered in `EmbeddingDomainModule`, `NetworkModule`, `DetailModule`, `androidModule`, and `KoinHelper`.

### Rate limiting:
`EmbedOnBrowseUseCase` checks `embeddingRepository.get(modelId) != null` before downloading — already-embedded models are skipped instantly with zero network/inference cost. Combined with the fact that embeddings are only triggered from the detail screen (not the scroll list), this prevents hammering inference during rapid browsing.

### Platform behavior:
- **Android**: ONNX Runtime inference via `ImageEmbeddingModel.android`
- **iOS**: Core ML inference via `SigLIP2Bridge` → `ImageEmbeddingModel.ios`
- **Desktop**: No-op (`isAvailable = false`, short-circuits immediately)