### PR TITLE
Audit cleanup: resource leak, accessibility, design tokens, URL centralization

### DIFF
--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/detail/CivitaiLinkSendSection.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/detail/CivitaiLinkSendSection.kt
@@ -15,6 +15,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.riox432.civitdeck.data.api.CivitAiUrls
 import com.riox432.civitdeck.domain.model.CivitaiLinkResource
 import com.riox432.civitdeck.domain.model.CivitaiLinkStatus
 import com.riox432.civitdeck.domain.model.Model
@@ -73,7 +74,7 @@ private fun CivitaiLinkSendSheetContent(
                         versionId = version.id,
                         modelId = safeModel.id,
                         versionName = version.name,
-                        downloadUrl = "https://civitai.com/api/download/models/${version.id}",
+                        downloadUrl = CivitAiUrls.downloadUrl(version.id),
                     )
                 )
             },

--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/qrcode/QRCodeSheet.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/qrcode/QRCodeSheet.kt
@@ -37,6 +37,7 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.core.content.FileProvider
 import com.riox432.civitdeck.R
+import com.riox432.civitdeck.data.api.CivitAiUrls
 import com.riox432.civitdeck.ui.theme.CornerRadius
 import com.riox432.civitdeck.ui.theme.Spacing
 import java.io.File
@@ -50,7 +51,7 @@ fun QRCodeSheet(
 ) {
     val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
     val context = LocalContext.current
-    val civitaiUrl = "https://civitai.com/models/$modelId"
+    val civitaiUrl = CivitAiUrls.modelUrl(modelId)
     val qrBitmap = remember(civitaiUrl) { QRCodeGenerator.generate(civitaiUrl) }
 
     ModalBottomSheet(

--- a/core/core-domain/build.gradle.kts
+++ b/core/core-domain/build.gradle.kts
@@ -6,7 +6,6 @@ plugins {
 kotlin {
     sourceSets {
         commonMain.dependencies {
-            api(libs.androidx.lifecycle.viewmodel)
             implementation(libs.kotlinx.serialization.json)
             implementation(libs.koin.core)
             implementation(libs.kotlinx.coroutines.core)

--- a/core/core-network/src/commonMain/kotlin/com/riox432/civitdeck/data/api/CivitAiUrls.kt
+++ b/core/core-network/src/commonMain/kotlin/com/riox432/civitdeck/data/api/CivitAiUrls.kt
@@ -1,0 +1,9 @@
+package com.riox432.civitdeck.data.api
+
+object CivitAiUrls {
+    const val BASE_URL = "https://civitai.com"
+
+    fun modelUrl(modelId: Long) = "$BASE_URL/models/$modelId"
+
+    fun downloadUrl(versionId: Long) = "$BASE_URL/api/download/models/$versionId"
+}

--- a/core/core-network/src/commonMain/kotlin/com/riox432/civitdeck/di/NetworkModule.kt
+++ b/core/core-network/src/commonMain/kotlin/com/riox432/civitdeck/di/NetworkModule.kt
@@ -4,7 +4,6 @@ import com.riox432.civitdeck.data.api.ApiKeyProvider
 import com.riox432.civitdeck.data.api.CivitAiApi
 import com.riox432.civitdeck.data.api.GitHubReleaseApi
 import com.riox432.civitdeck.data.api.ThumbnailDownloaderImpl
-import com.riox432.civitdeck.domain.repository.ThumbnailDownloader
 import com.riox432.civitdeck.data.api.civitailink.CivitaiLinkApi
 import com.riox432.civitdeck.data.api.comfyhub.ComfyHubApi
 import com.riox432.civitdeck.data.api.comfyui.ComfyUIApi
@@ -23,6 +22,7 @@ import com.riox432.civitdeck.data.api.webui.SDWebUIApi
 import com.riox432.civitdeck.data.api.webui.createSDWebUIHttpClient
 import com.riox432.civitdeck.domain.repository.HuggingFaceRepository
 import com.riox432.civitdeck.domain.repository.TensorArtRepository
+import com.riox432.civitdeck.domain.repository.ThumbnailDownloader
 import kotlinx.serialization.json.Json
 import org.koin.core.qualifier.named
 import org.koin.dsl.module

--- a/core/core-ui/src/commonMain/kotlin/com/riox432/civitdeck/ui/components/ModelCardLayout.kt
+++ b/core/core-ui/src/commonMain/kotlin/com/riox432/civitdeck/ui/components/ModelCardLayout.kt
@@ -176,7 +176,7 @@ private fun ModelCardInfoSection(model: Model, isOwned: Boolean = false) {
                         color = MaterialTheme.colorScheme.surfaceVariant,
                         shape = RoundedCornerShape(CornerRadius.chip),
                     )
-                    .padding(horizontal = 6.dp, vertical = 2.dp),
+                    .padding(horizontal = Spacing.sm, vertical = Spacing.xxs),
             )
             SourceBadge(source = model.source)
         }
@@ -206,6 +206,6 @@ private fun SourceBadge(source: ModelSource) {
                 color = color,
                 shape = RoundedCornerShape(CornerRadius.chip),
             )
-            .padding(horizontal = 6.dp, vertical = 2.dp),
+            .padding(horizontal = Spacing.sm, vertical = Spacing.xxs),
     )
 }

--- a/feature/feature-comfyui/src/commonMain/kotlin/com/riox432/civitdeck/feature/comfyui/domain/usecase/WorkflowTemplateUseCases.kt
+++ b/feature/feature-comfyui/src/commonMain/kotlin/com/riox432/civitdeck/feature/comfyui/domain/usecase/WorkflowTemplateUseCases.kt
@@ -11,10 +11,13 @@ import com.riox432.civitdeck.domain.model.WorkflowTemplateCategory
 import com.riox432.civitdeck.domain.model.WorkflowTemplateType
 import com.riox432.civitdeck.domain.repository.SavedPromptRepository
 import com.riox432.civitdeck.domain.util.currentTimeMillis
+import com.riox432.civitdeck.util.Logger
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
+
+private const val TAG = "WorkflowTemplate"
 
 private val templateJson = Json {
     ignoreUnknownKeys = true
@@ -115,12 +118,14 @@ private fun SavedPrompt.toWorkflowTemplate(): WorkflowTemplate? {
     val vars = try {
         templateJson.decodeFromString<List<TemplateVariableDto>>(templateVariables ?: "[]")
             .map { it.toModel() }
-    } catch (@Suppress("TooGenericExceptionCaught") _: Exception) {
+    } catch (@Suppress("TooGenericExceptionCaught") e: Exception) {
+        Logger.w(TAG, "Failed to parse template variables: ${e.message}")
         emptyList()
     }
     val metadata = try {
         templateJson.decodeFromString<TemplateMetadataDto>(templateMetadata ?: "{}")
-    } catch (@Suppress("TooGenericExceptionCaught") _: Exception) {
+    } catch (@Suppress("TooGenericExceptionCaught") e: Exception) {
+        Logger.w(TAG, "Failed to parse template metadata: ${e.message}")
         TemplateMetadataDto()
     }
     return WorkflowTemplate(

--- a/feature/feature-detail/src/commonMain/kotlin/com/riox432/civitdeck/feature/detail/presentation/ModelDetailViewModel.kt
+++ b/feature/feature-detail/src/commonMain/kotlin/com/riox432/civitdeck/feature/detail/presentation/ModelDetailViewModel.kt
@@ -17,11 +17,11 @@ import com.riox432.civitdeck.domain.model.RatingTotals
 import com.riox432.civitdeck.domain.model.ResourceReview
 import com.riox432.civitdeck.domain.model.ReviewSortOrder
 import com.riox432.civitdeck.domain.usecase.AddModelToCollectionUseCase
-import com.riox432.civitdeck.domain.usecase.EmbedOnBrowseUseCase
 import com.riox432.civitdeck.domain.usecase.AddPersonalTagUseCase
 import com.riox432.civitdeck.domain.usecase.CancelDownloadUseCase
 import com.riox432.civitdeck.domain.usecase.CreateCollectionUseCase
 import com.riox432.civitdeck.domain.usecase.DeleteModelNoteUseCase
+import com.riox432.civitdeck.domain.usecase.EmbedOnBrowseUseCase
 import com.riox432.civitdeck.domain.usecase.EnqueueDownloadUseCase
 import com.riox432.civitdeck.domain.usecase.EnrichModelImagesUseCase
 import com.riox432.civitdeck.domain.usecase.GetModelDetailUseCase

--- a/iosApp/iosApp/DesignSystem/CivitDeckColors.swift
+++ b/iosApp/iosApp/DesignSystem/CivitDeckColors.swift
@@ -50,6 +50,10 @@ extension Color {
     // MARK: - Scrim
     static let civitScrim = hex(0x000000)
 
+    // MARK: - External Source Badges
+    static let huggingFaceBadge = hex(0xFF9D00)
+    static let tensorArtBadge = hex(0x9C27B0)
+
     // MARK: - AMOLED Dark Mode
     static let amoledSurface = hex(0x000000)
     static let amoledSurfaceContainer = hex(0x0F0F0F)

--- a/iosApp/iosApp/DesignSystem/CivitDeckFonts.swift
+++ b/iosApp/iosApp/DesignSystem/CivitDeckFonts.swift
@@ -1,38 +1,45 @@
 import SwiftUI
 
 extension Font {
-    // headlineSmall: 24pt Regular
-    static let civitHeadlineSmall = Font.system(size: 24)
+    // MARK: - Text fonts (Dynamic Type enabled)
 
-    // titleMedium: 16pt Medium
-    static let civitTitleMedium = Font.system(size: 16, weight: .medium)
+    // headlineSmall: ~24pt Regular — scales with .title2
+    static let civitHeadlineSmall = Font.title2
 
-    // titleSmall: 14pt Medium
-    static let civitTitleSmall = Font.system(size: 14, weight: .medium)
+    // titleMedium: ~16pt Medium — scales with .headline
+    static let civitTitleMedium = Font.headline
 
-    // bodyMedium: 14pt Regular
-    static let civitBodyMedium = Font.system(size: 14)
+    // titleSmall: ~14pt Medium — scales with .subheadline (weight applied at call site)
+    static let civitTitleSmall = Font.subheadline.weight(.medium)
 
-    // bodySmall: 12pt Regular
-    static let civitBodySmall = Font.system(size: 12)
+    // bodyMedium: ~14pt Regular — scales with .subheadline
+    static let civitBodyMedium = Font.subheadline
 
-    // labelMedium: 12pt Medium
-    static let civitLabelMedium = Font.system(size: 12, weight: .medium)
+    // bodySmall: ~12pt Regular — scales with .caption
+    static let civitBodySmall = Font.caption
 
-    // labelSmall: 11pt Medium
-    static let civitLabelSmall = Font.system(size: 11, weight: .medium)
+    // labelMedium: ~12pt Medium — scales with .caption (weight applied at call site)
+    static let civitLabelMedium = Font.caption.weight(.medium)
 
-    // badgeLabel: 11pt Bold — compact badge counts
-    static let civitBadgeLabel = Font.system(size: 11, weight: .bold)
+    // labelSmall: ~11pt Medium — scales with .caption2
+    static let civitLabelSmall = Font.caption2.weight(.medium)
+
+    // badgeLabel: ~11pt Bold — scales with .caption2
+    static let civitBadgeLabel = Font.caption2.weight(.bold)
+
+    // labelXSmall: ~10pt Bold — tiny tag remove icons
+    static let civitLabelXSmall = Font.caption2.weight(.bold)
+
+    // labelXSmallSemibold: ~10pt Semibold — tag action icons
+    static let civitLabelXSmallSemibold = Font.caption2.weight(.semibold)
+
+    // monoCaption: caption monospaced — code/JSON editors
+    static let civitMonoCaption = Font.system(.caption, design: .monospaced)
+
+    // MARK: - Icon fonts (fixed size — decorative, no Dynamic Type)
 
     // iconMedium: 22pt Regular — action icon buttons
     static let civitIconMedium = Font.system(size: 22)
-
-    // labelXSmall: 10pt Bold — tiny tag remove icons
-    static let civitLabelXSmall = Font.system(size: 10, weight: .bold)
-
-    // labelXSmallSemibold: 10pt Semibold — tag action icons
-    static let civitLabelXSmallSemibold = Font.system(size: 10, weight: .semibold)
 
     // iconLarge: 44pt Regular — large icon overlays (e.g. play buttons)
     static let civitIconLarge = Font.system(size: 44)
@@ -42,9 +49,6 @@ extension Font {
 
     // iconXSmall: 9pt Bold — tiny compact badges
     static let civitIconXSmall = Font.system(size: 9, weight: .bold)
-
-    // monoCaption: caption monospaced — code/JSON editors
-    static let civitMonoCaption = Font.system(.caption, design: .monospaced)
 
     // iconSmallSemibold: 16pt Semibold — small icon overlays (e.g. comparison slider)
     static let civitIconSmallSemibold = Font.system(size: 16, weight: .semibold)

--- a/iosApp/iosApp/Features/Collections/AddToCollectionSheet.swift
+++ b/iosApp/iosApp/Features/Collections/AddToCollectionSheet.swift
@@ -24,6 +24,7 @@ struct AddToCollectionSheet: View {
                             if modelCollectionIds.contains(collection.id) {
                                 Image(systemName: "checkmark")
                                     .foregroundColor(.accentColor)
+                                    .accessibilityHidden(true)
                             }
                         }
                     }

--- a/iosApp/iosApp/Features/Collections/CollectionDetailScreen.swift
+++ b/iosApp/iosApp/Features/Collections/CollectionDetailScreen.swift
@@ -219,6 +219,7 @@ struct CollectionDetailScreen: View {
             Image(systemName: "tray")
                 .font(.largeTitle)
                 .foregroundColor(.civitOnSurfaceVariant)
+                .accessibilityHidden(true)
             Text("No models in this collection")
                 .font(.civitTitleMedium)
                 .foregroundColor(.civitOnSurfaceVariant)
@@ -288,6 +289,7 @@ private struct CollectionModelCard: View {
                     Image(systemName: "checkmark")
                         .font(.caption.bold())
                         .foregroundColor(theme.onPrimary)
+                        .accessibilityHidden(true)
                 }
             }
             .padding(Spacing.sm)

--- a/iosApp/iosApp/Features/Collections/CollectionsScreen.swift
+++ b/iosApp/iosApp/Features/Collections/CollectionsScreen.swift
@@ -192,6 +192,7 @@ private struct CollectionRow: View {
             .overlay {
                 Image(systemName: "folder")
                     .foregroundColor(.civitOnSurfaceVariant)
+                    .accessibilityHidden(true)
             }
     }
 }

--- a/iosApp/iosApp/Features/ComfyHub/ComfyHubDetailView.swift
+++ b/iosApp/iosApp/Features/ComfyHub/ComfyHubDetailView.swift
@@ -128,6 +128,7 @@ struct ComfyHubDetailView: View {
                     Text("Importing...")
                 } else {
                     Image(systemName: "arrow.down.circle")
+                        .accessibilityHidden(true)
                     Text("Import to ComfyUI")
                 }
             }

--- a/iosApp/iosApp/Features/ComfyUI/ComfyUIGenerationView.swift
+++ b/iosApp/iosApp/Features/ComfyUI/ComfyUIGenerationView.swift
@@ -37,6 +37,7 @@ struct ComfyUIGenerationView: View {
                     showTemplatePicker = true
                 } label: {
                     Image(systemName: "folder")
+                        .accessibilityLabel("Templates")
                 }
             }
         }

--- a/iosApp/iosApp/Features/ComfyUI/ComfyUIHistoryView.swift
+++ b/iosApp/iosApp/Features/ComfyUI/ComfyUIHistoryView.swift
@@ -96,6 +96,7 @@ struct ComfyUIHistoryView: View {
                         .overlay {
                             Image(systemName: "photo")
                                 .foregroundColor(.civitOnSurfaceVariant)
+                                .accessibilityHidden(true)
                         }
                 case .empty:
                     Color.civitSurfaceVariant

--- a/iosApp/iosApp/Features/ComfyUI/ComfyUIOutputDetailView.swift
+++ b/iosApp/iosApp/Features/ComfyUI/ComfyUIOutputDetailView.swift
@@ -209,6 +209,7 @@ private struct ComfyUIOutputDetailPage: View {
         HStack(spacing: Spacing.xs) {
             Image(systemName: icon)
                 .font(.civitBodySmall)
+                .accessibilityHidden(true)
             Text(label)
                 .font(.civitBodySmall)
         }

--- a/iosApp/iosApp/Features/ComfyUI/ComfyUISettingsView.swift
+++ b/iosApp/iosApp/Features/ComfyUI/ComfyUISettingsView.swift
@@ -30,6 +30,7 @@ struct ComfyUISettingsView: View {
                     viewModel.showAddSheet = true
                 } label: {
                     Image(systemName: "plus")
+                        .accessibilityLabel("Add connection")
                 }
             }
         }

--- a/iosApp/iosApp/Features/ComfyUI/WorkflowTemplateView.swift
+++ b/iosApp/iosApp/Features/ComfyUI/WorkflowTemplateView.swift
@@ -36,11 +36,13 @@ struct WorkflowTemplateView: View {
                             showImportSheet = true
                         } label: {
                             Image(systemName: "square.and.arrow.down")
+                                .accessibilityLabel("Import template")
                         }
                         Button {
                             showCreateEditor = true
                         } label: {
                             Image(systemName: "plus")
+                                .accessibilityLabel("Create template")
                         }
                     }
                 }
@@ -93,6 +95,7 @@ struct WorkflowTemplateView: View {
         HStack {
             Image(systemName: "magnifyingglass")
                 .foregroundColor(.civitOnSurfaceVariant)
+                .accessibilityHidden(true)
             TextField("Search templates...", text: $viewModel.searchQuery)
                 .font(.civitBodyMedium)
             if !viewModel.searchQuery.isEmpty {
@@ -101,6 +104,7 @@ struct WorkflowTemplateView: View {
                 } label: {
                     Image(systemName: "xmark.circle.fill")
                         .foregroundColor(.civitOnSurfaceVariant)
+                        .accessibilityLabel("Clear search")
                 }
             }
         }
@@ -266,6 +270,7 @@ private struct TemplateRow: View {
                 Button(action: { onSelect?() }) {
                     Image(systemName: "checkmark.circle")
                         .foregroundColor(theme.primary)
+                        .accessibilityLabel("Select template")
                 }
                 .buttonStyle(.plain)
             } else {
@@ -283,6 +288,7 @@ private struct TemplateRow: View {
                 } label: {
                     Image(systemName: "ellipsis.circle")
                         .foregroundColor(.civitOnSurfaceVariant)
+                        .accessibilityLabel("More options")
                 }
                 .buttonStyle(.plain)
             }

--- a/iosApp/iosApp/Features/Compare/ImageComparisonOverlay.swift
+++ b/iosApp/iosApp/Features/Compare/ImageComparisonOverlay.swift
@@ -40,6 +40,7 @@ struct ImageComparisonOverlay: View {
     private var topBar: some View {
         HStack {
             OverlayCircleButton(systemName: "xmark", action: onDismiss)
+                .accessibilityLabel("Close")
             Spacer()
             OverlayCircleButton(
                 systemName: orientation == .horizontal

--- a/iosApp/iosApp/Features/Create/CreateHubView.swift
+++ b/iosApp/iosApp/Features/Create/CreateHubView.swift
@@ -66,6 +66,7 @@ struct CreateHubView: View {
                 .font(.title3)
                 .foregroundColor(.civitPrimary)
                 .frame(width: 32, height: 32)
+                .accessibilityHidden(true)
 
             VStack(alignment: .leading, spacing: Spacing.xs) {
                 Text(title)

--- a/iosApp/iosApp/Features/Dataset/BatchTagEditorView.swift
+++ b/iosApp/iosApp/Features/Dataset/BatchTagEditorView.swift
@@ -146,8 +146,11 @@ struct BatchTagEditorView: View {
                     Image(systemName: "checkmark")
                         .font(.caption.bold())
                         .foregroundColor(theme.onPrimary)
+                        .accessibilityHidden(true)
                 }
             }
+            .frame(minWidth: 44, minHeight: 44)
+            .contentShape(Rectangle())
             .padding(Spacing.sm)
     }
 

--- a/iosApp/iosApp/Features/Dataset/DatasetDetailView.swift
+++ b/iosApp/iosApp/Features/Dataset/DatasetDetailView.swift
@@ -243,6 +243,7 @@ struct DatasetDetailView: View {
                     Image(systemName: "checkmark")
                         .font(.caption.bold())
                         .foregroundColor(theme.onPrimary)
+                        .accessibilityHidden(true)
                 }
             }
             .padding(Spacing.sm)

--- a/iosApp/iosApp/Features/Dataset/DatasetListView.swift
+++ b/iosApp/iosApp/Features/Dataset/DatasetListView.swift
@@ -128,6 +128,7 @@ private struct DatasetRow: View {
                 .overlay {
                     Image(systemName: "photo.on.rectangle.angled")
                         .foregroundColor(.civitOnSurfaceVariant)
+                        .accessibilityHidden(true)
                 }
             VStack(alignment: .leading, spacing: Spacing.xs) {
                 Text(dataset.name)

--- a/iosApp/iosApp/Features/Dataset/ExportDatasetSheet.swift
+++ b/iosApp/iosApp/Features/Dataset/ExportDatasetSheet.swift
@@ -163,6 +163,7 @@ struct ExportProgressOverlay: View {
                 Image(systemName: "checkmark.circle.fill")
                     .font(.civitIconExtraLarge)
                     .foregroundColor(theme.primary)
+                    .accessibilityHidden(true)
                 Text("Export Complete").font(.civitTitleMedium)
                 Text(fileName).font(.civitBodySmall).foregroundColor(.civitOnSurfaceVariant)
                 if warnings > 0 {
@@ -195,6 +196,7 @@ struct ExportProgressOverlay: View {
                 Image(systemName: "xmark.circle.fill")
                     .font(.civitIconExtraLarge)
                     .foregroundColor(.civitError)
+                    .accessibilityHidden(true)
                 Text("Export Failed").font(.civitTitleMedium)
                 Text(message).font(.civitBodySmall).foregroundColor(.civitOnSurfaceVariant)
                 Button("OK") { onDismiss() }.buttonStyle(.borderedProminent)

--- a/iosApp/iosApp/Features/Detail/CivitaiLinkSendSheet.swift
+++ b/iosApp/iosApp/Features/Detail/CivitaiLinkSendSheet.swift
@@ -63,6 +63,7 @@ struct CivitaiLinkSendSheet: View {
     private var notConnectedView: some View {
         VStack(spacing: Spacing.md) {
             Image(systemName: "link.circle").font(.civitIconExtraLarge)
+                .accessibilityHidden(true)
             Text("Civitai Link not configured").font(.civitTitleMedium)
             Text("Set up Civitai Link in Settings \u{2192} Advanced to send models to your PC")
                 .font(.civitBodySmall)
@@ -80,7 +81,7 @@ struct CivitaiLinkSendSheet: View {
                         versionId: version.id,
                         modelId: model.id,
                         versionName: version.name,
-                        downloadUrl: "https://civitai.com/api/download/models/\(version.id)"
+                        downloadUrl: CivitAiUrls.downloadUrl(versionId: version.id)
                     )
                     dismiss()
                 }

--- a/iosApp/iosApp/Features/Detail/ModelDetailScreen.swift
+++ b/iosApp/iosApp/Features/Detail/ModelDetailScreen.swift
@@ -274,6 +274,7 @@ struct ModelDetailScreen: View {
                         VStack(spacing: Spacing.xxs) {
                             SwiftUI.Image(systemName: "square.grid.2x2")
                                 .font(.title3)
+                                .accessibilityHidden(true)
                             Text("\(currentCarouselPage + 1)/\(filteredImages.count)")
                                 .font(.civitLabelSmall)
                         }

--- a/iosApp/iosApp/Features/Detail/ReviewsSection.swift
+++ b/iosApp/iosApp/Features/Detail/ReviewsSection.swift
@@ -172,6 +172,7 @@ struct SubmitReviewSheet: View {
                                 SwiftUI.Image(systemName: i <= rating ? "star.fill" : "star")
                                     .font(.title2)
                                     .foregroundColor(i <= rating ? theme.primary : .civitOnSurfaceVariant.opacity(0.3))
+                                    .accessibilityLabel("\(i) star\(i == 1 ? "" : "s")")
                             }
                             .buttonStyle(.plain)
                         }

--- a/iosApp/iosApp/Features/Download/DownloadQueueView.swift
+++ b/iosApp/iosApp/Features/Download/DownloadQueueView.swift
@@ -27,12 +27,13 @@ struct DownloadQueueView: View {
     private var emptyState: some View {
         VStack(spacing: Spacing.md) {
             Image(systemName: "arrow.down.circle")
-                .font(.system(size: 48))
+                .font(.civitIconExtraLarge)
                 .foregroundColor(.secondary)
+                .accessibilityHidden(true)
             Text("No downloads yet")
-                .font(.headline)
+                .font(.civitTitleMedium)
             Text("Downloads from model pages will appear here")
-                .font(.subheadline)
+                .font(.civitBodyMedium)
                 .foregroundColor(.secondary)
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
@@ -163,12 +164,14 @@ private struct ActiveDownloadRow: View {
                 Button { onPause() } label: {
                     Image(systemName: "pause.fill")
                         .foregroundColor(.civitPrimary)
+                        .accessibilityLabel("Pause download")
                 }
                 .buttonStyle(.plain)
             } else if download.status == .paused {
                 Button { onResume() } label: {
                     Image(systemName: "play.fill")
                         .foregroundColor(.civitPrimary)
+                        .accessibilityLabel("Resume download")
                 }
                 .buttonStyle(.plain)
             } else {
@@ -178,6 +181,7 @@ private struct ActiveDownloadRow: View {
             Button { onCancel() } label: {
                 Image(systemName: "xmark.circle.fill")
                     .foregroundColor(.red)
+                    .accessibilityLabel("Cancel download")
             }
             .buttonStyle(.plain)
         }
@@ -222,11 +226,13 @@ private struct FailedDownloadRow: View {
             Button { onRetry() } label: {
                 Image(systemName: "arrow.clockwise")
                     .foregroundColor(.civitPrimary)
+                    .accessibilityLabel("Retry download")
             }
             .buttonStyle(.plain)
             Button { onDelete() } label: {
                 Image(systemName: "trash")
                     .foregroundColor(.red)
+                    .accessibilityLabel("Delete download")
             }
             .buttonStyle(.plain)
         }
@@ -254,9 +260,11 @@ private struct CompletedDownloadRow: View {
             Spacer()
             Image(systemName: "checkmark.circle.fill")
                 .foregroundColor(.civitPrimary)
+                .accessibilityLabel("Download complete")
             Button { onDelete() } label: {
                 Image(systemName: "trash")
                     .foregroundColor(.red)
+                    .accessibilityLabel("Delete download")
             }
             .buttonStyle(.plain)
         }

--- a/iosApp/iosApp/Features/ExternalServer/ExternalServerGalleryView.swift
+++ b/iosApp/iosApp/Features/ExternalServer/ExternalServerGalleryView.swift
@@ -194,6 +194,7 @@ private struct ServerImageCell: View {
                         .overlay {
                             Image(systemName: "photo")
                                 .foregroundColor(.civitOnSurfaceVariant)
+                                .accessibilityHidden(true)
                         }
                 case .empty:
                     Color.civitSurfaceVariant
@@ -213,6 +214,7 @@ private struct ServerImageCell: View {
                     .font(.title3)
                     .padding(Spacing.xs)
                     .shadow(radius: 2)
+                    .accessibilityLabel(isSelected ? "Selected" : "Not selected")
             }
         }
     }

--- a/iosApp/iosApp/Features/ExternalServer/ExternalServerImageDetailView.swift
+++ b/iosApp/iosApp/Features/ExternalServer/ExternalServerImageDetailView.swift
@@ -57,6 +57,7 @@ private struct ServerImageDetailPage: View {
                             .overlay {
                                 Image(systemName: "photo")
                                     .foregroundColor(.civitOnSurfaceVariant)
+                                    .accessibilityHidden(true)
                             }
                     case .empty:
                         Color.civitSurfaceVariant

--- a/iosApp/iosApp/Features/Gallery/ImageViewerScreen.swift
+++ b/iosApp/iosApp/Features/Gallery/ImageViewerScreen.swift
@@ -39,6 +39,7 @@ struct ImageViewerScreen: View {
                                     SwiftUI.Image(systemName: "play.slash")
                                         .font(.largeTitle)
                                         .foregroundColor(.civitInverseOnSurface)
+                                        .accessibilityHidden(true)
                                     Text("WebM format not supported on iOS")
                                         .font(.civitBodyMedium)
                                         .foregroundColor(.civitInverseOnSurface)

--- a/iosApp/iosApp/Features/Library/LibraryView.swift
+++ b/iosApp/iosApp/Features/Library/LibraryView.swift
@@ -66,6 +66,7 @@ struct LibraryView: View {
                 .font(.title3)
                 .foregroundColor(.civitPrimary)
                 .frame(width: 32, height: 32)
+                .accessibilityHidden(true)
 
             VStack(alignment: .leading, spacing: Spacing.xs) {
                 Text(title)

--- a/iosApp/iosApp/Features/NotificationCenter/NotificationCenterView.swift
+++ b/iosApp/iosApp/Features/NotificationCenter/NotificationCenterView.swift
@@ -29,6 +29,7 @@ struct NotificationCenterView: View {
                         viewModel.markAllRead()
                     } label: {
                         Image(systemName: "checkmark.circle")
+                            .accessibilityLabel("Mark all as read")
                     }
                 }
             }

--- a/iosApp/iosApp/Features/Plugin/PluginListView.swift
+++ b/iosApp/iosApp/Features/Plugin/PluginListView.swift
@@ -24,6 +24,7 @@ struct PluginListView: View {
             Image(systemName: "puzzlepiece.extension")
                 .font(.civitIconExtraLarge)
                 .foregroundColor(.civitOnSurfaceVariant)
+                .accessibilityHidden(true)
             Text("No plugins installed")
                 .font(.civitBodyMedium)
                 .foregroundColor(.civitOnSurface)
@@ -74,6 +75,7 @@ private struct PluginRow: View {
                 .frame(width: pluginIconSize, height: pluginIconSize)
             Image(systemName: "puzzlepiece.extension")
                 .foregroundColor(theme.onPrimaryContainer)
+                .accessibilityHidden(true)
         }
     }
 

--- a/iosApp/iosApp/Features/Prompts/SavedPromptsScreen.swift
+++ b/iosApp/iosApp/Features/Prompts/SavedPromptsScreen.swift
@@ -154,6 +154,7 @@ private struct PromptCardView: View {
             Button(action: onToggleTemplate) {
                 SwiftUI.Image(systemName: prompt.isTemplate ? "star.fill" : "star")
                     .foregroundColor(prompt.isTemplate ? theme.primary : .civitOnSurfaceVariant)
+                    .accessibilityLabel(prompt.isTemplate ? "Remove from templates" : "Add to templates")
             }
             .buttonStyle(.borderless)
         }
@@ -203,6 +204,7 @@ private struct PromptCardView: View {
                 onDelete()
             } label: {
                 SwiftUI.Image(systemName: "trash")
+                    .accessibilityLabel("Delete prompt")
             }
             .buttonStyle(.borderless)
         }

--- a/iosApp/iosApp/Features/QRCode/QRCodeSheet.swift
+++ b/iosApp/iosApp/Features/QRCode/QRCodeSheet.swift
@@ -6,7 +6,7 @@ struct QRCodeSheet: View {
     @Environment(\.dismiss) private var dismiss
 
     private var civitaiUrl: String {
-        "https://civitai.com/models/\(modelId)"
+        CivitAiUrls.modelUrl(modelId: modelId)
     }
 
     private var qrImage: UIImage? {

--- a/iosApp/iosApp/Features/Search/ModelCardView.swift
+++ b/iosApp/iosApp/Features/Search/ModelCardView.swift
@@ -84,8 +84,8 @@ struct SourceBadgeView: View {
 
     private var badgeColor: Color {
         switch source {
-        case .huggingFace: return Color(red: 1.0, green: 0.616, blue: 0.0)
-        case .tensorArt: return Color(red: 0.612, green: 0.153, blue: 0.69)
+        case .huggingFace: return .huggingFaceBadge
+        case .tensorArt: return .tensorArtBadge
         default: return .clear
         }
     }

--- a/iosApp/iosApp/Features/Search/ModelSearchScreen.swift
+++ b/iosApp/iosApp/Features/Search/ModelSearchScreen.swift
@@ -202,12 +202,14 @@ struct ModelSearchScreen: View {
                             showSavedFiltersSheet = true
                         } label: {
                             Image(systemName: "bookmark.fill")
+                                .accessibilityLabel("Saved filters")
                         }
                         Button {
                             saveFilterName = ""
                             showSaveFilterAlert = true
                         } label: {
                             Image(systemName: "bookmark.badge.plus")
+                                .accessibilityLabel("Save current filter")
                         }
                         Button("Done") {
                             showFilterSheet = false
@@ -256,6 +258,7 @@ struct ModelSearchScreen: View {
                                 .padding(.leading, Spacing.lg)
                                 .padding(.vertical, Spacing.sm)
                                 .padding(.trailing, Spacing.sm)
+                                .accessibilityLabel("Remove from history")
                         }
                         Button {
                             viewModel.onHistoryItemClick(item)
@@ -453,6 +456,7 @@ extension ModelSearchScreen { // MARK: - Filter FAB
                 Image(systemName: "line.3.horizontal.decrease")
                     .font(.title2)
                     .foregroundColor(theme.primary)
+                    .accessibilityLabel("Filters")
                     .frame(width: 56, height: 56)
                     .background(Color.civitSurfaceContainerHigh)
                     .clipShape(RoundedRectangle(cornerRadius: CornerRadius.large))

--- a/iosApp/iosApp/Features/Share/SocialShareSheet.swift
+++ b/iosApp/iosApp/Features/Share/SocialShareSheet.swift
@@ -109,6 +109,7 @@ struct SocialShareSheet: View {
                     } label: {
                         Image(systemName: "xmark")
                             .font(.civitLabelXSmall)
+                            .accessibilityLabel("Remove hashtag")
                     }
                 }
             }
@@ -131,6 +132,7 @@ struct SocialShareSheet: View {
             Button { addTag() } label: {
                 Image(systemName: "plus")
                     .fontWeight(.semibold)
+                    .accessibilityLabel("Add tag")
             }
             .disabled(newTagInput.trimmingCharacters(in: .whitespaces).isEmpty)
         }

--- a/iosApp/iosApp/Features/TextSearch/TextSearchView.swift
+++ b/iosApp/iosApp/Features/TextSearch/TextSearchView.swift
@@ -48,6 +48,7 @@ struct TextSearchView: View {
             } label: {
                 Image(systemName: "magnifyingglass")
                     .font(.body)
+                    .accessibilityLabel("Search")
             }
             .disabled(viewModel.query.trimmingCharacters(in: .whitespaces).isEmpty)
         }

--- a/iosApp/iosApp/Utils/FormatHelper.swift
+++ b/iosApp/iosApp/Utils/FormatHelper.swift
@@ -1,5 +1,21 @@
 import Foundation
 
+// MARK: - CivitAI URL Constants
+
+enum CivitAiUrls {
+    static let baseUrl = "https://civitai.com"
+
+    static func modelUrl(modelId: Int64) -> String {
+        "\(baseUrl)/models/\(modelId)"
+    }
+
+    static func downloadUrl(versionId: Int64) -> String {
+        "\(baseUrl)/api/download/models/\(versionId)"
+    }
+}
+
+// MARK: - Format Helpers
+
 /// Native Swift formatting helpers that mirror FormatUtils in the shared KMP module.
 /// iOS DesignSystem components must NOT import FormatUtils (KMP-only).
 enum FormatHelper {

--- a/shared/src/commonMain/kotlin/com/riox432/civitdeck/data/export/ExportRepositoryImpl.kt
+++ b/shared/src/commonMain/kotlin/com/riox432/civitdeck/data/export/ExportRepositoryImpl.kt
@@ -41,8 +41,8 @@ class ExportRepositoryImpl(
         val outputDir = getExportCacheDirectory()
         val outputPath = "$outputDir/$datasetDir.zip"
 
+        val zipWriter = DatasetZipWriter(outputPath)
         try {
-            val zipWriter = DatasetZipWriter(outputPath)
             exportable.forEachIndexed { index, image ->
                 emit(ExportProgress.Downloading(index + 1, exportable.size))
                 val imageBytes = httpClient.get(image.imageUrl).bodyAsBytes()
@@ -59,12 +59,13 @@ class ExportRepositoryImpl(
             emit(ExportProgress.WritingManifest)
             val manifest = buildManifest(exportable, datasetDir)
             zipWriter.addEntry("$datasetDir/manifest.jsonl", manifest.encodeToByteArray())
-            zipWriter.close()
 
             emit(ExportProgress.Completed(outputPath, warningCount))
         } catch (@Suppress("TooGenericExceptionCaught") e: Exception) {
             Logger.e(TAG, "Export failed for dataset $datasetId: ${e.message}")
             emit(ExportProgress.Failed(e.message ?: "Export failed"))
+        } finally {
+            zipWriter.close()
         }
     }
 }


### PR DESCRIPTION
## Description

Codebase health audit findings — fixes for resource leaks, accessibility, design system consistency, and hardcoded values.

### Changes
- **Resource leak fix**: `DatasetZipWriter` now uses `try-finally` to guarantee close (#717)
- **Error logging**: Silent `catch` blocks in `WorkflowTemplateUseCases` now log warnings (#730)
- **iOS accessibility**: Added `accessibilityLabel`/`accessibilityHidden` to 50+ `Image(systemName:)` icons across 27 files (#725)
- **Dynamic Type**: `CivitDeckFonts` now uses SwiftUI text styles that scale with system font size (#726)
- **Design tokens**: Replaced hardcoded spacing in `ModelCardLayout`, badge colors in `ModelCardView`, system fonts in `DownloadQueueView` (#732, #737, #738)
- **URL centralization**: Extracted `CivitAiUrls` constants for both Android and iOS (#723)
- **Architecture**: Removed unused `lifecycle.viewmodel` dependency from `core-domain` (#728)
- **Touch target**: Increased `BatchTagEditorView` selection circle to 44pt minimum (#731)

### Issues closed as not applicable
- #722 — False positive (exceptions are logged and re-thrown, not swallowed)
- #729 — Outdated convention (Search VM intentionally in commonMain)
- #718 — Requires larger refactor (feature modules have data layer code)
- #735 — Duplicate of #713

### Remaining issues (large refactors for future PRs)
- #719 KoinHelper service locator pattern
- #720 ModelSearchViewModel decomposition
- #721 ModelDetailViewModel decomposition
- #724 Shared module architecture
- #727 UiState pattern deduplication
- #736 TooManyFunctions decomposition
- #734 ignoresSafeArea (audited, all appropriate for fullscreen viewers)

Closes #717, #723, #725, #726, #728, #730, #731, #732, #733, #737, #738