### PR TITLE
Fix off-grid dp sizes in Android UI

### DIFF
--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/collections/CollectionDetailScreen.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/collections/CollectionDetailScreen.kt
@@ -59,6 +59,7 @@ import com.riox432.civitdeck.ui.components.CivitAsyncImage
 import com.riox432.civitdeck.ui.components.EmptyStateMessage
 import com.riox432.civitdeck.ui.components.ModelStatsRow
 import com.riox432.civitdeck.ui.theme.CornerRadius
+import com.riox432.civitdeck.ui.theme.IconSize
 import com.riox432.civitdeck.ui.theme.Spacing
 
 @Suppress("LongParameterList")
@@ -373,7 +374,7 @@ private fun SelectionOverlay(isSelected: Boolean) {
                 imageVector = Icons.Default.CheckCircle,
                 contentDescription = stringResource(R.string.cd_selected),
                 tint = MaterialTheme.colorScheme.onPrimary,
-                modifier = Modifier.size(20.dp),
+                modifier = Modifier.size(IconSize.small),
             )
         }
     }
@@ -433,7 +434,7 @@ private fun ModelCardInfo(model: FavoriteModelSummary) {
                     color = MaterialTheme.colorScheme.surfaceVariant,
                     shape = RoundedCornerShape(CornerRadius.chip),
                 )
-                .padding(horizontal = 6.dp, vertical = 2.dp),
+                .padding(horizontal = Spacing.sm, vertical = Spacing.xxs),
         )
         ModelStatsRow(
             downloadCount = model.downloadCount,

--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/comfyhub/ComfyHubBrowserScreen.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/comfyhub/ComfyHubBrowserScreen.kt
@@ -45,6 +45,7 @@ import com.riox432.civitdeck.feature.comfyui.presentation.ComfyHubBrowserViewMod
 import com.riox432.civitdeck.ui.components.EmptyStateMessage
 import com.riox432.civitdeck.ui.components.ErrorStateView
 import com.riox432.civitdeck.ui.components.LoadingStateOverlay
+import com.riox432.civitdeck.ui.theme.IconSize
 import com.riox432.civitdeck.ui.theme.Spacing
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -192,7 +193,7 @@ private fun WorkflowStats(workflow: ComfyHubWorkflow) {
             Icon(
                 Icons.Outlined.Download,
                 contentDescription = null,
-                modifier = Modifier.size(14.dp),
+                modifier = Modifier.size(IconSize.small),
                 tint = MaterialTheme.colorScheme.onSurfaceVariant,
             )
             Text(
@@ -208,7 +209,7 @@ private fun WorkflowStats(workflow: ComfyHubWorkflow) {
             Icon(
                 Icons.Outlined.Star,
                 contentDescription = null,
-                modifier = Modifier.size(14.dp),
+                modifier = Modifier.size(IconSize.small),
                 tint = MaterialTheme.colorScheme.onSurfaceVariant,
             )
             Text(

--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/comfyui/CivitaiLinkSettingsScreen.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/comfyui/CivitaiLinkSettingsScreen.kt
@@ -37,7 +37,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.PasswordVisualTransformation
-import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.riox432.civitdeck.R
 import com.riox432.civitdeck.domain.model.CivitaiLinkActivity
@@ -45,6 +44,7 @@ import com.riox432.civitdeck.domain.model.CivitaiLinkStatus
 import com.riox432.civitdeck.feature.comfyui.presentation.CivitaiLinkSettingsUiState
 import com.riox432.civitdeck.feature.comfyui.presentation.CivitaiLinkSettingsViewModel
 import com.riox432.civitdeck.ui.theme.CivitDeckColors
+import com.riox432.civitdeck.ui.theme.DotSize
 import com.riox432.civitdeck.ui.theme.Spacing
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -137,7 +137,7 @@ private fun StatusCard(
 private fun StatusDot(status: CivitaiLinkStatus) {
     Box(
         modifier = Modifier
-            .size(10.dp)
+            .size(DotSize.indicator)
             .background(color = status.dotColor(), shape = CircleShape),
     )
 }

--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/dataset/BatchTagEditorScreen.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/dataset/BatchTagEditorScreen.kt
@@ -55,6 +55,7 @@ import com.riox432.civitdeck.ui.adaptive.adaptiveGridColumns
 import com.riox432.civitdeck.ui.components.CivitAsyncImage
 import com.riox432.civitdeck.ui.components.EmptyStateMessage
 import com.riox432.civitdeck.ui.theme.CornerRadius
+import com.riox432.civitdeck.ui.theme.IconSize
 import com.riox432.civitdeck.ui.theme.Spacing
 
 private const val BATCH_GRID_BASE_COLUMNS = 3
@@ -317,7 +318,7 @@ private fun BatchSelectionOverlay(isSelected: Boolean) {
     Box(
         modifier = Modifier
             .padding(Spacing.xs)
-            .size(22.dp)
+            .size(IconSize.medium)
             .clip(CircleShape)
             .background(
                 if (isSelected) {
@@ -333,7 +334,7 @@ private fun BatchSelectionOverlay(isSelected: Boolean) {
                 imageVector = Icons.Default.CheckCircle,
                 contentDescription = stringResource(R.string.cd_selected),
                 tint = MaterialTheme.colorScheme.onPrimary,
-                modifier = Modifier.size(18.dp),
+                modifier = Modifier.size(IconSize.small),
             )
         }
     }

--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/dataset/DatasetImageItem.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/dataset/DatasetImageItem.kt
@@ -34,6 +34,7 @@ import com.riox432.civitdeck.domain.model.DatasetImage
 import com.riox432.civitdeck.domain.model.ImageSource
 import com.riox432.civitdeck.ui.components.CivitAsyncImage
 import com.riox432.civitdeck.ui.theme.CornerRadius
+import com.riox432.civitdeck.ui.theme.IconSize
 import com.riox432.civitdeck.ui.theme.Spacing
 
 private const val IMAGE_ASPECT_RATIO = 1f
@@ -181,7 +182,7 @@ internal fun DatasetImageSelectionOverlay(isSelected: Boolean) {
                 imageVector = Icons.Default.CheckCircle,
                 contentDescription = stringResource(R.string.cd_selected),
                 tint = MaterialTheme.colorScheme.onPrimary,
-                modifier = Modifier.size(20.dp),
+                modifier = Modifier.size(IconSize.small),
             )
         }
     }

--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/detail/ReviewsSection.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/detail/ReviewsSection.kt
@@ -40,6 +40,7 @@ import com.riox432.civitdeck.domain.model.RatingTotals
 import com.riox432.civitdeck.domain.model.ResourceReview
 import com.riox432.civitdeck.domain.model.ReviewSortOrder
 import com.riox432.civitdeck.ui.theme.CornerRadius
+import com.riox432.civitdeck.ui.theme.IconSize
 import com.riox432.civitdeck.ui.theme.Spacing
 
 @Composable
@@ -156,7 +157,7 @@ private fun ThumbsSummary(up: Int, down: Int) {
             Icon(
                 Icons.Outlined.ThumbUp,
                 contentDescription = stringResource(R.string.cd_recommended),
-                modifier = Modifier.size(14.dp),
+                modifier = Modifier.size(IconSize.small),
                 tint = MaterialTheme.colorScheme.primary,
             )
             Spacer(Modifier.width(Spacing.xs))
@@ -166,7 +167,7 @@ private fun ThumbsSummary(up: Int, down: Int) {
             Icon(
                 Icons.Outlined.ThumbDown,
                 contentDescription = stringResource(R.string.cd_not_recommended),
-                modifier = Modifier.size(14.dp),
+                modifier = Modifier.size(IconSize.small),
                 tint = MaterialTheme.colorScheme.error,
             )
             Spacer(Modifier.width(Spacing.xs))
@@ -195,7 +196,7 @@ private fun ReviewCardHeader(review: ResourceReview) {
     Row(verticalAlignment = Alignment.CenterVertically) {
         Box(
             modifier = Modifier
-                .size(28.dp)
+                .size(Spacing.xxl)
                 .clip(CircleShape)
                 .background(MaterialTheme.colorScheme.primaryContainer),
             contentAlignment = Alignment.Center,
@@ -215,7 +216,7 @@ private fun ReviewCardHeader(review: ResourceReview) {
         Icon(
             imageVector = if (review.recommended) Icons.Outlined.ThumbUp else Icons.Outlined.ThumbDown,
             contentDescription = if (review.recommended) "Recommended" else "Not recommended",
-            modifier = Modifier.size(14.dp),
+            modifier = Modifier.size(IconSize.small),
             tint = if (review.recommended) {
                 MaterialTheme.colorScheme.primary
             } else {
@@ -232,7 +233,7 @@ private fun ReviewCardRecommendation(recommended: Boolean) {
         Icon(
             imageVector = if (recommended) Icons.Outlined.ThumbUp else Icons.Outlined.ThumbDown,
             contentDescription = if (recommended) "Recommended" else "Not recommended",
-            modifier = Modifier.size(12.dp),
+            modifier = Modifier.size(IconSize.small),
             tint = if (recommended) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.error,
         )
         Spacer(Modifier.width(Spacing.xs))

--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/search/FilterChipComponents.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/search/FilterChipComponents.kt
@@ -51,6 +51,7 @@ import com.riox432.civitdeck.ui.components.rememberHapticFeedback
 import com.riox432.civitdeck.ui.theme.CornerRadius
 import com.riox432.civitdeck.ui.theme.Duration
 import com.riox432.civitdeck.ui.theme.Easing
+import com.riox432.civitdeck.ui.theme.IconSize
 import com.riox432.civitdeck.ui.theme.Spacing
 
 internal val filterTypes = listOf(null) + listOf(
@@ -276,7 +277,7 @@ private fun TagChip(
             Icon(
                 imageVector = Icons.Default.Close,
                 contentDescription = stringResource(R.string.cd_remove_tag, tag),
-                modifier = Modifier.size(14.dp),
+                modifier = Modifier.size(IconSize.small),
                 tint = foreground,
             )
         }

--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/settings/AppearanceComponents.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/settings/AppearanceComponents.kt
@@ -31,6 +31,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import com.riox432.civitdeck.R
 import com.riox432.civitdeck.domain.model.AccentColor
+import com.riox432.civitdeck.ui.theme.IconSize
 import com.riox432.civitdeck.ui.theme.Spacing
 
 @Composable
@@ -68,7 +69,7 @@ internal fun AccentColorSwatch(
     val swatchColor = Color(color.seedHex)
     Box(
         modifier = Modifier
-            .size(40.dp)
+            .size(IconSize.large)
             .clip(CircleShape)
             .background(swatchColor)
             .then(
@@ -86,7 +87,7 @@ internal fun AccentColorSwatch(
                 imageVector = Icons.Default.Check,
                 contentDescription = stringResource(R.string.cd_selected),
                 tint = MaterialTheme.colorScheme.onPrimary,
-                modifier = Modifier.size(20.dp),
+                modifier = Modifier.size(IconSize.small),
             )
         }
     }


### PR DESCRIPTION
## Summary
- Replace off-grid sizes (10/14/18/20/22/28/40dp) with design tokens (`IconSize.small`, `IconSize.medium`, `IconSize.large`, `DotSize.indicator`, `Spacing.sm`, `Spacing.xxs`, `Spacing.xxl`)
- 8 files across settings, comfyhub, comfyui, dataset, search, detail, and collections screens
- Borders/strokes (2.dp) and elevation values kept as-is

## Changes by file
| File | Before | After |
|---|---|---|
| AppearanceComponents.kt | 40.dp swatch, 20.dp icon | `IconSize.large`, `IconSize.small` |
| ComfyHubBrowserScreen.kt | 14.dp stat icons | `IconSize.small` |
| CivitaiLinkSettingsScreen.kt | 10.dp status dot | `DotSize.indicator` |
| DatasetImageItem.kt | 20.dp check icon | `IconSize.small` |
| BatchTagEditorScreen.kt | 22.dp overlay, 18.dp icon | `IconSize.medium`, `IconSize.small` |
| FilterChipComponents.kt | 14.dp close icon | `IconSize.small` |
| ReviewsSection.kt | 14.dp/12.dp thumbs, 28.dp avatar | `IconSize.small`, `Spacing.xxl` |
| CollectionDetailScreen.kt | 20.dp icon, 6.dp/2.dp padding | `IconSize.small`, `Spacing.sm`/`Spacing.xxs` |

## Test plan
- [ ] Verify color swatch in Appearance settings renders correctly at 48dp
- [ ] Verify stat icons in ComfyHub workflow cards are properly sized
- [ ] Verify status dot in Civitai Link settings is visible
- [ ] Verify selection overlays in dataset/collection screens look correct
- [ ] Verify filter chip close buttons in search are tappable

Closes #815