### PR TITLE
Standardize UiState loading pattern with UiLoadingState interface

### DIFF
--- a/feature/feature-comfyui/src/commonMain/kotlin/com/riox432/civitdeck/feature/comfyui/presentation/ComfyHubBrowserViewModel.kt
+++ b/feature/feature-comfyui/src/commonMain/kotlin/com/riox432/civitdeck/feature/comfyui/presentation/ComfyHubBrowserViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.viewModelScope
 import com.riox432.civitdeck.domain.model.ComfyHubCategory
 import com.riox432.civitdeck.domain.model.ComfyHubSortOrder
 import com.riox432.civitdeck.domain.model.ComfyHubWorkflow
+import com.riox432.civitdeck.domain.util.UiLoadingState
 import com.riox432.civitdeck.feature.comfyui.domain.usecase.SearchComfyHubWorkflowsUseCase
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -14,12 +15,12 @@ import kotlinx.coroutines.launch
 
 data class ComfyHubBrowserUiState(
     val workflows: List<ComfyHubWorkflow> = emptyList(),
-    val isLoading: Boolean = true,
-    val error: String? = null,
+    override val isLoading: Boolean = true,
+    override val error: String? = null,
     val query: String = "",
     val selectedCategory: ComfyHubCategory = ComfyHubCategory.ALL,
     val sortOrder: ComfyHubSortOrder = ComfyHubSortOrder.MOST_DOWNLOADED,
-)
+) : UiLoadingState
 
 class ComfyHubBrowserViewModel(
     private val searchWorkflows: SearchComfyHubWorkflowsUseCase,

--- a/feature/feature-comfyui/src/commonMain/kotlin/com/riox432/civitdeck/feature/comfyui/presentation/ComfyHubDetailViewModel.kt
+++ b/feature/feature-comfyui/src/commonMain/kotlin/com/riox432/civitdeck/feature/comfyui/presentation/ComfyHubDetailViewModel.kt
@@ -3,6 +3,7 @@ package com.riox432.civitdeck.feature.comfyui.presentation
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.riox432.civitdeck.domain.model.ComfyHubWorkflow
+import com.riox432.civitdeck.domain.util.UiLoadingState
 import com.riox432.civitdeck.feature.comfyui.domain.usecase.GetComfyHubWorkflowDetailUseCase
 import com.riox432.civitdeck.feature.comfyui.domain.usecase.ImportComfyHubWorkflowUseCase
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -17,13 +18,13 @@ import kotlinx.serialization.json.jsonPrimitive
 
 data class ComfyHubDetailUiState(
     val workflow: ComfyHubWorkflow? = null,
-    val isLoading: Boolean = true,
-    val error: String? = null,
+    override val isLoading: Boolean = true,
+    override val error: String? = null,
     val isImporting: Boolean = false,
     val importSuccess: Boolean = false,
     val importError: String? = null,
     val nodeNames: List<String> = emptyList(),
-)
+) : UiLoadingState
 
 class ComfyHubDetailViewModel(
     private val workflowId: String,

--- a/feature/feature-detail/src/commonMain/kotlin/com/riox432/civitdeck/feature/detail/presentation/ModelDetailViewModel.kt
+++ b/feature/feature-detail/src/commonMain/kotlin/com/riox432/civitdeck/feature/detail/presentation/ModelDetailViewModel.kt
@@ -39,6 +39,7 @@ import com.riox432.civitdeck.domain.usecase.SaveModelNoteUseCase
 import com.riox432.civitdeck.domain.usecase.SubmitReviewUseCase
 import com.riox432.civitdeck.domain.usecase.ToggleFavoriteUseCase
 import com.riox432.civitdeck.domain.usecase.TrackModelViewUseCase
+import com.riox432.civitdeck.domain.util.UiLoadingState
 import com.riox432.civitdeck.domain.util.currentTimeMillis
 import com.riox432.civitdeck.domain.util.suspendRunCatching
 import com.riox432.civitdeck.util.Logger
@@ -58,8 +59,8 @@ import kotlinx.coroutines.withTimeoutOrNull
 data class ModelDetailUiState(
     val model: Model? = null,
     val isFavorite: Boolean = false,
-    val isLoading: Boolean = true,
-    val error: String? = null,
+    override val isLoading: Boolean = true,
+    override val error: String? = null,
     val selectedVersionIndex: Int = 0,
     val nsfwFilterLevel: NsfwFilterLevel = NsfwFilterLevel.Off,
     val powerUserMode: Boolean = false,
@@ -73,7 +74,7 @@ data class ModelDetailUiState(
     val reviewsError: String? = null,
     val isSubmittingReview: Boolean = false,
     val reviewSubmitSuccess: Boolean = false,
-)
+) : UiLoadingState
 
 @Suppress("LongParameterList", "TooManyFunctions")
 class ModelDetailViewModel(

--- a/feature/feature-gallery/src/commonMain/kotlin/com/riox432/civitdeck/feature/gallery/presentation/DownloadQueueViewModel.kt
+++ b/feature/feature-gallery/src/commonMain/kotlin/com/riox432/civitdeck/feature/gallery/presentation/DownloadQueueViewModel.kt
@@ -11,6 +11,7 @@ import com.riox432.civitdeck.domain.usecase.DeleteDownloadUseCase
 import com.riox432.civitdeck.domain.usecase.ObserveDownloadsUseCase
 import com.riox432.civitdeck.domain.usecase.PauseDownloadUseCase
 import com.riox432.civitdeck.domain.usecase.ResumeDownloadUseCase
+import com.riox432.civitdeck.domain.util.UiLoadingState
 import com.riox432.civitdeck.util.Logger
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -23,9 +24,10 @@ data class DownloadQueueUiState(
     val activeDownloads: List<ModelDownload> = emptyList(),
     val completedDownloads: List<ModelDownload> = emptyList(),
     val failedDownloads: List<ModelDownload> = emptyList(),
-    val isLoading: Boolean = true,
+    override val isLoading: Boolean = true,
+    override val error: String? = null,
     val totalStorageBytes: Long = 0,
-)
+) : UiLoadingState
 
 class DownloadQueueViewModel(
     observeDownloadsUseCase: ObserveDownloadsUseCase,

--- a/feature/feature-gallery/src/commonMain/kotlin/com/riox432/civitdeck/feature/gallery/presentation/NotificationCenterViewModel.kt
+++ b/feature/feature-gallery/src/commonMain/kotlin/com/riox432/civitdeck/feature/gallery/presentation/NotificationCenterViewModel.kt
@@ -6,14 +6,16 @@ import com.riox432.civitdeck.domain.model.ModelUpdateNotification
 import com.riox432.civitdeck.domain.usecase.GetModelUpdateNotificationsUseCase
 import com.riox432.civitdeck.domain.usecase.MarkAllNotificationsReadUseCase
 import com.riox432.civitdeck.domain.usecase.MarkNotificationReadUseCase
+import com.riox432.civitdeck.domain.util.UiLoadingState
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
 
 data class NotificationCenterUiState(
     val notifications: List<ModelUpdateNotification> = emptyList(),
-    val isLoading: Boolean = true,
-)
+    override val isLoading: Boolean = true,
+    override val error: String? = null,
+) : UiLoadingState
 
 class NotificationCenterViewModel(
     private val getNotificationsUseCase: GetModelUpdateNotificationsUseCase,


### PR DESCRIPTION
## Summary
- Add `UiLoadingState` interface implementation to 5 UiState data classes that had `isLoading`/`error` fields without the shared interface
- Changed: `ModelDetailUiState`, `NotificationCenterUiState`, `DownloadQueueUiState`, `ComfyHubDetailUiState`, `ComfyHubBrowserUiState`
- Added missing `error: String?` field to `NotificationCenterUiState` and `DownloadQueueUiState` (required by interface contract)
- No public API changes — property names and types remain identical, only `override` modifier added

Closes #811

## Test plan
- [x] `./gradlew detekt` passes
- [ ] Android build succeeds
- [ ] iOS build (pre-existing failures unrelated to this change — missing KMP framework types in ThemeManager/AppearanceSettings)