### PR TITLE
Unify hardcoded design token values across Android and iOS

### DIFF
--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/collections/CollectionsScreen.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/collections/CollectionsScreen.kt
@@ -57,8 +57,8 @@ import com.riox432.civitdeck.ui.components.CivitAsyncImage
 import com.riox432.civitdeck.ui.components.EmptyStateMessage
 import com.riox432.civitdeck.ui.prompts.SavedPromptsScreen
 import com.riox432.civitdeck.ui.theme.CornerRadius
-import com.riox432.civitdeck.ui.theme.IconSize
 import com.riox432.civitdeck.ui.theme.Spacing
+import com.riox432.civitdeck.ui.theme.ThumbnailSize
 
 private enum class CollectionsScreenTab { Collections, Prompts, Datasets }
 
@@ -318,7 +318,7 @@ private fun CollectionOverflowMenu(
 
 @Composable
 private fun CollectionThumbnail(thumbnailUrl: String?) {
-    val thumbnailSize = IconSize.xlarge // TODO: Unify with shared design token
+    val thumbnailSize = ThumbnailSize.collection
     if (thumbnailUrl != null) {
         CivitAsyncImage(
             imageUrl = thumbnailUrl,

--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/history/BrowsingHistoryScreen.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/history/BrowsingHistoryScreen.kt
@@ -52,8 +52,8 @@ import com.riox432.civitdeck.feature.search.presentation.BrowsingHistoryUiState
 import com.riox432.civitdeck.feature.search.presentation.BrowsingHistoryViewModel
 import com.riox432.civitdeck.ui.components.CivitAsyncImage
 import com.riox432.civitdeck.ui.components.EmptyStateMessage
-import com.riox432.civitdeck.ui.theme.IconSize
 import com.riox432.civitdeck.ui.theme.Spacing
+import com.riox432.civitdeck.ui.theme.ThumbnailSize
 import kotlinx.coroutines.launch
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -249,9 +249,8 @@ private fun HistoryItemContent(item: RecentlyViewedModel, onClick: () -> Unit) {
         CivitAsyncImage(
             imageUrl = item.thumbnailUrl,
             contentDescription = item.modelName,
-            modifier = Modifier.size(
-                IconSize.xlarge
-            ).clip(MaterialTheme.shapes.small), // TODO: Unify with shared design token
+            modifier = Modifier.size(ThumbnailSize.collection)
+                .clip(MaterialTheme.shapes.small),
         )
         Column(modifier = Modifier.weight(1f)) {
             Text(

--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/notificationcenter/NotificationCenterScreen.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/notificationcenter/NotificationCenterScreen.kt
@@ -39,12 +39,11 @@ import com.riox432.civitdeck.domain.model.ModelUpdateNotification
 import com.riox432.civitdeck.domain.model.UpdateSource
 import com.riox432.civitdeck.feature.gallery.presentation.NotificationCenterViewModel
 import com.riox432.civitdeck.ui.components.EmptyStateMessage
+import com.riox432.civitdeck.ui.theme.DotSize
 import com.riox432.civitdeck.ui.theme.Spacing
 import java.util.concurrent.TimeUnit
 
-/** Size of the unread indicator dot. */
-// TODO: Unify with shared design token
-private val UnreadDotSize = Spacing.sm
+private val UnreadDotSize = DotSize.indicator
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable

--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/plugin/PluginManagementScreen.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/plugin/PluginManagementScreen.kt
@@ -163,7 +163,7 @@ private fun PluginRow(
 private fun PluginIcon() {
     Box(
         modifier = Modifier
-            .size(IconSize.large) // 48.dp — TODO: Unify with shared design token
+            .size(IconSize.large)
             .clip(RoundedCornerShape(CornerRadius.image))
             .background(MaterialTheme.colorScheme.primaryContainer),
         contentAlignment = Alignment.Center,

--- a/core/core-ui/src/commonMain/kotlin/com/riox432/civitdeck/ui/theme/Shape.kt
+++ b/core/core-ui/src/commonMain/kotlin/com/riox432/civitdeck/ui/theme/Shape.kt
@@ -44,3 +44,13 @@ object IconSize {
     val xlarge = 56.dp
     val navBar = 24.dp
 }
+
+/** Sizes for small indicator dots (unread badges, status indicators). */
+object DotSize {
+    val indicator = 8.dp
+}
+
+/** Sizes for content thumbnails (collection covers, history items). */
+object ThumbnailSize {
+    val collection = IconSize.xlarge
+}

--- a/iosApp/iosApp/DesignSystem/CivitDeckShapes.swift
+++ b/iosApp/iosApp/DesignSystem/CivitDeckShapes.swift
@@ -9,6 +9,21 @@ enum CornerRadius {
     static let searchBar: CGFloat = 8
 }
 
+/// Frame dimension tokens for icon containers and interactive areas.
+/// Font-based icon sizes remain in CivitDeckFonts.swift.
 enum IconSize {
-    // Icon sizes now defined as Font tokens in CivitDeckFonts.swift
+    static let small: CGFloat = 16
+    static let medium: CGFloat = 24
+    static let large: CGFloat = 48
+    static let xlarge: CGFloat = 56
+}
+
+/// Sizes for small indicator dots (unread badges, status indicators).
+enum DotSize {
+    static let indicator: CGFloat = 8
+}
+
+/// Sizes for content thumbnails (collection covers, history items).
+enum ThumbnailSize {
+    static let collection: CGFloat = IconSize.xlarge
 }

--- a/iosApp/iosApp/Features/Collections/CollectionsScreen.swift
+++ b/iosApp/iosApp/Features/Collections/CollectionsScreen.swift
@@ -1,8 +1,7 @@
 import SwiftUI
 import Shared
 
-/// Collection thumbnail size. TODO: Unify with shared design token
-private let collectionThumbnailSize: CGFloat = 56
+private let collectionThumbnailSize: CGFloat = ThumbnailSize.collection
 
 private enum CollectionsScreenTab {
     case collections, prompts

--- a/iosApp/iosApp/Features/Discovery/SwipeDiscoveryView.swift
+++ b/iosApp/iosApp/Features/Discovery/SwipeDiscoveryView.swift
@@ -2,9 +2,8 @@ import SwiftUI
 import Shared
 
 private let cardStackOffset: CGFloat = Spacing.md
-// TODO: Unify with shared design token
-private let undoButtonSize: CGFloat = 48   // Maps to IconSize.large
-private let actionButtonSize: CGFloat = 56 // Maps to IconSize.xlarge
+private let undoButtonSize: CGFloat = IconSize.large
+private let actionButtonSize: CGFloat = IconSize.xlarge
 
 struct SwipeDiscoveryView: View {
     @StateObject private var viewModel = SwipeDiscoveryViewModelOwner()

--- a/iosApp/iosApp/Features/NotificationCenter/NotificationCenterView.swift
+++ b/iosApp/iosApp/Features/NotificationCenter/NotificationCenterView.swift
@@ -1,9 +1,7 @@
 import SwiftUI
 import Shared
 
-/// Size of the unread indicator dot.
-// TODO: Unify with shared design token
-private let unreadDotSize: CGFloat = 8
+private let unreadDotSize: CGFloat = DotSize.indicator
 
 struct NotificationCenterView: View {
     @StateObject private var viewModel = NotificationCenterViewModelOwner()


### PR DESCRIPTION
## Summary
- Add `DotSize.indicator` (8dp/pt) and `ThumbnailSize.collection` (56dp/pt) tokens to both Android (`Shape.kt`) and iOS (`CivitDeckShapes.swift`) design systems
- Populate iOS `IconSize` enum with frame dimension tokens (`small`/`medium`/`large`/`xlarge`) matching the existing Android counterparts
- Replace all hardcoded values and remove 7 `TODO: Unify with shared design token` comments across 9 files

## Test plan
- [ ] Android build passes (`assembleDebug` + `detekt`)
- [ ] iOS build passes (`xcodebuild` Simulator)
- [ ] Verify discovery swipe button sizes unchanged (48pt/56pt)
- [ ] Verify notification unread dot size unchanged (8dp/pt)
- [ ] Verify collection thumbnail size unchanged (56dp/pt)
- [ ] Verify browsing history thumbnail size unchanged (56dp)

Closes #807