### PR TITLE
Replace generic Exception catches with specific exception types

### DIFF
--- a/core/core-network/src/commonMain/kotlin/com/riox432/civitdeck/data/api/comfyhub/ComfyHubApi.kt
+++ b/core/core-network/src/commonMain/kotlin/com/riox432/civitdeck/data/api/comfyhub/ComfyHubApi.kt
@@ -1,8 +1,5 @@
 package com.riox432.civitdeck.data.api.comfyhub
 
-import com.riox432.civitdeck.util.Logger
-import kotlin.coroutines.cancellation.CancellationException
-
 /**
  * API client for browsing published ComfyUI workflows.
  *
@@ -22,36 +19,29 @@ class ComfyHubApi {
         sort: String = "Most Downloaded",
         page: Int = 1,
     ): ComfyHubSearchResponse {
-        return try {
-            val filtered = builtInWorkflows.filter { workflow ->
-                val matchesQuery = query.isBlank() ||
-                    workflow.name.contains(query, ignoreCase = true) ||
-                    workflow.description.contains(query, ignoreCase = true) ||
-                    workflow.tags.any { it.contains(query, ignoreCase = true) }
-                val matchesCategory = category == "All" ||
-                    workflow.category.equals(category, ignoreCase = true)
-                matchesQuery && matchesCategory
-            }.let { list ->
-                when (sort) {
-                    "Highest Rated" -> list.sortedByDescending { it.rating }
-                    "Newest" -> list.reversed()
-                    else -> list.sortedByDescending { it.downloads }
-                }
+        val filtered = builtInWorkflows.filter { workflow ->
+            val matchesQuery = query.isBlank() ||
+                workflow.name.contains(query, ignoreCase = true) ||
+                workflow.description.contains(query, ignoreCase = true) ||
+                workflow.tags.any { it.contains(query, ignoreCase = true) }
+            val matchesCategory = category == "All" ||
+                workflow.category.equals(category, ignoreCase = true)
+            matchesQuery && matchesCategory
+        }.let { list ->
+            when (sort) {
+                "Highest Rated" -> list.sortedByDescending { it.rating }
+                "Newest" -> list.reversed()
+                else -> list.sortedByDescending { it.downloads }
             }
-            ComfyHubSearchResponse(
-                items = filtered,
-                metadata = ComfyHubPagination(
-                    totalItems = filtered.size,
-                    currentPage = page,
-                    totalPages = 1,
-                ),
-            )
-        } catch (e: CancellationException) {
-            throw e
-        } catch (@Suppress("TooGenericExceptionCaught") e: Exception) {
-            Logger.e(TAG, "searchWorkflows failed: ${e.message}", e)
-            throw e
         }
+        return ComfyHubSearchResponse(
+            items = filtered,
+            metadata = ComfyHubPagination(
+                totalItems = filtered.size,
+                currentPage = page,
+                totalPages = 1,
+            ),
+        )
     }
 
     /**
@@ -60,9 +50,5 @@ class ComfyHubApi {
     fun getWorkflowDetail(workflowId: String): ComfyHubWorkflowDto {
         return builtInWorkflows.firstOrNull { it.id == workflowId }
             ?: error("Workflow not found: $workflowId")
-    }
-
-    private companion object {
-        const val TAG = "ComfyHubApi"
     }
 }

--- a/core/core-network/src/commonMain/kotlin/com/riox432/civitdeck/data/api/externalserver/ExternalServerApi.kt
+++ b/core/core-network/src/commonMain/kotlin/com/riox432/civitdeck/data/api/externalserver/ExternalServerApi.kt
@@ -3,6 +3,9 @@ package com.riox432.civitdeck.data.api.externalserver
 import com.riox432.civitdeck.util.Logger
 import io.ktor.client.HttpClient
 import io.ktor.client.call.body
+import io.ktor.client.network.sockets.ConnectTimeoutException
+import io.ktor.client.plugins.HttpRequestTimeoutException
+import io.ktor.client.plugins.ResponseException
 import io.ktor.client.request.get
 import io.ktor.client.request.header
 import io.ktor.client.request.post
@@ -11,6 +14,7 @@ import io.ktor.http.ContentType
 import io.ktor.http.URLBuilder
 import io.ktor.http.Url
 import io.ktor.http.contentType
+import kotlinx.io.IOException
 import kotlin.concurrent.Volatile
 
 /**
@@ -121,7 +125,16 @@ class ExternalServerApi(
             if (cfg.apiKey.isNotBlank()) header("X-API-Key", cfg.apiKey)
         }
         true
-    } catch (@Suppress("TooGenericExceptionCaught") e: Exception) {
+    } catch (e: IOException) {
+        Logger.w(TAG, "Connection test failed: ${e.message}")
+        false
+    } catch (e: HttpRequestTimeoutException) {
+        Logger.w(TAG, "Connection test failed: ${e.message}")
+        false
+    } catch (e: ConnectTimeoutException) {
+        Logger.w(TAG, "Connection test failed: ${e.message}")
+        false
+    } catch (e: ResponseException) {
         Logger.w(TAG, "Connection test failed: ${e.message}")
         false
     }

--- a/shared/src/commonMain/kotlin/com/riox432/civitdeck/data/repository/CreatorFollowRepositoryImpl.kt
+++ b/shared/src/commonMain/kotlin/com/riox432/civitdeck/data/repository/CreatorFollowRepositoryImpl.kt
@@ -13,8 +13,13 @@ import com.riox432.civitdeck.domain.model.ModelStats
 import com.riox432.civitdeck.domain.model.ModelType
 import com.riox432.civitdeck.domain.repository.CreatorFollowRepository
 import com.riox432.civitdeck.util.Logger
+import io.ktor.client.network.sockets.ConnectTimeoutException
+import io.ktor.client.plugins.HttpRequestTimeoutException
+import io.ktor.client.plugins.ResponseException
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
+import kotlinx.io.IOException
+import kotlinx.serialization.SerializationException
 
 class CreatorFollowRepositoryImpl(
     private val followedCreatorDao: FollowedCreatorDao,
@@ -114,7 +119,6 @@ class CreatorFollowRepositoryImpl(
         }
     }
 
-    @Suppress("TooGenericExceptionCaught")
     private suspend fun refreshFeedCache(
         creators: List<FollowedCreatorEntity>,
         now: Long,
@@ -148,8 +152,16 @@ class CreatorFollowRepositoryImpl(
                     )
                 }
                 feedCacheDao.insertAll(entities)
-            } catch (@Suppress("TooGenericExceptionCaught") e: Exception) {
-                // Skip this creator on network error, use cached data
+            } catch (e: IOException) {
+                // Skip this creator on network/IO error, use cached data
+                Logger.w(TAG, "Failed to refresh feed for ${creator.username}: ${e.message}")
+            } catch (e: HttpRequestTimeoutException) {
+                Logger.w(TAG, "Failed to refresh feed for ${creator.username}: ${e.message}")
+            } catch (e: ConnectTimeoutException) {
+                Logger.w(TAG, "Failed to refresh feed for ${creator.username}: ${e.message}")
+            } catch (e: ResponseException) {
+                Logger.w(TAG, "Failed to refresh feed for ${creator.username}: ${e.message}")
+            } catch (e: SerializationException) {
                 Logger.w(TAG, "Failed to refresh feed for ${creator.username}: ${e.message}")
             }
         }

--- a/shared/src/commonMain/kotlin/com/riox432/civitdeck/di/ThemePluginInitializer.kt
+++ b/shared/src/commonMain/kotlin/com/riox432/civitdeck/di/ThemePluginInitializer.kt
@@ -7,6 +7,7 @@ import com.riox432.civitdeck.plugin.PluginRegistry
 import com.riox432.civitdeck.plugin.theme.JsonThemePlugin
 import com.riox432.civitdeck.plugin.theme.ThemeDefinition
 import kotlinx.coroutines.flow.first
+import kotlinx.serialization.SerializationException
 import kotlinx.serialization.json.Json
 
 private val json = Json { ignoreUnknownKeys = true }
@@ -26,9 +27,11 @@ suspend fun registerThemePlugins() {
     }
 
     for (installed in themePlugins) {
-        val definition = runCatching {
+        val definition = try {
             json.decodeFromString<ThemeDefinition>(installed.configJson)
-        }.getOrNull() ?: continue
+        } catch (_: SerializationException) {
+            continue
+        }
 
         val plugin = JsonThemePlugin(definition)
         registry.register(plugin)


### PR DESCRIPTION
## Summary
- **ComfyHubApi**: Removed unnecessary try-catch entirely — purely in-memory filtering/sorting needs no exception handling, and the catch was just re-throwing
- **ExternalServerApi**: Replaced `catch (Exception)` with specific `IOException`, `HttpRequestTimeoutException`, `ConnectTimeoutException`, `ResponseException` for the health check
- **CreatorFollowRepositoryImpl**: Replaced `catch (Exception)` with specific `IOException`, `HttpRequestTimeoutException`, `ConnectTimeoutException`, `ResponseException`, `SerializationException` for feed refresh
- **ThemePluginInitializer**: Replaced `runCatching` (which silently catches `CancellationException`) with explicit `try-catch(SerializationException)` for JSON parsing

All `@Suppress("TooGenericExceptionCaught")` annotations removed.

Closes #849

## Test plan
- [ ] Verify detekt passes with no `TooGenericExceptionCaught` issues in these files
- [ ] Verify Android build succeeds
- [ ] Test feed refresh with a followed creator (network error gracefully skipped)
- [ ] Test external server connection test (returns false on timeout/unreachable)
- [ ] Test theme plugin loading with corrupted JSON (skips gracefully)