### PR TITLE
Replace hardcoded colors with CivitDeckColors tokens in iOS ComfyUI views

### DIFF
--- a/iosApp/iosApp/DesignSystem/CivitDeckColors.swift
+++ b/iosApp/iosApp/DesignSystem/CivitDeckColors.swift
@@ -50,6 +50,20 @@ extension Color {
     // MARK: - Scrim
     static let civitScrim = hex(0x000000)
 
+    // MARK: - Status Indicators
+    // Fixed semantic colors for connection/download/queue state dots.
+    // Values match Android CivitDeckColors for cross-platform consistency.
+    static let civitStatusSuccess = hex(0x4CAF50)
+    static let civitStatusWarning = hex(0xFFC107)
+    static let civitStatusError = hex(0xF44336)
+    static let civitStatusNeutral = hex(0x9E9E9E)
+
+    // MARK: - Mask Editor
+    // Intentionally vivid, fixed colors for visibility on any image background.
+    // Apply .opacity(0.5) at usage site for mask overlay.
+    static let civitMaskOverlay = hex(0xFF0000)
+    static let civitEraserActiveIcon = hex(0xFF9800)
+
     // MARK: - External Source Badges
     static let huggingFaceBadge = hex(0xFF9D00)
     static let tensorArtBadge = hex(0x9C27B0)

--- a/iosApp/iosApp/Features/ComfyUI/CivitaiLinkSettingsView.swift
+++ b/iosApp/iosApp/Features/ComfyUI/CivitaiLinkSettingsView.swift
@@ -83,10 +83,10 @@ struct CivitaiLinkSettingsView: View {
 
     private var statusColor: Color {
         switch viewModel.status {
-        case .connected: return .green
-        case .connecting: return .yellow
-        case .error: return .red
-        default: return .gray
+        case .connected: return .civitStatusSuccess
+        case .connecting: return .civitStatusWarning
+        case .error: return .civitStatusError
+        default: return .civitStatusNeutral
         }
     }
 

--- a/iosApp/iosApp/Features/ComfyUI/ComfyUIQueueView.swift
+++ b/iosApp/iosApp/Features/ComfyUI/ComfyUIQueueView.swift
@@ -89,7 +89,7 @@ private struct QueueJobRow: View {
         switch job.status {
         case .running: return theme.primary
         case .error: return .civitError
-        case .completed: return .green
+        case .completed: return .civitStatusSuccess
         default: return .civitOnSurfaceVariant
         }
     }

--- a/iosApp/iosApp/Features/ComfyUI/MaskEditorView.swift
+++ b/iosApp/iosApp/Features/ComfyUI/MaskEditorView.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 import Shared
 
-private let eraserActiveColor = Color.orange
+private let eraserActiveColor = Color.civitEraserActiveIcon
 
 struct MaskEditorView: View {
     @StateObject private var viewModel = MaskEditorViewModelOwner()

--- a/iosApp/iosApp/Features/ComfyUI/MaskPaintCanvasView.swift
+++ b/iosApp/iosApp/Features/ComfyUI/MaskPaintCanvasView.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 import Shared
 
-private let maskColor = Color.red.opacity(0.5)
+private let maskColor = Color.civitMaskOverlay.opacity(0.5)
 private let referenceCanvasSize: CGFloat = 400
 
 /// A canvas view that renders mask paint strokes and captures new drawing input


### PR DESCRIPTION
## Summary
- Add status indicator tokens (`civitStatusSuccess`, `civitStatusWarning`, `civitStatusError`, `civitStatusNeutral`) and mask editor tokens (`civitMaskOverlay`, `civitEraserActiveIcon`) to iOS `CivitDeckColors.swift`, matching Android `CivitDeckColors` hex values
- Replace `.green`/`.red`/`.gray`/`.yellow` in `CivitaiLinkSettingsView` with status tokens
- Replace `.green` in `ComfyUIQueueView` completed status with `civitStatusSuccess`
- Replace `Color.orange` in `MaskEditorView` with `civitEraserActiveIcon`
- Replace `Color.red.opacity(0.5)` in `MaskPaintCanvasView` with `civitMaskOverlay.opacity(0.5)`

Closes #814