### PR TITLE
Add accessibilityLabel to iOS onTapGesture elements

### DIFF
--- a/iosApp/iosApp/Features/ComfyUI/ComfyUIOutputDetailView.swift
+++ b/iosApp/iosApp/Features/ComfyUI/ComfyUIOutputDetailView.swift
@@ -157,6 +157,7 @@ private struct ComfyUIOutputDetailPage: View {
         }
         .frame(maxWidth: .infinity)
         .accessibilityLabel("Generated image")
+        .accessibilityAddTraits(.isButton)
         .onTapGesture { showImageViewer = true }
     }
 

--- a/iosApp/iosApp/Features/ComfyUI/SDWebUISettingsView.swift
+++ b/iosApp/iosApp/Features/ComfyUI/SDWebUISettingsView.swift
@@ -91,6 +91,8 @@ struct SDWebUISettingsView: View {
                 .foregroundColor(theme.primary)
                 .accessibilityLabel(conn.id == viewModel.activeConnection?.id
                     ? "Active connection" : "Inactive connection")
+                .accessibilityHint("Activate this connection")
+                .accessibilityAddTraits(.isButton)
                 .onTapGesture { viewModel.onActivate(id: conn.id) }
             VStack(alignment: .leading) {
                 Text(conn.name).font(.civitBodyMedium)

--- a/iosApp/iosApp/Features/ComfyUI/WorkflowTemplateView.swift
+++ b/iosApp/iosApp/Features/ComfyUI/WorkflowTemplateView.swift
@@ -294,6 +294,8 @@ private struct TemplateRow: View {
             }
         }
         .contentShape(Rectangle())
+        .accessibilityLabel("Select workflow: \(template.name)")
+        .accessibilityAddTraits(.isButton)
         .onTapGesture {
             if isPicker { onSelect?() } else { onSelect?() }
         }

--- a/iosApp/iosApp/Features/Dataset/BatchTagEditorView.swift
+++ b/iosApp/iosApp/Features/Dataset/BatchTagEditorView.swift
@@ -134,6 +134,8 @@ struct BatchTagEditorView: View {
         .clipShape(RoundedRectangle(cornerRadius: CornerRadius.image))
         .overlay(alignment: .topLeading) { selectionIndicator(isSelected: isSelected) }
         .overlay(alignment: .bottomTrailing) { tagCountBadge(image: image) }
+        .accessibilityLabel(isSelected ? "Deselect image" : "Select image")
+        .accessibilityAddTraits(.isButton)
         .onTapGesture { viewModel.toggleSelection(image.id) }
     }
 


### PR DESCRIPTION
## Summary
- Add `.accessibilityAddTraits(.isButton)` to `ComfyUIOutputDetailView` generated image tap target (label already existed)
- Add `.accessibilityLabel` and `.accessibilityAddTraits(.isButton)` to `BatchTagEditorView` image selection
- Add `.accessibilityHint` and `.accessibilityAddTraits(.isButton)` to `SDWebUISettingsView` connection activation (label already existed)
- Add `.accessibilityLabel` and `.accessibilityAddTraits(.isButton)` to `WorkflowTemplateView` template row tap target
- `ModelDetailScreen` and `ModelNotesSection` already had proper labels and button traits — no changes needed

## Test plan
- [ ] Enable VoiceOver on iOS Simulator, navigate to each modified screen
- [ ] Verify VoiceOver announces the label and identifies each element as a button

Closes #813