### PR TITLE
Replace broad exception catches with specific types in ComfyUIApi and ImageDownloader

### DIFF
--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/gallery/ImageDownloader.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/gallery/ImageDownloader.kt
@@ -10,6 +10,7 @@ import kotlinx.coroutines.withContext
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import java.io.File
+import java.io.IOException
 
 object ImageDownloader {
 
@@ -21,7 +22,9 @@ object ImageDownloader {
                 val bytes = downloadBytes(imageUrl) ?: return@withContext false
                 val fileName = extractFileName(imageUrl)
                 saveToGallery(context, fileName, bytes)
-            } catch (@Suppress("TooGenericExceptionCaught") _: Exception) {
+            } catch (_: IOException) {
+                false
+            } catch (_: SecurityException) {
                 false
             }
         }
@@ -79,7 +82,10 @@ object ImageDownloader {
             values.put(MediaStore.MediaColumns.IS_PENDING, 0)
             resolver.update(uri, values, null, null)
             true
-        } catch (@Suppress("TooGenericExceptionCaught") _: Exception) {
+        } catch (_: IOException) {
+            resolver.delete(uri, null, null)
+            false
+        } catch (_: SecurityException) {
             resolver.delete(uri, null, null)
             false
         }
@@ -98,7 +104,9 @@ object ImageDownloader {
             dir.mkdirs()
             File(dir, fileName).writeBytes(bytes)
             true
-        } catch (@Suppress("TooGenericExceptionCaught") _: Exception) {
+        } catch (_: IOException) {
+            false
+        } catch (_: SecurityException) {
             false
         }
     }

--- a/core/core-network/src/commonMain/kotlin/com/riox432/civitdeck/data/api/comfyui/ComfyUIApi.kt
+++ b/core/core-network/src/commonMain/kotlin/com/riox432/civitdeck/data/api/comfyui/ComfyUIApi.kt
@@ -3,6 +3,9 @@ package com.riox432.civitdeck.data.api.comfyui
 import com.riox432.civitdeck.util.Logger
 import io.ktor.client.HttpClient
 import io.ktor.client.call.body
+import io.ktor.client.network.sockets.ConnectTimeoutException
+import io.ktor.client.plugins.HttpRequestTimeoutException
+import io.ktor.client.plugins.ResponseException
 import io.ktor.client.request.forms.formData
 import io.ktor.client.request.forms.submitFormWithBinaryData
 import io.ktor.client.request.get
@@ -15,12 +18,12 @@ import io.ktor.http.HttpHeaders
 import io.ktor.http.URLBuilder
 import io.ktor.http.contentType
 import io.ktor.http.path
+import kotlinx.serialization.SerializationException
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.put
 import kotlin.concurrent.Volatile
-import kotlin.coroutines.cancellation.CancellationException
 
 @Suppress("TooManyFunctions")
 class ComfyUIApi(
@@ -47,138 +50,91 @@ class ComfyUIApi(
 
     /**
      * Health check / queue status: GET /queue
-     * @throws CancellationException if coroutine is cancelled
-     * @throws Exception on network or deserialization failure
+     * @throws ResponseException on HTTP error response
+     * @throws SerializationException on deserialization failure
+     * @throws HttpRequestTimeoutException on request timeout
+     * @throws ConnectTimeoutException on connection timeout
      */
-    suspend fun getQueue(): QueueResponse {
-        val url = baseUrl
-        return try {
-            client.get("$url/queue").body()
-        } catch (e: CancellationException) {
-            throw e
-        } catch (@Suppress("TooGenericExceptionCaught") e: Exception) {
-            Logger.e(TAG, "getQueue failed: ${e.message}", e)
-            throw e
-        }
-    }
+    suspend fun getQueue(): QueueResponse =
+        logAndRethrow("getQueue") { client.get("$baseUrl/queue").body() }
 
     /**
      * Fetch available checkpoints: GET /object_info/CheckpointLoaderSimple
-     * @throws CancellationException if coroutine is cancelled
-     * @throws Exception on network or deserialization failure
+     * @throws ResponseException on HTTP error response
+     * @throws SerializationException on deserialization failure
+     * @throws HttpRequestTimeoutException on request timeout
+     * @throws ConnectTimeoutException on connection timeout
      */
-    suspend fun getCheckpoints(): List<String> {
-        val url = baseUrl
-        return try {
-            val text = client.get("$url/object_info/CheckpointLoaderSimple").bodyAsText()
-            parseCheckpointNames(text)
-        } catch (e: CancellationException) {
-            throw e
-        } catch (@Suppress("TooGenericExceptionCaught") e: Exception) {
-            Logger.e(TAG, "getCheckpoints failed: ${e.message}", e)
-            throw e
-        }
+    suspend fun getCheckpoints(): List<String> = logAndRethrow("getCheckpoints") {
+        val text = client.get("$baseUrl/object_info/CheckpointLoaderSimple").bodyAsText()
+        parseCheckpointNames(text)
     }
 
     /**
      * Fetch available LoRA models: GET /object_info/LoraLoader
-     * @throws CancellationException if coroutine is cancelled
-     * @throws Exception on network or deserialization failure
+     * @throws ResponseException on HTTP error response
+     * @throws SerializationException on deserialization failure
+     * @throws HttpRequestTimeoutException on request timeout
+     * @throws ConnectTimeoutException on connection timeout
      */
-    suspend fun getLoras(): List<String> {
-        val url = baseUrl
-        return try {
-            val text = client.get("$url/object_info/LoraLoader").bodyAsText()
-            parseNodeInputList(text, "LoraLoader", "lora_name")
-        } catch (e: CancellationException) {
-            throw e
-        } catch (@Suppress("TooGenericExceptionCaught") e: Exception) {
-            Logger.e(TAG, "getLoras failed: ${e.message}", e)
-            throw e
-        }
+    suspend fun getLoras(): List<String> = logAndRethrow("getLoras") {
+        val text = client.get("$baseUrl/object_info/LoraLoader").bodyAsText()
+        parseNodeInputList(text, "LoraLoader", "lora_name")
     }
 
     /**
      * Fetch available ControlNet models: GET /object_info/ControlNetLoader
-     * @throws CancellationException if coroutine is cancelled
-     * @throws Exception on network or deserialization failure
+     * @throws ResponseException on HTTP error response
+     * @throws SerializationException on deserialization failure
+     * @throws HttpRequestTimeoutException on request timeout
+     * @throws ConnectTimeoutException on connection timeout
      */
-    suspend fun getControlNets(): List<String> {
-        val url = baseUrl
-        return try {
-            val text = client.get("$url/object_info/ControlNetLoader").bodyAsText()
-            parseNodeInputList(text, "ControlNetLoader", "control_net_name")
-        } catch (e: CancellationException) {
-            throw e
-        } catch (@Suppress("TooGenericExceptionCaught") e: Exception) {
-            Logger.e(TAG, "getControlNets failed: ${e.message}", e)
-            throw e
-        }
+    suspend fun getControlNets(): List<String> = logAndRethrow("getControlNets") {
+        val text = client.get("$baseUrl/object_info/ControlNetLoader").bodyAsText()
+        parseNodeInputList(text, "ControlNetLoader", "control_net_name")
     }
 
     /**
      * Fetch the full /object_info response containing schemas for all node types.
      * Used for dynamic parameter extraction (dropdown options, min/max ranges, etc.).
-     * @throws CancellationException if coroutine is cancelled
-     * @throws Exception on network or deserialization failure
+     * @throws ResponseException on HTTP error response
+     * @throws HttpRequestTimeoutException on request timeout
+     * @throws ConnectTimeoutException on connection timeout
      */
-    suspend fun getFullObjectInfo(): String {
-        val url = baseUrl
-        return try {
-            client.get("$url/object_info").bodyAsText()
-        } catch (e: CancellationException) {
-            throw e
-        } catch (@Suppress("TooGenericExceptionCaught") e: Exception) {
-            Logger.e(TAG, "getFullObjectInfo failed: ${e.message}", e)
-            throw e
-        }
-    }
+    suspend fun getFullObjectInfo(): String =
+        logAndRethrow("getFullObjectInfo") { client.get("$baseUrl/object_info").bodyAsText() }
 
     /**
      * Submit workflow: POST /prompt
-     * @throws CancellationException if coroutine is cancelled
-     * @throws Exception on network or deserialization failure
+     * @throws ResponseException on HTTP error response
+     * @throws SerializationException on deserialization failure
+     * @throws HttpRequestTimeoutException on request timeout
+     * @throws ConnectTimeoutException on connection timeout
      */
-    suspend fun submitPrompt(workflow: JsonObject): PromptResponse {
-        val url = baseUrl
+    suspend fun submitPrompt(workflow: JsonObject): PromptResponse = logAndRethrow("submitPrompt") {
         val body = buildJsonObject { put("prompt", workflow) }
-        return try {
-            client.post("$url/prompt") {
-                contentType(ContentType.Application.Json)
-                setBody(body)
-            }.body()
-        } catch (e: CancellationException) {
-            throw e
-        } catch (@Suppress("TooGenericExceptionCaught") e: Exception) {
-            Logger.e(TAG, "submitPrompt failed: ${e.message}", e)
-            throw e
-        }
+        client.post("$baseUrl/prompt") {
+            contentType(ContentType.Application.Json)
+            setBody(body)
+        }.body()
     }
 
     /**
      * Interrupt the currently running generation: POST /interrupt
-     * @throws CancellationException if coroutine is cancelled
-     * @throws Exception on network failure
+     * @throws ResponseException on HTTP error response
+     * @throws HttpRequestTimeoutException on request timeout
+     * @throws ConnectTimeoutException on connection timeout
      */
-    suspend fun interrupt() {
-        val url = baseUrl
-        try {
-            client.post("$url/interrupt")
-        } catch (e: CancellationException) {
-            throw e
-        } catch (@Suppress("TooGenericExceptionCaught") e: Exception) {
-            Logger.e(TAG, "interrupt failed: ${e.message}", e)
-            throw e
-        }
-    }
+    suspend fun interrupt(): Unit =
+        logAndRethrow("interrupt") { client.post("$baseUrl/interrupt") }
 
     /**
      * Delete (cancel) queued prompts: POST /queue with {"delete": [...promptIds]}
-     * @throws CancellationException if coroutine is cancelled
-     * @throws Exception on network failure
+     * @throws ResponseException on HTTP error response
+     * @throws HttpRequestTimeoutException on request timeout
+     * @throws ConnectTimeoutException on connection timeout
      */
-    suspend fun deleteQueue(promptIds: List<String>) {
-        val url = baseUrl
+    suspend fun deleteQueue(promptIds: List<String>): Unit = logAndRethrow("deleteQueue") {
         val body = buildJsonObject {
             put(
                 "delete",
@@ -187,95 +143,71 @@ class ComfyUIApi(
                 }
             )
         }
-        try {
-            client.post("$url/queue") {
-                contentType(ContentType.Application.Json)
-                setBody(body)
-            }
-        } catch (e: CancellationException) {
-            throw e
-        } catch (@Suppress("TooGenericExceptionCaught") e: Exception) {
-            Logger.e(TAG, "deleteQueue failed: ${e.message}", e)
-            throw e
+        client.post("$baseUrl/queue") {
+            contentType(ContentType.Application.Json)
+            setBody(body)
         }
     }
 
     /**
      * Get all generation history: GET /history
      * Returns a map of prompt_id -> HistoryEntry for all completed prompts.
-     * @throws CancellationException if coroutine is cancelled
-     * @throws Exception on network or deserialization failure
+     * @throws ResponseException on HTTP error response
+     * @throws SerializationException on deserialization failure
+     * @throws HttpRequestTimeoutException on request timeout
+     * @throws ConnectTimeoutException on connection timeout
      */
-    suspend fun getAllHistory(): Map<String, HistoryEntry> {
-        val url = baseUrl
-        return try {
-            val text = client.get("$url/history").bodyAsText()
-            json.decodeFromString(text)
-        } catch (e: CancellationException) {
-            throw e
-        } catch (@Suppress("TooGenericExceptionCaught") e: Exception) {
-            Logger.e(TAG, "getAllHistory failed: ${e.message}", e)
-            throw e
-        }
+    suspend fun getAllHistory(): Map<String, HistoryEntry> = logAndRethrow("getAllHistory") {
+        val text = client.get("$baseUrl/history").bodyAsText()
+        json.decodeFromString(text)
     }
 
     /**
      * Get generation history: GET /history/{promptId}
-     * @throws CancellationException if coroutine is cancelled
-     * @throws Exception on network or deserialization failure
+     * @throws ResponseException on HTTP error response
+     * @throws SerializationException on deserialization failure
+     * @throws HttpRequestTimeoutException on request timeout
+     * @throws ConnectTimeoutException on connection timeout
      */
-    suspend fun getHistory(promptId: String): HistoryEntry? {
-        val url = baseUrl
-        return try {
-            val text = client.get("$url/history/$promptId").bodyAsText()
+    suspend fun getHistory(promptId: String): HistoryEntry? =
+        logAndRethrow("getHistory (promptId=$promptId)") {
+            val text = client.get("$baseUrl/history/$promptId").bodyAsText()
             val root = json.decodeFromString<Map<String, HistoryEntry>>(text)
             root[promptId]
-        } catch (e: CancellationException) {
-            throw e
-        } catch (@Suppress("TooGenericExceptionCaught") e: Exception) {
-            Logger.e(TAG, "getHistory failed (promptId=$promptId): ${e.message}", e)
-            throw e
         }
-    }
 
     /**
      * Upload an image to the ComfyUI server: POST /upload/image (multipart form data).
      * Returns the uploaded filename from the server response.
-     * @throws CancellationException if coroutine is cancelled
-     * @throws Exception on network or deserialization failure
+     * @throws ResponseException on HTTP error response
+     * @throws SerializationException on deserialization failure
+     * @throws HttpRequestTimeoutException on request timeout
+     * @throws ConnectTimeoutException on connection timeout
      */
     suspend fun uploadImage(
         imageBytes: ByteArray,
         filename: String,
         subfolder: String = "",
         imageType: String = "input",
-    ): UploadImageResponse {
-        val url = baseUrl
-        return try {
-            client.submitFormWithBinaryData(
-                url = "$url/upload/image",
-                formData = formData {
-                    append(
-                        "image",
-                        imageBytes,
-                        Headers.build {
-                            append(HttpHeaders.ContentType, "image/png")
-                            append(
-                                HttpHeaders.ContentDisposition,
-                                "filename=\"$filename\"",
-                            )
-                        }
-                    )
-                    append("subfolder", subfolder)
-                    append("type", imageType)
-                },
-            ).body()
-        } catch (e: CancellationException) {
-            throw e
-        } catch (@Suppress("TooGenericExceptionCaught") e: Exception) {
-            Logger.e(TAG, "uploadImage failed: ${e.message}", e)
-            throw e
-        }
+    ): UploadImageResponse = logAndRethrow("uploadImage") {
+        client.submitFormWithBinaryData(
+            url = "$baseUrl/upload/image",
+            formData = formData {
+                append(
+                    "image",
+                    imageBytes,
+                    Headers.build {
+                        append(HttpHeaders.ContentType, "image/png")
+                        append(
+                            HttpHeaders.ContentDisposition,
+                            "filename=\"$filename\"",
+                        )
+                    }
+                )
+                append("subfolder", subfolder)
+                append("type", imageType)
+            },
+        ).body()
     }
 
     /**
@@ -292,6 +224,30 @@ class ComfyUIApi(
                 parameters.append("subfolder", image.subfolder)
             }
         }.buildString()
+    }
+
+    /**
+     * Executes [block], catching known Ktor / serialization exceptions,
+     * logging them, and rethrowing. Unknown exceptions propagate without logging.
+     */
+    private suspend inline fun <T> logAndRethrow(operation: String, block: () -> T): T {
+        try {
+            return block()
+        } catch (e: ResponseException) {
+            logApiError(operation, e)
+        } catch (e: SerializationException) {
+            logApiError(operation, e)
+        } catch (e: HttpRequestTimeoutException) {
+            logApiError(operation, e)
+        } catch (e: ConnectTimeoutException) {
+            logApiError(operation, e)
+        }
+    }
+
+    /** Logs an API error and rethrows the exception. */
+    private fun logApiError(operation: String, cause: Throwable): Nothing {
+        Logger.e(TAG, "$operation failed: ${cause.message}", cause)
+        throw cause
     }
 
     private fun parseCheckpointNames(responseText: String): List<String> {
@@ -318,7 +274,10 @@ class ComfyUIApi(
             val namesList = fieldArray.firstOrNull() as? kotlinx.serialization.json.JsonArray
                 ?: return emptyList()
             namesList.mapNotNull { (it as? kotlinx.serialization.json.JsonPrimitive)?.content }
-        } catch (@Suppress("TooGenericExceptionCaught") e: Exception) {
+        } catch (e: SerializationException) {
+            Logger.w(TAG, "Failed to parse node input list ($nodeType/$fieldName): ${e.message}")
+            emptyList()
+        } catch (e: IllegalArgumentException) {
             Logger.w(TAG, "Failed to parse node input list ($nodeType/$fieldName): ${e.message}")
             emptyList()
         }


### PR DESCRIPTION
## Summary
- Replace 12 generic `catch (Exception)` blocks in `ComfyUIApi.kt` with specific `ResponseException`, `SerializationException`, `HttpRequestTimeoutException`, and `ConnectTimeoutException` catches
- Replace 3 generic `catch (Exception)` blocks in `ImageDownloader.kt` with specific `IOException` and `SecurityException` catches
- Extract `logAndRethrow` / `logApiError` helpers in ComfyUIApi to consolidate logging while satisfying detekt's ThrowsCount rule
- Remove all `@Suppress("TooGenericExceptionCaught")` annotations from both files

## Test plan
- [x] `./gradlew :core:core-network:detekt` passes
- [x] `./gradlew :androidApp:detekt` passes
- [x] `./gradlew :androidApp:assembleDebug` passes

Closes #803