### PR TITLE
Add warning logs to ImageDownloader catch blocks

### DIFF
--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/gallery/ImageDownloader.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/gallery/ImageDownloader.kt
@@ -5,6 +5,7 @@ import android.content.Context
 import android.os.Build
 import android.os.Environment
 import android.provider.MediaStore
+import android.util.Log
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import okhttp3.OkHttpClient
@@ -14,6 +15,7 @@ import java.io.IOException
 
 object ImageDownloader {
 
+    private const val TAG = "ImageDownloader"
     private val httpClient = OkHttpClient()
 
     suspend fun download(context: Context, imageUrl: String): Boolean =
@@ -22,9 +24,11 @@ object ImageDownloader {
                 val bytes = downloadBytes(imageUrl) ?: return@withContext false
                 val fileName = extractFileName(imageUrl)
                 saveToGallery(context, fileName, bytes)
-            } catch (_: IOException) {
+            } catch (e: IOException) {
+                Log.w(TAG, "Failed to download image: $imageUrl", e)
                 false
-            } catch (_: SecurityException) {
+            } catch (e: SecurityException) {
+                Log.w(TAG, "Permission denied during image download: $imageUrl", e)
                 false
             }
         }
@@ -82,10 +86,12 @@ object ImageDownloader {
             values.put(MediaStore.MediaColumns.IS_PENDING, 0)
             resolver.update(uri, values, null, null)
             true
-        } catch (_: IOException) {
+        } catch (e: IOException) {
+            Log.w(TAG, "Failed to write image via MediaStore: $fileName", e)
             resolver.delete(uri, null, null)
             false
-        } catch (_: SecurityException) {
+        } catch (e: SecurityException) {
+            Log.w(TAG, "Permission denied writing to MediaStore: $fileName", e)
             resolver.delete(uri, null, null)
             false
         }
@@ -104,9 +110,11 @@ object ImageDownloader {
             dir.mkdirs()
             File(dir, fileName).writeBytes(bytes)
             true
-        } catch (_: IOException) {
+        } catch (e: IOException) {
+            Log.w(TAG, "Failed to save image to external storage: $fileName", e)
             false
-        } catch (_: SecurityException) {
+        } catch (e: SecurityException) {
+            Log.w(TAG, "Permission denied saving to external storage: $fileName", e)
             false
         }
     }


### PR DESCRIPTION
## Summary
- Add `Log.w` logging to all 6 catch blocks in `ImageDownloader` that previously swallowed exceptions silently
- Each log includes the TAG, a descriptive message with context (URL or filename), and the exception
- Covers `download()`, `saveWithMediaStore()`, and `saveToExternalStorage()`

**Caller already surfaces failure to the user** via a "Download failed" toast in `ImageViewerOverlay.kt` (line 158). No UI changes needed.

**Helper extraction not warranted**: the 3 catch sites have different cleanup logic (MediaStore deletes the pending URI, external storage and download do not), so a shared helper would add indirection without reducing complexity.

Closes #844

## Test plan
- [ ] Trigger an image download with no network — verify logcat shows the IOException warning
- [ ] Verify the "Download failed" toast still appears for the user
- [ ] Verify successful downloads still work and show "Saved to Pictures"