### PR TITLE
Align iOS Spacing enum with 8pt grid

### DIFF
--- a/iosApp/iosApp/DesignSystem/ChipButton.swift
+++ b/iosApp/iosApp/DesignSystem/ChipButton.swift
@@ -13,7 +13,7 @@ struct ChipButton: View {
                 .font(.civitLabelMedium)
                 .fontWeight(isSelected ? .semibold : .regular)
                 .padding(.horizontal, Spacing.md)
-                .padding(.vertical, Spacing.xsPlus)
+                .padding(.vertical, Spacing.sm)
                 .background(isSelected ? theme.primary.opacity(0.2) : Color.civitSurfaceVariant)
                 .foregroundColor(isSelected ? theme.primary : .civitOnSurface)
                 .clipShape(Capsule())

--- a/iosApp/iosApp/DesignSystem/CivitDeckSpacing.swift
+++ b/iosApp/iosApp/DesignSystem/CivitDeckSpacing.swift
@@ -3,9 +3,7 @@ import Foundation
 enum Spacing {
     static let xxs: CGFloat = 2
     static let xs: CGFloat = 4
-    static let xsPlus: CGFloat = 6
     static let sm: CGFloat = 8
-    static let smPlus: CGFloat = 10
     static let md: CGFloat = 12
     static let lg: CGFloat = 16
     static let xl: CGFloat = 24

--- a/iosApp/iosApp/DesignSystem/SearchBarView.swift
+++ b/iosApp/iosApp/DesignSystem/SearchBarView.swift
@@ -22,7 +22,7 @@ struct SearchBarView: View {
                 }
             }
         }
-        .padding(Spacing.smPlus)
+        .padding(Spacing.md)
         .overlay(
             RoundedRectangle(cornerRadius: CornerRadius.searchBar)
                 .stroke(Color.civitOutlineVariant, lineWidth: 1)

--- a/iosApp/iosApp/Features/Collections/CollectionDetailScreen.swift
+++ b/iosApp/iosApp/Features/Collections/CollectionDetailScreen.swift
@@ -263,7 +263,7 @@ private struct CollectionModelCard: View {
                 .lineLimit(1)
             Text(model.type.name)
                 .font(.civitLabelSmall)
-                .padding(.horizontal, Spacing.xsPlus)
+                .padding(.horizontal, Spacing.sm)
                 .padding(.vertical, Spacing.xxs)
                 .background(Color.civitSurfaceVariant)
                 .clipShape(Capsule())

--- a/iosApp/iosApp/Features/ComfyUI/CivitaiLinkSettingsView.swift
+++ b/iosApp/iosApp/Features/ComfyUI/CivitaiLinkSettingsView.swift
@@ -36,8 +36,8 @@ struct CivitaiLinkSettingsView: View {
             HStack {
                 Circle()
                     .fill(statusColor)
-                    // Status indicator dot — intentionally small, one-off size
-                    .frame(width: Spacing.smPlus, height: Spacing.smPlus)
+                    // Status indicator dot — small circle, snapped to 8pt grid
+                    .frame(width: Spacing.sm, height: Spacing.sm)
                 Text(statusLabel)
                     .font(.civitBodyMedium)
                 Spacer()

--- a/iosApp/iosApp/Features/ComfyUI/ComfyUIOutputDetailView.swift
+++ b/iosApp/iosApp/Features/ComfyUI/ComfyUIOutputDetailView.swift
@@ -326,7 +326,7 @@ private struct SingleImageViewer: View {
                 .font(.title3)
                 .fontWeight(.semibold)
                 .foregroundColor(.civitInverseOnSurface)
-                .padding(Spacing.smPlus)
+                .padding(Spacing.md)
                 .background(.ultraThinMaterial, in: Circle())
         }
         .accessibilityLabel(label)
@@ -379,7 +379,7 @@ private struct SingleImageViewer: View {
                 .fontWeight(.medium)
                 .foregroundColor(.civitInverseOnSurface)
                 .padding(.horizontal, Spacing.lg)
-                .padding(.vertical, Spacing.smPlus)
+                .padding(.vertical, Spacing.md)
                 .background(.ultraThinMaterial, in: Capsule())
                 .padding(.bottom, Spacing.floatingOffset)
         }

--- a/iosApp/iosApp/Features/Detail/ModelDetailComponents.swift
+++ b/iosApp/iosApp/Features/Detail/ModelDetailComponents.swift
@@ -136,7 +136,7 @@ struct CarouselViewer: View {
                 .font(.civitTitleSmall)
                 .foregroundColor(.white)
                 .padding(.horizontal, Spacing.lg)
-                .padding(.vertical, Spacing.smPlus)
+                .padding(.vertical, Spacing.md)
                 .background(.ultraThinMaterial, in: Capsule())
                 .padding(.bottom, Spacing.floatingOffset)
         }
@@ -273,7 +273,7 @@ struct GridImageViewer: View {
                         .font(.civitTitleSmall)
                         .foregroundColor(.white)
                         .padding(.horizontal, Spacing.lg)
-                        .padding(.vertical, Spacing.smPlus)
+                        .padding(.vertical, Spacing.md)
                         .background(.ultraThinMaterial, in: Capsule())
                         .padding(.bottom, Spacing.floatingOffset)
                 }
@@ -365,7 +365,7 @@ struct ViewerCircleButton: View {
                 .font(.title3)
                 .fontWeight(.semibold)
                 .foregroundColor(.white)
-                .padding(Spacing.smPlus)
+                .padding(Spacing.md)
                 .background(.ultraThinMaterial, in: Circle())
         }
         .accessibilityLabel(label ?? systemName)
@@ -432,7 +432,7 @@ struct WrappingHStack: View {
             ForEach(tags, id: \.self) { tag in
                 Text(tag)
                     .font(.civitLabelMedium)
-                    .padding(.horizontal, Spacing.smPlus)
+                    .padding(.horizontal, Spacing.md)
                     .padding(.vertical, Spacing.xs)
                     .background(Color.civitSurfaceVariant)
                     .clipShape(Capsule())

--- a/iosApp/iosApp/Features/Detail/ModelDetailScreen.swift
+++ b/iosApp/iosApp/Features/Detail/ModelDetailScreen.swift
@@ -371,7 +371,7 @@ struct ModelDetailScreen: View {
                                     .font(.civitLabelMedium)
                                     .fontWeight(selected ? .semibold : .regular)
                                     .padding(.horizontal, Spacing.md)
-                                    .padding(.vertical, Spacing.xsPlus)
+                                    .padding(.vertical, Spacing.sm)
                                     .background(
                                         selected
                                             ? theme.primary.opacity(0.2)

--- a/iosApp/iosApp/Features/Detail/ModelNotesSection.swift
+++ b/iosApp/iosApp/Features/Detail/ModelNotesSection.swift
@@ -162,7 +162,7 @@ struct PersonalTagsSection: View {
                     .font(.civitLabelXSmallSemibold)
             }
         }
-        .padding(.horizontal, Spacing.smPlus)
+        .padding(.horizontal, Spacing.md)
         .padding(.vertical, Spacing.xs)
         .background(theme.primary.opacity(0.15))
         .foregroundColor(theme.primary)

--- a/iosApp/iosApp/Features/ExternalServer/ExternalServerImageDetailView.swift
+++ b/iosApp/iosApp/Features/ExternalServer/ExternalServerImageDetailView.swift
@@ -260,7 +260,7 @@ private struct ServerImageViewer: View {
                 .font(.title3)
                 .fontWeight(.semibold)
                 .foregroundColor(.white)
-                .padding(Spacing.smPlus)
+                .padding(Spacing.md)
                 .background(.ultraThinMaterial, in: Circle())
         }
         .accessibilityLabel(label)
@@ -309,7 +309,7 @@ private struct ServerImageViewer: View {
                 .fontWeight(.medium)
                 .foregroundColor(.white)
                 .padding(.horizontal, Spacing.lg)
-                .padding(.vertical, Spacing.smPlus)
+                .padding(.vertical, Spacing.md)
                 .background(.ultraThinMaterial, in: Capsule())
                 .padding(.bottom, Spacing.floatingOffset)
         }

--- a/iosApp/iosApp/Features/Gallery/ImageViewerScreen.swift
+++ b/iosApp/iosApp/Features/Gallery/ImageViewerScreen.swift
@@ -223,7 +223,7 @@ struct ImageViewerScreen: View {
                 .fontWeight(.medium)
                 .foregroundColor(.civitInverseOnSurface)
                 .padding(.horizontal, Spacing.lg)
-                .padding(.vertical, Spacing.smPlus)
+                .padding(.vertical, Spacing.md)
                 .background(.ultraThinMaterial, in: Capsule())
                 .padding(.bottom, Spacing.floatingOffset)
         }
@@ -280,7 +280,7 @@ private struct ControlCircleButton: View {
                 .font(.title3)
                 .fontWeight(.semibold)
                 .foregroundColor(.civitInverseOnSurface)
-                .padding(Spacing.smPlus)
+                .padding(Spacing.md)
                 .background(.ultraThinMaterial, in: Circle())
         }
         .accessibilityLabel(label ?? systemName)

--- a/iosApp/iosApp/Features/Search/ModelCardView.swift
+++ b/iosApp/iosApp/Features/Search/ModelCardView.swift
@@ -27,7 +27,7 @@ struct ModelCardView: View {
                 HStack(spacing: Spacing.xs) {
                     Text(model.type.name)
                         .font(.civitLabelSmall)
-                        .padding(.horizontal, Spacing.xsPlus)
+                        .padding(.horizontal, Spacing.sm)
                         .padding(.vertical, Spacing.xxs)
                         .background(Color.civitSurfaceVariant)
                         .clipShape(Capsule())
@@ -67,7 +67,7 @@ struct SourceBadgeView: View {
             Text(badgeLabel)
                 .font(.civitLabelXSmall)
                 .foregroundColor(.white)
-                .padding(.horizontal, Spacing.xsPlus)
+                .padding(.horizontal, Spacing.sm)
                 .padding(.vertical, Spacing.xxs)
                 .background(badgeColor)
                 .clipShape(Capsule())

--- a/iosApp/iosApp/Features/Settings/AdvancedSettingsView.swift
+++ b/iosApp/iosApp/Features/Settings/AdvancedSettingsView.swift
@@ -87,7 +87,7 @@ struct AdvancedSettingsView: View {
                         }
                     }
                     .padding(.horizontal, Spacing.md)
-                    .padding(.vertical, Spacing.xsPlus)
+                    .padding(.vertical, Spacing.sm)
                     .background(hashtag.isEnabled ? theme.primary.opacity(0.2) : Color.civitSurfaceVariant)
                     .foregroundColor(hashtag.isEnabled ? theme.primary : .civitOnSurface)
                     .clipShape(Capsule())

--- a/iosApp/iosApp/Features/Share/SocialShareSheet.swift
+++ b/iosApp/iosApp/Features/Share/SocialShareSheet.swift
@@ -114,7 +114,7 @@ struct SocialShareSheet: View {
                 }
             }
             .padding(.horizontal, Spacing.md)
-            .padding(.vertical, Spacing.xsPlus)
+            .padding(.vertical, Spacing.sm)
             .background(hashtag.isEnabled ? theme.primary.opacity(0.2) : Color.civitSurfaceVariant)
             .foregroundColor(hashtag.isEnabled ? theme.primary : .civitOnSurface)
             .clipShape(Capsule())


### PR DESCRIPTION
## Summary
- Remove `xsPlus` (6pt) and `smPlus` (10pt) from `Spacing` enum — these violated the 8pt grid rule
- `xsPlus` (6pt) → `sm` (8pt): chip/badge vertical and horizontal padding across 7 files
- `smPlus` (10pt) → `md` (12pt): search bar padding, circular action buttons, toast vertical padding, tag horizontal padding across 7 files
- `smPlus` status indicator dot in CivitaiLinkSettingsView → `sm` (8pt) since it's a small circle, not spacing
- `xxs` (2pt) kept as-is — legitimate sub-grid value for fine details (borders, thin separators)

## Changes
| Token | Old Value | New Token | New Value | Rationale |
|---|---|---|---|---|
| `xsPlus` | 6pt | `sm` | 8pt | Nearest 8pt grid value; chips slightly taller |
| `smPlus` | 10pt | `md` | 12pt | Nearest 8pt grid value; slightly more spacious |
| `smPlus` (dot) | 10pt | `sm` | 8pt | Status indicator dot should be smaller |
| `xxs` | 2pt | kept | 2pt | Sub-grid fine-detail value |

## Files Modified (14)
- `DesignSystem/CivitDeckSpacing.swift` — removed `xsPlus` and `smPlus` definitions
- 6 files: `xsPlus` → `sm` replacements
- 7 files: `smPlus` → `md` (or `sm` for status dot) replacements

## Test Plan
- [x] iOS Simulator build passes (`** BUILD SUCCEEDED **`)
- [ ] Visual check: chips, badges, search bar, action buttons, toasts, tags look correct with new spacing

Closes #823