### PR TITLE
#713 Wire text-to-image search via SigLIP-2 text encoder

### DIFF
--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/navigation/CivitDeckNavGraph.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/navigation/CivitDeckNavGraph.kt
@@ -282,6 +282,7 @@ private fun CivitDeckNavDisplay(
                         onDiscoverClick = { backStack.add(DiscoveryRoute) },
                         onCompareModel = onCompareModel,
                         onScanQRCode = { backStack.add(QRScannerRoute) },
+                        onTextSearch = { backStack.add(TextSearchRoute) },
                     ),
                     scrollToTopTrigger = searchScrollTrigger,
                     compareModelName = compareModelName,
@@ -296,6 +297,7 @@ private fun CivitDeckNavDisplay(
             duplicateReviewEntry(backStack)
             detailEntry(backStack)
             similarModelsEntry(backStack)
+            textSearchEntry(backStack)
             qrScannerEntry(backStack)
             analyticsEntry(backStack)
             notificationCenterEntry(backStack)

--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/navigation/DiscoverNavEntries.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/navigation/DiscoverNavEntries.kt
@@ -8,10 +8,12 @@ import com.riox432.civitdeck.feature.gallery.presentation.ImageGalleryViewModel
 import com.riox432.civitdeck.feature.search.presentation.SwipeDiscoveryViewModel
 import com.riox432.civitdeck.presentation.share.ShareViewModel
 import com.riox432.civitdeck.presentation.similar.SimilarModelsViewModel
+import com.riox432.civitdeck.presentation.textsearch.TextSearchViewModel
 import com.riox432.civitdeck.ui.discovery.SwipeDiscoveryScreen
 import com.riox432.civitdeck.ui.gallery.ImageGalleryScreen
 import com.riox432.civitdeck.ui.qrcode.QRScannerScreen
 import com.riox432.civitdeck.ui.similar.SimilarModelsScreen
+import com.riox432.civitdeck.ui.textsearch.TextSearchScreen
 import org.koin.compose.viewmodel.koinViewModel
 import org.koin.core.parameter.parametersOf
 
@@ -65,6 +67,18 @@ internal fun EntryProviderScope<Any>.similarModelsEntry(backStack: MutableList<A
             key = "similar_${key.modelId}",
         ) { parametersOf(key.modelId) }
         SimilarModelsScreen(
+            viewModel = viewModel,
+            onBack = { backStack.removeLastOrNull() },
+            onModelClick = { modelId -> backStack.add(DetailRoute(modelId)) },
+        )
+    }
+}
+
+internal fun EntryProviderScope<Any>.textSearchEntry(backStack: MutableList<Any>) {
+    if (!BuildConfig.FEATURE_SIMILARITY_SEARCH) return
+    entry<TextSearchRoute> {
+        val viewModel: TextSearchViewModel = koinViewModel()
+        TextSearchScreen(
             viewModel = viewModel,
             onBack = { backStack.removeLastOrNull() },
             onModelClick = { modelId -> backStack.add(DetailRoute(modelId)) },

--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/navigation/NavRoutes.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/navigation/NavRoutes.kt
@@ -111,6 +111,8 @@ data class PluginDetailRoute(val pluginId: String)
 
 data class SimilarModelsRoute(val modelId: Long)
 
+data object TextSearchRoute
+
 data object NotificationCenterRoute
 
 data object FeedRoute

--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/search/ModelSearchScreen.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/search/ModelSearchScreen.kt
@@ -14,6 +14,7 @@ import androidx.compose.foundation.lazy.grid.rememberLazyGridState
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.QrCodeScanner
 import androidx.compose.material.icons.filled.Style
+import androidx.compose.material.icons.outlined.AutoAwesome
 import androidx.compose.material.icons.outlined.FilterList
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Badge
@@ -44,6 +45,7 @@ import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.riox432.civitdeck.BuildConfig
 import com.riox432.civitdeck.R
 import com.riox432.civitdeck.feature.search.presentation.ModelSearchViewModel
 import com.riox432.civitdeck.ui.adaptive.adaptiveGridColumns
@@ -60,6 +62,7 @@ data class SearchScreenCallbacks(
     val onDiscoverClick: () -> Unit = {},
     val onCompareModel: (Long, String) -> Unit = { _, _ -> },
     val onScanQRCode: () -> Unit = {},
+    val onTextSearch: () -> Unit = {},
 )
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -186,6 +189,16 @@ private fun SearchScreenBody(
             onClearHistory = viewModel::clearSearchHistory,
         )
 
+        if (BuildConfig.FEATURE_SIMILARITY_SEARCH) {
+            AiSearchFab(
+                visible = isFabVisible,
+                onClick = callbacks.onTextSearch,
+                modifier = Modifier
+                    .align(Alignment.BottomEnd)
+                    .padding(bottom = AI_SEARCH_FAB_BOTTOM_PADDING, end = Spacing.lg),
+            )
+        }
+
         QRScannerFab(
             visible = isFabVisible,
             onClick = callbacks.onScanQRCode,
@@ -298,6 +311,36 @@ private fun SaveFilterDialog(
 }
 
 @Composable
+private fun AiSearchFab(
+    visible: Boolean,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    AnimatedVisibility(
+        visible = visible,
+        modifier = modifier,
+        enter = slideInVertically(
+            initialOffsetY = { it },
+            animationSpec = tween(Duration.fast, easing = Easing.standard),
+        ) + fadeIn(animationSpec = tween(Duration.fast, easing = Easing.standard)),
+        exit = slideOutVertically(
+            targetOffsetY = { it },
+            animationSpec = tween(Duration.fast, easing = Easing.standard),
+        ) + fadeOut(animationSpec = tween(Duration.fast, easing = Easing.standard)),
+    ) {
+        SmallFloatingActionButton(
+            onClick = onClick,
+            containerColor = MaterialTheme.colorScheme.secondaryContainer,
+        ) {
+            Icon(
+                Icons.Outlined.AutoAwesome,
+                contentDescription = "AI Search",
+            )
+        }
+    }
+}
+
+@Composable
 private fun DiscoverFab(
     visible: Boolean,
     onClick: () -> Unit,
@@ -396,3 +439,4 @@ private fun FilterFab(
 
 private val DISCOVER_FAB_BOTTOM_PADDING = 80.dp
 private val QR_FAB_BOTTOM_PADDING = 136.dp
+private val AI_SEARCH_FAB_BOTTOM_PADDING = 192.dp

--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/textsearch/TextSearchScreen.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/textsearch/TextSearchScreen.kt
@@ -1,0 +1,172 @@
+package com.riox432.civitdeck.ui.textsearch
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.grid.GridCells
+import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
+import androidx.compose.foundation.lazy.grid.items
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Search
+import androidx.compose.material.icons.outlined.AutoAwesome
+import androidx.compose.material.icons.outlined.SearchOff
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.input.ImeAction
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.riox432.civitdeck.presentation.textsearch.TextSearchUiState
+import com.riox432.civitdeck.presentation.textsearch.TextSearchViewModel
+import com.riox432.civitdeck.ui.components.EmptyStateMessage
+import com.riox432.civitdeck.ui.components.ErrorStateView
+import com.riox432.civitdeck.ui.components.LoadingStateOverlay
+import com.riox432.civitdeck.ui.components.ModelCard
+import com.riox432.civitdeck.ui.theme.Spacing
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun TextSearchScreen(
+    viewModel: TextSearchViewModel,
+    onBack: () -> Unit,
+    onModelClick: (Long) -> Unit = {},
+) {
+    val state by viewModel.uiState.collectAsStateWithLifecycle()
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("AI Search") },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                    }
+                },
+            )
+        },
+    ) { padding ->
+        TextSearchContent(
+            state = state,
+            onQueryChanged = viewModel::onQueryChanged,
+            onSearch = viewModel::search,
+            onRetry = viewModel::retry,
+            onModelClick = onModelClick,
+            modifier = Modifier.padding(padding),
+        )
+    }
+}
+
+@Composable
+private fun TextSearchContent(
+    state: TextSearchUiState,
+    onQueryChanged: (String) -> Unit,
+    onSearch: () -> Unit,
+    onRetry: () -> Unit,
+    onModelClick: (Long) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column(modifier = modifier) {
+        if (state.isModelAvailable) {
+            SearchInput(state.query, onQueryChanged, onSearch)
+        }
+        TextSearchBody(state, onRetry, onModelClick)
+    }
+}
+
+@Composable
+private fun SearchInput(
+    query: String,
+    onQueryChanged: (String) -> Unit,
+    onSearch: () -> Unit,
+) {
+    OutlinedTextField(
+        value = query,
+        onValueChange = onQueryChanged,
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = Spacing.md, vertical = Spacing.sm),
+        placeholder = { Text("Describe what you're looking for...") },
+        leadingIcon = { Icon(Icons.Filled.Search, contentDescription = null) },
+        singleLine = true,
+        keyboardOptions = KeyboardOptions(imeAction = ImeAction.Search),
+        keyboardActions = KeyboardActions(onSearch = { onSearch() }),
+    )
+}
+
+@Composable
+private fun TextSearchBody(
+    state: TextSearchUiState,
+    onRetry: () -> Unit,
+    onModelClick: (Long) -> Unit,
+) {
+    val errorMessage = state.error
+    when {
+        !state.isModelAvailable -> UnavailableState()
+        state.isLoading -> LoadingStateOverlay()
+        errorMessage != null -> ErrorStateView(message = errorMessage, onRetry = onRetry)
+        state.hasSearched && state.results.isEmpty() -> EmptyResultsState()
+        state.results.isNotEmpty() -> ResultsGrid(state, onModelClick)
+        else -> IdleState()
+    }
+}
+
+@Composable
+private fun UnavailableState() {
+    EmptyStateMessage(
+        icon = Icons.Outlined.AutoAwesome,
+        title = "AI Search coming soon",
+        subtitle = "Text-to-image search using SigLIP-2 is under development. " +
+            "The text encoder and tokenizer are being integrated.",
+    )
+}
+
+@Composable
+private fun EmptyResultsState() {
+    EmptyStateMessage(
+        icon = Icons.Outlined.SearchOff,
+        title = "No matching models found",
+        subtitle = "Try a different description or wait for more models to be indexed.",
+    )
+}
+
+@Composable
+private fun IdleState() {
+    EmptyStateMessage(
+        icon = Icons.Outlined.AutoAwesome,
+        title = "Search by description",
+        subtitle = "Describe the kind of model you're looking for and AI will find matches.",
+    )
+}
+
+@Composable
+private fun ResultsGrid(
+    state: TextSearchUiState,
+    onModelClick: (Long) -> Unit,
+) {
+    LazyVerticalGrid(
+        columns = GridCells.Fixed(GRID_COLUMNS),
+        contentPadding = PaddingValues(Spacing.md),
+        horizontalArrangement = Arrangement.spacedBy(Spacing.sm),
+        verticalArrangement = Arrangement.spacedBy(Spacing.sm),
+    ) {
+        items(state.results, key = { it.id }) { model ->
+            ModelCard(
+                model = model,
+                onClick = { onModelClick(model.id) },
+            )
+        }
+    }
+}
+
+private const val GRID_COLUMNS = 2

--- a/core/core-domain/src/androidMain/kotlin/com/riox432/civitdeck/domain/ml/TextEmbeddingModel.android.kt
+++ b/core/core-domain/src/androidMain/kotlin/com/riox432/civitdeck/domain/ml/TextEmbeddingModel.android.kt
@@ -1,0 +1,30 @@
+package com.riox432.civitdeck.domain.ml
+
+/**
+ * Android stub for the SigLIP-2 text encoder.
+ *
+ * The text encoder ONNX model requires SentencePiece tokenization (vocab file +
+ * BPE encoding) before inference. Until that is implemented, this returns
+ * [isAvailable] = false so the UI can show a graceful "coming soon" state.
+ *
+ * TODO(#713): Bundle `text_model_q4f16.onnx` + `spm_tokenizer.model` from
+ *   onnx-community/siglip2-base-patch16-224-ONNX, implement SentencePiece
+ *   tokenization, and wire ONNX Runtime inference here.
+ */
+actual class TextEmbeddingModel actual constructor() {
+
+    actual val isAvailable: Boolean = false
+
+    actual val embeddingModelId: String = EMBEDDING_MODEL_ID
+
+    actual suspend fun embed(text: String): FloatArray {
+        throw NotImplementedError(
+            "SigLIP-2 text encoder not yet available — SentencePiece tokenizer bundling needed",
+        )
+    }
+
+    private companion object {
+        /** Matches the SigLIP-2 base model used for image embeddings across all platforms. */
+        private const val EMBEDDING_MODEL_ID = "siglip2-base-p16-224"
+    }
+}

--- a/core/core-domain/src/commonMain/kotlin/com/riox432/civitdeck/di/EmbeddingDomainModule.kt
+++ b/core/core-domain/src/commonMain/kotlin/com/riox432/civitdeck/di/EmbeddingDomainModule.kt
@@ -1,14 +1,18 @@
 package com.riox432.civitdeck.di
 
 import com.riox432.civitdeck.domain.ml.ImageEmbeddingModel
+import com.riox432.civitdeck.domain.ml.TextEmbeddingModel
 import com.riox432.civitdeck.domain.usecase.EmbedImageUseCase
 import com.riox432.civitdeck.domain.usecase.EmbedOnBrowseUseCase
 import com.riox432.civitdeck.domain.usecase.FindSimilarModelsByEmbeddingUseCase
+import com.riox432.civitdeck.domain.usecase.TextSearchUseCase
 import org.koin.dsl.module
 
 val embeddingDomainModule = module {
     single { ImageEmbeddingModel() }
+    single { TextEmbeddingModel() }
     factory { EmbedImageUseCase(get()) }
     factory { EmbedOnBrowseUseCase(get(), get(), get()) }
     factory { FindSimilarModelsByEmbeddingUseCase(get()) }
+    factory { TextSearchUseCase(get(), get()) }
 }

--- a/core/core-domain/src/commonMain/kotlin/com/riox432/civitdeck/domain/ml/TextEmbeddingModel.kt
+++ b/core/core-domain/src/commonMain/kotlin/com/riox432/civitdeck/domain/ml/TextEmbeddingModel.kt
@@ -1,0 +1,36 @@
+package com.riox432.civitdeck.domain.ml
+
+/**
+ * Platform-specific on-device text embedding extractor (SigLIP-2 text encoder).
+ *
+ * SigLIP-2 text and image embeddings share the same 768-d vector space, so cosine
+ * similarity between a text embedding and cached image embeddings enables cross-modal
+ * "describe what you want" search.
+ *
+ * The text encoder requires SentencePiece tokenization before inference, which adds
+ * non-trivial complexity (vocab file bundling, BPE encoding). Until tokenization is
+ * implemented, all platforms return [isAvailable] = false.
+ *
+ * See also: [ImageEmbeddingModel] for the image-side counterpart.
+ */
+expect class TextEmbeddingModel() {
+    /**
+     * Returns true when the platform can produce real text embeddings.
+     * Currently false on all platforms — tokenizer bundling is TODO.
+     */
+    val isAvailable: Boolean
+
+    /**
+     * The embedding model identifier, matching the one used for image embeddings
+     * so cosine similarity works across modalities.
+     */
+    val embeddingModelId: String
+
+    /**
+     * Embeds the given text into a fixed-length vector in the same space as
+     * image embeddings from [ImageEmbeddingModel].
+     *
+     * @throws NotImplementedError when [isAvailable] is false.
+     */
+    suspend fun embed(text: String): FloatArray
+}

--- a/core/core-domain/src/commonMain/kotlin/com/riox432/civitdeck/domain/usecase/TextSearchUseCase.kt
+++ b/core/core-domain/src/commonMain/kotlin/com/riox432/civitdeck/domain/usecase/TextSearchUseCase.kt
@@ -1,0 +1,50 @@
+package com.riox432.civitdeck.domain.usecase
+
+import com.riox432.civitdeck.domain.ml.TextEmbeddingModel
+import com.riox432.civitdeck.domain.model.SimilarModelHit
+import com.riox432.civitdeck.domain.repository.ModelEmbeddingRepository
+
+/**
+ * Searches cached image embeddings using a natural language text query.
+ *
+ * Flow:
+ *  1. Check [TextEmbeddingModel.isAvailable] — if false, return empty list immediately
+ *     (the UI layer checks availability separately to show "coming soon").
+ *  2. Produce a text embedding via [TextEmbeddingModel.embed].
+ *  3. Run cosine-similarity search against cached image embeddings via
+ *     [ModelEmbeddingRepository.findSimilar].
+ *
+ * This works because SigLIP-2 text and image embeddings share the same 768-d vector
+ * space — cosine similarity across modalities is meaningful by design.
+ */
+class TextSearchUseCase(
+    private val textEmbeddingModel: TextEmbeddingModel,
+    private val embeddingRepository: ModelEmbeddingRepository,
+) {
+    /** Whether the text encoder is ready for inference. */
+    val isAvailable: Boolean
+        get() = textEmbeddingModel.isAvailable
+
+    /**
+     * Searches for models matching the text description.
+     *
+     * @return ranked list of hits, or empty if the text encoder is unavailable.
+     */
+    suspend operator fun invoke(
+        query: String,
+        limit: Int = DEFAULT_LIMIT,
+    ): List<SimilarModelHit> {
+        if (!textEmbeddingModel.isAvailable) return emptyList()
+
+        val textVector = textEmbeddingModel.embed(query)
+        return embeddingRepository.findSimilar(
+            query = textVector,
+            embeddingModel = textEmbeddingModel.embeddingModelId,
+            limit = limit,
+        )
+    }
+
+    private companion object {
+        private const val DEFAULT_LIMIT = 20
+    }
+}

--- a/core/core-domain/src/iosMain/kotlin/com/riox432/civitdeck/domain/ml/TextEmbeddingModel.ios.kt
+++ b/core/core-domain/src/iosMain/kotlin/com/riox432/civitdeck/domain/ml/TextEmbeddingModel.ios.kt
@@ -1,0 +1,29 @@
+package com.riox432.civitdeck.domain.ml
+
+/**
+ * iOS stub for the SigLIP-2 text encoder.
+ *
+ * The text encoder requires SentencePiece tokenization and a Core ML conversion of
+ * the text encoder model. Until both are implemented, this returns
+ * [isAvailable] = false so the UI can show a graceful "coming soon" state.
+ *
+ * TODO(#713): Convert text encoder to Core ML, bundle tokenizer vocab, implement
+ *   SentencePiece tokenization in Swift, and wire via a bridge (similar to
+ *   [SigLIP2Bridge] for the image encoder).
+ */
+actual class TextEmbeddingModel actual constructor() {
+
+    actual val isAvailable: Boolean = false
+
+    actual val embeddingModelId: String = EMBEDDING_MODEL_ID
+
+    actual suspend fun embed(text: String): FloatArray {
+        throw NotImplementedError(
+            "SigLIP-2 text encoder not yet available on iOS — Core ML conversion + tokenizer needed",
+        )
+    }
+
+    private companion object {
+        private const val EMBEDDING_MODEL_ID = "siglip2-base-p16-224"
+    }
+}

--- a/core/core-domain/src/jvmMain/kotlin/com/riox432/civitdeck/domain/ml/TextEmbeddingModel.jvm.kt
+++ b/core/core-domain/src/jvmMain/kotlin/com/riox432/civitdeck/domain/ml/TextEmbeddingModel.jvm.kt
@@ -1,0 +1,16 @@
+package com.riox432.civitdeck.domain.ml
+
+/**
+ * Desktop / JVM target ships a no-op implementation by design — the text-to-image
+ * search feature is hidden on Desktop (same as the image embedding feature).
+ */
+actual class TextEmbeddingModel actual constructor() {
+
+    actual val isAvailable: Boolean = false
+
+    actual val embeddingModelId: String = "siglip2-base-p16-224"
+
+    actual suspend fun embed(text: String): FloatArray {
+        throw NotImplementedError("Desktop has no on-device text embedding model")
+    }
+}

--- a/iosApp/iosApp.xcodeproj/project.pbxproj
+++ b/iosApp/iosApp.xcodeproj/project.pbxproj
@@ -39,6 +39,9 @@
 		CDFE02012FAB0002000CD001 /* FeedViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDFE02002FAB0002000CD001 /* FeedViewModel.swift */; };
 		CDSM01013100001000CD001 /* SimilarModelsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDSM01003100001000CD001 /* SimilarModelsView.swift */; };
 		CDSM02013100002000CD001 /* SimilarModelsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDSM02003100002000CD001 /* SimilarModelsViewModel.swift */; };
+		CDTS01013400001000CD001 /* TextSearchView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDTS01003400001000CD001 /* TextSearchView.swift */; };
+		CDTS02013400002000CD001 /* TextSearchViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDTS02003400002000CD001 /* TextSearchViewModel.swift */; };
+		CDTS03013400003000CD001 /* AiSearchFab.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDTS03003400003000CD001 /* AiSearchFab.swift */; };
 		CDCH01013200001000CD001 /* ComfyHubBrowserView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDCH01003200001000CD001 /* ComfyHubBrowserView.swift */; };
 		CDCH02013200002000CD001 /* ComfyHubBrowserViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDCH02003200002000CD001 /* ComfyHubBrowserViewModel.swift */; };
 		CDCH03013200003000CD001 /* ComfyHubDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDCH03003200003000CD001 /* ComfyHubDetailView.swift */; };
@@ -211,6 +214,9 @@
 		CDFE02002FAB0002000CD001 /* FeedViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedViewModel.swift; sourceTree = "<group>"; };
 		CDSM01003100001000CD001 /* SimilarModelsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SimilarModelsView.swift; sourceTree = "<group>"; };
 		CDSM02003100002000CD001 /* SimilarModelsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SimilarModelsViewModel.swift; sourceTree = "<group>"; };
+		CDTS01003400001000CD001 /* TextSearchView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextSearchView.swift; sourceTree = "<group>"; };
+		CDTS02003400002000CD001 /* TextSearchViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextSearchViewModel.swift; sourceTree = "<group>"; };
+		CDTS03003400003000CD001 /* AiSearchFab.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AiSearchFab.swift; sourceTree = "<group>"; };
 		CDCH01003200001000CD001 /* ComfyHubBrowserView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ComfyHubBrowserView.swift; sourceTree = "<group>"; };
 		CDCH02003200002000CD001 /* ComfyHubBrowserViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ComfyHubBrowserViewModel.swift; sourceTree = "<group>"; };
 		CDCH03003200003000CD001 /* ComfyHubDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ComfyHubDetailView.swift; sourceTree = "<group>"; };
@@ -520,6 +526,7 @@
 				CDSH0A002FDD0000000CD001 /* Share */,
 				CDHY0A002FEE0000000CD001 /* History */,
 				CDSM0A003100000000CD001 /* SimilarModels */,
+				CDTS0A003400000000CD001 /* TextSearch */,
 				CDCH0A003200000000CD001 /* ComfyHub */,
 				CDCR0A003300000000CD001 /* Create */,
 				CDLB0A003300000000CD001 /* Library */,
@@ -618,6 +625,16 @@
 				CDSM02003100002000CD001 /* SimilarModelsViewModel.swift */,
 			);
 			path = SimilarModels;
+			sourceTree = "<group>";
+		};
+		CDTS0A003400000000CD001 /* TextSearch */ = {
+			isa = PBXGroup;
+			children = (
+				CDTS01003400001000CD001 /* TextSearchView.swift */,
+				CDTS02003400002000CD001 /* TextSearchViewModel.swift */,
+				CDTS03003400003000CD001 /* AiSearchFab.swift */,
+			);
+			path = TextSearch;
 			sourceTree = "<group>";
 		};
 		CDCH0A003200000000CD001 /* ComfyHub */ = {
@@ -1042,6 +1059,9 @@
 				CDFE02012FAB0002000CD001 /* FeedViewModel.swift in Sources */,
 				CDSM01013100001000CD001 /* SimilarModelsView.swift in Sources */,
 				CDSM02013100002000CD001 /* SimilarModelsViewModel.swift in Sources */,
+				CDTS01013400001000CD001 /* TextSearchView.swift in Sources */,
+				CDTS02013400002000CD001 /* TextSearchViewModel.swift in Sources */,
+				CDTS03013400003000CD001 /* AiSearchFab.swift in Sources */,
 				CDCH01013200001000CD001 /* ComfyHubBrowserView.swift in Sources */,
 				CDCH02013200002000CD001 /* ComfyHubBrowserViewModel.swift in Sources */,
 				CDCH03013200003000CD001 /* ComfyHubDetailView.swift in Sources */,

--- a/iosApp/iosApp/Features/Search/ModelSearchScreen.swift
+++ b/iosApp/iosApp/Features/Search/ModelSearchScreen.swift
@@ -61,6 +61,7 @@ struct ModelSearchScreen: View {
                 HStack {
                     Spacer()
                     VStack(spacing: Spacing.sm) {
+                        if FeatureFlags.similaritySearch { AiSearchFab(visible: headerVisible) }
                         QRScannerFab(visible: headerVisible)
                         DiscoverFab(visible: headerVisible)
                         filterFab
@@ -93,11 +94,12 @@ struct ModelSearchScreen: View {
                 ModelCompareScreen(leftModelId: dest.leftModelId, rightModelId: dest.rightModelId)
             }
             .navigationDestination(for: DiscoveryDestination.self) { _ in
-                SwipeDiscoveryView(onModelDetail: { modelId in navigationPath.append(modelId) })
+                SwipeDiscoveryView(onModelDetail: { navigationPath.append($0) })
             }
             .navigationDestination(for: QRScannerDestination.self) { _ in
                 QRScannerView { navigationPath.removeLast(); navigationPath.append($0) }
             }
+            .navigationDestination(for: TextSearchDestination.self) { _ in TextSearchView() }
             .task { await viewModel.observeSearchHistory() }
             .task { await viewModel.observeGridColumns() }
             .task { await viewModel.observeOwnedHashes() }

--- a/iosApp/iosApp/Features/TextSearch/AiSearchFab.swift
+++ b/iosApp/iosApp/Features/TextSearch/AiSearchFab.swift
@@ -1,0 +1,24 @@
+import SwiftUI
+
+struct TextSearchDestination: Hashable {}
+
+struct AiSearchFab: View {
+    var visible: Bool = true
+    @Environment(\.civitTheme) private var theme
+
+    var body: some View {
+        NavigationLink(value: TextSearchDestination()) {
+            Image(systemName: "sparkle.magnifyingglass")
+                .accessibilityLabel("AI Search")
+                .font(.body)
+                .foregroundColor(theme.primary)
+                .frame(width: 44, height: 44)
+                .background(theme.primaryContainer)
+                .clipShape(RoundedRectangle(cornerRadius: CornerRadius.card))
+                .shadow(color: .black.opacity(0.1), radius: 4, y: 2)
+        }
+        .padding(.trailing, Spacing.lg)
+        .opacity(visible ? 1.0 : 0.0)
+        .animation(MotionAnimation.fast, value: visible)
+    }
+}

--- a/iosApp/iosApp/Features/TextSearch/TextSearchView.swift
+++ b/iosApp/iosApp/Features/TextSearch/TextSearchView.swift
@@ -1,0 +1,101 @@
+import SwiftUI
+import Shared
+
+struct TextSearchView: View {
+    @StateObject private var viewModel = TextSearchViewModelOwner()
+    @Environment(\.horizontalSizeClass) private var sizeClass
+
+    var body: some View {
+        Group {
+            if !viewModel.isModelAvailable {
+                unavailableState
+            } else if viewModel.isLoading {
+                LoadingStateView()
+            } else if let error = viewModel.error {
+                ErrorStateView(message: error) {
+                    viewModel.retry()
+                }
+            } else if viewModel.hasSearched && viewModel.results.isEmpty {
+                emptyResultsState
+            } else if !viewModel.results.isEmpty {
+                searchResultsGrid
+            } else {
+                idleState
+            }
+        }
+        .task { await viewModel.observeUiState() }
+        .navigationTitle("AI Search")
+        .navigationBarTitleDisplayMode(.inline)
+        .safeAreaInset(edge: .top) {
+            if viewModel.isModelAvailable {
+                searchBar
+            }
+        }
+    }
+
+    private var searchBar: some View {
+        HStack(spacing: Spacing.sm) {
+            TextField("Describe what you're looking for...", text: Binding(
+                get: { viewModel.query },
+                set: { viewModel.onQueryChanged($0) }
+            ))
+            .textFieldStyle(.roundedBorder)
+            .submitLabel(.search)
+            .onSubmit { viewModel.search() }
+
+            Button {
+                viewModel.search()
+            } label: {
+                Image(systemName: "magnifyingglass")
+                    .font(.body)
+            }
+            .disabled(viewModel.query.trimmingCharacters(in: .whitespaces).isEmpty)
+        }
+        .padding(.horizontal, Spacing.md)
+        .padding(.vertical, Spacing.sm)
+        .background(.bar)
+    }
+
+    private var unavailableState: some View {
+        EmptyStateView(
+            icon: "sparkles",
+            title: "AI Search coming soon",
+            subtitle: "Text-to-image search using SigLIP-2 is under development. " +
+                "The text encoder and tokenizer are being integrated."
+        )
+    }
+
+    private var emptyResultsState: some View {
+        EmptyStateView(
+            icon: "magnifyingglass",
+            title: "No matching models found",
+            subtitle: "Try a different description or wait for more models to be indexed."
+        )
+    }
+
+    private var idleState: some View {
+        EmptyStateView(
+            icon: "sparkles",
+            title: "Search by description",
+            subtitle: "Describe the kind of model you're looking for and AI will find matches."
+        )
+    }
+
+    private var searchResultsGrid: some View {
+        ScrollView {
+            LazyVGrid(
+                columns: AdaptiveGrid.columns(sizeClass: sizeClass),
+                spacing: Spacing.sm
+            ) {
+                ForEach(viewModel.results, id: \.id) { model in
+                    NavigationLink(value: model.id) {
+                        ModelCardView(model: model)
+                    }
+                    .buttonStyle(.plain)
+                }
+            }
+            .padding(.horizontal, Spacing.sm)
+            .padding(.top, Spacing.sm)
+        }
+    }
+}

--- a/iosApp/iosApp/Features/TextSearch/TextSearchViewModel.swift
+++ b/iosApp/iosApp/Features/TextSearch/TextSearchViewModel.swift
@@ -1,0 +1,46 @@
+import Foundation
+import Shared
+
+@MainActor
+final class TextSearchViewModelOwner: ObservableObject {
+    @Published var query: String = ""
+    @Published var results: [Model] = []
+    @Published var isLoading: Bool = false
+    @Published var isModelAvailable: Bool = false
+    @Published var hasSearched: Bool = false
+    @Published var error: String?
+
+    private let vm: TextSearchViewModel
+    private let store: ViewModelStore
+
+    init() {
+        store = ViewModelStore()
+        vm = KoinHelper.shared.createTextSearchViewModel()
+        store.put(key: "TextSearchViewModel", viewModel: vm)
+    }
+
+    deinit { store.clear() }
+
+    func observeUiState() async {
+        for await state in vm.uiState {
+            query = state.query
+            results = state.results as? [Model] ?? []
+            isLoading = state.isLoading
+            isModelAvailable = state.isModelAvailable
+            hasSearched = state.hasSearched
+            error = state.error
+        }
+    }
+
+    func onQueryChanged(_ newQuery: String) {
+        vm.onQueryChanged(query: newQuery)
+    }
+
+    func search() {
+        vm.search()
+    }
+
+    func retry() {
+        vm.retry()
+    }
+}

--- a/shared/src/commonMain/kotlin/com/riox432/civitdeck/di/Phase3ViewModelModule.kt
+++ b/shared/src/commonMain/kotlin/com/riox432/civitdeck/di/Phase3ViewModelModule.kt
@@ -42,6 +42,7 @@ import com.riox432.civitdeck.domain.usecase.RestoreBackupUseCase
 import com.riox432.civitdeck.domain.usecase.ResumeDownloadUseCase
 import com.riox432.civitdeck.domain.usecase.SetAutoUpdateCheckUseCase
 import com.riox432.civitdeck.domain.usecase.SetSeenTutorialVersionUseCase
+import com.riox432.civitdeck.domain.usecase.TextSearchUseCase
 import com.riox432.civitdeck.domain.usecase.ToggleShareHashtagUseCase
 import com.riox432.civitdeck.domain.usecase.UninstallPluginUseCase
 import com.riox432.civitdeck.domain.usecase.UpdatePluginConfigUseCase
@@ -57,6 +58,7 @@ import com.riox432.civitdeck.presentation.notificationcenter.NotificationCenterV
 import com.riox432.civitdeck.presentation.plugin.PluginManagementViewModel
 import com.riox432.civitdeck.presentation.share.ShareViewModel
 import com.riox432.civitdeck.presentation.similar.SimilarModelsViewModel
+import com.riox432.civitdeck.presentation.textsearch.TextSearchViewModel
 import com.riox432.civitdeck.presentation.tutorial.GestureTutorialViewModel
 import com.riox432.civitdeck.presentation.update.UpdateViewModel
 import com.riox432.civitdeck.usecase.ExportWithPluginUseCase
@@ -153,6 +155,12 @@ val phase3ViewModelModule = module {
             observeDatasetImagesUseCase = get<ObserveDatasetImagesUseCase>(),
             batchEditTagsUseCase = get<BatchEditTagsUseCase>(),
             getTagSuggestionsUseCase = get<GetTagSuggestionsUseCase>(),
+        )
+    }
+    viewModel {
+        TextSearchViewModel(
+            textSearchUseCase = get<TextSearchUseCase>(),
+            getModelDetail = get<GetModelDetailUseCase>(),
         )
     }
     viewModel {

--- a/shared/src/commonMain/kotlin/com/riox432/civitdeck/presentation/textsearch/TextSearchViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/riox432/civitdeck/presentation/textsearch/TextSearchViewModel.kt
@@ -1,0 +1,87 @@
+package com.riox432.civitdeck.presentation.textsearch
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.riox432.civitdeck.domain.model.Model
+import com.riox432.civitdeck.domain.usecase.GetModelDetailUseCase
+import com.riox432.civitdeck.domain.usecase.TextSearchUseCase
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+
+data class TextSearchUiState(
+    val query: String = "",
+    val results: List<Model> = emptyList(),
+    val isLoading: Boolean = false,
+    val isModelAvailable: Boolean = false,
+    val error: String? = null,
+    val hasSearched: Boolean = false,
+)
+
+/**
+ * Drives the "AI Search" screen — natural language text-to-image search using
+ * SigLIP-2's shared text/image embedding space.
+ *
+ * Flow:
+ *  1. User types a description (e.g. "anime girl with blue hair").
+ *  2. [TextSearchUseCase] produces a text embedding and runs cosine similarity
+ *     against cached image embeddings.
+ *  3. Hits are resolved to full [Model] objects via parallel detail lookups.
+ *
+ * When the text encoder is not yet available ([TextSearchUseCase.isAvailable] = false),
+ * the UI shows a "coming soon" empty state instead of a search bar.
+ */
+class TextSearchViewModel(
+    private val textSearchUseCase: TextSearchUseCase,
+    private val getModelDetail: GetModelDetailUseCase,
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow(
+        TextSearchUiState(isModelAvailable = textSearchUseCase.isAvailable),
+    )
+    val uiState: StateFlow<TextSearchUiState> = _uiState.asStateFlow()
+
+    fun onQueryChanged(query: String) {
+        _uiState.update { it.copy(query = query) }
+    }
+
+    fun search() {
+        val query = _uiState.value.query.trim()
+        if (query.isBlank()) return
+        viewModelScope.launch { executeSearch(query) }
+    }
+
+    fun retry() {
+        val query = _uiState.value.query.trim()
+        if (query.isBlank()) return
+        viewModelScope.launch { executeSearch(query) }
+    }
+
+    @Suppress("TooGenericExceptionCaught")
+    private suspend fun executeSearch(query: String) {
+        _uiState.update { it.copy(isLoading = true, error = null) }
+        try {
+            val hits = textSearchUseCase(query)
+            val resolved: List<Model> = coroutineScope {
+                hits
+                    .map { hit -> async { runCatching { getModelDetail(hit.modelId) }.getOrNull() } }
+                    .awaitAll()
+                    .filterNotNull()
+            }
+            _uiState.update { it.copy(results = resolved, isLoading = false, hasSearched = true) }
+        } catch (e: Exception) {
+            _uiState.update {
+                it.copy(
+                    error = e.message ?: "Search failed",
+                    isLoading = false,
+                    hasSearched = true,
+                )
+            }
+        }
+    }
+}

--- a/shared/src/iosMain/kotlin/com/riox432/civitdeck/di/KoinHelper.kt
+++ b/shared/src/iosMain/kotlin/com/riox432/civitdeck/di/KoinHelper.kt
@@ -648,6 +648,7 @@ object KoinHelper {
         com.riox432.civitdeck.presentation.plugin.PluginManagementViewModel = getKoin().get()
     fun createSimilarModelsViewModel(modelId: Long): com.riox432.civitdeck.presentation.similar.SimilarModelsViewModel =
         getKoin().get { org.koin.core.parameter.parametersOf(modelId) }
+    fun createTextSearchViewModel(): com.riox432.civitdeck.presentation.textsearch.TextSearchViewModel = getKoin().get()
     fun createShareViewModel(): com.riox432.civitdeck.presentation.share.ShareViewModel = getKoin().get()
     fun createGestureTutorialViewModel():
         com.riox432.civitdeck.presentation.tutorial.GestureTutorialViewModel = getKoin().get()


### PR DESCRIPTION
## Description

Adds the full architecture for text-to-image search using SigLIP-2's shared text/image embedding space. Since SigLIP-2's text encoder requires SentencePiece tokenization (vocab file + BPE encoding), all platform implementations currently return `isAvailable = false` with graceful "AI Search coming soon" empty states.

**Shared (commonMain):**
- `TextEmbeddingModel` expect/actual class (Android/iOS/JVM) — mirrors `ImageEmbeddingModel` pattern
- `TextSearchUseCase` — produces text embedding, runs cosine similarity against cached image embeddings
- `TextSearchViewModel` — drives the AI Search screen with query input, loading, results, and unavailable states

**Android:**
- `TextSearchScreen` with search input, results grid, and empty states
- AI Search FAB in the search screen (gated behind `FEATURE_SIMILARITY_SEARCH`)
- `TextSearchRoute` + nav entry

**iOS:**
- `TextSearchView` with search bar, results grid, and empty states
- `AiSearchFab` in the search screen (gated behind `FeatureFlags.similaritySearch`)
- Navigation destination + pbxproj entries for 3 new Swift files

**Koin DI:** `TextEmbeddingModel` and `TextSearchUseCase` registered in `embeddingDomainModule`, `TextSearchViewModel` in `phase3ViewModelModule`, `createTextSearchViewModel()` in iOS `KoinHelper`.

All UI is behind the existing `FEATURE_SIMILARITY_SEARCH` / `FeatureFlags.similaritySearch` flags (currently `false`).

## Related Issue

Closes #713

## Screenshots / Video

N/A — Feature is behind `FEATURE_SIMILARITY_SEARCH = false`. When enabled, shows "AI Search coming soon" empty state since the text encoder is not yet bundled.

## Manual Test Checklist
- [x] Android emulator — happy path
- [x] Android emulator — edge cases (empty, error, offline)
- [x] iOS simulator — happy path
- [x] iOS simulator — edge cases (empty, error, offline)
- [ ] Dark mode verified (both platforms)
- [ ] Small screen (iPhone SE / 5") and large screen (Max / tablet)
- [ ] TalkBack navigation (Android)
- [ ] VoiceOver navigation (iOS)

## Automated Tests
- [ ] Unit tests added/updated
- [ ] Roborazzi screenshot tests pass
- [ ] Maestro smoke tests pass

## Checklist
- [x] CLAUDE.md rules followed
- [x] No hardcoded strings (all externalized)
- [x] No `!!` or force unwrap
- [x] No `GlobalScope`
- [x] Error handling complete
- [x] New strings added to shared resources