### PR TITLE
Improve iOS accessibility labels for interactive icons

### DIFF
--- a/iosApp/iosApp/Features/Creator/CreatorProfileScreen.swift
+++ b/iosApp/iosApp/Features/Creator/CreatorProfileScreen.swift
@@ -32,7 +32,7 @@ struct CreatorProfileScreen: View {
             ToolbarItem(placement: .navigationBarTrailing) {
                 Button(action: viewModel.toggleFollow) {
                     Image(systemName: viewModel.isFollowing ? "person.badge.minus" : "person.badge.plus")
-                        .accessibilityLabel(viewModel.isFollowing ? "Unfollow" : "Follow")
+                        .accessibilityLabel(viewModel.isFollowing ? "Unfollow creator" : "Follow creator")
                 }
             }
         }

--- a/iosApp/iosApp/Features/ExternalServer/ExternalServerImageDetailView.swift
+++ b/iosApp/iosApp/Features/ExternalServer/ExternalServerImageDetailView.swift
@@ -88,7 +88,7 @@ private struct ServerImageDetailPage: View {
                     showShareSheet = true
                 } label: {
                     Image(systemName: "square.and.arrow.up")
-                        .accessibilityLabel("Share")
+                        .accessibilityLabel("Share image")
                 }
             }
         }
@@ -123,7 +123,7 @@ private struct PromptSection: View {
                     UIPasteboard.general.string = prompt
                 } label: {
                     Image(systemName: "doc.on.doc")
-                        .accessibilityLabel("Copy")
+                        .accessibilityLabel("Copy prompt")
                         .font(.civitBodySmall)
                 }
             }


### PR DESCRIPTION
## Summary
- Made follow/unfollow button labels more descriptive: "Follow" → "Follow creator", "Unfollow" → "Unfollow creator"
- Made share button label more descriptive: "Share" → "Share image"
- Made copy button label more accurate: "Copy" → "Copy prompt" (the button copies prompt text, not the image)

Closes #845