### PR TITLE
Make SSL trust-all bypass configurable for ComfyUI clients

### DIFF
--- a/core/core-network/src/androidMain/kotlin/com/riox432/civitdeck/data/api/comfyui/ComfyUIHttpClientFactory.android.kt
+++ b/core/core-network/src/androidMain/kotlin/com/riox432/civitdeck/data/api/comfyui/ComfyUIHttpClientFactory.android.kt
@@ -23,28 +23,37 @@ private const val REQUEST_TIMEOUT_MS = 120_000L
 private const val SOCKET_TIMEOUT_MS = 120_000L
 
 /**
- * Creates an OkHttp-backed Ktor client that trusts all certificates.
- * WARNING: Only for self-signed cert scenarios (local dev servers).
+ * Creates an OkHttp-backed Ktor client with configurable TLS trust.
+ * When [trustSelfSignedCerts] is `true`, bypasses certificate validation for self-signed setups.
+ * When `false`, uses the platform default trust manager (standard CA validation).
  */
 @Suppress("EmptyFunctionBlock", "TrustAllX509TrustManager", "CustomX509TrustManager")
-actual fun createComfyUIHttpClientWithSelfSignedTls(): HttpClient {
-    val trustAllManager = object : X509TrustManager {
-        override fun checkClientTrusted(chain: Array<out X509Certificate>?, authType: String?) {
-            // Intentionally empty — trust all client certificates
-        }
-        override fun checkServerTrusted(chain: Array<out X509Certificate>?, authType: String?) {
-            // Intentionally empty — trust all server certificates for self-signed setups
-        }
-        override fun getAcceptedIssuers(): Array<X509Certificate> = emptyArray()
-    }
-    val sslContext = SSLContext.getInstance("TLS").apply {
-        init(null, arrayOf<TrustManager>(trustAllManager), SecureRandom())
-    }
+actual fun createPlatformComfyUIHttpClient(trustSelfSignedCerts: Boolean): HttpClient {
     return HttpClient(OkHttp) {
         engine {
-            config {
-                sslSocketFactory(sslContext.socketFactory, trustAllManager)
-                hostnameVerifier { _, _ -> true }
+            if (trustSelfSignedCerts) {
+                val trustAllManager = object : X509TrustManager {
+                    override fun checkClientTrusted(
+                        chain: Array<out X509Certificate>?,
+                        authType: String?,
+                    ) {
+                        // Intentionally empty — trust all client certificates
+                    }
+                    override fun checkServerTrusted(
+                        chain: Array<out X509Certificate>?,
+                        authType: String?,
+                    ) {
+                        // Intentionally empty — trust all server certificates for self-signed setups
+                    }
+                    override fun getAcceptedIssuers(): Array<X509Certificate> = emptyArray()
+                }
+                val sslContext = SSLContext.getInstance("TLS").apply {
+                    init(null, arrayOf<TrustManager>(trustAllManager), SecureRandom())
+                }
+                config {
+                    sslSocketFactory(sslContext.socketFactory, trustAllManager)
+                    hostnameVerifier { _, _ -> true }
+                }
             }
         }
         install(ContentNegotiation) {
@@ -53,7 +62,7 @@ actual fun createComfyUIHttpClientWithSelfSignedTls(): HttpClient {
                     ignoreUnknownKeys = true
                     isLenient = true
                     coerceInputValues = true
-                }
+                },
             )
         }
         install(HttpTimeout) {

--- a/core/core-network/src/commonMain/kotlin/com/riox432/civitdeck/data/api/comfyui/ComfyUIHttpClientFactory.kt
+++ b/core/core-network/src/commonMain/kotlin/com/riox432/civitdeck/data/api/comfyui/ComfyUIHttpClientFactory.kt
@@ -1,5 +1,6 @@
 package com.riox432.civitdeck.data.api.comfyui
 
+import com.riox432.civitdeck.util.Logger
 import io.ktor.client.HttpClient
 import io.ktor.client.plugins.HttpTimeout
 import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
@@ -43,8 +44,31 @@ fun createComfyUIHttpClient(): HttpClient {
     }
 }
 
+private const val TAG = "ComfyUIHttpClientFactory"
+
 /**
  * Creates an HttpClient with TLS trust configuration for self-signed certificates.
- * Platform-specific engines configure certificate trust via expect/actual [configureSelfSignedTls].
+ * Platform-specific engines configure certificate trust via expect/actual.
+ *
+ * @param trustSelfSignedCerts When `true`, bypasses SSL certificate validation to support
+ *   self-signed certificates commonly used by local ComfyUI servers. When `false`, uses
+ *   standard SSL validation requiring valid CA-signed certificates. Defaults to `true`
+ *   for backward compatibility with local network setups.
  */
-expect fun createComfyUIHttpClientWithSelfSignedTls(): HttpClient
+fun createComfyUIHttpClientWithSelfSignedTls(trustSelfSignedCerts: Boolean = true): HttpClient {
+    if (trustSelfSignedCerts) {
+        Logger.w(
+            TAG,
+            "SSL trust-all mode is active — certificate validation is bypassed. " +
+                "This is intended for local ComfyUI servers with self-signed certificates only.",
+        )
+    }
+    return createPlatformComfyUIHttpClient(trustSelfSignedCerts)
+}
+
+/**
+ * Platform-specific HttpClient creation with configurable TLS trust.
+ * When [trustSelfSignedCerts] is `true`, the platform engine skips certificate validation.
+ * When `false`, standard SSL validation is used.
+ */
+expect fun createPlatformComfyUIHttpClient(trustSelfSignedCerts: Boolean): HttpClient

--- a/core/core-network/src/iosMain/kotlin/com/riox432/civitdeck/data/api/comfyui/ComfyUIHttpClientFactory.ios.kt
+++ b/core/core-network/src/iosMain/kotlin/com/riox432/civitdeck/data/api/comfyui/ComfyUIHttpClientFactory.ios.kt
@@ -18,13 +18,14 @@ private const val REQUEST_TIMEOUT_MS = 120_000L
 private const val SOCKET_TIMEOUT_MS = 120_000L
 
 /**
- * Creates a Darwin-backed Ktor client for self-signed certificate scenarios.
+ * Creates a Darwin-backed Ktor client with configurable TLS trust.
  * On iOS, full self-signed TLS bypass requires NSURLSessionDelegate configuration
- * which is complex to implement via K/N cinterop. This returns a standard client
- * for now — users should add the self-signed cert to the iOS trust store via
- * Settings > General > About > Certificate Trust Settings, or use a tunnel (Cloudflare/Tailscale).
+ * which is complex to implement via K/N cinterop. This returns a standard Darwin client
+ * regardless of [trustSelfSignedCerts] — users should add the self-signed cert to the iOS
+ * trust store via Settings > General > About > Certificate Trust Settings, or use a tunnel
+ * (Cloudflare/Tailscale).
  */
-actual fun createComfyUIHttpClientWithSelfSignedTls(): HttpClient {
+actual fun createPlatformComfyUIHttpClient(trustSelfSignedCerts: Boolean): HttpClient {
     return HttpClient(Darwin) {
         install(ContentNegotiation) {
             json(
@@ -32,7 +33,7 @@ actual fun createComfyUIHttpClientWithSelfSignedTls(): HttpClient {
                     ignoreUnknownKeys = true
                     isLenient = true
                     coerceInputValues = true
-                }
+                },
             )
         }
         install(HttpTimeout) {

--- a/core/core-network/src/jvmMain/kotlin/com/riox432/civitdeck/data/api/comfyui/ComfyUIHttpClientFactory.jvm.kt
+++ b/core/core-network/src/jvmMain/kotlin/com/riox432/civitdeck/data/api/comfyui/ComfyUIHttpClientFactory.jvm.kt
@@ -20,24 +20,33 @@ private const val REQUEST_TIMEOUT_MS = 120_000L
 private const val SOCKET_TIMEOUT_MS = 120_000L
 
 /**
- * Creates a CIO-backed Ktor client that trusts all certificates.
- * WARNING: Only for self-signed cert scenarios.
+ * Creates a CIO-backed Ktor client with configurable TLS trust.
+ * When [trustSelfSignedCerts] is `true`, bypasses certificate validation for self-signed setups.
+ * When `false`, uses the platform default trust manager (standard CA validation).
  */
 @Suppress("EmptyFunctionBlock", "TrustAllX509TrustManager", "CustomX509TrustManager")
-actual fun createComfyUIHttpClientWithSelfSignedTls(): HttpClient {
-    val trustAllManager = object : X509TrustManager {
-        override fun checkClientTrusted(chain: Array<out X509Certificate>?, authType: String?) {
-            // Intentionally empty — trust all client certificates
-        }
-        override fun checkServerTrusted(chain: Array<out X509Certificate>?, authType: String?) {
-            // Intentionally empty — trust all server certificates for self-signed setups
-        }
-        override fun getAcceptedIssuers(): Array<X509Certificate> = emptyArray()
-    }
+actual fun createPlatformComfyUIHttpClient(trustSelfSignedCerts: Boolean): HttpClient {
     return HttpClient(CIO) {
         engine {
-            https {
-                trustManager = trustAllManager
+            if (trustSelfSignedCerts) {
+                val trustAllManager = object : X509TrustManager {
+                    override fun checkClientTrusted(
+                        chain: Array<out X509Certificate>?,
+                        authType: String?,
+                    ) {
+                        // Intentionally empty — trust all client certificates
+                    }
+                    override fun checkServerTrusted(
+                        chain: Array<out X509Certificate>?,
+                        authType: String?,
+                    ) {
+                        // Intentionally empty — trust all server certificates for self-signed setups
+                    }
+                    override fun getAcceptedIssuers(): Array<X509Certificate> = emptyArray()
+                }
+                https {
+                    trustManager = trustAllManager
+                }
             }
         }
         install(ContentNegotiation) {


### PR DESCRIPTION
## Summary
- Add `trustSelfSignedCerts` parameter to `createComfyUIHttpClientWithSelfSignedTls()` (default: `true` for backward compatibility)
- When `false`, Android (OkHttp) and Desktop (CIO) use standard SSL validation instead of trust-all
- Log `Logger.w` warning when trust-all mode is active
- Refactor `expect`/`actual` to `createPlatformComfyUIHttpClient(Boolean)` so the logging and parameter live in common code
- iOS implementation unchanged (Darwin engine cannot bypass TLS via K/N; users must add certs to iOS trust store)

## Test plan
- [ ] Verify Android ComfyUI connection still works with self-signed cert (default `true`)
- [ ] Verify Desktop ComfyUI connection still works with self-signed cert (default `true`)
- [ ] Verify passing `false` enforces standard SSL validation (connection to self-signed server should fail)
- [ ] Verify warning log appears in logcat/console when trust-all mode is active
- [ ] `./gradlew detekt` passes

Closes #842