### PR TITLE
Replace non-null assertions (!!) in Desktop screens with safe handling

### DIFF
--- a/desktopApp/src/jvmMain/kotlin/com/riox432/civitdeck/ui/detail/DesktopDetailScreen.kt
+++ b/desktopApp/src/jvmMain/kotlin/com/riox432/civitdeck/ui/detail/DesktopDetailScreen.kt
@@ -57,13 +57,15 @@ fun DesktopDetailScreen(
                 message = uiState.error ?: "Unknown error",
                 onRetry = viewModel::retry,
             )
-            uiState.model != null -> DetailBody(
-                model = uiState.model!!,
-                uiState = uiState,
-                onVersionSelected = viewModel::onVersionSelected,
-                onImageClick = onImageClick,
-                onCreatorClick = onCreatorClick,
-            )
+            uiState.model != null -> uiState.model?.let { model ->
+                DetailBody(
+                    model = model,
+                    uiState = uiState,
+                    onVersionSelected = viewModel::onVersionSelected,
+                    onImageClick = onImageClick,
+                    onCreatorClick = onCreatorClick,
+                )
+            }
         }
     }
 }

--- a/desktopApp/src/jvmMain/kotlin/com/riox432/civitdeck/ui/detail/InfoPanel.kt
+++ b/desktopApp/src/jvmMain/kotlin/com/riox432/civitdeck/ui/detail/InfoPanel.kt
@@ -88,8 +88,8 @@ internal fun InfoPanel(
         if (selectedVersion != null && selectedVersion.files.isNotEmpty()) {
             item { FilesSection(files = selectedVersion.files) }
         }
-        if (!model.description.isNullOrBlank()) {
-            item { DescriptionSection(description = model.description!!) }
+        model.description?.takeIf { it.isNotBlank() }?.let { description ->
+            item { DescriptionSection(description = description) }
         }
     }
 }

--- a/desktopApp/src/jvmMain/kotlin/com/riox432/civitdeck/ui/prompts/DesktopPromptsScreen.kt
+++ b/desktopApp/src/jvmMain/kotlin/com/riox432/civitdeck/ui/prompts/DesktopPromptsScreen.kt
@@ -179,9 +179,9 @@ private fun PromptCard(
         elevation = CardDefaults.cardElevation(defaultElevation = Elevation.xs),
     ) {
         Column(modifier = Modifier.padding(Spacing.md)) {
-            if (prompt.templateName != null) {
+            prompt.templateName?.let { templateName ->
                 Text(
-                    text = prompt.templateName!!,
+                    text = templateName,
                     style = MaterialTheme.typography.titleSmall,
                     color = MaterialTheme.colorScheme.primary,
                 )

--- a/desktopApp/src/jvmMain/kotlin/com/riox432/civitdeck/ui/settings/DesktopSettingsScreen.kt
+++ b/desktopApp/src/jvmMain/kotlin/com/riox432/civitdeck/ui/settings/DesktopSettingsScreen.kt
@@ -315,27 +315,28 @@ private fun UpdateSection(viewModel: DesktopUpdateViewModel) {
     val state by viewModel.uiState.collectAsState()
 
     SettingsCard(title = "Updates") {
-        if (state.showBanner && state.updateResult != null) {
-            val result = state.updateResult!!
-            Text(
-                text = "Update available: v${result.currentVersion} \u2192 v${result.latestVersion}",
-                style = MaterialTheme.typography.bodyMedium,
-                color = MaterialTheme.colorScheme.primary,
-            )
-            Spacer(modifier = Modifier.height(Spacing.sm))
-            Row(horizontalArrangement = Arrangement.spacedBy(Spacing.sm)) {
-                Button(onClick = {
-                    if (AwtDesktop.isDesktopSupported()) {
-                        AwtDesktop.getDesktop().browse(URI(result.htmlUrl))
+        if (state.showBanner) {
+            state.updateResult?.let { result ->
+                Text(
+                    text = "Update available: v${result.currentVersion} \u2192 v${result.latestVersion}",
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.primary,
+                )
+                Spacer(modifier = Modifier.height(Spacing.sm))
+                Row(horizontalArrangement = Arrangement.spacedBy(Spacing.sm)) {
+                    Button(onClick = {
+                        if (AwtDesktop.isDesktopSupported()) {
+                            AwtDesktop.getDesktop().browse(URI(result.htmlUrl))
+                        }
+                    }) {
+                        Text("Download")
                     }
-                }) {
-                    Text("Download")
+                    OutlinedButton(onClick = viewModel::dismissBanner) {
+                        Text("Dismiss")
+                    }
                 }
-                OutlinedButton(onClick = viewModel::dismissBanner) {
-                    Text("Dismiss")
-                }
+                Spacer(modifier = Modifier.height(Spacing.md))
             }
-            Spacer(modifier = Modifier.height(Spacing.md))
         }
         SwitchSetting(
             label = "Auto-check for updates",


### PR DESCRIPTION
## Summary
- Replace 4 instances of `!!` (non-null assertion) in Desktop composables with safe null handling using `?.let {}` blocks
- `DesktopSettingsScreen.kt`: `state.updateResult!!` → `state.updateResult?.let { result -> ... }`
- `DesktopDetailScreen.kt`: `uiState.model!!` → `uiState.model?.let { model -> ... }`
- `InfoPanel.kt`: `model.description!!` → `model.description?.takeIf { it.isNotBlank() }?.let { ... }`
- `DesktopPromptsScreen.kt`: `prompt.templateName!!` → `prompt.templateName?.let { ... }`

Closes #820