### PR TITLE
Move theme use cases from shared to core-plugin

### DIFF
--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/MainActivity.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/MainActivity.kt
@@ -18,7 +18,7 @@ import com.riox432.civitdeck.ui.navigation.CivitDeckNavGraph
 import com.riox432.civitdeck.ui.navigation.Tab
 import com.riox432.civitdeck.ui.theme.CivitDeckTheme
 import com.riox432.civitdeck.ui.tutorial.GestureTutorialScreen
-import com.riox432.civitdeck.usecase.GetActiveThemeUseCase
+import com.riox432.civitdeck.plugin.usecase.GetActiveThemeUseCase
 import org.koin.compose.viewmodel.koinViewModel
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject

--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/settings/AppearanceSettingsScreen.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/settings/AppearanceSettingsScreen.kt
@@ -39,9 +39,9 @@ import com.riox432.civitdeck.feature.settings.presentation.DisplaySettingsViewMo
 import com.riox432.civitdeck.plugin.ThemePlugin
 import com.riox432.civitdeck.plugin.model.PluginState
 import com.riox432.civitdeck.ui.theme.Spacing
-import com.riox432.civitdeck.usecase.ActivateThemePluginUseCase
-import com.riox432.civitdeck.usecase.ImportThemeUseCase
-import com.riox432.civitdeck.usecase.ObserveThemePluginsUseCase
+import com.riox432.civitdeck.plugin.usecase.ActivateThemePluginUseCase
+import com.riox432.civitdeck.plugin.usecase.ImportThemeUseCase
+import com.riox432.civitdeck.plugin.usecase.ObserveThemePluginsUseCase
 import kotlinx.coroutines.launch
 import org.koin.compose.koinInject
 

--- a/core/core-plugin/build.gradle.kts
+++ b/core/core-plugin/build.gradle.kts
@@ -1,12 +1,15 @@
 plugins {
     id("civitdeck.kmp.library")
+    alias(libs.plugins.kotlin.serialization)
 }
 
 kotlin {
     sourceSets {
         commonMain.dependencies {
+            implementation(project(":core:core-domain"))
             implementation(libs.koin.core)
             implementation(libs.kotlinx.coroutines.core)
+            implementation(libs.kotlinx.serialization.json)
         }
 
         commonTest.dependencies {

--- a/core/core-plugin/src/commonMain/kotlin/com/riox432/civitdeck/plugin/di/PluginModule.kt
+++ b/core/core-plugin/src/commonMain/kotlin/com/riox432/civitdeck/plugin/di/PluginModule.kt
@@ -2,10 +2,20 @@ package com.riox432.civitdeck.plugin.di
 
 import com.riox432.civitdeck.plugin.InMemoryPluginRegistry
 import com.riox432.civitdeck.plugin.PluginRegistry
+import com.riox432.civitdeck.plugin.usecase.ActivateThemePluginUseCase
+import com.riox432.civitdeck.plugin.usecase.GetActiveThemeUseCase
+import com.riox432.civitdeck.plugin.usecase.ImportThemeUseCase
+import com.riox432.civitdeck.plugin.usecase.ObserveThemePluginsUseCase
 import org.koin.core.module.dsl.bind
 import org.koin.core.module.dsl.singleOf
 import org.koin.dsl.module
 
 val pluginModule = module {
     singleOf(::InMemoryPluginRegistry) { bind<PluginRegistry>() }
+
+    // Theme plugin use cases
+    factory { ImportThemeUseCase(get(), get()) }
+    factory { GetActiveThemeUseCase(get()) }
+    factory { ObserveThemePluginsUseCase(get()) }
+    factory { ActivateThemePluginUseCase(get(), get()) }
 }

--- a/core/core-plugin/src/commonMain/kotlin/com/riox432/civitdeck/plugin/theme/JsonThemePlugin.kt
+++ b/core/core-plugin/src/commonMain/kotlin/com/riox432/civitdeck/plugin/theme/JsonThemePlugin.kt
@@ -1,4 +1,4 @@
-package com.riox432.civitdeck.data.theme
+package com.riox432.civitdeck.plugin.theme
 
 import com.riox432.civitdeck.plugin.ThemeColorScheme
 import com.riox432.civitdeck.plugin.ThemePlugin

--- a/core/core-plugin/src/commonMain/kotlin/com/riox432/civitdeck/plugin/theme/ThemeDefinition.kt
+++ b/core/core-plugin/src/commonMain/kotlin/com/riox432/civitdeck/plugin/theme/ThemeDefinition.kt
@@ -1,4 +1,4 @@
-package com.riox432.civitdeck.data.theme
+package com.riox432.civitdeck.plugin.theme
 
 import kotlinx.serialization.Serializable
 

--- a/core/core-plugin/src/commonMain/kotlin/com/riox432/civitdeck/plugin/usecase/ActivateThemePluginUseCase.kt
+++ b/core/core-plugin/src/commonMain/kotlin/com/riox432/civitdeck/plugin/usecase/ActivateThemePluginUseCase.kt
@@ -1,4 +1,4 @@
-package com.riox432.civitdeck.usecase
+package com.riox432.civitdeck.plugin.usecase
 
 import com.riox432.civitdeck.domain.model.InstalledPluginState
 import com.riox432.civitdeck.domain.repository.PluginRepository

--- a/core/core-plugin/src/commonMain/kotlin/com/riox432/civitdeck/plugin/usecase/GetActiveThemeUseCase.kt
+++ b/core/core-plugin/src/commonMain/kotlin/com/riox432/civitdeck/plugin/usecase/GetActiveThemeUseCase.kt
@@ -1,4 +1,4 @@
-package com.riox432.civitdeck.usecase
+package com.riox432.civitdeck.plugin.usecase
 
 import com.riox432.civitdeck.plugin.PluginRegistry
 import com.riox432.civitdeck.plugin.ThemeColorScheme

--- a/core/core-plugin/src/commonMain/kotlin/com/riox432/civitdeck/plugin/usecase/ImportThemeUseCase.kt
+++ b/core/core-plugin/src/commonMain/kotlin/com/riox432/civitdeck/plugin/usecase/ImportThemeUseCase.kt
@@ -1,15 +1,15 @@
-package com.riox432.civitdeck.usecase
+package com.riox432.civitdeck.plugin.usecase
 
-import com.riox432.civitdeck.data.local.currentTimeMillis
-import com.riox432.civitdeck.data.theme.JsonThemePlugin
-import com.riox432.civitdeck.data.theme.ThemeDefinition
 import com.riox432.civitdeck.domain.model.InstalledPlugin
 import com.riox432.civitdeck.domain.model.InstalledPluginState
 import com.riox432.civitdeck.domain.model.InstalledPluginType
 import com.riox432.civitdeck.domain.repository.PluginRepository
+import com.riox432.civitdeck.domain.util.currentTimeMillis
 import com.riox432.civitdeck.domain.util.suspendRunCatching
 import com.riox432.civitdeck.plugin.PluginRegistry
 import com.riox432.civitdeck.plugin.capability.ThemeCapability
+import com.riox432.civitdeck.plugin.theme.JsonThemePlugin
+import com.riox432.civitdeck.plugin.theme.ThemeDefinition
 import kotlinx.serialization.json.Json
 
 /**

--- a/core/core-plugin/src/commonMain/kotlin/com/riox432/civitdeck/plugin/usecase/ObserveThemePluginsUseCase.kt
+++ b/core/core-plugin/src/commonMain/kotlin/com/riox432/civitdeck/plugin/usecase/ObserveThemePluginsUseCase.kt
@@ -1,4 +1,4 @@
-package com.riox432.civitdeck.usecase
+package com.riox432.civitdeck.plugin.usecase
 
 import com.riox432.civitdeck.plugin.PluginRegistry
 import com.riox432.civitdeck.plugin.ThemePlugin

--- a/shared/src/commonMain/kotlin/com/riox432/civitdeck/di/DataModule.kt
+++ b/shared/src/commonMain/kotlin/com/riox432/civitdeck/di/DataModule.kt
@@ -37,10 +37,6 @@ import com.riox432.civitdeck.domain.repository.TagRepository
 import com.riox432.civitdeck.domain.repository.UpdateRepository
 import com.riox432.civitdeck.feature.collections.domain.usecase.ExportWithPluginUseCase
 import com.riox432.civitdeck.feature.collections.domain.usecase.GetAvailableExportFormatsUseCase
-import com.riox432.civitdeck.usecase.ActivateThemePluginUseCase
-import com.riox432.civitdeck.usecase.GetActiveThemeUseCase
-import com.riox432.civitdeck.usecase.ImportThemeUseCase
-import com.riox432.civitdeck.usecase.ObserveThemePluginsUseCase
 import org.koin.core.module.dsl.bind
 import org.koin.core.module.dsl.singleOf
 import org.koin.dsl.module
@@ -74,12 +70,6 @@ val dataModule = module {
     single { KohyaZipExportPlugin(get()) }
     factory { GetAvailableExportFormatsUseCase(get()) }
     factory { ExportWithPluginUseCase(get()) }
-
-    // Theme plugins
-    factory { ImportThemeUseCase(get(), get()) }
-    factory { GetActiveThemeUseCase(get()) }
-    factory { ObserveThemePluginsUseCase(get()) }
-    factory { ActivateThemePluginUseCase(get(), get()) }
 
     // Backup DAO wrappers
     single { CollectionDaos(get()) }

--- a/shared/src/commonMain/kotlin/com/riox432/civitdeck/di/ThemePluginInitializer.kt
+++ b/shared/src/commonMain/kotlin/com/riox432/civitdeck/di/ThemePluginInitializer.kt
@@ -1,11 +1,11 @@
 package com.riox432.civitdeck.di
 
-import com.riox432.civitdeck.data.theme.JsonThemePlugin
-import com.riox432.civitdeck.data.theme.ThemeDefinition
 import com.riox432.civitdeck.domain.model.InstalledPluginState
 import com.riox432.civitdeck.domain.model.InstalledPluginType
 import com.riox432.civitdeck.domain.repository.PluginRepository
 import com.riox432.civitdeck.plugin.PluginRegistry
+import com.riox432.civitdeck.plugin.theme.JsonThemePlugin
+import com.riox432.civitdeck.plugin.theme.ThemeDefinition
 import kotlinx.coroutines.flow.first
 import kotlinx.serialization.json.Json
 

--- a/shared/src/iosMain/kotlin/com/riox432/civitdeck/di/KoinHelperSettings.kt
+++ b/shared/src/iosMain/kotlin/com/riox432/civitdeck/di/KoinHelperSettings.kt
@@ -68,10 +68,10 @@ import com.riox432.civitdeck.feature.prompts.domain.usecase.ObserveSavedPromptsU
 import com.riox432.civitdeck.feature.prompts.domain.usecase.ObserveTemplatesUseCase
 import com.riox432.civitdeck.feature.prompts.domain.usecase.SearchSavedPromptsUseCase
 import com.riox432.civitdeck.feature.prompts.domain.usecase.ToggleTemplateUseCase
-import com.riox432.civitdeck.usecase.ActivateThemePluginUseCase
-import com.riox432.civitdeck.usecase.GetActiveThemeUseCase
-import com.riox432.civitdeck.usecase.ImportThemeUseCase
-import com.riox432.civitdeck.usecase.ObserveThemePluginsUseCase
+import com.riox432.civitdeck.plugin.usecase.ActivateThemePluginUseCase
+import com.riox432.civitdeck.plugin.usecase.GetActiveThemeUseCase
+import com.riox432.civitdeck.plugin.usecase.ImportThemeUseCase
+import com.riox432.civitdeck.plugin.usecase.ObserveThemePluginsUseCase
 import org.koin.mp.KoinPlatform.getKoin
 
 // Theme & Display Settings


### PR DESCRIPTION
## Summary
- Moved 4 theme use cases (`ActivateThemePluginUseCase`, `GetActiveThemeUseCase`, `ImportThemeUseCase`, `ObserveThemePluginsUseCase`) from `shared/.../usecase/` to `core/core-plugin/.../plugin/usecase/`
- Moved `JsonThemePlugin` and `ThemeDefinition` from `shared/.../data/theme/` to `core/core-plugin/.../plugin/theme/` (they only depend on core-plugin types)
- Registered theme use cases in `PluginModule` instead of `DataModule`
- Added `core-domain` and `kotlinx.serialization` dependencies to `core-plugin`
- Updated all import references in `DataModule`, `KoinHelperSettings`, `ThemePluginInitializer`, `MainActivity`, and `AppearanceSettingsScreen`

Closes #804