### PR TITLE
Replace magic numbers in ML image preprocessing

### DIFF
--- a/androidApp/src/androidTest/kotlin/com/riox432/civitdeck/ml/ImageEmbeddingModelTest.kt
+++ b/androidApp/src/androidTest/kotlin/com/riox432/civitdeck/ml/ImageEmbeddingModelTest.kt
@@ -91,9 +91,9 @@ class ImageEmbeddingModelTest {
      * Creates a synthetic 224x224 JPEG test image (gradient pattern).
      * Using a deterministic pattern ensures reproducible embeddings.
      */
-    @Suppress("MagicNumber")
+    @Suppress("MagicNumber") // RGB gradient calculation (255, 2) — standard 8-bit color range
     private fun createTestImage(): ByteArray {
-        val size = 224
+        val size = SIGLIP_INPUT_SIZE
         val bitmap = Bitmap.createBitmap(size, size, Bitmap.Config.ARGB_8888)
         for (y in 0 until size) {
             for (x in 0 until size) {
@@ -104,13 +104,15 @@ class ImageEmbeddingModelTest {
             }
         }
         val stream = ByteArrayOutputStream()
-        bitmap.compress(Bitmap.CompressFormat.JPEG, 95, stream)
+        bitmap.compress(Bitmap.CompressFormat.JPEG, JPEG_QUALITY, stream)
         bitmap.recycle()
         return stream.toByteArray()
     }
 
     private companion object {
         private const val EMBEDDING_DIM = 768
+        private const val SIGLIP_INPUT_SIZE = 224
+        private const val JPEG_QUALITY = 95
         private const val NORM_TOLERANCE = 0.01f
         private const val DETERMINISM_TOLERANCE = 1e-6f
     }

--- a/core/core-domain/src/androidMain/kotlin/com/riox432/civitdeck/domain/ml/ImageEmbeddingModel.android.kt
+++ b/core/core-domain/src/androidMain/kotlin/com/riox432/civitdeck/domain/ml/ImageEmbeddingModel.android.kt
@@ -88,6 +88,7 @@ actual class ImageEmbeddingModel actual constructor() {
     private companion object {
         private const val ASSET_PATH = "ml/siglip2_vision_q4f16.onnx"
         private const val IMAGE_SIZE = 224
+        private const val BATCH_SIZE = 1
         private const val CHANNELS = 3
         private const val INPUT_NAME = "pixel_values"
         private const val OUTPUT_NAME = "pooler_output"
@@ -101,13 +102,17 @@ actual class ImageEmbeddingModel actual constructor() {
      * Decodes JPEG/PNG bytes into a 224x224 bitmap, then packs pixels into an
      * NCHW float32 [OnnxTensor] with SigLIP normalization.
      */
-    @Suppress("MagicNumber")
     private fun preprocessImage(imageBytes: ByteArray): OnnxTensor {
         val bitmap = decodeBitmap(imageBytes)
         val floatBuf = bitmapToNchwBuffer(bitmap)
         bitmap.recycle()
 
-        val shape = longArrayOf(1, CHANNELS.toLong(), IMAGE_SIZE.toLong(), IMAGE_SIZE.toLong())
+        val shape = longArrayOf(
+            BATCH_SIZE.toLong(),
+            CHANNELS.toLong(),
+            IMAGE_SIZE.toLong(),
+            IMAGE_SIZE.toLong(),
+        )
         return OnnxTensor.createTensor(ortEnv, floatBuf, shape)
     }
 
@@ -128,12 +133,12 @@ actual class ImageEmbeddingModel actual constructor() {
      * Packs a 224x224 bitmap into a direct [java.nio.FloatBuffer] in NCHW
      * layout with SigLIP normalization (mean=0.5, std=0.5 per channel).
      */
-    @Suppress("MagicNumber")
+    @Suppress("MagicNumber") // ARGB bit-shift constants (0xFF, shr 16/8) — standard pixel extraction
     private fun bitmapToNchwBuffer(bitmap: Bitmap): java.nio.FloatBuffer {
         val pixels = IntArray(IMAGE_SIZE * IMAGE_SIZE)
         bitmap.getPixels(pixels, 0, IMAGE_SIZE, 0, 0, IMAGE_SIZE, IMAGE_SIZE)
 
-        val floatCount = 1 * CHANNELS * IMAGE_SIZE * IMAGE_SIZE
+        val floatCount = BATCH_SIZE * CHANNELS * IMAGE_SIZE * IMAGE_SIZE
         val buffer = ByteBuffer
             .allocateDirect(floatCount * Float.SIZE_BYTES)
             .order(ByteOrder.nativeOrder())


### PR DESCRIPTION
## Summary
- Extract `BATCH_SIZE = 1` constant in `ImageEmbeddingModel.android.kt`, replacing magic `1` in tensor shape and buffer size calculations; remove `@Suppress("MagicNumber")` from `preprocessImage`
- Extract `SIGLIP_INPUT_SIZE = 224` and `JPEG_QUALITY = 95` constants in `ImageEmbeddingModelTest.kt`, replacing local `val size = 224` and inline `95`
- Retain `@Suppress("MagicNumber")` where remaining numbers are standard bitwise ARGB extraction constants (`0xFF`, `shr 16/8`) — same rationale as Fp16.kt IEEE 754 values

Closes #858