### PR TITLE
Extract TimeoutConfig and RetryConfig for HTTP clients

### DIFF
--- a/core/core-network/src/androidMain/kotlin/com/riox432/civitdeck/data/api/comfyui/ComfyUIHttpClientFactory.android.kt
+++ b/core/core-network/src/androidMain/kotlin/com/riox432/civitdeck/data/api/comfyui/ComfyUIHttpClientFactory.android.kt
@@ -1,5 +1,6 @@
 package com.riox432.civitdeck.data.api.comfyui
 
+import com.riox432.civitdeck.data.api.TimeoutConfig
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.okhttp.OkHttp
 import io.ktor.client.plugins.HttpTimeout
@@ -18,17 +19,16 @@ import javax.net.ssl.SSLContext
 import javax.net.ssl.TrustManager
 import javax.net.ssl.X509TrustManager
 
-private const val CONNECT_TIMEOUT_MS = 5_000L
-private const val REQUEST_TIMEOUT_MS = 120_000L
-private const val SOCKET_TIMEOUT_MS = 120_000L
-
 /**
  * Creates an OkHttp-backed Ktor client with configurable TLS trust.
  * When [trustSelfSignedCerts] is `true`, bypasses certificate validation for self-signed setups.
  * When `false`, uses the platform default trust manager (standard CA validation).
  */
 @Suppress("EmptyFunctionBlock", "TrustAllX509TrustManager", "CustomX509TrustManager")
-actual fun createPlatformComfyUIHttpClient(trustSelfSignedCerts: Boolean): HttpClient {
+actual fun createPlatformComfyUIHttpClient(
+    trustSelfSignedCerts: Boolean,
+    timeoutConfig: TimeoutConfig,
+): HttpClient {
     return HttpClient(OkHttp) {
         engine {
             if (trustSelfSignedCerts) {
@@ -66,9 +66,9 @@ actual fun createPlatformComfyUIHttpClient(trustSelfSignedCerts: Boolean): HttpC
             )
         }
         install(HttpTimeout) {
-            connectTimeoutMillis = CONNECT_TIMEOUT_MS
-            requestTimeoutMillis = REQUEST_TIMEOUT_MS
-            socketTimeoutMillis = SOCKET_TIMEOUT_MS
+            connectTimeoutMillis = timeoutConfig.connectTimeoutMs
+            requestTimeoutMillis = timeoutConfig.requestTimeoutMs
+            socketTimeoutMillis = timeoutConfig.socketTimeoutMs
         }
         install(Logging) { level = LogLevel.NONE }
         install(WebSockets)

--- a/core/core-network/src/commonMain/kotlin/com/riox432/civitdeck/data/api/HttpClientConfig.kt
+++ b/core/core-network/src/commonMain/kotlin/com/riox432/civitdeck/data/api/HttpClientConfig.kt
@@ -1,0 +1,74 @@
+package com.riox432.civitdeck.data.api
+
+/**
+ * Configuration for HTTP request timeouts.
+ *
+ * Each factory defines its own defaults matching the service's expected latency profile:
+ * - CivitAI/HuggingFace/TensorArt: 15s connect, 30s request (fast public APIs)
+ * - ComfyUI: 5s connect, 120s request (local server, long generation jobs)
+ * - SDWebUI: 5s connect, 300s request (local server, very long generation jobs)
+ * - ExternalServer: 5s connect, 60s request (user-configured server)
+ */
+data class TimeoutConfig(
+    val connectTimeoutMs: Long = DEFAULT_CONNECT_TIMEOUT_MS,
+    val requestTimeoutMs: Long = DEFAULT_REQUEST_TIMEOUT_MS,
+    val socketTimeoutMs: Long = DEFAULT_SOCKET_TIMEOUT_MS,
+) {
+    companion object {
+        const val DEFAULT_CONNECT_TIMEOUT_MS = 15_000L
+        const val DEFAULT_REQUEST_TIMEOUT_MS = 30_000L
+        const val DEFAULT_SOCKET_TIMEOUT_MS = 30_000L
+
+        /** CivitAI, HuggingFace, TensorArt — public APIs with moderate latency. */
+        val PublicApi = TimeoutConfig()
+
+        /** ComfyUI — local server with long-running generation jobs. */
+        val ComfyUI = TimeoutConfig(
+            connectTimeoutMs = 5_000L,
+            requestTimeoutMs = 120_000L,
+            socketTimeoutMs = 120_000L,
+        )
+
+        /** SDWebUI — local server with very long generation jobs. */
+        val SDWebUI = TimeoutConfig(
+            connectTimeoutMs = 5_000L,
+            requestTimeoutMs = 300_000L,
+            socketTimeoutMs = 300_000L,
+        )
+
+        /** External server — user-configured with moderate timeout. */
+        val ExternalServer = TimeoutConfig(
+            connectTimeoutMs = 5_000L,
+            requestTimeoutMs = 60_000L,
+            socketTimeoutMs = 60_000L,
+        )
+    }
+}
+
+/**
+ * Configuration for HTTP request retry with exponential backoff.
+ *
+ * Used by both Ktor's [io.ktor.client.plugins.HttpRequestRetry] plugin
+ * and the manual WebSocket reconnection logic in [ComfyUIWebSocketApi].
+ */
+data class RetryConfig(
+    val maxRetries: Int = DEFAULT_MAX_RETRIES,
+    val baseDelayMs: Long = DEFAULT_BASE_DELAY_MS,
+    val maxDelayMs: Long = DEFAULT_MAX_DELAY_MS,
+) {
+    companion object {
+        const val DEFAULT_MAX_RETRIES = 2
+        const val DEFAULT_BASE_DELAY_MS = 1_000L
+        const val DEFAULT_MAX_DELAY_MS = 16_000L
+
+        /** Standard retry for public API clients (CivitAI, HuggingFace, TensorArt). */
+        val Default = RetryConfig()
+
+        /** WebSocket reconnection with more retries and capped backoff. */
+        val WebSocket = RetryConfig(
+            maxRetries = 5,
+            baseDelayMs = 1_000L,
+            maxDelayMs = 16_000L,
+        )
+    }
+}

--- a/core/core-network/src/commonMain/kotlin/com/riox432/civitdeck/data/api/HttpClientFactory.kt
+++ b/core/core-network/src/commonMain/kotlin/com/riox432/civitdeck/data/api/HttpClientFactory.kt
@@ -12,13 +12,11 @@ import io.ktor.http.HttpHeaders
 import io.ktor.serialization.kotlinx.json.json
 import kotlinx.serialization.json.Json
 
-private const val CONNECT_TIMEOUT_MS = 15_000L
-private const val REQUEST_TIMEOUT_MS = 30_000L
-private const val SOCKET_TIMEOUT_MS = 30_000L
-private const val MAX_RETRIES = 2
-private const val RETRY_BASE_DELAY_MS = 1000L
-
-fun createHttpClient(apiKeyProvider: ApiKeyProvider): HttpClient {
+fun createHttpClient(
+    apiKeyProvider: ApiKeyProvider,
+    timeoutConfig: TimeoutConfig = TimeoutConfig.PublicApi,
+    retryConfig: RetryConfig = RetryConfig.Default,
+): HttpClient {
     return HttpClient {
         install(ContentNegotiation) {
             json(
@@ -31,14 +29,14 @@ fun createHttpClient(apiKeyProvider: ApiKeyProvider): HttpClient {
             )
         }
         install(HttpTimeout) {
-            connectTimeoutMillis = CONNECT_TIMEOUT_MS
-            requestTimeoutMillis = REQUEST_TIMEOUT_MS
-            socketTimeoutMillis = SOCKET_TIMEOUT_MS
+            connectTimeoutMillis = timeoutConfig.connectTimeoutMs
+            requestTimeoutMillis = timeoutConfig.requestTimeoutMs
+            socketTimeoutMillis = timeoutConfig.socketTimeoutMs
         }
         install(HttpRequestRetry) {
-            retryOnServerErrors(maxRetries = MAX_RETRIES)
-            retryOnException(maxRetries = MAX_RETRIES, retryOnTimeout = true)
-            exponentialDelay(baseDelayMs = RETRY_BASE_DELAY_MS)
+            retryOnServerErrors(maxRetries = retryConfig.maxRetries)
+            retryOnException(maxRetries = retryConfig.maxRetries, retryOnTimeout = true)
+            exponentialDelay(baseDelayMs = retryConfig.baseDelayMs)
         }
         install(Logging) {
             level = LogLevel.NONE

--- a/core/core-network/src/commonMain/kotlin/com/riox432/civitdeck/data/api/comfyui/ComfyUIHttpClientFactory.kt
+++ b/core/core-network/src/commonMain/kotlin/com/riox432/civitdeck/data/api/comfyui/ComfyUIHttpClientFactory.kt
@@ -1,5 +1,6 @@
 package com.riox432.civitdeck.data.api.comfyui
 
+import com.riox432.civitdeck.data.api.TimeoutConfig
 import com.riox432.civitdeck.util.Logger
 import io.ktor.client.HttpClient
 import io.ktor.client.plugins.HttpTimeout
@@ -13,11 +14,9 @@ import io.ktor.http.HttpHeaders
 import io.ktor.serialization.kotlinx.json.json
 import kotlinx.serialization.json.Json
 
-private const val CONNECT_TIMEOUT_MS = 5_000L
-private const val REQUEST_TIMEOUT_MS = 120_000L
-private const val SOCKET_TIMEOUT_MS = 120_000L
-
-fun createComfyUIHttpClient(): HttpClient {
+fun createComfyUIHttpClient(
+    timeoutConfig: TimeoutConfig = TimeoutConfig.ComfyUI,
+): HttpClient {
     return HttpClient {
         install(ContentNegotiation) {
             json(
@@ -30,9 +29,9 @@ fun createComfyUIHttpClient(): HttpClient {
             )
         }
         install(HttpTimeout) {
-            connectTimeoutMillis = CONNECT_TIMEOUT_MS
-            requestTimeoutMillis = REQUEST_TIMEOUT_MS
-            socketTimeoutMillis = SOCKET_TIMEOUT_MS
+            connectTimeoutMillis = timeoutConfig.connectTimeoutMs
+            requestTimeoutMillis = timeoutConfig.requestTimeoutMs
+            socketTimeoutMillis = timeoutConfig.socketTimeoutMs
         }
         install(Logging) {
             level = LogLevel.NONE
@@ -54,8 +53,12 @@ private const val TAG = "ComfyUIHttpClientFactory"
  *   self-signed certificates commonly used by local ComfyUI servers. When `false`, uses
  *   standard SSL validation requiring valid CA-signed certificates. Defaults to `true`
  *   for backward compatibility with local network setups.
+ * @param timeoutConfig Timeout configuration. Defaults to [TimeoutConfig.ComfyUI].
  */
-fun createComfyUIHttpClientWithSelfSignedTls(trustSelfSignedCerts: Boolean = true): HttpClient {
+fun createComfyUIHttpClientWithSelfSignedTls(
+    trustSelfSignedCerts: Boolean = true,
+    timeoutConfig: TimeoutConfig = TimeoutConfig.ComfyUI,
+): HttpClient {
     if (trustSelfSignedCerts) {
         Logger.w(
             TAG,
@@ -63,7 +66,7 @@ fun createComfyUIHttpClientWithSelfSignedTls(trustSelfSignedCerts: Boolean = tru
                 "This is intended for local ComfyUI servers with self-signed certificates only.",
         )
     }
-    return createPlatformComfyUIHttpClient(trustSelfSignedCerts)
+    return createPlatformComfyUIHttpClient(trustSelfSignedCerts, timeoutConfig)
 }
 
 /**
@@ -71,4 +74,7 @@ fun createComfyUIHttpClientWithSelfSignedTls(trustSelfSignedCerts: Boolean = tru
  * When [trustSelfSignedCerts] is `true`, the platform engine skips certificate validation.
  * When `false`, standard SSL validation is used.
  */
-expect fun createPlatformComfyUIHttpClient(trustSelfSignedCerts: Boolean): HttpClient
+expect fun createPlatformComfyUIHttpClient(
+    trustSelfSignedCerts: Boolean,
+    timeoutConfig: TimeoutConfig,
+): HttpClient

--- a/core/core-network/src/commonMain/kotlin/com/riox432/civitdeck/data/api/comfyui/ComfyUIWebSocketApi.kt
+++ b/core/core-network/src/commonMain/kotlin/com/riox432/civitdeck/data/api/comfyui/ComfyUIWebSocketApi.kt
@@ -1,5 +1,6 @@
 package com.riox432.civitdeck.data.api.comfyui
 
+import com.riox432.civitdeck.data.api.RetryConfig
 import com.riox432.civitdeck.util.Logger
 import io.ktor.client.HttpClient
 import io.ktor.client.network.sockets.ConnectTimeoutException
@@ -19,9 +20,6 @@ import kotlinx.serialization.SerializationException
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.decodeFromJsonElement
 
-private const val MAX_RETRIES = 5
-private const val BASE_DELAY_MS = 1_000L
-private const val MAX_DELAY_MS = 16_000L
 private const val BINARY_HEADER_SIZE = 8
 private const val DEFAULT_WS_PORT = 80
 private const val DEFAULT_WSS_PORT = 443
@@ -37,6 +35,7 @@ private const val TAG = "ComfyUIWebSocketApi"
 class ComfyUIWebSocketApi(
     private val client: HttpClient,
     private val json: Json,
+    private val retryConfig: RetryConfig = RetryConfig.WebSocket,
 ) {
     /**
      * Opens a WebSocket connection using the provided [baseUrl] scheme (ws/wss).
@@ -51,12 +50,13 @@ class ComfyUIWebSocketApi(
         promptId: String,
     ): Flow<ComfyUIWebSocketMessage> = flow {
         var attempt = 0
+        val maxRetries = retryConfig.maxRetries
         var lastError: Exception? = null
-        while (attempt <= MAX_RETRIES) {
+        while (attempt <= maxRetries) {
             lastError = null
             try {
                 runWebSocketSession(baseUrl, wsScheme, clientId, promptId)
-                attempt = MAX_RETRIES + 1
+                attempt = maxRetries + 1
             } catch (e: WebSocketException) {
                 lastError = logAndRetry(e, attempt)
                 attempt++
@@ -224,8 +224,11 @@ class ComfyUIWebSocketApi(
      */
     private suspend fun logAndRetry(e: Exception, attempt: Int): Exception {
         Logger.w(TAG, "WebSocket connection failed (attempt $attempt): ${e.message}")
-        if (attempt + 1 <= MAX_RETRIES) {
-            val backoff = minOf(BASE_DELAY_MS * (1L shl attempt), MAX_DELAY_MS)
+        if (attempt + 1 <= retryConfig.maxRetries) {
+            val backoff = minOf(
+                retryConfig.baseDelayMs * (1L shl attempt),
+                retryConfig.maxDelayMs,
+            )
             delay(backoff)
         }
         return e

--- a/core/core-network/src/commonMain/kotlin/com/riox432/civitdeck/data/api/externalserver/ExternalServerHttpClientFactory.kt
+++ b/core/core-network/src/commonMain/kotlin/com/riox432/civitdeck/data/api/externalserver/ExternalServerHttpClientFactory.kt
@@ -1,5 +1,6 @@
 package com.riox432.civitdeck.data.api.externalserver
 
+import com.riox432.civitdeck.data.api.TimeoutConfig
 import io.ktor.client.HttpClient
 import io.ktor.client.plugins.HttpTimeout
 import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
@@ -11,11 +12,9 @@ import io.ktor.http.HttpHeaders
 import io.ktor.serialization.kotlinx.json.json
 import kotlinx.serialization.json.Json
 
-private const val CONNECT_TIMEOUT_MS = 5_000L
-private const val REQUEST_TIMEOUT_MS = 60_000L
-private const val SOCKET_TIMEOUT_MS = 60_000L
-
-fun createExternalServerHttpClient(): HttpClient {
+fun createExternalServerHttpClient(
+    timeoutConfig: TimeoutConfig = TimeoutConfig.ExternalServer,
+): HttpClient {
     return HttpClient {
         install(ContentNegotiation) {
             json(
@@ -27,9 +26,9 @@ fun createExternalServerHttpClient(): HttpClient {
             )
         }
         install(HttpTimeout) {
-            connectTimeoutMillis = CONNECT_TIMEOUT_MS
-            requestTimeoutMillis = REQUEST_TIMEOUT_MS
-            socketTimeoutMillis = SOCKET_TIMEOUT_MS
+            connectTimeoutMillis = timeoutConfig.connectTimeoutMs
+            requestTimeoutMillis = timeoutConfig.requestTimeoutMs
+            socketTimeoutMillis = timeoutConfig.socketTimeoutMs
         }
         install(Logging) { level = LogLevel.NONE }
         defaultRequest { header(HttpHeaders.Accept, "application/json") }

--- a/core/core-network/src/commonMain/kotlin/com/riox432/civitdeck/data/api/huggingface/HuggingFaceHttpClientFactory.kt
+++ b/core/core-network/src/commonMain/kotlin/com/riox432/civitdeck/data/api/huggingface/HuggingFaceHttpClientFactory.kt
@@ -1,5 +1,7 @@
 package com.riox432.civitdeck.data.api.huggingface
 
+import com.riox432.civitdeck.data.api.RetryConfig
+import com.riox432.civitdeck.data.api.TimeoutConfig
 import io.ktor.client.HttpClient
 import io.ktor.client.plugins.HttpRequestRetry
 import io.ktor.client.plugins.HttpTimeout
@@ -12,13 +14,10 @@ import io.ktor.http.HttpHeaders
 import io.ktor.serialization.kotlinx.json.json
 import kotlinx.serialization.json.Json
 
-private const val CONNECT_TIMEOUT_MS = 15_000L
-private const val REQUEST_TIMEOUT_MS = 30_000L
-private const val SOCKET_TIMEOUT_MS = 30_000L
-private const val MAX_RETRIES = 2
-private const val RETRY_BASE_DELAY_MS = 1000L
-
-fun createHuggingFaceHttpClient(): HttpClient {
+fun createHuggingFaceHttpClient(
+    timeoutConfig: TimeoutConfig = TimeoutConfig.PublicApi,
+    retryConfig: RetryConfig = RetryConfig.Default,
+): HttpClient {
     return HttpClient {
         install(ContentNegotiation) {
             json(
@@ -31,14 +30,14 @@ fun createHuggingFaceHttpClient(): HttpClient {
             )
         }
         install(HttpTimeout) {
-            connectTimeoutMillis = CONNECT_TIMEOUT_MS
-            requestTimeoutMillis = REQUEST_TIMEOUT_MS
-            socketTimeoutMillis = SOCKET_TIMEOUT_MS
+            connectTimeoutMillis = timeoutConfig.connectTimeoutMs
+            requestTimeoutMillis = timeoutConfig.requestTimeoutMs
+            socketTimeoutMillis = timeoutConfig.socketTimeoutMs
         }
         install(HttpRequestRetry) {
-            retryOnServerErrors(maxRetries = MAX_RETRIES)
-            retryOnException(maxRetries = MAX_RETRIES, retryOnTimeout = true)
-            exponentialDelay(baseDelayMs = RETRY_BASE_DELAY_MS)
+            retryOnServerErrors(maxRetries = retryConfig.maxRetries)
+            retryOnException(maxRetries = retryConfig.maxRetries, retryOnTimeout = true)
+            exponentialDelay(baseDelayMs = retryConfig.baseDelayMs)
         }
         install(Logging) {
             level = LogLevel.NONE

--- a/core/core-network/src/commonMain/kotlin/com/riox432/civitdeck/data/api/tensorart/TensorArtHttpClientFactory.kt
+++ b/core/core-network/src/commonMain/kotlin/com/riox432/civitdeck/data/api/tensorart/TensorArtHttpClientFactory.kt
@@ -1,5 +1,7 @@
 package com.riox432.civitdeck.data.api.tensorart
 
+import com.riox432.civitdeck.data.api.RetryConfig
+import com.riox432.civitdeck.data.api.TimeoutConfig
 import io.ktor.client.HttpClient
 import io.ktor.client.plugins.HttpRequestRetry
 import io.ktor.client.plugins.HttpTimeout
@@ -12,17 +14,14 @@ import io.ktor.http.HttpHeaders
 import io.ktor.serialization.kotlinx.json.json
 import kotlinx.serialization.json.Json
 
-private const val CONNECT_TIMEOUT_MS = 15_000L
-private const val REQUEST_TIMEOUT_MS = 30_000L
-private const val SOCKET_TIMEOUT_MS = 30_000L
-private const val MAX_RETRIES = 2
-private const val RETRY_BASE_DELAY_MS = 1000L
-
 /**
  * Creates an [HttpClient] configured for the TensorArt API.
  * No authentication required for search.
  */
-fun createTensorArtHttpClient(): HttpClient {
+fun createTensorArtHttpClient(
+    timeoutConfig: TimeoutConfig = TimeoutConfig.PublicApi,
+    retryConfig: RetryConfig = RetryConfig.Default,
+): HttpClient {
     return HttpClient {
         install(ContentNegotiation) {
             json(
@@ -35,14 +34,14 @@ fun createTensorArtHttpClient(): HttpClient {
             )
         }
         install(HttpTimeout) {
-            connectTimeoutMillis = CONNECT_TIMEOUT_MS
-            requestTimeoutMillis = REQUEST_TIMEOUT_MS
-            socketTimeoutMillis = SOCKET_TIMEOUT_MS
+            connectTimeoutMillis = timeoutConfig.connectTimeoutMs
+            requestTimeoutMillis = timeoutConfig.requestTimeoutMs
+            socketTimeoutMillis = timeoutConfig.socketTimeoutMs
         }
         install(HttpRequestRetry) {
-            retryOnServerErrors(maxRetries = MAX_RETRIES)
-            retryOnException(maxRetries = MAX_RETRIES, retryOnTimeout = true)
-            exponentialDelay(baseDelayMs = RETRY_BASE_DELAY_MS)
+            retryOnServerErrors(maxRetries = retryConfig.maxRetries)
+            retryOnException(maxRetries = retryConfig.maxRetries, retryOnTimeout = true)
+            exponentialDelay(baseDelayMs = retryConfig.baseDelayMs)
         }
         install(Logging) { level = LogLevel.NONE }
         defaultRequest { header(HttpHeaders.Accept, "application/json") }

--- a/core/core-network/src/commonMain/kotlin/com/riox432/civitdeck/data/api/webui/SDWebUIHttpClientFactory.kt
+++ b/core/core-network/src/commonMain/kotlin/com/riox432/civitdeck/data/api/webui/SDWebUIHttpClientFactory.kt
@@ -1,5 +1,6 @@
 package com.riox432.civitdeck.data.api.webui
 
+import com.riox432.civitdeck.data.api.TimeoutConfig
 import io.ktor.client.HttpClient
 import io.ktor.client.plugins.HttpTimeout
 import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
@@ -11,11 +12,9 @@ import io.ktor.http.HttpHeaders
 import io.ktor.serialization.kotlinx.json.json
 import kotlinx.serialization.json.Json
 
-private const val CONNECT_TIMEOUT_MS = 5_000L
-private const val REQUEST_TIMEOUT_MS = 300_000L
-private const val SOCKET_TIMEOUT_MS = 300_000L
-
-fun createSDWebUIHttpClient(): HttpClient {
+fun createSDWebUIHttpClient(
+    timeoutConfig: TimeoutConfig = TimeoutConfig.SDWebUI,
+): HttpClient {
     return HttpClient {
         install(ContentNegotiation) {
             json(
@@ -27,9 +26,9 @@ fun createSDWebUIHttpClient(): HttpClient {
             )
         }
         install(HttpTimeout) {
-            connectTimeoutMillis = CONNECT_TIMEOUT_MS
-            requestTimeoutMillis = REQUEST_TIMEOUT_MS
-            socketTimeoutMillis = SOCKET_TIMEOUT_MS
+            connectTimeoutMillis = timeoutConfig.connectTimeoutMs
+            requestTimeoutMillis = timeoutConfig.requestTimeoutMs
+            socketTimeoutMillis = timeoutConfig.socketTimeoutMs
         }
         install(Logging) { level = LogLevel.NONE }
         defaultRequest { header(HttpHeaders.Accept, "application/json") }

--- a/core/core-network/src/iosMain/kotlin/com/riox432/civitdeck/data/api/comfyui/ComfyUIHttpClientFactory.ios.kt
+++ b/core/core-network/src/iosMain/kotlin/com/riox432/civitdeck/data/api/comfyui/ComfyUIHttpClientFactory.ios.kt
@@ -1,5 +1,6 @@
 package com.riox432.civitdeck.data.api.comfyui
 
+import com.riox432.civitdeck.data.api.TimeoutConfig
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.darwin.Darwin
 import io.ktor.client.plugins.HttpTimeout
@@ -13,10 +14,6 @@ import io.ktor.http.HttpHeaders
 import io.ktor.serialization.kotlinx.json.json
 import kotlinx.serialization.json.Json
 
-private const val CONNECT_TIMEOUT_MS = 5_000L
-private const val REQUEST_TIMEOUT_MS = 120_000L
-private const val SOCKET_TIMEOUT_MS = 120_000L
-
 /**
  * Creates a Darwin-backed Ktor client with configurable TLS trust.
  * On iOS, full self-signed TLS bypass requires NSURLSessionDelegate configuration
@@ -25,7 +22,10 @@ private const val SOCKET_TIMEOUT_MS = 120_000L
  * trust store via Settings > General > About > Certificate Trust Settings, or use a tunnel
  * (Cloudflare/Tailscale).
  */
-actual fun createPlatformComfyUIHttpClient(trustSelfSignedCerts: Boolean): HttpClient {
+actual fun createPlatformComfyUIHttpClient(
+    trustSelfSignedCerts: Boolean,
+    timeoutConfig: TimeoutConfig,
+): HttpClient {
     return HttpClient(Darwin) {
         install(ContentNegotiation) {
             json(
@@ -37,9 +37,9 @@ actual fun createPlatformComfyUIHttpClient(trustSelfSignedCerts: Boolean): HttpC
             )
         }
         install(HttpTimeout) {
-            connectTimeoutMillis = CONNECT_TIMEOUT_MS
-            requestTimeoutMillis = REQUEST_TIMEOUT_MS
-            socketTimeoutMillis = SOCKET_TIMEOUT_MS
+            connectTimeoutMillis = timeoutConfig.connectTimeoutMs
+            requestTimeoutMillis = timeoutConfig.requestTimeoutMs
+            socketTimeoutMillis = timeoutConfig.socketTimeoutMs
         }
         install(Logging) { level = LogLevel.NONE }
         install(WebSockets)

--- a/core/core-network/src/jvmMain/kotlin/com/riox432/civitdeck/data/api/comfyui/ComfyUIHttpClientFactory.jvm.kt
+++ b/core/core-network/src/jvmMain/kotlin/com/riox432/civitdeck/data/api/comfyui/ComfyUIHttpClientFactory.jvm.kt
@@ -1,5 +1,6 @@
 package com.riox432.civitdeck.data.api.comfyui
 
+import com.riox432.civitdeck.data.api.TimeoutConfig
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.cio.CIO
 import io.ktor.client.plugins.HttpTimeout
@@ -15,17 +16,16 @@ import kotlinx.serialization.json.Json
 import java.security.cert.X509Certificate
 import javax.net.ssl.X509TrustManager
 
-private const val CONNECT_TIMEOUT_MS = 5_000L
-private const val REQUEST_TIMEOUT_MS = 120_000L
-private const val SOCKET_TIMEOUT_MS = 120_000L
-
 /**
  * Creates a CIO-backed Ktor client with configurable TLS trust.
  * When [trustSelfSignedCerts] is `true`, bypasses certificate validation for self-signed setups.
  * When `false`, uses the platform default trust manager (standard CA validation).
  */
 @Suppress("EmptyFunctionBlock", "TrustAllX509TrustManager", "CustomX509TrustManager")
-actual fun createPlatformComfyUIHttpClient(trustSelfSignedCerts: Boolean): HttpClient {
+actual fun createPlatformComfyUIHttpClient(
+    trustSelfSignedCerts: Boolean,
+    timeoutConfig: TimeoutConfig,
+): HttpClient {
     return HttpClient(CIO) {
         engine {
             if (trustSelfSignedCerts) {
@@ -53,9 +53,9 @@ actual fun createPlatformComfyUIHttpClient(trustSelfSignedCerts: Boolean): HttpC
             json(Json { ignoreUnknownKeys = true; isLenient = true; coerceInputValues = true })
         }
         install(HttpTimeout) {
-            connectTimeoutMillis = CONNECT_TIMEOUT_MS
-            requestTimeoutMillis = REQUEST_TIMEOUT_MS
-            socketTimeoutMillis = SOCKET_TIMEOUT_MS
+            connectTimeoutMillis = timeoutConfig.connectTimeoutMs
+            requestTimeoutMillis = timeoutConfig.requestTimeoutMs
+            socketTimeoutMillis = timeoutConfig.socketTimeoutMs
         }
         install(Logging) { level = LogLevel.NONE }
         install(WebSockets)


### PR DESCRIPTION
## Summary
- Created `TimeoutConfig` and `RetryConfig` data classes in `HttpClientConfig.kt` to consolidate duplicated timeout/retry constants across 6 HTTP client factories and the WebSocket API
- Each factory now accepts config parameters with sensible defaults (e.g., `TimeoutConfig.ComfyUI`, `TimeoutConfig.SDWebUI`, `RetryConfig.WebSocket`)
- All default values are preserved — no behavioral change

## Changed Files
- **New**: `HttpClientConfig.kt` — `TimeoutConfig` (with `PublicApi`, `ComfyUI`, `SDWebUI`, `ExternalServer` presets) and `RetryConfig` (with `Default`, `WebSocket` presets)
- **Updated**: `HttpClientFactory.kt`, `ComfyUIHttpClientFactory.kt` (common + 3 platform actuals), `SDWebUIHttpClientFactory.kt`, `ExternalServerHttpClientFactory.kt`, `HuggingFaceHttpClientFactory.kt`, `TensorArtHttpClientFactory.kt`, `ComfyUIWebSocketApi.kt`

## Test plan
- [ ] Detekt passes (verified locally)
- [ ] No behavioral change — all default values match the previous hardcoded constants

Closes #851