### PR TITLE
Replace @Volatile mutable vars with MutableStateFlow in API classes

### DIFF
--- a/core/core-network/src/commonMain/kotlin/com/riox432/civitdeck/data/api/comfyui/ComfyUIApi.kt
+++ b/core/core-network/src/commonMain/kotlin/com/riox432/civitdeck/data/api/comfyui/ComfyUIApi.kt
@@ -18,34 +18,33 @@ import io.ktor.http.HttpHeaders
 import io.ktor.http.URLBuilder
 import io.ktor.http.contentType
 import io.ktor.http.path
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.serialization.SerializationException
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.put
-import kotlin.concurrent.Volatile
 
 @Suppress("TooManyFunctions")
 class ComfyUIApi(
     private val client: HttpClient,
     private val json: Json,
 ) {
-    @Volatile
-    private var baseUrl: String = ""
+    private val _baseUrl = MutableStateFlow("")
 
     /**
      * Sets the API base URL. Accepts a full URL (e.g. "https://myserver:8188")
      * or falls back to constructing one from hostname + port.
      */
     fun setBaseUrl(url: String) {
-        baseUrl = url.trimEnd('/')
+        _baseUrl.value = url.trimEnd('/')
     }
 
     /**
      * Legacy overload: constructs http:// URL from hostname and port.
      */
     fun setBaseUrl(hostname: String, port: Int) {
-        baseUrl = "http://$hostname:$port"
+        _baseUrl.value = "http://$hostname:$port"
     }
 
     /**
@@ -56,7 +55,7 @@ class ComfyUIApi(
      * @throws ConnectTimeoutException on connection timeout
      */
     suspend fun getQueue(): QueueResponse =
-        logAndRethrow("getQueue") { client.get("$baseUrl/queue").body() }
+        logAndRethrow("getQueue") { client.get("${_baseUrl.value}/queue").body() }
 
     /**
      * Fetch available checkpoints: GET /object_info/CheckpointLoaderSimple
@@ -66,7 +65,7 @@ class ComfyUIApi(
      * @throws ConnectTimeoutException on connection timeout
      */
     suspend fun getCheckpoints(): List<String> = logAndRethrow("getCheckpoints") {
-        val text = client.get("$baseUrl/object_info/CheckpointLoaderSimple").bodyAsText()
+        val text = client.get("${_baseUrl.value}/object_info/CheckpointLoaderSimple").bodyAsText()
         parseCheckpointNames(text)
     }
 
@@ -78,7 +77,7 @@ class ComfyUIApi(
      * @throws ConnectTimeoutException on connection timeout
      */
     suspend fun getLoras(): List<String> = logAndRethrow("getLoras") {
-        val text = client.get("$baseUrl/object_info/LoraLoader").bodyAsText()
+        val text = client.get("${_baseUrl.value}/object_info/LoraLoader").bodyAsText()
         parseNodeInputList(text, "LoraLoader", "lora_name")
     }
 
@@ -90,7 +89,7 @@ class ComfyUIApi(
      * @throws ConnectTimeoutException on connection timeout
      */
     suspend fun getControlNets(): List<String> = logAndRethrow("getControlNets") {
-        val text = client.get("$baseUrl/object_info/ControlNetLoader").bodyAsText()
+        val text = client.get("${_baseUrl.value}/object_info/ControlNetLoader").bodyAsText()
         parseNodeInputList(text, "ControlNetLoader", "control_net_name")
     }
 
@@ -102,7 +101,7 @@ class ComfyUIApi(
      * @throws ConnectTimeoutException on connection timeout
      */
     suspend fun getFullObjectInfo(): String =
-        logAndRethrow("getFullObjectInfo") { client.get("$baseUrl/object_info").bodyAsText() }
+        logAndRethrow("getFullObjectInfo") { client.get("${_baseUrl.value}/object_info").bodyAsText() }
 
     /**
      * Submit workflow: POST /prompt
@@ -113,7 +112,7 @@ class ComfyUIApi(
      */
     suspend fun submitPrompt(workflow: JsonObject): PromptResponse = logAndRethrow("submitPrompt") {
         val body = buildJsonObject { put("prompt", workflow) }
-        client.post("$baseUrl/prompt") {
+        client.post("${_baseUrl.value}/prompt") {
             contentType(ContentType.Application.Json)
             setBody(body)
         }.body()
@@ -126,7 +125,7 @@ class ComfyUIApi(
      * @throws ConnectTimeoutException on connection timeout
      */
     suspend fun interrupt(): Unit =
-        logAndRethrow("interrupt") { client.post("$baseUrl/interrupt") }
+        logAndRethrow("interrupt") { client.post("${_baseUrl.value}/interrupt") }
 
     /**
      * Delete (cancel) queued prompts: POST /queue with {"delete": [...promptIds]}
@@ -143,7 +142,7 @@ class ComfyUIApi(
                 }
             )
         }
-        client.post("$baseUrl/queue") {
+        client.post("${_baseUrl.value}/queue") {
             contentType(ContentType.Application.Json)
             setBody(body)
         }
@@ -158,7 +157,7 @@ class ComfyUIApi(
      * @throws ConnectTimeoutException on connection timeout
      */
     suspend fun getAllHistory(): Map<String, HistoryEntry> = logAndRethrow("getAllHistory") {
-        val text = client.get("$baseUrl/history").bodyAsText()
+        val text = client.get("${_baseUrl.value}/history").bodyAsText()
         json.decodeFromString(text)
     }
 
@@ -171,7 +170,7 @@ class ComfyUIApi(
      */
     suspend fun getHistory(promptId: String): HistoryEntry? =
         logAndRethrow("getHistory (promptId=$promptId)") {
-            val text = client.get("$baseUrl/history/$promptId").bodyAsText()
+            val text = client.get("${_baseUrl.value}/history/$promptId").bodyAsText()
             val root = json.decodeFromString<Map<String, HistoryEntry>>(text)
             root[promptId]
         }
@@ -191,7 +190,7 @@ class ComfyUIApi(
         imageType: String = "input",
     ): UploadImageResponse = logAndRethrow("uploadImage") {
         client.submitFormWithBinaryData(
-            url = "$baseUrl/upload/image",
+            url = "${_baseUrl.value}/upload/image",
             formData = formData {
                 append(
                     "image",
@@ -215,7 +214,7 @@ class ComfyUIApi(
      * Omits subfolder when empty to avoid ComfyUI rejecting the request.
      */
     fun getImageUrl(image: ComfyUIOutputImage): String {
-        val url = baseUrl
+        val url = _baseUrl.value
         return URLBuilder(url).apply {
             path("view")
             parameters.append("filename", image.filename)

--- a/core/core-network/src/commonMain/kotlin/com/riox432/civitdeck/data/api/externalserver/ExternalServerApi.kt
+++ b/core/core-network/src/commonMain/kotlin/com/riox432/civitdeck/data/api/externalserver/ExternalServerApi.kt
@@ -14,8 +14,8 @@ import io.ktor.http.ContentType
 import io.ktor.http.URLBuilder
 import io.ktor.http.Url
 import io.ktor.http.contentType
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.io.IOException
-import kotlin.concurrent.Volatile
 
 /**
  * Holds the server configuration as an immutable snapshot so that
@@ -26,15 +26,14 @@ private data class ServerConfig(val baseUrl: String = "", val apiKey: String = "
 class ExternalServerApi(
     private val client: HttpClient,
 ) {
-    @Volatile
-    private var config: ServerConfig = ServerConfig()
+    private val _config = MutableStateFlow(ServerConfig())
 
     fun configure(baseUrl: String, apiKey: String) {
-        config = ServerConfig(baseUrl.trimEnd('/'), apiKey)
+        _config.value = ServerConfig(baseUrl.trimEnd('/'), apiKey)
     }
 
     suspend fun getCapabilities(): CapabilitiesResponseDto {
-        val cfg = config
+        val cfg = _config.value
         return client.get("${cfg.baseUrl}/capabilities") {
             if (cfg.apiKey.isNotBlank()) header("X-API-Key", cfg.apiKey)
         }.body()
@@ -45,7 +44,7 @@ class ExternalServerApi(
         perPage: Int,
         filters: Map<String, String>,
     ): PaginatedImagesResponseDto {
-        val cfg = config
+        val cfg = _config.value
         val url = URLBuilder("${cfg.baseUrl}/images").apply {
             parameters.append("page", page.toString())
             parameters.append("per_page", perPage.toString())
@@ -59,14 +58,14 @@ class ExternalServerApi(
     }
 
     suspend fun getGenerationOptions(): GenerationOptionsResponseDto {
-        val cfg = config
+        val cfg = _config.value
         return client.get("${cfg.baseUrl}/generation/options") {
             if (cfg.apiKey.isNotBlank()) header("X-API-Key", cfg.apiKey)
         }.body()
     }
 
     suspend fun getDependentChoices(endpoint: String): List<GenerationChoiceDto> {
-        val cfg = config
+        val cfg = _config.value
         // Absolute paths (starting with /) are resolved against the server origin,
         // not baseUrl, because servers may return full paths including their prefix.
         val url = when {
@@ -82,7 +81,7 @@ class ExternalServerApi(
     suspend fun executeGeneration(
         params: Map<String, String>,
     ): GenerationExecuteResponseDto {
-        val cfg = config
+        val cfg = _config.value
         return client.post("${cfg.baseUrl}/generation/execute") {
             if (cfg.apiKey.isNotBlank()) header("X-API-Key", cfg.apiKey)
             contentType(ContentType.Application.Json)
@@ -91,7 +90,7 @@ class ExternalServerApi(
     }
 
     suspend fun getGenerationStatus(jobId: String): GenerationStatusResponseDto {
-        val cfg = config
+        val cfg = _config.value
         return client.get("${cfg.baseUrl}/generation/status") {
             if (cfg.apiKey.isNotBlank()) header("X-API-Key", cfg.apiKey)
             url { parameters.append("job_id", jobId) }
@@ -99,7 +98,7 @@ class ExternalServerApi(
     }
 
     suspend fun deleteImage(cloudKey: String): DeleteResponseDto {
-        val cfg = config
+        val cfg = _config.value
         return client.post("${cfg.baseUrl}/images/delete") {
             if (cfg.apiKey.isNotBlank()) header("X-API-Key", cfg.apiKey)
             contentType(ContentType.Application.Json)
@@ -108,7 +107,7 @@ class ExternalServerApi(
     }
 
     suspend fun deleteImages(cloudKeys: List<String>): DeleteResponseDto {
-        val cfg = config
+        val cfg = _config.value
         return client.post("${cfg.baseUrl}/images/delete-bulk") {
             if (cfg.apiKey.isNotBlank()) header("X-API-Key", cfg.apiKey)
             contentType(ContentType.Application.Json)
@@ -120,7 +119,7 @@ class ExternalServerApi(
      * Health check: tries GET /capabilities and returns true if reachable.
      */
     suspend fun testConnection(): Boolean = try {
-        val cfg = config
+        val cfg = _config.value
         client.get("${cfg.baseUrl}/capabilities") {
             if (cfg.apiKey.isNotBlank()) header("X-API-Key", cfg.apiKey)
         }

--- a/core/core-network/src/commonMain/kotlin/com/riox432/civitdeck/data/api/webui/SDWebUIApi.kt
+++ b/core/core-network/src/commonMain/kotlin/com/riox432/civitdeck/data/api/webui/SDWebUIApi.kt
@@ -11,15 +11,14 @@ import io.ktor.client.request.post
 import io.ktor.client.request.setBody
 import io.ktor.http.ContentType
 import io.ktor.http.contentType
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.serialization.SerializationException
-import kotlin.concurrent.Volatile
 
 class SDWebUIApi(private val client: HttpClient) {
-    @Volatile
-    private var baseUrl: String = ""
+    private val _baseUrl = MutableStateFlow("")
 
     fun setBaseUrl(hostname: String, port: Int) {
-        baseUrl = "http://$hostname:$port"
+        _baseUrl.value = "http://$hostname:$port"
     }
 
     /**
@@ -29,7 +28,7 @@ class SDWebUIApi(private val client: HttpClient) {
      * @throws ConnectTimeoutException on connection timeout
      */
     suspend fun getModels(): List<SDWebUIModelInfo> =
-        logAndRethrow("getModels") { client.get("$baseUrl/sdapi/v1/sd-models").body() }
+        logAndRethrow("getModels") { client.get("${_baseUrl.value}/sdapi/v1/sd-models").body() }
 
     /**
      * @throws ResponseException on HTTP error response
@@ -38,7 +37,7 @@ class SDWebUIApi(private val client: HttpClient) {
      * @throws ConnectTimeoutException on connection timeout
      */
     suspend fun getSamplers(): List<SDWebUISamplerInfo> =
-        logAndRethrow("getSamplers") { client.get("$baseUrl/sdapi/v1/samplers").body() }
+        logAndRethrow("getSamplers") { client.get("${_baseUrl.value}/sdapi/v1/samplers").body() }
 
     /**
      * @throws ResponseException on HTTP error response
@@ -47,7 +46,7 @@ class SDWebUIApi(private val client: HttpClient) {
      * @throws ConnectTimeoutException on connection timeout
      */
     suspend fun getVaes(): List<SDWebUIVaeInfo> =
-        logAndRethrow("getVaes") { client.get("$baseUrl/sdapi/v1/vae").body() }
+        logAndRethrow("getVaes") { client.get("${_baseUrl.value}/sdapi/v1/vae").body() }
 
     /**
      * @throws ResponseException on HTTP error response
@@ -57,7 +56,7 @@ class SDWebUIApi(private val client: HttpClient) {
      */
     suspend fun txt2img(request: SDWebUITxt2ImgRequest): SDWebUIGenerationResponse =
         logAndRethrow("txt2img") {
-            client.post("$baseUrl/sdapi/v1/txt2img") {
+            client.post("${_baseUrl.value}/sdapi/v1/txt2img") {
                 contentType(ContentType.Application.Json)
                 setBody(request)
             }.body()
@@ -71,7 +70,7 @@ class SDWebUIApi(private val client: HttpClient) {
      */
     suspend fun img2img(request: SDWebUIImg2ImgRequest): SDWebUIGenerationResponse =
         logAndRethrow("img2img") {
-            client.post("$baseUrl/sdapi/v1/img2img") {
+            client.post("${_baseUrl.value}/sdapi/v1/img2img") {
                 contentType(ContentType.Application.Json)
                 setBody(request)
             }.body()
@@ -85,7 +84,7 @@ class SDWebUIApi(private val client: HttpClient) {
      */
     suspend fun getProgress(): SDWebUIProgressResponse =
         logAndRethrow("getProgress") {
-            client.get("$baseUrl/sdapi/v1/progress?skip_current_image=true").body()
+            client.get("${_baseUrl.value}/sdapi/v1/progress?skip_current_image=true").body()
         }
 
     /**
@@ -94,7 +93,7 @@ class SDWebUIApi(private val client: HttpClient) {
      * @throws ConnectTimeoutException on connection timeout
      */
     suspend fun interrupt(): Unit =
-        logAndRethrow("interrupt") { client.post("$baseUrl/sdapi/v1/interrupt") }
+        logAndRethrow("interrupt") { client.post("${_baseUrl.value}/sdapi/v1/interrupt") }
 
     /**
      * Executes [block], catching known Ktor / serialization exceptions,


### PR DESCRIPTION
## Summary
- Replace `@Volatile private var baseUrl` in `ComfyUIApi` and `SDWebUIApi` with `private val _baseUrl = MutableStateFlow("")`
- Replace `@Volatile private var config` in `ExternalServerApi` with `private val _config = MutableStateFlow(ServerConfig())`
- All read sites updated to use `.value` — thread-safe, idiomatic Kotlin coroutines pattern
- Removes `kotlin.concurrent.Volatile` import from all three files

Closes #816