### PR TITLE
Fix FilterChip 40dp touch target to 48dp

### DIFF
--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/search/FilterChipComponents.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/search/FilterChipComponents.kt
@@ -142,7 +142,7 @@ internal fun FilterChipItem(
     )
     Row(
         modifier = Modifier
-            .defaultMinSize(minHeight = 40.dp)
+            .defaultMinSize(minHeight = 48.dp)
             .clip(RoundedCornerShape(CornerRadius.chip))
             .background(backgroundColor)
             .clickable(


### PR DESCRIPTION
## Summary
- Fix `defaultMinSize(minHeight = 40.dp)` → `48.dp` in `FilterChipComponents.kt` to meet the Android minimum touch target of 48dp

Closes #812