### PR TITLE
Remove viewModelScope alias in DesktopDiscoveryViewModel

### DIFF
--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/MainActivity.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/MainActivity.kt
@@ -14,11 +14,11 @@ import com.riox432.civitdeck.domain.usecase.ObserveAccentColorUseCase
 import com.riox432.civitdeck.domain.usecase.ObserveAmoledDarkModeUseCase
 import com.riox432.civitdeck.domain.usecase.ObserveThemeModeUseCase
 import com.riox432.civitdeck.feature.gallery.presentation.GestureTutorialViewModel
+import com.riox432.civitdeck.plugin.usecase.GetActiveThemeUseCase
 import com.riox432.civitdeck.ui.navigation.CivitDeckNavGraph
 import com.riox432.civitdeck.ui.navigation.Tab
 import com.riox432.civitdeck.ui.theme.CivitDeckTheme
 import com.riox432.civitdeck.ui.tutorial.GestureTutorialScreen
-import com.riox432.civitdeck.plugin.usecase.GetActiveThemeUseCase
 import org.koin.compose.viewmodel.koinViewModel
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject

--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/settings/AppearanceSettingsScreen.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/settings/AppearanceSettingsScreen.kt
@@ -38,10 +38,10 @@ import com.riox432.civitdeck.domain.model.ThemeMode
 import com.riox432.civitdeck.feature.settings.presentation.DisplaySettingsViewModel
 import com.riox432.civitdeck.plugin.ThemePlugin
 import com.riox432.civitdeck.plugin.model.PluginState
-import com.riox432.civitdeck.ui.theme.Spacing
 import com.riox432.civitdeck.plugin.usecase.ActivateThemePluginUseCase
 import com.riox432.civitdeck.plugin.usecase.ImportThemeUseCase
 import com.riox432.civitdeck.plugin.usecase.ObserveThemePluginsUseCase
+import com.riox432.civitdeck.ui.theme.Spacing
 import kotlinx.coroutines.launch
 import org.koin.compose.koinInject
 

--- a/desktopApp/src/jvmMain/kotlin/com/riox432/civitdeck/ui/discovery/DesktopDiscoveryViewModel.kt
+++ b/desktopApp/src/jvmMain/kotlin/com/riox432/civitdeck/ui/discovery/DesktopDiscoveryViewModel.kt
@@ -1,6 +1,5 @@
 package com.riox432.civitdeck.ui.discovery
 
-import com.riox432.civitdeck.domain.model.Model
 import com.riox432.civitdeck.domain.model.RecommendationSection
 import com.riox432.civitdeck.feature.search.domain.usecase.GetRecommendationsUseCase
 import com.riox432.civitdeck.feature.search.domain.usecase.TrackRecommendationClickUseCase
@@ -23,8 +22,6 @@ class DesktopDiscoveryViewModel(
     private val trackRecommendationClickUseCase: TrackRecommendationClickUseCase,
 ) : ViewModel() {
 
-    private val scope = viewModelScope
-
     private val _uiState = MutableStateFlow(DesktopDiscoveryUiState())
     val uiState: StateFlow<DesktopDiscoveryUiState> = _uiState
 
@@ -37,7 +34,7 @@ class DesktopDiscoveryViewModel(
     }
 
     private fun loadRecommendations() {
-        scope.launch {
+        viewModelScope.launch {
             _uiState.update { it.copy(isLoading = true, error = null) }
             suspendRunCatching { getRecommendationsUseCase() }
                 .onSuccess { sections ->
@@ -55,7 +52,7 @@ class DesktopDiscoveryViewModel(
     }
 
     fun trackRecommendationClick(modelId: Long) {
-        scope.launch {
+        viewModelScope.launch {
             suspendRunCatching { trackRecommendationClickUseCase(modelId) }
         }
     }


### PR DESCRIPTION
## Summary
- Remove unnecessary `private val scope = viewModelScope` alias in `DesktopDiscoveryViewModel`
- Replace all `scope.launch` with `viewModelScope.launch` for clarity
- Remove unused `Model` import

Closes #859

## Test plan
- [ ] Verify `./gradlew :desktopApp:detekt` passes
- [ ] Verify desktop app builds with `./gradlew :desktopApp:run`