### PR TITLE
Replace generic exception catches in SDWebUIApi and ComfyUIWebSocketApi

### DIFF
--- a/core/core-network/src/commonMain/kotlin/com/riox432/civitdeck/data/api/comfyui/ComfyUIWebSocketApi.kt
+++ b/core/core-network/src/commonMain/kotlin/com/riox432/civitdeck/data/api/comfyui/ComfyUIWebSocketApi.kt
@@ -2,6 +2,10 @@ package com.riox432.civitdeck.data.api.comfyui
 
 import com.riox432.civitdeck.util.Logger
 import io.ktor.client.HttpClient
+import io.ktor.client.network.sockets.ConnectTimeoutException
+import io.ktor.client.plugins.HttpRequestTimeoutException
+import io.ktor.client.plugins.ResponseException
+import io.ktor.client.plugins.websocket.WebSocketException
 import io.ktor.client.plugins.websocket.webSocket
 import io.ktor.client.plugins.websocket.wss
 import io.ktor.websocket.Frame
@@ -10,6 +14,7 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.FlowCollector
 import kotlinx.coroutines.flow.flow
+import kotlinx.serialization.SerializationException
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.decodeFromJsonElement
 
@@ -51,14 +56,18 @@ class ComfyUIWebSocketApi(
             try {
                 runWebSocketSession(baseUrl, wsScheme, clientId, promptId)
                 attempt = MAX_RETRIES + 1
-            } catch (@Suppress("TooGenericExceptionCaught") e: Exception) {
-                Logger.w(TAG, "WebSocket connection failed (attempt $attempt): ${e.message}")
-                lastError = e
+            } catch (e: WebSocketException) {
+                lastError = logAndRetry(e, attempt)
                 attempt++
-                if (attempt <= MAX_RETRIES) {
-                    val backoff = minOf(BASE_DELAY_MS * (1L shl (attempt - 1)), MAX_DELAY_MS)
-                    delay(backoff)
-                }
+            } catch (e: ResponseException) {
+                lastError = logAndRetry(e, attempt)
+                attempt++
+            } catch (e: HttpRequestTimeoutException) {
+                lastError = logAndRetry(e, attempt)
+                attempt++
+            } catch (e: ConnectTimeoutException) {
+                lastError = logAndRetry(e, attempt)
+                attempt++
             }
         }
         lastError?.let { throw it }
@@ -178,10 +187,26 @@ class ComfyUIWebSocketApi(
                 }
                 else -> ComfyUIWebSocketMessage.Unknown(envelope.type)
             }
-        } catch (@Suppress("TooGenericExceptionCaught") e: Exception) {
+        } catch (e: SerializationException) {
+            Logger.w(TAG, "Failed to parse WebSocket message: ${e.message}")
+            null
+        } catch (e: IllegalArgumentException) {
             Logger.w(TAG, "Failed to parse WebSocket message: ${e.message}")
             null
         }
+    }
+
+    /**
+     * Logs a WebSocket connection failure, waits with exponential backoff if retries remain,
+     * and returns the exception so the caller can store it as [lastError].
+     */
+    private suspend fun logAndRetry(e: Exception, attempt: Int): Exception {
+        Logger.w(TAG, "WebSocket connection failed (attempt $attempt): ${e.message}")
+        if (attempt + 1 <= MAX_RETRIES) {
+            val backoff = minOf(BASE_DELAY_MS * (1L shl attempt), MAX_DELAY_MS)
+            delay(backoff)
+        }
+        return e
     }
 
     /** Returns true for messages that carry a promptId matching the active job, or status messages. */

--- a/core/core-network/src/commonMain/kotlin/com/riox432/civitdeck/data/api/webui/SDWebUIApi.kt
+++ b/core/core-network/src/commonMain/kotlin/com/riox432/civitdeck/data/api/webui/SDWebUIApi.kt
@@ -3,13 +3,16 @@ package com.riox432.civitdeck.data.api.webui
 import com.riox432.civitdeck.util.Logger
 import io.ktor.client.HttpClient
 import io.ktor.client.call.body
+import io.ktor.client.network.sockets.ConnectTimeoutException
+import io.ktor.client.plugins.HttpRequestTimeoutException
+import io.ktor.client.plugins.ResponseException
 import io.ktor.client.request.get
 import io.ktor.client.request.post
 import io.ktor.client.request.setBody
 import io.ktor.http.ContentType
 import io.ktor.http.contentType
+import kotlinx.serialization.SerializationException
 import kotlin.concurrent.Volatile
-import kotlin.coroutines.cancellation.CancellationException
 
 class SDWebUIApi(private val client: HttpClient) {
     @Volatile
@@ -20,121 +23,101 @@ class SDWebUIApi(private val client: HttpClient) {
     }
 
     /**
-     * @throws CancellationException if coroutine is cancelled
-     * @throws Exception on network or deserialization failure
+     * @throws ResponseException on HTTP error response
+     * @throws SerializationException on deserialization failure
+     * @throws HttpRequestTimeoutException on request timeout
+     * @throws ConnectTimeoutException on connection timeout
      */
-    suspend fun getModels(): List<SDWebUIModelInfo> {
-        val url = baseUrl
-        return try {
-            client.get("$url/sdapi/v1/sd-models").body()
-        } catch (e: CancellationException) {
-            throw e
-        } catch (@Suppress("TooGenericExceptionCaught") e: Exception) {
-            Logger.e(TAG, "getModels failed: ${e.message}", e)
-            throw e
-        }
-    }
+    suspend fun getModels(): List<SDWebUIModelInfo> =
+        logAndRethrow("getModels") { client.get("$baseUrl/sdapi/v1/sd-models").body() }
 
     /**
-     * @throws CancellationException if coroutine is cancelled
-     * @throws Exception on network or deserialization failure
+     * @throws ResponseException on HTTP error response
+     * @throws SerializationException on deserialization failure
+     * @throws HttpRequestTimeoutException on request timeout
+     * @throws ConnectTimeoutException on connection timeout
      */
-    suspend fun getSamplers(): List<SDWebUISamplerInfo> {
-        val url = baseUrl
-        return try {
-            client.get("$url/sdapi/v1/samplers").body()
-        } catch (e: CancellationException) {
-            throw e
-        } catch (@Suppress("TooGenericExceptionCaught") e: Exception) {
-            Logger.e(TAG, "getSamplers failed: ${e.message}", e)
-            throw e
-        }
-    }
+    suspend fun getSamplers(): List<SDWebUISamplerInfo> =
+        logAndRethrow("getSamplers") { client.get("$baseUrl/sdapi/v1/samplers").body() }
 
     /**
-     * @throws CancellationException if coroutine is cancelled
-     * @throws Exception on network or deserialization failure
+     * @throws ResponseException on HTTP error response
+     * @throws SerializationException on deserialization failure
+     * @throws HttpRequestTimeoutException on request timeout
+     * @throws ConnectTimeoutException on connection timeout
      */
-    suspend fun getVaes(): List<SDWebUIVaeInfo> {
-        val url = baseUrl
-        return try {
-            client.get("$url/sdapi/v1/vae").body()
-        } catch (e: CancellationException) {
-            throw e
-        } catch (@Suppress("TooGenericExceptionCaught") e: Exception) {
-            Logger.e(TAG, "getVaes failed: ${e.message}", e)
-            throw e
-        }
-    }
+    suspend fun getVaes(): List<SDWebUIVaeInfo> =
+        logAndRethrow("getVaes") { client.get("$baseUrl/sdapi/v1/vae").body() }
 
     /**
-     * @throws CancellationException if coroutine is cancelled
-     * @throws Exception on network or deserialization failure
+     * @throws ResponseException on HTTP error response
+     * @throws SerializationException on deserialization failure
+     * @throws HttpRequestTimeoutException on request timeout
+     * @throws ConnectTimeoutException on connection timeout
      */
-    suspend fun txt2img(request: SDWebUITxt2ImgRequest): SDWebUIGenerationResponse {
-        val url = baseUrl
-        return try {
-            client.post("$url/sdapi/v1/txt2img") {
+    suspend fun txt2img(request: SDWebUITxt2ImgRequest): SDWebUIGenerationResponse =
+        logAndRethrow("txt2img") {
+            client.post("$baseUrl/sdapi/v1/txt2img") {
                 contentType(ContentType.Application.Json)
                 setBody(request)
             }.body()
-        } catch (e: CancellationException) {
-            throw e
-        } catch (@Suppress("TooGenericExceptionCaught") e: Exception) {
-            Logger.e(TAG, "txt2img failed: ${e.message}", e)
-            throw e
         }
-    }
 
     /**
-     * @throws CancellationException if coroutine is cancelled
-     * @throws Exception on network or deserialization failure
+     * @throws ResponseException on HTTP error response
+     * @throws SerializationException on deserialization failure
+     * @throws HttpRequestTimeoutException on request timeout
+     * @throws ConnectTimeoutException on connection timeout
      */
-    suspend fun img2img(request: SDWebUIImg2ImgRequest): SDWebUIGenerationResponse {
-        val url = baseUrl
-        return try {
-            client.post("$url/sdapi/v1/img2img") {
+    suspend fun img2img(request: SDWebUIImg2ImgRequest): SDWebUIGenerationResponse =
+        logAndRethrow("img2img") {
+            client.post("$baseUrl/sdapi/v1/img2img") {
                 contentType(ContentType.Application.Json)
                 setBody(request)
             }.body()
-        } catch (e: CancellationException) {
-            throw e
-        } catch (@Suppress("TooGenericExceptionCaught") e: Exception) {
-            Logger.e(TAG, "img2img failed: ${e.message}", e)
-            throw e
         }
-    }
 
     /**
-     * @throws CancellationException if coroutine is cancelled
-     * @throws Exception on network or deserialization failure
+     * @throws ResponseException on HTTP error response
+     * @throws SerializationException on deserialization failure
+     * @throws HttpRequestTimeoutException on request timeout
+     * @throws ConnectTimeoutException on connection timeout
      */
-    suspend fun getProgress(): SDWebUIProgressResponse {
-        val url = baseUrl
-        return try {
-            client.get("$url/sdapi/v1/progress?skip_current_image=true").body()
-        } catch (e: CancellationException) {
-            throw e
-        } catch (@Suppress("TooGenericExceptionCaught") e: Exception) {
-            Logger.e(TAG, "getProgress failed: ${e.message}", e)
-            throw e
+    suspend fun getProgress(): SDWebUIProgressResponse =
+        logAndRethrow("getProgress") {
+            client.get("$baseUrl/sdapi/v1/progress?skip_current_image=true").body()
         }
-    }
 
     /**
-     * @throws CancellationException if coroutine is cancelled
-     * @throws Exception on network failure
+     * @throws ResponseException on HTTP error response
+     * @throws HttpRequestTimeoutException on request timeout
+     * @throws ConnectTimeoutException on connection timeout
      */
-    suspend fun interrupt() {
-        val url = baseUrl
+    suspend fun interrupt(): Unit =
+        logAndRethrow("interrupt") { client.post("$baseUrl/sdapi/v1/interrupt") }
+
+    /**
+     * Executes [block], catching known Ktor / serialization exceptions,
+     * logging them, and rethrowing. Unknown exceptions propagate without logging.
+     */
+    private suspend inline fun <T> logAndRethrow(operation: String, block: () -> T): T {
         try {
-            client.post("$url/sdapi/v1/interrupt")
-        } catch (e: CancellationException) {
-            throw e
-        } catch (@Suppress("TooGenericExceptionCaught") e: Exception) {
-            Logger.e(TAG, "interrupt failed: ${e.message}", e)
-            throw e
+            return block()
+        } catch (e: ResponseException) {
+            logApiError(operation, e)
+        } catch (e: SerializationException) {
+            logApiError(operation, e)
+        } catch (e: HttpRequestTimeoutException) {
+            logApiError(operation, e)
+        } catch (e: ConnectTimeoutException) {
+            logApiError(operation, e)
         }
+    }
+
+    /** Logs an API error and rethrows the exception. */
+    private fun logApiError(operation: String, cause: Throwable): Nothing {
+        Logger.e(TAG, "$operation failed: ${cause.message}", cause)
+        throw cause
     }
 
     private companion object {


### PR DESCRIPTION
## Summary
- Replace 7 generic `catch (Exception)` blocks in `SDWebUIApi.kt` with specific `ResponseException`, `SerializationException`, `HttpRequestTimeoutException`, and `ConnectTimeoutException` catches via `logAndRethrow`/`logApiError` helpers (same pattern as ComfyUIApi from PR #835)
- Replace 2 generic `catch (Exception)` blocks in `ComfyUIWebSocketApi.kt`:
  - `observeProgress` retry loop: catches `WebSocketException`, `ResponseException`, `HttpRequestTimeoutException`, `ConnectTimeoutException` with a `logAndRetry` helper for exponential backoff
  - `parseMessage`: catches `SerializationException` and `IllegalArgumentException` (matching ComfyUIApi's `parseNodeInputList` pattern)
- Remove all `@Suppress("TooGenericExceptionCaught")` annotations from both files

## Test plan
- [x] `./gradlew :core:core-network:detekt` passes
- [x] `./gradlew :androidApp:assembleDebug` passes

Closes #809