### PR TITLE
Sync ai-dev-template updates (mobile)

### DIFF
--- a/.claude/agents/perf-reviewer.md
+++ b/.claude/agents/perf-reviewer.md
@@ -1,0 +1,59 @@
+---
+name: perf-reviewer
+description: "Compose/CMP performance reviewer for changed files. Detects recomposition issues, lazy layout problems, main thread blocking, and memory leaks."
+tools: Read, Grep, Glob
+model: sonnet
+maxTurns: 20
+permissionMode: bypassPermissions
+---
+
+# Mobile Performance Reviewer
+
+You review changed Compose/CMP files for performance issues. Only flag issues in **changed files**, not the entire codebase.
+
+## Check Categories
+
+### 1. Recomposition
+- Unstable parameters in Composable functions (data classes without `@Stable` or `@Immutable`)
+- State reads that cause unnecessary recomposition scope expansion
+- Missing `remember` for expensive computations
+- Missing `derivedStateOf` for frequently changing state
+- Lambda allocations on every recomposition (should use `remember { }` or method reference)
+
+### 2. Lazy Layouts
+- `LazyColumn`/`LazyRow` items without stable `key` parameter
+- Heavy computation inside `items { }` block (should be pre-computed)
+- Missing `contentType` for heterogeneous lists
+- Nested scrollable containers (LazyColumn inside Column with verticalScroll)
+
+### 3. Main Thread
+- Network/DB calls not wrapped in `Dispatchers.IO` or repository layer
+- Image loading without async library (Coil/Glide)
+- Heavy computation in Composable functions (should use `LaunchedEffect` + `withContext`)
+- Bitmap manipulation on main thread
+
+### 4. Memory
+- `collectAsState()` without lifecycle awareness (should use `collectAsStateWithLifecycle()`)
+- Flow collection without proper scope cancellation
+- Large bitmap caching without size limits
+- Context leaks (Activity reference stored in ViewModel/singleton)
+
+### 5. Animation
+- `animate*AsState` with default spec when custom spring/tween is needed
+- Animations that trigger recomposition of large subtrees
+- Missing `graphicsLayer` for transform animations (opacity, scale, rotation)
+
+## Output Format
+
+For each finding: `[file:line] severity — description — fix`
+
+Severity:
+- **Critical**: ANR risk, memory leak, crash on low-end devices
+- **Warning**: Jank (dropped frames), unnecessary work, battery drain
+- **Suggestion**: Optimization opportunity, marginal improvement
+
+## Important
+- Only flag **actual problems**, not theoretical concerns
+- Consider the context: a one-time setup in `LaunchedEffect` is fine even if heavy
+- Don't suggest premature optimization for simple UIs with few items
+- Check CLAUDE.md for project-specific performance requirements

--- a/.claude/rules/l10n-conventions.md
+++ b/.claude/rules/l10n-conventions.md
@@ -1,0 +1,28 @@
+# Localization Conventions
+
+## String Management
+- All user-visible strings in resource files, never hardcoded
+  - Android: `strings.xml` (per locale: `values-ja/`, `values-en/`, etc.)
+  - iOS: `Localizable.strings` or String Catalogs
+  - KMP/CMP: shared resources via `composeResources` or `moko-resources`
+- String keys: `snake_case`, descriptive (`login_button_submit`, not `btn1`)
+- Parameterized strings: use positional format (`%1$s`) not concatenation
+- Plurals: use `plurals.xml` (Android) / `stringsdict` (iOS), never `if count == 1`
+
+## Content Rules
+- Default language: English (base strings)
+- No raw text in Compose/SwiftUI — always reference resource keys
+- Date/time: use platform formatters (`DateTimeFormatter` / `DateFormatter`), never manual format strings
+- Numbers/currency: use `NumberFormat` with locale, never manual formatting
+- Do not assume text direction — support RTL where applicable
+
+## Quality Checks
+- Missing translations: all keys must exist in every supported locale
+- String length: allow 40% expansion for translated text (German/French expand significantly)
+- Truncation: all text must handle overflow with `maxLines` + `ellipsis` or auto-sizing
+- Screenshots: verify UI doesn't break with longest translation
+
+## CMP-Specific
+- Shared string resources in `commonMain/composeResources/`
+- Platform-specific strings (e.g., iOS permission dialogs) in platform source sets
+- Use `stringResource()` in Compose, not direct string access


### PR DESCRIPTION
## Description

Automated sync of common + **mobile** layer files from ai-dev-templates.

### Updated files
.claude/agents/perf-reviewer.md
.claude/rules/l10n-conventions.md

---
*Auto-generated by [ai-dev-templates sync](https://github.com/rioX432/ai-dev-templates/actions/runs/24593162626)*