### PR TITLE
Move hardcoded user-facing strings to string resources

### DIFF
--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/analytics/AnalyticsScreen.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/analytics/AnalyticsScreen.kt
@@ -55,7 +55,7 @@ fun AnalyticsScreen(viewModel: AnalyticsViewModel, onBack: () -> Unit) {
     Scaffold(
         topBar = {
             TopAppBar(
-                title = { Text("Usage Stats") },
+                title = { Text(stringResource(R.string.analytics_title)) },
                 navigationIcon = {
                     IconButton(onClick = onBack) {
                         Icon(

--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/backup/BackupScreen.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/backup/BackupScreen.kt
@@ -96,7 +96,7 @@ fun BackupScreen(
 @Composable
 private fun BackupTopBar(onBack: () -> Unit) {
     TopAppBar(
-        title = { Text("Backup & Restore") },
+        title = { Text(stringResource(R.string.backup_title)) },
         navigationIcon = {
             IconButton(onClick = onBack) {
                 Icon(
@@ -145,7 +145,7 @@ private fun BackupContent(
     LazyColumn(
         modifier = Modifier.fillMaxSize().padding(padding),
     ) {
-        item { SectionTitle("Select Data") }
+        item { SectionTitle(stringResource(R.string.backup_select_data)) }
         item { SelectionControls(viewModel) }
         items(BackupCategory.entries.toList(), key = { it.name }) { category ->
             CategoryRow(
@@ -178,8 +178,8 @@ private fun SelectionControls(viewModel: BackupViewModel) {
             .padding(horizontal = Spacing.lg),
         horizontalArrangement = Arrangement.spacedBy(Spacing.sm),
     ) {
-        TextButton(onClick = viewModel::onSelectAll) { Text("Select All") }
-        TextButton(onClick = viewModel::onDeselectAll) { Text("Deselect All") }
+        TextButton(onClick = viewModel::onSelectAll) { Text(stringResource(R.string.action_select_all)) }
+        TextButton(onClick = viewModel::onDeselectAll) { Text(stringResource(R.string.action_deselect_all)) }
     }
 }
 
@@ -228,7 +228,7 @@ private fun ActionButtons(
                     color = MaterialTheme.colorScheme.onPrimary,
                 )
             }
-            Text("Export Backup")
+            Text(stringResource(R.string.backup_export))
         }
         OutlinedButton(
             onClick = { importLauncher.launch(arrayOf("application/json", "application/octet-stream", "*/*")) },
@@ -238,7 +238,7 @@ private fun ActionButtons(
             if (state.isImporting) {
                 CircularProgressIndicator(modifier = Modifier.padding(end = Spacing.sm))
             }
-            Text("Import from File")
+            Text(stringResource(R.string.backup_import))
         }
         Spacer(Modifier.height(Spacing.lg))
     }
@@ -254,16 +254,16 @@ private fun ImportConfirmationDialog(
 ) {
     AlertDialog(
         onDismissRequest = onDismiss,
-        title = { Text("Restore Backup") },
+        title = { Text(stringResource(R.string.backup_restore_title)) },
         text = { ImportDialogContent(state, onStrategyChanged, onToggleCategory) },
         confirmButton = {
             TextButton(
                 onClick = onConfirm,
                 enabled = state.selectedCategories.isNotEmpty(),
-            ) { Text("Restore") }
+            ) { Text(stringResource(R.string.action_restore)) }
         },
         dismissButton = {
-            TextButton(onClick = onDismiss) { Text("Cancel") }
+            TextButton(onClick = onDismiss) { Text(stringResource(R.string.action_cancel)) }
         },
     )
 }
@@ -276,11 +276,11 @@ private fun ImportDialogContent(
 ) {
     Column {
         Text(
-            "Found data for ${state.importCategories.size} categories.",
+            stringResource(R.string.backup_found_categories, state.importCategories.size),
             style = MaterialTheme.typography.bodyMedium,
         )
         Spacer(Modifier.height(Spacing.md))
-        Text("Restore Strategy:", style = MaterialTheme.typography.titleSmall)
+        Text(stringResource(R.string.backup_restore_strategy), style = MaterialTheme.typography.titleSmall)
         RestoreStrategy.entries.forEach { strategy ->
             key(strategy.name) {
                 Row(
@@ -299,7 +299,7 @@ private fun ImportDialogContent(
             }
         }
         Spacer(Modifier.height(Spacing.sm))
-        Text("Categories to restore:", style = MaterialTheme.typography.titleSmall)
+        Text(stringResource(R.string.backup_categories_to_restore), style = MaterialTheme.typography.titleSmall)
         state.importCategories.forEach { category ->
             key(category.name) {
                 Row(

--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/collections/AddToCollectionSheet.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/collections/AddToCollectionSheet.kt
@@ -69,7 +69,7 @@ fun AddToCollectionSheet(
                 modifier = Modifier.padding(horizontal = Spacing.md),
             ) {
                 Icon(Icons.Default.Add, contentDescription = stringResource(R.string.cd_create_new_collection))
-                Text("Create New Collection", modifier = Modifier.padding(start = Spacing.sm))
+                Text(stringResource(R.string.collection_create_new), modifier = Modifier.padding(start = Spacing.sm))
             }
         }
     }

--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/collections/CollectionDetailScreen.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/collections/CollectionDetailScreen.kt
@@ -233,7 +233,7 @@ private fun TypeDropdown(
 ) {
     DropdownMenu(expanded = expanded, onDismissRequest = onDismiss) {
         DropdownMenuItem(
-            text = { Text("All Types") },
+            text = { Text(stringResource(R.string.collection_all_types)) },
             onClick = {
                 onTypeFilterChange(null)
                 onDismiss()

--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/collections/CollectionsScreen.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/collections/CollectionsScreen.kt
@@ -297,7 +297,7 @@ private fun CollectionOverflowMenu(
             onDismissRequest = { onToggleMenu(false) },
         ) {
             DropdownMenuItem(
-                text = { Text("Rename") },
+                text = { Text(stringResource(R.string.action_rename)) },
                 leadingIcon = { Icon(Icons.Default.Edit, contentDescription = stringResource(R.string.cd_rename)) },
                 onClick = {
                     onToggleMenu(false)
@@ -305,7 +305,7 @@ private fun CollectionOverflowMenu(
                 },
             )
             DropdownMenuItem(
-                text = { Text("Delete") },
+                text = { Text(stringResource(R.string.action_delete)) },
                 leadingIcon = { Icon(Icons.Default.Delete, contentDescription = stringResource(R.string.cd_delete)) },
                 onClick = {
                     onToggleMenu(false)
@@ -356,12 +356,12 @@ internal fun CreateCollectionDialog(
 
     AlertDialog(
         onDismissRequest = onDismiss,
-        title = { Text("New Collection") },
+        title = { Text(stringResource(R.string.collection_new_title)) },
         text = {
             OutlinedTextField(
                 value = name,
                 onValueChange = { name = it },
-                label = { Text("Collection name") },
+                label = { Text(stringResource(R.string.collection_name_label)) },
                 singleLine = true,
             )
         },
@@ -370,12 +370,12 @@ internal fun CreateCollectionDialog(
                 onClick = { onConfirm(name.trim()) },
                 enabled = name.isNotBlank(),
             ) {
-                Text("Create")
+                Text(stringResource(R.string.action_create))
             }
         },
         dismissButton = {
             TextButton(onClick = onDismiss) {
-                Text("Cancel")
+                Text(stringResource(R.string.action_cancel))
             }
         },
     )
@@ -389,13 +389,13 @@ private fun DeleteCollectionDialog(
 ) {
     AlertDialog(
         onDismissRequest = onDismiss,
-        title = { Text("Delete Collection") },
-        text = { Text("Are you sure you want to delete \"$collectionName\"? This cannot be undone.") },
+        title = { Text(stringResource(R.string.collection_delete_title)) },
+        text = { Text(stringResource(R.string.collection_delete_confirm, collectionName)) },
         confirmButton = {
-            TextButton(onClick = onConfirm) { Text("Delete") }
+            TextButton(onClick = onConfirm) { Text(stringResource(R.string.action_delete)) }
         },
         dismissButton = {
-            TextButton(onClick = onDismiss) { Text("Cancel") }
+            TextButton(onClick = onDismiss) { Text(stringResource(R.string.action_cancel)) }
         },
     )
 }
@@ -410,12 +410,12 @@ private fun RenameCollectionDialog(
 
     AlertDialog(
         onDismissRequest = onDismiss,
-        title = { Text("Rename Collection") },
+        title = { Text(stringResource(R.string.collection_rename_title)) },
         text = {
             OutlinedTextField(
                 value = name,
                 onValueChange = { name = it },
-                label = { Text("Collection name") },
+                label = { Text(stringResource(R.string.collection_name_label)) },
                 singleLine = true,
             )
         },
@@ -424,12 +424,12 @@ private fun RenameCollectionDialog(
                 onClick = { onConfirm(name.trim()) },
                 enabled = name.isNotBlank(),
             ) {
-                Text("Rename")
+                Text(stringResource(R.string.action_rename))
             }
         },
         dismissButton = {
             TextButton(onClick = onDismiss) {
-                Text("Cancel")
+                Text(stringResource(R.string.action_cancel))
             }
         },
     )

--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/comfyhub/ComfyHubBrowserScreen.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/comfyhub/ComfyHubBrowserScreen.kt
@@ -60,7 +60,7 @@ fun ComfyHubBrowserScreen(
     Scaffold(
         topBar = {
             TopAppBar(
-                title = { Text("ComfyHub Workflows") },
+                title = { Text(stringResource(R.string.comfyhub_workflows_title)) },
                 navigationIcon = {
                     IconButton(onClick = onBack) {
                         Icon(
@@ -91,7 +91,7 @@ private fun SearchBar(query: String, onQueryChange: (String) -> Unit) {
         modifier = Modifier
             .fillMaxWidth()
             .padding(horizontal = Spacing.md, vertical = Spacing.sm),
-        placeholder = { Text("Search workflows...") },
+        placeholder = { Text(stringResource(R.string.comfyhub_search_placeholder)) },
         singleLine = true,
     )
 }

--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/comfyhub/ComfyHubDetailScreen.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/comfyhub/ComfyHubDetailScreen.kt
@@ -227,10 +227,10 @@ private fun ImportButton(isImporting: Boolean, onImport: () -> Unit) {
                 modifier = Modifier.size(16.dp),
                 strokeWidth = 2.dp,
             )
-            Text("Importing...", modifier = Modifier.padding(start = Spacing.sm))
+            Text(stringResource(R.string.label_importing), modifier = Modifier.padding(start = Spacing.sm))
         } else {
             Icon(Icons.Outlined.Download, contentDescription = "Import workflow")
-            Text("Import to ComfyUI", modifier = Modifier.padding(start = Spacing.sm))
+            Text(stringResource(R.string.comfyhub_import_to_comfyui), modifier = Modifier.padding(start = Spacing.sm))
         }
     }
 }

--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/comfyui/CivitaiLinkSettingsScreen.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/comfyui/CivitaiLinkSettingsScreen.kt
@@ -58,7 +58,7 @@ fun CivitaiLinkSettingsScreen(
     Scaffold(
         topBar = {
             TopAppBar(
-                title = { Text("Civitai Link") },
+                title = { Text(stringResource(R.string.civitai_link_title)) },
                 navigationIcon = {
                     IconButton(onClick = onBack) {
                         Icon(
@@ -126,7 +126,7 @@ private fun StatusCard(
             }
             if (state.status == CivitaiLinkStatus.Connected) {
                 TextButton(onClick = onDisconnect) {
-                    Text("Disconnect", color = MaterialTheme.colorScheme.error)
+                    Text(stringResource(R.string.action_disconnect), color = MaterialTheme.colorScheme.error)
                 }
             }
         }
@@ -164,8 +164,8 @@ private fun ConfigCard(
             OutlinedTextField(
                 value = state.linkKey,
                 onValueChange = onKeyChanged,
-                label = { Text("Link Key") },
-                placeholder = { Text("Paste your Civitai Link key here") },
+                label = { Text(stringResource(R.string.civitai_link_key_label)) },
+                placeholder = { Text(stringResource(R.string.civitai_link_key_placeholder)) },
                 visualTransformation = PasswordVisualTransformation(),
                 singleLine = true,
                 modifier = Modifier.fillMaxWidth(),
@@ -256,7 +256,7 @@ private fun ActivityCard(
                         contentColor = MaterialTheme.colorScheme.error,
                     ),
                 ) {
-                    Text("Cancel")
+                    Text(stringResource(R.string.action_cancel))
                 }
             }
         }

--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/comfyui/ComfyUIGenerationScreen.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/comfyui/ComfyUIGenerationScreen.kt
@@ -79,14 +79,16 @@ private fun SaveResultSnackbar(
     snackbarHostState: SnackbarHostState,
     onDismiss: () -> Unit,
 ) {
+    val savedMessage = stringResource(R.string.comfyui_image_saved)
+    val failedMessage = stringResource(R.string.comfyui_image_save_failed)
     LaunchedEffect(imageSaveSuccess) {
         when (imageSaveSuccess) {
             true -> {
-                snackbarHostState.showSnackbar("Image saved to gallery")
+                snackbarHostState.showSnackbar(savedMessage)
                 onDismiss()
             }
             false -> {
-                snackbarHostState.showSnackbar("Failed to save image")
+                snackbarHostState.showSnackbar(failedMessage)
                 onDismiss()
             }
             null -> {}
@@ -104,7 +106,7 @@ private fun GenerationTopBar(
 ) {
     Column {
         TopAppBar(
-            title = { Text("txt2img") },
+            title = { Text(stringResource(R.string.comfyui_txt2img_title)) },
             navigationIcon = {
                 IconButton(onClick = onBack) {
                     Icon(
@@ -166,7 +168,11 @@ private fun LoraSection(state: GenerationUiState, viewModel: ComfyUIGenerationVi
     Card(modifier = Modifier.fillMaxWidth()) {
         Column(modifier = Modifier.padding(Spacing.md), verticalArrangement = Arrangement.spacedBy(Spacing.sm)) {
             Row(verticalAlignment = Alignment.CenterVertically) {
-                Text("LoRA", style = MaterialTheme.typography.labelLarge, modifier = Modifier.weight(1f))
+                Text(
+                    stringResource(R.string.comfyui_lora_label),
+                    style = MaterialTheme.typography.labelLarge,
+                    modifier = Modifier.weight(1f)
+                )
                 IconButton(onClick = { expanded = true }, enabled = state.availableLoras.isNotEmpty()) {
                     Icon(Icons.Default.Add, contentDescription = stringResource(R.string.cd_add_lora))
                 }
@@ -187,7 +193,7 @@ private fun LoraSection(state: GenerationUiState, viewModel: ComfyUIGenerationVi
             }
             if (state.availableLoras.isEmpty() && !state.isLoadingLoras) {
                 Text(
-                    "No LoRAs found on server",
+                    stringResource(R.string.comfyui_no_loras),
                     style = MaterialTheme.typography.bodySmall,
                     color = MaterialTheme.colorScheme.onSurfaceVariant
                 )
@@ -225,7 +231,11 @@ private fun ControlNetSection(state: GenerationUiState, viewModel: ComfyUIGenera
     Card(modifier = Modifier.fillMaxWidth()) {
         Column(modifier = Modifier.padding(Spacing.md), verticalArrangement = Arrangement.spacedBy(Spacing.sm)) {
             Row(verticalAlignment = Alignment.CenterVertically) {
-                Text("ControlNet", style = MaterialTheme.typography.labelLarge, modifier = Modifier.weight(1f))
+                Text(
+                    stringResource(R.string.comfyui_controlnet_label),
+                    style = MaterialTheme.typography.labelLarge,
+                    modifier = Modifier.weight(1f)
+                )
                 Switch(checked = state.controlNetEnabled, onCheckedChange = viewModel::onControlNetToggled)
             }
             if (state.controlNetEnabled) {
@@ -320,17 +330,20 @@ private fun CustomWorkflowContent(state: GenerationUiState, onImport: () -> Unit
         )
         if (state.extractedParameters.isNotEmpty()) {
             Button(onClick = onEditParams, modifier = Modifier.fillMaxWidth()) {
-                Text("Edit Parameters (${state.extractedParameters.size})")
+                Text(stringResource(R.string.comfyui_edit_parameters_count, state.extractedParameters.size))
             }
         } else if (state.isLoadingParameters) {
             Text(
-                "Loading parameters...",
+                stringResource(R.string.comfyui_loading_parameters),
                 style = MaterialTheme.typography.bodySmall,
                 color = MaterialTheme.colorScheme.onSurfaceVariant
             )
         }
     } else {
-        Button(onClick = onImport, modifier = Modifier.fillMaxWidth()) { Text("Import Workflow JSON") }
+        Button(
+            onClick = onImport,
+            modifier = Modifier.fillMaxWidth()
+        ) { Text(stringResource(R.string.comfyui_import_workflow_json)) }
     }
 }
 
@@ -343,19 +356,19 @@ private fun WorkflowImportDialog(
 ) {
     androidx.compose.material3.AlertDialog(
         onDismissRequest = onDismiss,
-        title = { Text("Paste ComfyUI Workflow JSON") },
+        title = { Text(stringResource(R.string.comfyui_paste_workflow_json)) },
         text = {
             OutlinedTextField(
                 value = text,
                 onValueChange = onTextChange,
-                label = { Text("Workflow JSON") },
+                label = { Text(stringResource(R.string.comfyui_workflow_json_label)) },
                 modifier = Modifier.fillMaxWidth(),
                 minLines = 6,
                 maxLines = 12,
             )
         },
-        confirmButton = { Button(onClick = onConfirm) { Text("Import") } },
-        dismissButton = { TextButton(onClick = onDismiss) { Text("Cancel") } },
+        confirmButton = { Button(onClick = onConfirm) { Text(stringResource(R.string.action_import)) } },
+        dismissButton = { TextButton(onClick = onDismiss) { Text(stringResource(R.string.action_cancel)) } },
     )
 }
 
@@ -395,7 +408,7 @@ private fun InpaintingMaskContent(
                 modifier = Modifier.weight(1f),
             )
             TextButton(onClick = viewModel::onClearMask) {
-                Text("Clear")
+                Text(stringResource(R.string.action_clear))
             }
         }
         SliderRow(
@@ -416,7 +429,7 @@ private fun InpaintingMaskContent(
             },
             modifier = Modifier.fillMaxWidth(),
         ) {
-            Text("Add Mask")
+            Text(stringResource(R.string.comfyui_add_mask))
         }
     }
 }

--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/comfyui/ComfyUIHistoryScreen.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/comfyui/ComfyUIHistoryScreen.kt
@@ -87,7 +87,7 @@ fun ComfyUIHistoryScreen(
     Scaffold(
         topBar = {
             TopAppBar(
-                title = { Text("Output Gallery") },
+                title = { Text(stringResource(R.string.comfyui_output_gallery_title)) },
                 navigationIcon = {
                     IconButton(onClick = onBack) {
                         Icon(
@@ -265,7 +265,7 @@ private fun HistoryImageItem(
             onDismissRequest = { showMenu = false },
         ) {
             DropdownMenuItem(
-                text = { Text("Add to Dataset") },
+                text = { Text(stringResource(R.string.comfyui_add_to_dataset)) },
                 onClick = {
                     showMenu = false
                     onAddToDataset()

--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/comfyui/ComfyUIParameterSection.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/comfyui/ComfyUIParameterSection.kt
@@ -20,6 +20,8 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import com.riox432.civitdeck.R
 import com.riox432.civitdeck.feature.comfyui.presentation.ComfyUIGenerationViewModel
 import com.riox432.civitdeck.feature.comfyui.presentation.GenerationUiState
 import com.riox432.civitdeck.ui.components.LoadingStateOverlay
@@ -32,7 +34,7 @@ internal fun CheckpointSelector(
 ) {
     var expanded by remember { mutableStateOf(false) }
     Column {
-        Text("Checkpoint", style = MaterialTheme.typography.labelMedium)
+        Text(stringResource(R.string.comfyui_checkpoint_label), style = MaterialTheme.typography.labelMedium)
         if (state.isLoadingCheckpoints) {
             LoadingStateOverlay()
         } else {
@@ -62,7 +64,7 @@ internal fun PromptInputs(state: GenerationUiState, viewModel: ComfyUIGeneration
     OutlinedTextField(
         value = state.prompt,
         onValueChange = viewModel::onPromptChanged,
-        label = { Text("Prompt") },
+        label = { Text(stringResource(R.string.label_prompt)) },
         modifier = Modifier.fillMaxWidth(),
         minLines = 3,
         maxLines = 6,
@@ -70,7 +72,7 @@ internal fun PromptInputs(state: GenerationUiState, viewModel: ComfyUIGeneration
     OutlinedTextField(
         value = state.negativePrompt,
         onValueChange = viewModel::onNegativePromptChanged,
-        label = { Text("Negative Prompt") },
+        label = { Text(stringResource(R.string.label_negative_prompt)) },
         modifier = Modifier.fillMaxWidth(),
         minLines = 2,
         maxLines = 4,
@@ -143,14 +145,14 @@ private fun ResolutionRow(
         OutlinedTextField(
             value = width.toString(),
             onValueChange = { it.toIntOrNull()?.let(viewModel::onWidthChanged) },
-            label = { Text("Width") },
+            label = { Text(stringResource(R.string.comfyui_width_label)) },
             modifier = Modifier.weight(1f),
             singleLine = true,
         )
         OutlinedTextField(
             value = height.toString(),
             onValueChange = { it.toIntOrNull()?.let(viewModel::onHeightChanged) },
-            label = { Text("Height") },
+            label = { Text(stringResource(R.string.comfyui_height_label)) },
             modifier = Modifier.weight(1f),
             singleLine = true,
         )
@@ -165,7 +167,7 @@ private fun SeedInput(seed: Long, onChanged: (Long) -> Unit) {
             val parsed = it.toLongOrNull() ?: -1L
             onChanged(parsed)
         },
-        label = { Text("Seed (-1 = random)") },
+        label = { Text(stringResource(R.string.comfyui_seed_label)) },
         modifier = Modifier.fillMaxWidth(),
         singleLine = true,
     )

--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/comfyui/ComfyUIQueueScreen.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/comfyui/ComfyUIQueueScreen.kt
@@ -49,7 +49,7 @@ fun ComfyUIQueueScreen(
     Scaffold(
         topBar = {
             TopAppBar(
-                title = { Text("Queue") },
+                title = { Text(stringResource(R.string.comfyui_queue_title)) },
                 navigationIcon = {
                     IconButton(onClick = onBack) {
                         Icon(

--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/comfyui/ComfyUIResultSection.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/comfyui/ComfyUIResultSection.kt
@@ -110,7 +110,7 @@ private fun GenerationProgressSection(state: GenerationUiState) {
             )
         } else {
             LinearProgressIndicator(modifier = Modifier.fillMaxWidth())
-            Text("Generating...", style = MaterialTheme.typography.bodySmall)
+            Text(stringResource(R.string.comfyui_result_generating), style = MaterialTheme.typography.bodySmall)
         }
         if (state.currentNodeName.isNotEmpty()) {
             Text(

--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/comfyui/ComfyUISettingsScreen.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/comfyui/ComfyUISettingsScreen.kt
@@ -69,7 +69,7 @@ fun ComfyUISettingsScreen(
     Scaffold(
         topBar = {
             TopAppBar(
-                title = { Text("ComfyUI") },
+                title = { Text(stringResource(R.string.comfyui_title)) },
                 navigationIcon = {
                     IconButton(onClick = onBack) {
                         Icon(
@@ -134,12 +134,12 @@ private fun LazyListScope.settingsItems(
     if (state.connectionStatus == ComfyUIConnectionStatus.Connected) {
         item {
             TextButton(onClick = onNavigateToGeneration, modifier = Modifier.fillMaxWidth()) {
-                Text("Open txt2img Generator")
+                Text(stringResource(R.string.comfyui_open_txt2img))
             }
         }
         item {
             TextButton(onClick = onNavigateToHistory, modifier = Modifier.fillMaxWidth()) {
-                Text("View Output Gallery")
+                Text(stringResource(R.string.comfyui_view_gallery))
             }
         }
     }
@@ -202,7 +202,7 @@ private fun StatusHeader(state: ComfyUISettingsUiState, onTest: () -> Unit) {
         if (state.isTesting) {
             CircularProgressIndicator(modifier = Modifier.size(24.dp))
         } else if (state.activeConnection != null) {
-            TextButton(onClick = onTest) { Text("Test") }
+            TextButton(onClick = onTest) { Text(stringResource(R.string.action_test)) }
         }
     }
 }
@@ -236,11 +236,11 @@ private fun ScanLanSection(
                 horizontalArrangement = Arrangement.SpaceBetween,
                 verticalAlignment = Alignment.CenterVertically,
             ) {
-                Text("LAN Discovery", style = MaterialTheme.typography.titleSmall)
+                Text(stringResource(R.string.comfyui_lan_discovery), style = MaterialTheme.typography.titleSmall)
                 if (state.isScanning) {
                     CircularProgressIndicator(modifier = Modifier.size(24.dp))
                 } else {
-                    OutlinedButton(onClick = onScan) { Text("Scan LAN") }
+                    OutlinedButton(onClick = onScan) { Text(stringResource(R.string.comfyui_scan_lan)) }
                 }
             }
             if (state.discoveredServers.isNotEmpty()) {
@@ -250,7 +250,7 @@ private fun ScanLanSection(
                 }
             } else if (!state.isScanning) {
                 Text(
-                    "Scan your local network for ComfyUI servers",
+                    stringResource(R.string.comfyui_lan_scan_hint),
                     style = MaterialTheme.typography.bodySmall,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                 )
@@ -272,7 +272,7 @@ private fun DiscoveredServerRow(server: DiscoveredServer, onSelect: (DiscoveredS
             Text(server.displayName, style = MaterialTheme.typography.bodyMedium)
             Text("${server.ip}:${server.port}", style = MaterialTheme.typography.bodySmall)
         }
-        TextButton(onClick = { onSelect(server) }) { Text("Add") }
+        TextButton(onClick = { onSelect(server) }) { Text(stringResource(R.string.action_add)) }
     }
 }
 
@@ -330,7 +330,13 @@ private fun AddConnectionDialog(
 
     AlertDialog(
         onDismissRequest = onDismiss,
-        title = { Text(if (editing != null) "Edit Connection" else "Add Connection") },
+        title = {
+            Text(
+                stringResource(
+                    if (editing != null) R.string.comfyui_edit_connection else R.string.comfyui_add_connection
+                )
+            )
+        },
         text = {
             AddConnectionDialogContent(
                 name = name,
@@ -352,9 +358,9 @@ private fun AddConnectionDialog(
                     onSave(name.ifBlank { hostname }, hostname, port, useHttps, acceptSelfSigned)
                 },
                 enabled = hostname.isNotBlank(),
-            ) { Text("Save") }
+            ) { Text(stringResource(R.string.action_save)) }
         },
-        dismissButton = { TextButton(onClick = onDismiss) { Text("Cancel") } },
+        dismissButton = { TextButton(onClick = onDismiss) { Text(stringResource(R.string.action_cancel)) } },
     )
 }
 
@@ -376,23 +382,23 @@ private fun AddConnectionDialogContent(
         OutlinedTextField(
             value = name,
             onValueChange = onNameChange,
-            label = { Text("Name") },
-            placeholder = { Text("e.g. Home PC") },
+            label = { Text(stringResource(R.string.label_name)) },
+            placeholder = { Text(stringResource(R.string.comfyui_name_placeholder)) },
             singleLine = true,
             modifier = Modifier.fillMaxWidth(),
         )
         OutlinedTextField(
             value = hostname,
             onValueChange = onHostnameChange,
-            label = { Text("Hostname / IP") },
-            placeholder = { Text("192.168.1.100") },
+            label = { Text(stringResource(R.string.comfyui_hostname_label)) },
+            placeholder = { Text(stringResource(R.string.comfyui_hostname_placeholder)) },
             singleLine = true,
             modifier = Modifier.fillMaxWidth(),
         )
         OutlinedTextField(
             value = portText,
             onValueChange = onPortChange,
-            label = { Text("Port") },
+            label = { Text(stringResource(R.string.label_port)) },
             singleLine = true,
             modifier = Modifier.fillMaxWidth(),
         )
@@ -401,7 +407,7 @@ private fun AddConnectionDialogContent(
             horizontalArrangement = Arrangement.SpaceBetween,
             verticalAlignment = Alignment.CenterVertically,
         ) {
-            Text("Use HTTPS", style = MaterialTheme.typography.bodyMedium)
+            Text(stringResource(R.string.comfyui_use_https), style = MaterialTheme.typography.bodyMedium)
             Switch(checked = useHttps, onCheckedChange = onHttpsChange)
         }
         if (useHttps) {
@@ -410,17 +416,18 @@ private fun AddConnectionDialogContent(
                 horizontalArrangement = Arrangement.SpaceBetween,
                 verticalAlignment = Alignment.CenterVertically,
             ) {
-                Text("Accept self-signed certificates", style = MaterialTheme.typography.bodySmall)
+                Text(stringResource(R.string.comfyui_accept_self_signed), style = MaterialTheme.typography.bodySmall)
                 Switch(checked = acceptSelfSigned, onCheckedChange = onSelfSignedChange)
             }
         }
     }
 }
 
+@Composable
 private fun statusLabel(status: ComfyUIConnectionStatus): String = when (status) {
-    ComfyUIConnectionStatus.Connected -> "Connected"
-    ComfyUIConnectionStatus.Disconnected -> "Disconnected"
-    ComfyUIConnectionStatus.Testing -> "Testing..."
-    ComfyUIConnectionStatus.Error -> "Connection Error"
-    ComfyUIConnectionStatus.NotConfigured -> "No server configured"
+    ComfyUIConnectionStatus.Connected -> stringResource(R.string.comfyui_status_connected)
+    ComfyUIConnectionStatus.Disconnected -> stringResource(R.string.comfyui_status_disconnected)
+    ComfyUIConnectionStatus.Testing -> stringResource(R.string.comfyui_status_testing)
+    ComfyUIConnectionStatus.Error -> stringResource(R.string.comfyui_status_error)
+    ComfyUIConnectionStatus.NotConfigured -> stringResource(R.string.comfyui_status_not_configured)
 }

--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/comfyui/MaskEditorScreen.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/comfyui/MaskEditorScreen.kt
@@ -115,7 +115,7 @@ private fun MaskEditorTopBar(
     hasContent: Boolean,
 ) {
     TopAppBar(
-        title = { Text("Mask Editor") },
+        title = { Text(stringResource(R.string.comfyui_mask_editor_title)) },
         navigationIcon = {
             IconButton(onClick = onBack) {
                 Icon(

--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/comfyui/SDWebUIGenerationScreen.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/comfyui/SDWebUIGenerationScreen.kt
@@ -71,7 +71,7 @@ fun SDWebUIGenerationScreen(
     Scaffold(
         topBar = {
             TopAppBar(
-                title = { Text("SD WebUI Generation") },
+                title = { Text(stringResource(R.string.sdwebui_generation_title)) },
                 navigationIcon = {
                     IconButton(onClick = onBack) {
                         Icon(
@@ -171,7 +171,7 @@ private fun LazyListScope.sdwebuiFormItems(
         OutlinedTextField(
             value = state.prompt,
             onValueChange = onPromptChanged,
-            label = { Text("Prompt") },
+            label = { Text(stringResource(R.string.label_prompt)) },
             minLines = 3,
             modifier = Modifier.fillMaxWidth(),
         )
@@ -180,7 +180,7 @@ private fun LazyListScope.sdwebuiFormItems(
         OutlinedTextField(
             value = state.negativePrompt,
             onValueChange = onNegativePromptChanged,
-            label = { Text("Negative Prompt") },
+            label = { Text(stringResource(R.string.label_negative_prompt)) },
             minLines = 2,
             modifier = Modifier.fillMaxWidth(),
         )
@@ -234,7 +234,7 @@ private fun SDWebUIDropdownRow(
 private fun SDWebUIStepsSection(steps: Int, onChanged: (Int) -> Unit) {
     Column {
         Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceBetween) {
-            Text("Steps", style = MaterialTheme.typography.labelMedium)
+            Text(stringResource(R.string.sdwebui_steps_label), style = MaterialTheme.typography.labelMedium)
             Text("$steps", style = MaterialTheme.typography.bodySmall)
         }
         Slider(
@@ -250,7 +250,7 @@ private fun SDWebUIStepsSection(steps: Int, onChanged: (Int) -> Unit) {
 private fun SDWebUICfgSection(cfg: Double, onChanged: (Double) -> Unit) {
     Column {
         Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceBetween) {
-            Text("CFG Scale", style = MaterialTheme.typography.labelMedium)
+            Text(stringResource(R.string.sdwebui_cfg_scale_label), style = MaterialTheme.typography.labelMedium)
             Text(String.format(java.util.Locale.US, "%.1f", cfg), style = MaterialTheme.typography.bodySmall)
         }
         Slider(
@@ -293,7 +293,7 @@ private fun SDWebUISeedRow(seed: Long, onChanged: (Long) -> Unit) {
             text = v
             v.toLongOrNull()?.let { onChanged(it) }
         },
-        label = { Text("Seed (-1 = random)") },
+        label = { Text(stringResource(R.string.comfyui_seed_label)) },
         singleLine = true,
         modifier = Modifier.fillMaxWidth(),
     )
@@ -320,7 +320,7 @@ private fun SDWebUIGenerateButton(
                 modifier = Modifier.fillMaxWidth(),
             )
             OutlinedButton(onClick = onInterrupt, modifier = Modifier.fillMaxWidth()) {
-                Text("Interrupt")
+                Text(stringResource(R.string.action_interrupt))
             }
         } else {
             Button(
@@ -328,7 +328,7 @@ private fun SDWebUIGenerateButton(
                 enabled = !promptBlank,
                 modifier = Modifier.fillMaxWidth(),
             ) {
-                Text("Generate")
+                Text(stringResource(R.string.action_generate))
             }
         }
     }
@@ -337,7 +337,7 @@ private fun SDWebUIGenerateButton(
 @Composable
 private fun SDWebUIResultGrid(base64Images: List<String>) {
     Column(verticalArrangement = Arrangement.spacedBy(Spacing.sm)) {
-        Text("Generated Images", style = MaterialTheme.typography.titleSmall)
+        Text(stringResource(R.string.sdwebui_generated_images), style = MaterialTheme.typography.titleSmall)
         Row(
             modifier = Modifier.fillMaxWidth(),
             horizontalArrangement = Arrangement.spacedBy(Spacing.xs),
@@ -371,7 +371,7 @@ private fun SDWebUIBase64Image(base64: String) {
             modifier = Modifier.fillMaxWidth().aspectRatio(1f),
             contentAlignment = Alignment.Center,
         ) {
-            Text("Image error", style = MaterialTheme.typography.bodySmall)
+            Text(stringResource(R.string.sdwebui_image_error), style = MaterialTheme.typography.bodySmall)
         }
     }
 }

--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/comfyui/SDWebUISettingsScreen.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/comfyui/SDWebUISettingsScreen.kt
@@ -61,7 +61,7 @@ fun SDWebUISettingsScreen(
     Scaffold(
         topBar = {
             TopAppBar(
-                title = { Text("SD WebUI") },
+                title = { Text(stringResource(R.string.sdwebui_title)) },
                 navigationIcon = {
                     IconButton(onClick = onBack) {
                         Icon(
@@ -121,7 +121,7 @@ private fun SDWebUISettingsContent(
                     onClick = onNavigateToGeneration,
                     modifier = Modifier.fillMaxWidth(),
                 ) {
-                    Text("Open Generator")
+                    Text(stringResource(R.string.sdwebui_open_generator))
                 }
             }
         }
@@ -165,7 +165,7 @@ private fun SDWebUIStatusSection(state: SDWebUISettingsUiState, onTest: () -> Un
                 if (state.isTesting) {
                     CircularProgressIndicator(modifier = Modifier.size(24.dp))
                 } else if (state.activeConnection != null) {
-                    TextButton(onClick = onTest) { Text("Test") }
+                    TextButton(onClick = onTest) { Text(stringResource(R.string.action_test)) }
                 }
             }
             state.testError?.let {
@@ -216,30 +216,36 @@ private fun SDWebUIAddConnectionDialog(
 
     AlertDialog(
         onDismissRequest = onDismiss,
-        title = { Text(if (editing != null) "Edit Connection" else "Add Connection") },
+        title = {
+            Text(
+                stringResource(
+                    if (editing != null) R.string.comfyui_edit_connection else R.string.comfyui_add_connection
+                )
+            )
+        },
         text = {
             Column(verticalArrangement = Arrangement.spacedBy(Spacing.sm)) {
                 OutlinedTextField(
                     value = name,
                     onValueChange = { name = it },
-                    label = { Text("Name") },
-                    placeholder = { Text("e.g. Home PC") },
+                    label = { Text(stringResource(R.string.label_name)) },
+                    placeholder = { Text(stringResource(R.string.comfyui_name_placeholder)) },
                     singleLine = true,
                     modifier = Modifier.fillMaxWidth(),
                 )
                 OutlinedTextField(
                     value = hostname,
                     onValueChange = { hostname = it },
-                    label = { Text("Hostname / IP") },
-                    placeholder = { Text("192.168.1.100") },
+                    label = { Text(stringResource(R.string.comfyui_hostname_label)) },
+                    placeholder = { Text(stringResource(R.string.comfyui_hostname_placeholder)) },
                     singleLine = true,
                     modifier = Modifier.fillMaxWidth(),
                 )
                 OutlinedTextField(
                     value = portText,
                     onValueChange = { portText = it },
-                    label = { Text("Port") },
-                    placeholder = { Text("7860") },
+                    label = { Text(stringResource(R.string.label_port)) },
+                    placeholder = { Text(stringResource(R.string.sdwebui_port_placeholder)) },
                     singleLine = true,
                     modifier = Modifier.fillMaxWidth(),
                 )
@@ -252,16 +258,17 @@ private fun SDWebUIAddConnectionDialog(
                     onSave(name.ifBlank { hostname }, hostname, port)
                 },
                 enabled = hostname.isNotBlank(),
-            ) { Text("Save") }
+            ) { Text(stringResource(R.string.action_save)) }
         },
-        dismissButton = { TextButton(onClick = onDismiss) { Text("Cancel") } },
+        dismissButton = { TextButton(onClick = onDismiss) { Text(stringResource(R.string.action_cancel)) } },
     )
 }
 
+@Composable
 private fun sdwebuiStatusLabel(status: SDWebUIConnectionStatus): String = when (status) {
-    SDWebUIConnectionStatus.Connected -> "Connected"
-    SDWebUIConnectionStatus.Disconnected -> "Disconnected"
-    SDWebUIConnectionStatus.Testing -> "Testing..."
-    SDWebUIConnectionStatus.Error -> "Connection Error"
-    SDWebUIConnectionStatus.NotConfigured -> "No server configured"
+    SDWebUIConnectionStatus.Connected -> stringResource(R.string.comfyui_status_connected)
+    SDWebUIConnectionStatus.Disconnected -> stringResource(R.string.comfyui_status_disconnected)
+    SDWebUIConnectionStatus.Testing -> stringResource(R.string.comfyui_status_testing)
+    SDWebUIConnectionStatus.Error -> stringResource(R.string.comfyui_status_error)
+    SDWebUIConnectionStatus.NotConfigured -> stringResource(R.string.comfyui_status_not_configured)
 }

--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/comfyui/TemplateParameterScreen.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/comfyui/TemplateParameterScreen.kt
@@ -98,7 +98,7 @@ fun TemplateParameterScreen(
                         .filter { it.required }
                         .all { (values[it.name] ?: "").isNotBlank() },
                 ) {
-                    Text("Generate")
+                    Text(stringResource(R.string.action_generate))
                 }
             }
         }
@@ -232,7 +232,13 @@ private fun TextInput(
         minLines = if (variable.name.contains("prompt")) 3 else 1,
         maxLines = if (variable.name.contains("prompt")) 6 else 1,
         placeholder = {
-            if (variable.required) Text("Required") else Text("Optional")
+            if (variable.required) {
+                Text(
+                    stringResource(R.string.label_required)
+                )
+            } else {
+                Text(stringResource(R.string.label_optional))
+            }
         },
     )
 }

--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/comfyui/WorkflowTemplateEditorScreen.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/comfyui/WorkflowTemplateEditorScreen.kt
@@ -107,7 +107,13 @@ private fun EditorTopBar(
     onSave: () -> Unit,
 ) {
     TopAppBar(
-        title = { Text(if (isNew) "Create Template" else "Edit Template") },
+        title = {
+            Text(
+                stringResource(
+                    if (isNew) R.string.template_editor_create else R.string.template_editor_edit
+                )
+            )
+        },
         navigationIcon = {
             IconButton(
                 onClick = onBack
@@ -119,7 +125,7 @@ private fun EditorTopBar(
             }
         },
         actions = {
-            TextButton(onClick = onSave, enabled = canSave) { Text("Save") }
+            TextButton(onClick = onSave, enabled = canSave) { Text(stringResource(R.string.action_save)) }
         },
     )
 }
@@ -148,7 +154,7 @@ private fun EditorContent(
             OutlinedTextField(
                 value = name,
                 onValueChange = onNameChange,
-                label = { Text("Template Name") },
+                label = { Text(stringResource(R.string.template_name_label)) },
                 modifier = Modifier.fillMaxWidth(),
                 singleLine = true,
             )
@@ -157,7 +163,7 @@ private fun EditorContent(
             OutlinedTextField(
                 value = description,
                 onValueChange = onDescriptionChange,
-                label = { Text("Description") },
+                label = { Text(stringResource(R.string.label_description)) },
                 modifier = Modifier.fillMaxWidth(),
                 minLines = 2,
                 maxLines = 4,
@@ -197,7 +203,11 @@ private fun newVariable(size: Int) = TemplateVariable(
 @Composable
 private fun VariablesHeader(onAdd: () -> Unit) {
     Row(verticalAlignment = Alignment.CenterVertically) {
-        Text("Variables", style = MaterialTheme.typography.titleSmall, modifier = Modifier.weight(1f))
+        Text(
+            stringResource(R.string.template_variables),
+            style = MaterialTheme.typography.titleSmall,
+            modifier = Modifier.weight(1f)
+        )
         IconButton(onClick = onAdd) { Icon(Icons.Default.Add, "Add variable") }
     }
 }
@@ -206,7 +216,7 @@ private fun VariablesHeader(onAdd: () -> Unit) {
 private fun TypeSelector(type: WorkflowTemplateType, onTypeChange: (WorkflowTemplateType) -> Unit) {
     var typeMenuExpanded by remember { mutableStateOf(false) }
     Column {
-        Text("Type", style = MaterialTheme.typography.labelMedium)
+        Text(stringResource(R.string.label_type), style = MaterialTheme.typography.labelMedium)
         TextButton(onClick = { typeMenuExpanded = true }) { Text(typeLabel(type)) }
         DropdownMenu(expanded = typeMenuExpanded, onDismissRequest = { typeMenuExpanded = false }) {
             WorkflowTemplateType.entries.forEach { t ->
@@ -229,7 +239,7 @@ private fun CategorySelector(
 ) {
     var expanded by remember { mutableStateOf(false) }
     Column {
-        Text("Category", style = MaterialTheme.typography.labelMedium)
+        Text(stringResource(R.string.label_category), style = MaterialTheme.typography.labelMedium)
         TextButton(onClick = { expanded = true }) { Text(categoryLabel(category)) }
         DropdownMenu(expanded = expanded, onDismissRequest = { expanded = false }) {
             WorkflowTemplateCategory.entries.forEach { c ->
@@ -263,7 +273,11 @@ private fun VariableEditor(
                 SliderRangeRow(variable = variable, onUpdate = onUpdate)
             }
             Row(verticalAlignment = Alignment.CenterVertically) {
-                Text("Required", style = MaterialTheme.typography.bodySmall, modifier = Modifier.weight(1f))
+                Text(
+                    stringResource(R.string.label_required),
+                    style = MaterialTheme.typography.bodySmall,
+                    modifier = Modifier.weight(1f)
+                )
                 Switch(checked = variable.required, onCheckedChange = { onUpdate(variable.copy(required = it)) })
             }
         }
@@ -280,7 +294,7 @@ private fun VariableNameRow(
         OutlinedTextField(
             value = variable.name,
             onValueChange = { onUpdate(variable.copy(name = it)) },
-            label = { Text("Name") },
+            label = { Text(stringResource(R.string.label_name)) },
             modifier = Modifier.weight(1f),
             singleLine = true,
         )
@@ -298,7 +312,7 @@ private fun VariableLabelRow(
     OutlinedTextField(
         value = variable.label,
         onValueChange = { onUpdate(variable.copy(label = it)) },
-        label = { Text("Display Label") },
+        label = { Text(stringResource(R.string.template_display_label)) },
         modifier = Modifier.fillMaxWidth(),
         singleLine = true,
     )
@@ -315,7 +329,7 @@ private fun VariableTypeAndDefault(
         verticalAlignment = Alignment.CenterVertically,
     ) {
         Column {
-            Text("Type", style = MaterialTheme.typography.labelSmall)
+            Text(stringResource(R.string.label_type), style = MaterialTheme.typography.labelSmall)
             TextButton(onClick = { typeMenuExpanded = true }) { Text(variable.type.name) }
             DropdownMenu(expanded = typeMenuExpanded, onDismissRequest = { typeMenuExpanded = false }) {
                 TemplateVariableType.entries.forEach { t ->
@@ -332,7 +346,7 @@ private fun VariableTypeAndDefault(
         OutlinedTextField(
             value = variable.defaultValue,
             onValueChange = { onUpdate(variable.copy(defaultValue = it)) },
-            label = { Text("Default") },
+            label = { Text(stringResource(R.string.template_default_label)) },
             modifier = Modifier.weight(1f),
             singleLine = true,
         )
@@ -351,21 +365,21 @@ private fun SliderRangeRow(
         OutlinedTextField(
             value = variable.min?.toString() ?: "",
             onValueChange = { onUpdate(variable.copy(min = it.toDoubleOrNull())) },
-            label = { Text("Min") },
+            label = { Text(stringResource(R.string.template_min_label)) },
             modifier = Modifier.weight(1f),
             singleLine = true,
         )
         OutlinedTextField(
             value = variable.max?.toString() ?: "",
             onValueChange = { onUpdate(variable.copy(max = it.toDoubleOrNull())) },
-            label = { Text("Max") },
+            label = { Text(stringResource(R.string.template_max_label)) },
             modifier = Modifier.weight(1f),
             singleLine = true,
         )
         OutlinedTextField(
             value = variable.step?.toString() ?: "",
             onValueChange = { onUpdate(variable.copy(step = it.toDoubleOrNull())) },
-            label = { Text("Step") },
+            label = { Text(stringResource(R.string.template_step_label)) },
             modifier = Modifier.weight(1f),
             singleLine = true,
         )

--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/comfyui/WorkflowTemplateScreen.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/comfyui/WorkflowTemplateScreen.kt
@@ -151,7 +151,13 @@ private fun TemplateScaffold(
     Scaffold(
         topBar = {
             TopAppBar(
-                title = { Text(if (isPicker) "Pick Template" else "Workflow Templates") },
+                title = {
+                    Text(
+                        stringResource(
+                            if (isPicker) R.string.template_picker_title else R.string.template_list_title
+                        )
+                    )
+                },
                 navigationIcon = {
                     IconButton(onClick = onBack) {
                         Icon(
@@ -237,7 +243,7 @@ private fun LazyListScope.templateListItems(
 ) {
     when {
         state.isLoading -> item {
-            Text("Loading...", style = MaterialTheme.typography.bodyMedium)
+            Text(stringResource(R.string.label_loading), style = MaterialTheme.typography.bodyMedium)
         }
         state.filteredTemplates.isEmpty() -> item {
             Text(
@@ -277,7 +283,7 @@ private fun TemplateSearchBar(
                 onSearch = {},
                 expanded = false,
                 onExpandedChange = {},
-                placeholder = { Text("Search templates...") },
+                placeholder = { Text(stringResource(R.string.template_search_placeholder)) },
                 leadingIcon = { Icon(Icons.Default.Search, "Search") },
                 trailingIcon = if (query.isNotEmpty()) {
                     { IconButton(onClick = { onQueryChanged("") }) { Icon(Icons.Default.Close, "Clear") } }
@@ -306,7 +312,7 @@ private fun CategoryFilterRow(
         FilterChip(
             selected = selectedCategory == null,
             onClick = { onCategorySelected(null) },
-            label = { Text("All") },
+            label = { Text(stringResource(R.string.template_all_filter)) },
         )
         WorkflowTemplateCategory.entries.forEach { category ->
             FilterChip(
@@ -336,7 +342,7 @@ private fun TypeFilterRow(
         FilterChip(
             selected = selectedType == null,
             onClick = { onTypeSelected(null) },
-            label = { Text("All Types") },
+            label = { Text(stringResource(R.string.template_all_types_filter)) },
         )
         WorkflowTemplateType.entries.forEach { type ->
             FilterChip(
@@ -359,19 +365,19 @@ private fun ImportDialog(
 ) {
     AlertDialog(
         onDismissRequest = onDismiss,
-        title = { Text("Import Template JSON") },
+        title = { Text(stringResource(R.string.template_import_json)) },
         text = {
             OutlinedTextField(
                 value = text,
                 onValueChange = onTextChange,
-                label = { Text("Paste template JSON") },
+                label = { Text(stringResource(R.string.template_paste_json)) },
                 modifier = Modifier.fillMaxWidth(),
                 minLines = 5,
                 maxLines = 10,
             )
         },
-        confirmButton = { Button(onClick = onConfirm) { Text("Import") } },
-        dismissButton = { TextButton(onClick = onDismiss) { Text("Cancel") } },
+        confirmButton = { Button(onClick = onConfirm) { Text(stringResource(R.string.action_import)) } },
+        dismissButton = { TextButton(onClick = onDismiss) { Text(stringResource(R.string.action_cancel)) } },
     )
 }
 
@@ -379,7 +385,7 @@ private fun ImportDialog(
 private fun ExportDialog(json: String, onDismiss: () -> Unit) {
     AlertDialog(
         onDismissRequest = onDismiss,
-        title = { Text("Template JSON") },
+        title = { Text(stringResource(R.string.template_json_title)) },
         text = {
             OutlinedTextField(
                 value = json,
@@ -390,7 +396,7 @@ private fun ExportDialog(json: String, onDismiss: () -> Unit) {
                 maxLines = 12,
             )
         },
-        confirmButton = { Button(onClick = onDismiss) { Text("Done") } },
+        confirmButton = { Button(onClick = onDismiss) { Text(stringResource(R.string.action_done)) } },
     )
 }
 

--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/compare/ModelCompareScreen.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/compare/ModelCompareScreen.kt
@@ -75,7 +75,7 @@ fun ModelCompareScreen(
         topBar = {
             TopAppBar(
                 windowInsets = WindowInsets(0, 0, 0, 0),
-                title = { Text("Compare Models") },
+                title = { Text(stringResource(R.string.detail_compare_models_title)) },
                 navigationIcon = {
                     IconButton(onClick = onBack) {
                         Icon(
@@ -201,7 +201,7 @@ private fun CompareImagesButton(onClick: () -> Unit) {
         contentAlignment = Alignment.Center,
     ) {
         Button(onClick = onClick) {
-            Text("Compare Images")
+            Text(stringResource(R.string.detail_compare_images))
         }
     }
 }

--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/create/CreateHubScreen.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/create/CreateHubScreen.kt
@@ -25,7 +25,9 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
+import com.riox432.civitdeck.R
 import com.riox432.civitdeck.ui.theme.Spacing
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -38,7 +40,7 @@ fun CreateHubScreen(
 ) {
     Scaffold(
         topBar = {
-            TopAppBar(title = { Text("Create") })
+            TopAppBar(title = { Text(stringResource(R.string.create_hub_title)) })
         },
     ) { innerPadding ->
         LazyColumn(

--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/dataset/AddToDatasetSheet.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/dataset/AddToDatasetSheet.kt
@@ -65,7 +65,7 @@ fun AddToDatasetSheet(
                 modifier = Modifier.padding(horizontal = Spacing.md),
             ) {
                 Icon(Icons.Default.Add, contentDescription = stringResource(R.string.cd_create_new_dataset))
-                Text("Create New Dataset", modifier = Modifier.padding(start = Spacing.sm))
+                Text(stringResource(R.string.dataset_create_new), modifier = Modifier.padding(start = Spacing.sm))
             }
         }
     }

--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/dataset/BatchTagEditorScreen.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/dataset/BatchTagEditorScreen.kt
@@ -245,7 +245,7 @@ private fun TagInputRow(
             onClick = { onApplyTag(tagInput.trim()) },
             enabled = canApply,
         ) {
-            Text("Apply")
+            Text(stringResource(R.string.action_apply))
         }
     }
 }

--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/dataset/CaptionEditorSheet.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/dataset/CaptionEditorSheet.kt
@@ -15,7 +15,9 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
+import com.riox432.civitdeck.R
 import com.riox432.civitdeck.ui.theme.Spacing
 
 private const val MAX_CAPTION_LENGTH = 2000
@@ -65,10 +67,10 @@ private fun CaptionEditorContent(
             value = captionText,
             onValueChange = onTextChange,
             modifier = Modifier.fillMaxWidth(),
-            label = { Text("Caption") },
+            label = { Text(stringResource(R.string.dataset_caption_label)) },
             minLines = 4,
             maxLines = 8,
-            placeholder = { Text("Describe this image for training…") },
+            placeholder = { Text(stringResource(R.string.dataset_caption_placeholder)) },
         )
         Text(
             text = "${captionText.length} / $MAX_CAPTION_LENGTH",

--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/dataset/DatasetListScreen.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/dataset/DatasetListScreen.kt
@@ -68,7 +68,7 @@ fun DatasetListScreen(
     Scaffold(
         topBar = {
             TopAppBar(
-                title = { Text("Datasets") },
+                title = { Text(stringResource(R.string.dataset_list_title)) },
                 navigationIcon = {
                     IconButton(onClick = onBack) {
                         Icon(
@@ -246,7 +246,7 @@ private fun DatasetOverflowMenu(
             onDismissRequest = { onToggleMenu(false) },
         ) {
             DropdownMenuItem(
-                text = { Text("Rename") },
+                text = { Text(stringResource(R.string.action_rename)) },
                 leadingIcon = { Icon(Icons.Default.Edit, contentDescription = stringResource(R.string.cd_rename)) },
                 onClick = {
                     onToggleMenu(false)
@@ -254,7 +254,7 @@ private fun DatasetOverflowMenu(
                 },
             )
             DropdownMenuItem(
-                text = { Text("Delete") },
+                text = { Text(stringResource(R.string.action_delete)) },
                 leadingIcon = { Icon(Icons.Default.Delete, contentDescription = stringResource(R.string.cd_delete)) },
                 onClick = {
                     onToggleMenu(false)
@@ -282,7 +282,7 @@ internal fun DatasetNameDialog(
             OutlinedTextField(
                 value = name,
                 onValueChange = { name = it },
-                label = { Text("Dataset name") },
+                label = { Text(stringResource(R.string.dataset_name_label)) },
                 singleLine = true,
             )
         },
@@ -296,7 +296,7 @@ internal fun DatasetNameDialog(
         },
         dismissButton = {
             TextButton(onClick = onDismiss) {
-                Text("Cancel")
+                Text(stringResource(R.string.action_cancel))
             }
         },
     )

--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/dataset/DuplicateReviewScreen.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/dataset/DuplicateReviewScreen.kt
@@ -56,7 +56,7 @@ fun DuplicateReviewScreen(
     Scaffold(
         topBar = {
             TopAppBar(
-                title = { Text("Review Duplicates") },
+                title = { Text(stringResource(R.string.dataset_review_duplicates)) },
                 navigationIcon = {
                     IconButton(onClick = onBack) {
                         Icon(

--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/dataset/ExportDatasetSheet.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/dataset/ExportDatasetSheet.kt
@@ -25,7 +25,9 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
 import androidx.core.content.FileProvider
+import com.riox432.civitdeck.R
 import com.riox432.civitdeck.domain.model.ExportProgress
 import com.riox432.civitdeck.plugin.PluginExportFormat
 import com.riox432.civitdeck.ui.theme.Spacing
@@ -105,8 +107,11 @@ private fun ExportSheetContent(
             modifier = Modifier.fillMaxWidth(),
             horizontalArrangement = Arrangement.spacedBy(Spacing.sm, androidx.compose.ui.Alignment.End),
         ) {
-            OutlinedButton(onClick = onDismiss) { Text("Cancel") }
-            Button(onClick = onExport, enabled = selectedFormatId != null) { Text("Export") }
+            OutlinedButton(onClick = onDismiss) { Text(stringResource(R.string.action_cancel)) }
+            Button(
+                onClick = onExport,
+                enabled = selectedFormatId != null
+            ) { Text(stringResource(R.string.action_export)) }
         }
     }
 }
@@ -210,12 +215,12 @@ private fun ExportCompletedDialog(
             Button(onClick = {
                 onShare()
                 onDismiss()
-            }) { Text("Share") }
+            }) { Text(stringResource(R.string.action_share)) }
         },
         dismissButton = {
-            TextButton(onClick = onDismiss) { Text("Close") }
+            TextButton(onClick = onDismiss) { Text(stringResource(R.string.action_close)) }
         },
-        title = { Text("Export Complete") },
+        title = { Text(stringResource(R.string.dataset_export_complete)) },
         text = {
             Column {
                 Text("File ready: ${File(outputPath).name}")
@@ -235,8 +240,8 @@ private fun ExportCompletedDialog(
 private fun ExportFailedDialog(message: String, onDismiss: () -> Unit) {
     AlertDialog(
         onDismissRequest = onDismiss,
-        confirmButton = { TextButton(onClick = onDismiss) { Text("OK") } },
-        title = { Text("Export Failed") },
+        confirmButton = { TextButton(onClick = onDismiss) { Text(stringResource(R.string.action_ok)) } },
+        title = { Text(stringResource(R.string.dataset_export_failed)) },
         text = { Text(message) },
     )
 }
@@ -246,14 +251,14 @@ private fun LicenseWarningDialog(count: Int, onConfirm: () -> Unit, onDismiss: (
     AlertDialog(
         onDismissRequest = onDismiss,
         confirmButton = {
-            Button(onClick = onConfirm) { Text("Export Anyway") }
+            Button(onClick = onConfirm) { Text(stringResource(R.string.dataset_export_anyway)) }
         },
         dismissButton = {
-            TextButton(onClick = onDismiss) { Text("Cancel") }
+            TextButton(onClick = onDismiss) { Text(stringResource(R.string.action_cancel)) }
         },
-        title = { Text("License Warning") },
+        title = { Text(stringResource(R.string.dataset_license_warning)) },
         text = {
-            Text("$count images are non-trainable or have license restrictions. They will be excluded from the export.")
+            Text(stringResource(R.string.dataset_license_warning_message, count))
         },
     )
 }

--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/detail/ModelDetailScreen.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/detail/ModelDetailScreen.kt
@@ -346,7 +346,7 @@ private fun DetailOverflowMenu(
         DropdownMenu(expanded = expanded, onDismissRequest = { expanded = false }) {
             if (onFindSimilar != null) {
                 DropdownMenuItem(
-                    text = { Text("Find similar") },
+                    text = { Text(stringResource(R.string.detail_find_similar)) },
                     leadingIcon = { Icon(Icons.Default.ImageSearch, contentDescription = null) },
                     onClick = {
                         expanded = false
@@ -355,7 +355,7 @@ private fun DetailOverflowMenu(
                 )
             }
             DropdownMenuItem(
-                text = { Text("Add to collection") },
+                text = { Text(stringResource(R.string.detail_add_to_collection)) },
                 leadingIcon = { Icon(Icons.Default.CreateNewFolder, contentDescription = null) },
                 onClick = {
                     expanded = false
@@ -363,7 +363,7 @@ private fun DetailOverflowMenu(
                 },
             )
             DropdownMenuItem(
-                text = { Text("QR code") },
+                text = { Text(stringResource(R.string.detail_qr_code)) },
                 leadingIcon = { Icon(Icons.Default.QrCode2, contentDescription = null) },
                 onClick = {
                     expanded = false

--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/detail/ModelInfoSection.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/detail/ModelInfoSection.kt
@@ -21,6 +21,8 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import com.riox432.civitdeck.R
 import com.riox432.civitdeck.domain.model.Model
 import com.riox432.civitdeck.ui.components.ExpandableTextSection
 import com.riox432.civitdeck.ui.components.SectionHeader
@@ -123,10 +125,10 @@ internal fun ImageActionsRow(
                 contentColor = MaterialTheme.colorScheme.onSecondaryContainer,
             ),
         ) {
-            Text("View Community Images")
+            Text(stringResource(R.string.detail_view_community_images))
         }
         OutlinedButton(onClick = onSendToPC) {
-            Text("Send to PC")
+            Text(stringResource(R.string.detail_send_to_pc))
         }
         if (showTryInComfyUI) {
             Button(
@@ -136,7 +138,7 @@ internal fun ImageActionsRow(
                     contentColor = MaterialTheme.colorScheme.onTertiaryContainer,
                 ),
             ) {
-                Text("Try in ComfyUI")
+                Text(stringResource(R.string.detail_try_in_comfyui))
             }
         }
     }

--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/detail/ModelNotesSection.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/detail/ModelNotesSection.kt
@@ -129,7 +129,7 @@ private fun NoteEditor(
         value = text,
         onValueChange = onTextChange,
         modifier = Modifier.fillMaxWidth(),
-        placeholder = { Text("e.g. Works great with X LoRA") },
+        placeholder = { Text(stringResource(R.string.detail_note_placeholder)) },
         minLines = 2,
         maxLines = 5,
     )
@@ -137,8 +137,8 @@ private fun NoteEditor(
         modifier = Modifier.fillMaxWidth(),
         horizontalArrangement = Arrangement.End,
     ) {
-        TextButton(onClick = onCancel) { Text("Cancel") }
-        TextButton(onClick = onSave) { Text("Save") }
+        TextButton(onClick = onCancel) { Text(stringResource(R.string.action_cancel)) }
+        TextButton(onClick = onSave) { Text(stringResource(R.string.action_save)) }
     }
 }
 
@@ -235,14 +235,14 @@ private fun TagInput(
             value = text,
             onValueChange = onTextChange,
             modifier = Modifier.weight(1f),
-            placeholder = { Text("Tag name") },
+            placeholder = { Text(stringResource(R.string.detail_tag_placeholder)) },
             singleLine = true,
             keyboardOptions = KeyboardOptions(imeAction = ImeAction.Done),
             keyboardActions = KeyboardActions(onDone = { if (text.isNotBlank()) onSubmit() }),
         )
         AssistChip(
             onClick = { if (text.isNotBlank()) onSubmit() },
-            label = { Text("Add") },
+            label = { Text(stringResource(R.string.action_add)) },
         )
     }
 }

--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/detail/ReviewsSection.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/detail/ReviewsSection.kt
@@ -117,7 +117,7 @@ private fun ReviewsSectionHeader(
         Row {
             SortDropdown(sortOrder = sortOrder, onSortChanged = onSortChanged)
             TextButton(onClick = onWriteReview) {
-                Text("Write", style = MaterialTheme.typography.labelMedium)
+                Text(stringResource(R.string.action_write), style = MaterialTheme.typography.labelMedium)
             }
         }
     }

--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/detail/SubmitReviewSheet.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/detail/SubmitReviewSheet.kt
@@ -93,7 +93,7 @@ private fun SubmitReviewContent(
         OutlinedTextField(
             value = details,
             onValueChange = onDetailsChange,
-            label = { Text("Details (optional)") },
+            label = { Text(stringResource(R.string.detail_review_details_label)) },
             modifier = Modifier.fillMaxWidth(),
             minLines = MIN_TEXT_LINES,
             maxLines = MAX_TEXT_LINES,
@@ -110,7 +110,7 @@ private fun SubmitReviewContent(
 
 @Composable
 private fun StarRatingSelector(rating: Int, onRatingChange: (Int) -> Unit) {
-    Text("Rating", style = MaterialTheme.typography.labelMedium)
+    Text(stringResource(R.string.label_rating), style = MaterialTheme.typography.labelMedium)
     Spacer(Modifier.height(Spacing.xs))
     Row(horizontalArrangement = Arrangement.spacedBy(Spacing.xs)) {
         for (i in 1..MAX_STARS) {
@@ -135,19 +135,19 @@ private fun StarRatingSelector(rating: Int, onRatingChange: (Int) -> Unit) {
 
 @Composable
 private fun RecommendationSelector(recommended: Boolean, onChanged: (Boolean) -> Unit) {
-    Text("Recommendation", style = MaterialTheme.typography.labelMedium)
+    Text(stringResource(R.string.label_recommendation), style = MaterialTheme.typography.labelMedium)
     Spacer(Modifier.height(Spacing.xs))
     Row(horizontalArrangement = Arrangement.spacedBy(Spacing.sm)) {
         FilterChip(
             selected = recommended,
             onClick = { onChanged(true) },
-            label = { Text("Recommend") },
+            label = { Text(stringResource(R.string.detail_recommend)) },
             leadingIcon = { Icon(Icons.Outlined.ThumbUp, null, Modifier.size(16.dp)) },
         )
         FilterChip(
             selected = !recommended,
             onClick = { onChanged(false) },
-            label = { Text("Not recommended") },
+            label = { Text(stringResource(R.string.detail_not_recommended)) },
             leadingIcon = { Icon(Icons.Outlined.ThumbDown, null, Modifier.size(16.dp)) },
         )
     }
@@ -164,7 +164,7 @@ private fun SubmitButton(
         if (isSubmitting) {
             CircularProgressIndicator(modifier = Modifier.size(16.dp), strokeWidth = 2.dp)
         } else {
-            Text("Submit")
+            Text(stringResource(R.string.action_submit))
         }
     }
 }

--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/discovery/SwipeDiscoveryScreen.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/discovery/SwipeDiscoveryScreen.kt
@@ -49,7 +49,7 @@ fun SwipeDiscoveryScreen(
     Scaffold(
         topBar = {
             TopAppBar(
-                title = { Text("Discover") },
+                title = { Text(stringResource(R.string.discovery_title)) },
                 navigationIcon = {
                     IconButton(onClick = onBack) {
                         Icon(

--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/externalserver/ExternalServerFilterSheet.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/externalserver/ExternalServerFilterSheet.kt
@@ -21,6 +21,8 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import com.riox432.civitdeck.R
 import com.riox432.civitdeck.feature.externalserver.domain.model.ExternalServerImageFilters
 import com.riox432.civitdeck.ui.theme.Spacing
 
@@ -83,7 +85,7 @@ private fun FilterSheetHeader(onReset: () -> Unit) {
         verticalAlignment = Alignment.CenterVertically,
     ) {
         Text("Filters", style = MaterialTheme.typography.titleMedium)
-        TextButton(onClick = onReset) { Text("Reset") }
+        TextButton(onClick = onReset) { Text(stringResource(R.string.action_reset)) }
     }
 }
 
@@ -99,21 +101,21 @@ private fun FilterTextFields(
     OutlinedTextField(
         value = search,
         onValueChange = onSearchChange,
-        label = { Text("Search") },
+        label = { Text(stringResource(R.string.external_server_search_label)) },
         singleLine = true,
         modifier = Modifier.fillMaxWidth(),
     )
     OutlinedTextField(
         value = character,
         onValueChange = onCharacterChange,
-        label = { Text("Character") },
+        label = { Text(stringResource(R.string.external_server_character_label)) },
         singleLine = true,
         modifier = Modifier.fillMaxWidth(),
     )
     OutlinedTextField(
         value = scenario,
         onValueChange = onScenarioChange,
-        label = { Text("Scenario") },
+        label = { Text(stringResource(R.string.external_server_scenario_label)) },
         singleLine = true,
         modifier = Modifier.fillMaxWidth(),
     )
@@ -144,7 +146,7 @@ private fun FilterApplyButton(onApply: () -> Unit) {
         modifier = Modifier.fillMaxWidth().padding(bottom = Spacing.lg),
         horizontalArrangement = Arrangement.End,
     ) {
-        Button(onClick = onApply) { Text("Apply") }
+        Button(onClick = onApply) { Text(stringResource(R.string.action_apply)) }
     }
 }
 

--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/externalserver/ExternalServerGenerationSheet.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/externalserver/ExternalServerGenerationSheet.kt
@@ -31,6 +31,8 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import com.riox432.civitdeck.R
 import com.riox432.civitdeck.feature.externalserver.domain.model.GenerationChoice
 import com.riox432.civitdeck.feature.externalserver.domain.model.GenerationJob
 import com.riox432.civitdeck.feature.externalserver.domain.model.GenerationJobStatus
@@ -97,7 +99,7 @@ fun ExternalServerGenerationSheet(
                     if (state.isSubmittingGeneration) {
                         CircularProgressIndicator()
                     } else {
-                        Text("Start Generation")
+                        Text(stringResource(R.string.external_server_start_generation))
                     }
                 }
             }

--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/externalserver/ExternalServerSettingsScreen.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/externalserver/ExternalServerSettingsScreen.kt
@@ -57,7 +57,7 @@ fun ExternalServerSettingsScreen(
     Scaffold(
         topBar = {
             TopAppBar(
-                title = { Text("Custom Server") },
+                title = { Text(stringResource(R.string.external_server_title)) },
                 navigationIcon = {
                     IconButton(onClick = onBack) {
                         Icon(
@@ -181,11 +181,13 @@ private fun ExternalServerStatusCard(
                     if (state.isTesting) {
                         CircularProgressIndicator(modifier = Modifier.padding(Spacing.xs))
                     } else {
-                        TextButton(onClick = onTest) { Text("Test Connection") }
+                        TextButton(onClick = onTest) { Text(stringResource(R.string.external_server_test_connection)) }
                     }
                 }
                 if (state.connectionStatus == ExternalServerConnectionStatus.Connected) {
-                    TextButton(onClick = onNavigateToGallery) { Text("Open Gallery") }
+                    TextButton(
+                        onClick = onNavigateToGallery
+                    ) { Text(stringResource(R.string.external_server_open_gallery)) }
                 }
             }
         }
@@ -241,14 +243,14 @@ private fun AddServerDialog(
                 OutlinedTextField(
                     value = name,
                     onValueChange = { name = it },
-                    label = { Text("Display Name") },
+                    label = { Text(stringResource(R.string.external_server_display_name_label)) },
                     singleLine = true,
                     modifier = Modifier.fillMaxWidth(),
                 )
                 OutlinedTextField(
                     value = baseUrl,
                     onValueChange = { baseUrl = it },
-                    label = { Text("Server URL") },
+                    label = { Text(stringResource(R.string.external_server_url_label)) },
                     placeholder = { Text("http://192.168.1.100:8000/civitdeck") },
                     singleLine = true,
                     modifier = Modifier.fillMaxWidth(),
@@ -256,7 +258,7 @@ private fun AddServerDialog(
                 OutlinedTextField(
                     value = apiKey,
                     onValueChange = { apiKey = it },
-                    label = { Text("API Key (optional)") },
+                    label = { Text(stringResource(R.string.external_server_api_key_label)) },
                     singleLine = true,
                     modifier = Modifier.fillMaxWidth(),
                 )
@@ -266,8 +268,8 @@ private fun AddServerDialog(
             TextButton(
                 onClick = { onSave(name.trim(), baseUrl.trim(), apiKey.trim()) },
                 enabled = name.isNotBlank() && baseUrl.isNotBlank(),
-            ) { Text("Save") }
+            ) { Text(stringResource(R.string.action_save)) }
         },
-        dismissButton = { TextButton(onClick = onDismiss) { Text("Cancel") } },
+        dismissButton = { TextButton(onClick = onDismiss) { Text(stringResource(R.string.action_cancel)) } },
     )
 }

--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/feed/FeedScreen.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/feed/FeedScreen.kt
@@ -65,7 +65,7 @@ fun FeedScreen(
     Scaffold(
         topBar = {
             TopAppBar(
-                title = { Text("Feed") },
+                title = { Text(stringResource(R.string.feed_title)) },
                 navigationIcon = {
                     if (onBack != null) {
                         androidx.compose.material3.IconButton(onClick = onBack) {

--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/gallery/ImageGalleryScreen.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/gallery/ImageGalleryScreen.kt
@@ -112,7 +112,7 @@ fun ImageGalleryScreen(
 @Composable
 private fun ImageGalleryTopBar(onBack: () -> Unit) {
     TopAppBar(
-        title = { Text("Images") },
+        title = { Text(stringResource(R.string.gallery_title)) },
         navigationIcon = {
             IconButton(onClick = onBack) {
                 Icon(

--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/gallery/MetadataBottomSheet.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/gallery/MetadataBottomSheet.kt
@@ -22,7 +22,9 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
+import com.riox432.civitdeck.R
 import com.riox432.civitdeck.domain.export.WorkflowExportService
 import com.riox432.civitdeck.domain.model.HapticFeedbackType
 import com.riox432.civitdeck.domain.model.ImageGenerationMeta
@@ -94,10 +96,10 @@ private fun PromptSection(
                     copyToClipboard(context, "Prompt", prompt)
                 },
             ) {
-                Text("Copy Prompt")
+                Text(stringResource(R.string.gallery_copy_prompt))
             }
             OutlinedButton(onClick = onSavePrompt) {
-                Text("Save Prompt")
+                Text(stringResource(R.string.gallery_save_prompt))
             }
         }
         Spacer(modifier = Modifier.height(Spacing.sm))
@@ -181,13 +183,13 @@ private fun ExportSection(meta: ImageGenerationMeta, context: Context) {
             val text = WorkflowExportService.generateComfyUIWorkflow(meta)
             shareText(context, text, "Export ComfyUI Workflow")
         }) {
-            Text("ComfyUI Workflow")
+            Text(stringResource(R.string.gallery_comfyui_workflow))
         }
         OutlinedButton(onClick = {
             val text = WorkflowExportService.generateA1111Params(meta)
             shareText(context, text, "Export A1111 Params")
         }) {
-            Text("A1111 Params")
+            Text(stringResource(R.string.gallery_a1111_params))
         }
     }
 }

--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/history/BrowsingHistoryScreen.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/history/BrowsingHistoryScreen.kt
@@ -120,7 +120,7 @@ private fun HistoryTopAppBar(
     onClear: () -> Unit,
 ) {
     TopAppBar(
-        title = { Text("Browsing History") },
+        title = { Text(stringResource(R.string.history_title)) },
         navigationIcon = {
             IconButton(onClick = onBack) {
                 Icon(
@@ -131,7 +131,7 @@ private fun HistoryTopAppBar(
         },
         actions = {
             if (!isEmpty) {
-                TextButton(onClick = onClear) { Text("Clear All") }
+                TextButton(onClick = onClear) { Text(stringResource(R.string.action_clear_all)) }
             }
         },
     )
@@ -187,10 +187,10 @@ private fun GroupHeader(label: String) {
 private fun ClearHistoryDialog(onConfirm: () -> Unit, onDismiss: () -> Unit) {
     AlertDialog(
         onDismissRequest = onDismiss,
-        title = { Text("Clear All History") },
-        text = { Text("Are you sure? This cannot be undone.") },
-        confirmButton = { TextButton(onClick = onConfirm) { Text("Clear") } },
-        dismissButton = { TextButton(onClick = onDismiss) { Text("Cancel") } },
+        title = { Text(stringResource(R.string.history_clear_all_title)) },
+        text = { Text(stringResource(R.string.history_clear_all_confirm)) },
+        confirmButton = { TextButton(onClick = onConfirm) { Text(stringResource(R.string.action_clear)) } },
+        dismissButton = { TextButton(onClick = onDismiss) { Text(stringResource(R.string.action_cancel)) } },
     )
 }
 

--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/modelfiles/ModelFileBrowserScreen.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/modelfiles/ModelFileBrowserScreen.kt
@@ -63,7 +63,7 @@ fun ModelFileBrowserScreen(
     Scaffold(
         topBar = {
             TopAppBar(
-                title = { Text("Model Files") },
+                title = { Text(stringResource(R.string.model_files_title)) },
                 navigationIcon = {
                     IconButton(onClick = onBack) {
                         Icon(
@@ -105,9 +105,13 @@ fun ModelFileBrowserScreen(
     state.errorMessage?.let { error ->
         AlertDialog(
             onDismissRequest = viewModel::onDismissError,
-            title = { Text("Scan Error") },
+            title = { Text(stringResource(R.string.model_files_scan_error)) },
             text = { Text(error) },
-            confirmButton = { TextButton(onClick = viewModel::onDismissError) { Text("OK") } },
+            confirmButton = {
+                TextButton(onClick = viewModel::onDismissError) {
+                    Text(stringResource(R.string.action_ok))
+                }
+            },
         )
     }
 }
@@ -228,16 +232,16 @@ private fun DirectoryItem(directory: ModelDirectory, onRemove: (Long) -> Unit) {
     if (showConfirm) {
         AlertDialog(
             onDismissRequest = { showConfirm = false },
-            title = { Text("Remove Directory") },
-            text = { Text("Remove this directory and all its scanned data?") },
+            title = { Text(stringResource(R.string.model_files_remove_directory)) },
+            text = { Text(stringResource(R.string.model_files_remove_confirm)) },
             confirmButton = {
                 TextButton(onClick = {
                     onRemove(directory.id)
                     showConfirm = false
-                }) { Text("Remove") }
+                }) { Text(stringResource(R.string.action_remove)) }
             },
             dismissButton = {
-                TextButton(onClick = { showConfirm = false }) { Text("Cancel") }
+                TextButton(onClick = { showConfirm = false }) { Text(stringResource(R.string.action_cancel)) }
             },
         )
     }
@@ -317,12 +321,12 @@ private fun AddDirectoryDialog(onAdd: (String) -> Unit, onDismiss: () -> Unit) {
     var path by rememberSaveable { mutableStateOf("") }
     AlertDialog(
         onDismissRequest = onDismiss,
-        title = { Text("Add Model Directory") },
+        title = { Text(stringResource(R.string.model_files_add_directory)) },
         text = {
             OutlinedTextField(
                 value = path,
                 onValueChange = { path = it },
-                placeholder = { Text("/path/to/models") },
+                placeholder = { Text(stringResource(R.string.model_files_path_placeholder)) },
                 singleLine = true,
                 modifier = Modifier.fillMaxWidth(),
             )
@@ -334,10 +338,10 @@ private fun AddDirectoryDialog(onAdd: (String) -> Unit, onDismiss: () -> Unit) {
                     onDismiss()
                 },
                 enabled = path.isNotBlank(),
-            ) { Text("Add") }
+            ) { Text(stringResource(R.string.action_add)) }
         },
         dismissButton = {
-            TextButton(onClick = onDismiss) { Text("Cancel") }
+            TextButton(onClick = onDismiss) { Text(stringResource(R.string.action_cancel)) }
         },
     )
 }

--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/notificationcenter/NotificationCenterScreen.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/notificationcenter/NotificationCenterScreen.kt
@@ -56,7 +56,7 @@ fun NotificationCenterScreen(
     Scaffold(
         topBar = {
             TopAppBar(
-                title = { Text("Notifications") },
+                title = { Text(stringResource(R.string.notification_center_title)) },
                 navigationIcon = {
                     IconButton(onClick = onBack) {
                         Icon(

--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/plugin/PluginDetailScreen.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/plugin/PluginDetailScreen.kt
@@ -154,7 +154,7 @@ private fun EnableToggleRow(
         horizontalArrangement = Arrangement.SpaceBetween,
         verticalAlignment = Alignment.CenterVertically,
     ) {
-        Text("Enabled", style = MaterialTheme.typography.bodyLarge)
+        Text(stringResource(R.string.plugin_enabled_label), style = MaterialTheme.typography.bodyLarge)
         Switch(
             checked = viewModel.isPluginActive(plugin),
             onCheckedChange = { viewModel.togglePlugin(plugin.id, it) },
@@ -197,7 +197,7 @@ private fun ConfigSection(
             value = editedConfig,
             onValueChange = { editedConfig = it },
             modifier = Modifier.fillMaxWidth(),
-            label = { Text("JSON Config") },
+            label = { Text(stringResource(R.string.plugin_json_config_label)) },
             minLines = 3,
             maxLines = 8,
         )
@@ -205,7 +205,7 @@ private fun ConfigSection(
             onClick = { viewModel.saveConfig(pluginId, editedConfig) },
             enabled = editedConfig != configJson,
         ) {
-            Text("Save Config")
+            Text(stringResource(R.string.plugin_save_config))
         }
     }
 }
@@ -224,7 +224,7 @@ private fun UninstallSection(
         ),
         modifier = Modifier.fillMaxWidth(),
     ) {
-        Text("Uninstall Plugin")
+        Text(stringResource(R.string.plugin_uninstall))
     }
     if (showConfirm) {
         UninstallConfirmDialog(
@@ -245,15 +245,15 @@ private fun UninstallConfirmDialog(
 ) {
     AlertDialog(
         onDismissRequest = onDismiss,
-        title = { Text("Uninstall Plugin") },
-        text = { Text("Are you sure? This will remove the plugin and its data.") },
+        title = { Text(stringResource(R.string.plugin_uninstall_confirm_title)) },
+        text = { Text(stringResource(R.string.plugin_uninstall_confirm_message)) },
         confirmButton = {
             TextButton(onClick = onConfirm) {
-                Text("Uninstall", color = MaterialTheme.colorScheme.error)
+                Text(stringResource(R.string.plugin_uninstall_action), color = MaterialTheme.colorScheme.error)
             }
         },
         dismissButton = {
-            TextButton(onClick = onDismiss) { Text("Cancel") }
+            TextButton(onClick = onDismiss) { Text(stringResource(R.string.action_cancel)) }
         },
     )
 }

--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/plugin/PluginManagementScreen.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/plugin/PluginManagementScreen.kt
@@ -58,7 +58,7 @@ fun PluginManagementScreen(
     Scaffold(
         topBar = {
             TopAppBar(
-                title = { Text("Plugins") },
+                title = { Text(stringResource(R.string.plugin_list_title)) },
                 navigationIcon = {
                     IconButton(onClick = onBack) {
                         Icon(

--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/prompts/SavedPromptsScreen.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/prompts/SavedPromptsScreen.kt
@@ -120,7 +120,7 @@ private fun SearchBar(query: String, onQueryChange: (String) -> Unit) {
         modifier = Modifier
             .fillMaxWidth()
             .padding(horizontal = Spacing.lg, vertical = Spacing.sm),
-        placeholder = { Text("Search prompts...") },
+        placeholder = { Text(stringResource(R.string.prompts_search_placeholder)) },
         singleLine = true,
     )
 }
@@ -264,21 +264,21 @@ private fun TemplateNameDialog(
 ) {
     AlertDialog(
         onDismissRequest = onDismiss,
-        title = { Text("Save as Template") },
+        title = { Text(stringResource(R.string.prompts_save_as_template)) },
         text = {
             OutlinedTextField(
                 value = name,
                 onValueChange = onNameChange,
-                label = { Text("Template name (optional)") },
+                label = { Text(stringResource(R.string.prompts_template_name_label)) },
                 singleLine = true,
                 modifier = Modifier.fillMaxWidth(),
             )
         },
         confirmButton = {
-            TextButton(onClick = onConfirm) { Text("Save") }
+            TextButton(onClick = onConfirm) { Text(stringResource(R.string.action_save)) }
         },
         dismissButton = {
-            TextButton(onClick = onDismiss) { Text("Cancel") }
+            TextButton(onClick = onDismiss) { Text(stringResource(R.string.action_cancel)) }
         },
     )
 }
@@ -385,14 +385,14 @@ private fun PromptActions(
     ) {
         if (onApply != null) {
             OutlinedButton(onClick = onApply) {
-                Text("Apply")
+                Text(stringResource(R.string.action_apply))
             }
         }
         OutlinedButton(onClick = onCopy) {
-            Text("Copy")
+            Text(stringResource(R.string.action_copy))
         }
         OutlinedButton(onClick = onExport) {
-            Text("Export")
+            Text(stringResource(R.string.action_export))
         }
         Spacer(modifier = Modifier.weight(1f))
         IconButton(onClick = onDelete) {
@@ -460,10 +460,10 @@ private fun ApplyTemplateDialog(
             TextButton(onClick = {
                 val result = PromptTemplateEngine.substitute(prompt.prompt, values.value)
                 onGenerate(result)
-            }) { Text("Generate") }
+            }) { Text(stringResource(R.string.action_generate)) }
         },
         dismissButton = {
-            TextButton(onClick = onDismiss) { Text("Cancel") }
+            TextButton(onClick = onDismiss) { Text(stringResource(R.string.action_cancel)) }
         },
     )
 }

--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/qrcode/QRCodeSheet.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/qrcode/QRCodeSheet.kt
@@ -150,7 +150,7 @@ private fun ShareButton(onShare: () -> Unit) {
         ) {
             Icon(Icons.Default.Share, contentDescription = stringResource(R.string.cd_share))
             Spacer(modifier = Modifier.width(Spacing.sm))
-            Text("Share QR Code")
+            Text(stringResource(R.string.qr_share))
         }
     }
 }

--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/qrcode/QRScannerScreen.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/qrcode/QRScannerScreen.kt
@@ -79,7 +79,7 @@ fun QRScannerScreen(
     Scaffold(
         topBar = {
             TopAppBar(
-                title = { Text("Scan QR Code") },
+                title = { Text(stringResource(R.string.qr_scanner_title)) },
                 windowInsets = WindowInsets(0, 0, 0, 0),
                 navigationIcon = {
                     IconButton(onClick = onBack) {

--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/search/FilterSheetSection.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/search/FilterSheetSection.kt
@@ -280,7 +280,7 @@ private fun FilterSheetHeader(
                 Icon(Icons.Default.BookmarkAdd, contentDescription = stringResource(R.string.cd_save_current_filter))
             }
             TextButton(onClick = onReset) {
-                Text("Reset")
+                Text(stringResource(R.string.search_filter_reset))
             }
         }
     }

--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/search/ModelGridItem.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/search/ModelGridItem.kt
@@ -61,7 +61,7 @@ internal fun ModelContextMenu(
     DropdownMenu(expanded = expanded, onDismissRequest = onDismiss) {
         if (showCompare) {
             DropdownMenuItem(
-                text = { Text("Compare") },
+                text = { Text(stringResource(R.string.search_compare)) },
                 onClick = {
                     onCompare()
                     onDismiss()
@@ -72,7 +72,7 @@ internal fun ModelContextMenu(
             )
         }
         DropdownMenuItem(
-            text = { Text("Hide model") },
+            text = { Text(stringResource(R.string.search_hide_model)) },
             onClick = {
                 onHide()
                 onDismiss()

--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/search/ModelSearchScreen.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/search/ModelSearchScreen.kt
@@ -276,20 +276,20 @@ private fun SaveFilterDialog(
 ) {
     AlertDialog(
         onDismissRequest = onDismiss,
-        title = { Text("Save Filter") },
+        title = { Text(stringResource(R.string.search_save_filter_title)) },
         text = {
             OutlinedTextField(
                 value = filterName,
                 onValueChange = onFilterNameChange,
-                label = { Text("Filter name") },
+                label = { Text(stringResource(R.string.search_filter_name_label)) },
                 singleLine = true,
             )
         },
         confirmButton = {
-            TextButton(onClick = onConfirm) { Text("Save") }
+            TextButton(onClick = onConfirm) { Text(stringResource(R.string.action_save)) }
         },
         dismissButton = {
-            TextButton(onClick = onDismiss) { Text("Cancel") }
+            TextButton(onClick = onDismiss) { Text(stringResource(R.string.action_cancel)) }
         },
     )
 }

--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/search/RecommendationRow.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/search/RecommendationRow.kt
@@ -111,7 +111,7 @@ internal fun ComparisonBottomBar(
                     )
                 }
                 TextButton(onClick = onCancel) {
-                    Text("Cancel")
+                    Text(stringResource(R.string.action_cancel))
                 }
             }
         }

--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/search/SearchBarSection.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/search/SearchBarSection.kt
@@ -198,7 +198,7 @@ private fun SearchTextField(
         value = query,
         onValueChange = onQueryChange,
         modifier = modifier.onFocusChanged { onFocusChanged(it.isFocused) },
-        placeholder = { Text("Search models...") },
+        placeholder = { Text(stringResource(R.string.search_placeholder)) },
         trailingIcon = {
             if (query.isNotEmpty()) {
                 IconButton(onClick = onClear) {

--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/share/ShareSettingsSection.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/share/ShareSettingsSection.kt
@@ -28,8 +28,10 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.unit.dp
+import com.riox432.civitdeck.R
 import com.riox432.civitdeck.domain.model.ShareHashtag
 import com.riox432.civitdeck.ui.theme.Spacing
 
@@ -112,7 +114,7 @@ private fun ShareHashtagAddRow(
         OutlinedTextField(
             value = input,
             onValueChange = onInputChange,
-            label = { Text("Add hashtag") },
+            label = { Text(stringResource(R.string.share_add_hashtag_label)) },
             modifier = Modifier.weight(1f),
             singleLine = true,
             keyboardOptions = KeyboardOptions(imeAction = ImeAction.Done),

--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/share/SocialShareSheet.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/share/SocialShareSheet.kt
@@ -43,8 +43,10 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.unit.dp
+import com.riox432.civitdeck.R
 import com.riox432.civitdeck.domain.model.ShareHashtag
 import com.riox432.civitdeck.ui.theme.Spacing
 
@@ -112,7 +114,7 @@ private fun CaptionField(caption: String, onCaptionChange: (String) -> Unit) {
     OutlinedTextField(
         value = caption,
         onValueChange = onCaptionChange,
-        label = { Text("Caption") },
+        label = { Text(stringResource(R.string.label_caption)) },
         modifier = Modifier.fillMaxWidth(),
         minLines = 2,
         maxLines = 5,
@@ -141,7 +143,7 @@ private fun HashtagSection(
     onToggle: (String, Boolean) -> Unit,
     onRemove: (String) -> Unit,
 ) {
-    Text("Hashtags", style = MaterialTheme.typography.labelMedium)
+    Text(stringResource(R.string.label_hashtags), style = MaterialTheme.typography.labelMedium)
     Spacer(modifier = Modifier.height(Spacing.xs))
     FlowRow(
         horizontalArrangement = Arrangement.spacedBy(Spacing.sm),
@@ -185,7 +187,7 @@ private fun AddTagRow(
         OutlinedTextField(
             value = input,
             onValueChange = onInputChange,
-            label = { Text("Add tag") },
+            label = { Text(stringResource(R.string.share_add_tag_label)) },
             modifier = Modifier.weight(1f),
             singleLine = true,
             keyboardOptions = KeyboardOptions(imeAction = ImeAction.Done),
@@ -217,7 +219,7 @@ private fun ActionButtons(
         ) {
             Icon(Icons.Default.ContentCopy, contentDescription = "Copy to clipboard", modifier = Modifier.size(18.dp))
             Spacer(modifier = Modifier.width(Spacing.xs))
-            Text("Copy")
+            Text(stringResource(R.string.action_copy))
         }
         Button(
             onClick = {
@@ -228,7 +230,7 @@ private fun ActionButtons(
         ) {
             Icon(Icons.Default.Share, contentDescription = "Share", modifier = Modifier.size(18.dp))
             Spacer(modifier = Modifier.width(Spacing.xs))
-            Text("Share")
+            Text(stringResource(R.string.action_share))
         }
     }
 }

--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/textsearch/TextSearchScreen.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/textsearch/TextSearchScreen.kt
@@ -49,7 +49,7 @@ fun TextSearchScreen(
     Scaffold(
         topBar = {
             TopAppBar(
-                title = { Text("AI Search") },
+                title = { Text(stringResource(R.string.text_search_title)) },
                 navigationIcon = {
                     IconButton(onClick = onBack) {
                         Icon(
@@ -101,7 +101,7 @@ private fun SearchInput(
         modifier = Modifier
             .fillMaxWidth()
             .padding(horizontal = Spacing.md, vertical = Spacing.sm),
-        placeholder = { Text("Describe what you're looking for...") },
+        placeholder = { Text(stringResource(R.string.text_search_placeholder)) },
         leadingIcon = { Icon(Icons.Filled.Search, contentDescription = null) },
         singleLine = true,
         keyboardOptions = KeyboardOptions(imeAction = ImeAction.Search),

--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/tutorial/GestureTutorialScreen.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/tutorial/GestureTutorialScreen.kt
@@ -24,7 +24,9 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
+import com.riox432.civitdeck.R
 import com.riox432.civitdeck.ui.theme.Spacing
 import kotlinx.coroutines.launch
 
@@ -59,7 +61,7 @@ fun GestureTutorialScreen(onDismiss: () -> Unit) {
 private fun SkipButton(onDismiss: () -> Unit) {
     Box(modifier = Modifier.fillMaxWidth(), contentAlignment = Alignment.CenterEnd) {
         TextButton(onClick = onDismiss) {
-            Text("Skip")
+            Text(stringResource(R.string.tutorial_skip))
         }
     }
 }

--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/update/UpdateBanner.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/update/UpdateBanner.kt
@@ -13,6 +13,8 @@ import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import com.riox432.civitdeck.R
 import com.riox432.civitdeck.domain.model.UpdateResult
 import com.riox432.civitdeck.ui.theme.Spacing
 
@@ -51,10 +53,10 @@ fun UpdateBanner(
                 verticalAlignment = Alignment.CenterVertically,
             ) {
                 TextButton(onClick = onDismiss) {
-                    Text("Dismiss")
+                    Text(stringResource(R.string.update_dismiss))
                 }
                 TextButton(onClick = onDownload) {
-                    Text("Download")
+                    Text(stringResource(R.string.update_download))
                 }
             }
         }

--- a/androidApp/src/main/res/values/strings.xml
+++ b/androidApp/src/main/res/values/strings.xml
@@ -246,4 +246,280 @@
     <string name="dataset_edit_caption">Edit caption</string>
     <string name="dataset_batch_edit_tags">Batch edit tags</string>
     <string name="dataset_select">Select</string>
+
+    <!-- Common actions -->
+    <string name="action_skip">Skip</string>
+    <string name="action_save">Save</string>
+    <string name="action_cancel">Cancel</string>
+    <string name="action_delete">Delete</string>
+    <string name="action_rename">Rename</string>
+    <string name="action_create">Create</string>
+    <string name="action_import">Import</string>
+    <string name="action_export">Export</string>
+    <string name="action_apply">Apply</string>
+    <string name="action_done">Done</string>
+    <string name="action_close">Close</string>
+    <string name="action_reset">Reset</string>
+    <string name="action_dismiss">Dismiss</string>
+    <string name="action_download">Download</string>
+    <string name="action_test">Test</string>
+    <string name="action_add">Add</string>
+    <string name="action_generate">Generate</string>
+    <string name="action_submit">Submit</string>
+    <string name="action_clear">Clear</string>
+    <string name="action_copy">Copy</string>
+    <string name="action_share">Share</string>
+    <string name="action_ok">OK</string>
+    <string name="action_remove">Remove</string>
+    <string name="action_restore">Restore</string>
+    <string name="action_select_all">Select All</string>
+    <string name="action_deselect_all">Deselect All</string>
+    <string name="action_clear_all">Clear All</string>
+    <string name="action_write">Write</string>
+    <string name="action_disconnect">Disconnect</string>
+    <string name="action_interrupt">Interrupt</string>
+    <string name="action_uninstall">Uninstall</string>
+
+    <!-- Common labels -->
+    <string name="label_loading">Loading…</string>
+    <string name="label_generating">Generating…</string>
+    <string name="label_importing">Importing…</string>
+    <string name="label_required">Required</string>
+    <string name="label_optional">Optional</string>
+    <string name="label_enabled">Enabled</string>
+    <string name="label_name">Name</string>
+    <string name="label_description">Description</string>
+    <string name="label_type">Type</string>
+    <string name="label_category">Category</string>
+    <string name="label_prompt">Prompt</string>
+    <string name="label_negative_prompt">Negative Prompt</string>
+    <string name="label_port">Port</string>
+    <string name="label_caption">Caption</string>
+    <string name="label_hashtags">Hashtags</string>
+    <string name="label_rating">Rating</string>
+    <string name="label_recommendation">Recommendation</string>
+
+    <!-- Tutorial -->
+    <string name="tutorial_skip">Skip</string>
+
+    <!-- Text search -->
+    <string name="text_search_title">AI Search</string>
+    <string name="text_search_placeholder">Describe what you\'re looking for…</string>
+
+    <!-- ComfyHub -->
+    <string name="comfyhub_workflows_title">ComfyHub Workflows</string>
+    <string name="comfyhub_search_placeholder">Search workflows…</string>
+    <string name="comfyhub_import_to_comfyui">Import to ComfyUI</string>
+
+    <!-- Update banner -->
+    <string name="update_dismiss">Dismiss</string>
+    <string name="update_download">Download</string>
+
+    <!-- ComfyUI -->
+    <string name="comfyui_title">ComfyUI</string>
+    <string name="comfyui_open_txt2img">Open txt2img Generator</string>
+    <string name="comfyui_view_gallery">View Output Gallery</string>
+    <string name="comfyui_scan_lan">Scan LAN</string>
+    <string name="comfyui_lan_discovery">LAN Discovery</string>
+    <string name="comfyui_lan_scan_hint">Scan your local network for ComfyUI servers</string>
+    <string name="comfyui_use_https">Use HTTPS</string>
+    <string name="comfyui_accept_self_signed">Accept self-signed certificates</string>
+    <string name="comfyui_hostname_label">Hostname / IP</string>
+    <string name="comfyui_hostname_placeholder">192.168.1.100</string>
+    <string name="comfyui_name_placeholder">e.g. Home PC</string>
+    <string name="comfyui_edit_connection">Edit Connection</string>
+    <string name="comfyui_add_connection">Add Connection</string>
+    <string name="comfyui_queue_title">Queue</string>
+    <string name="comfyui_txt2img_title">txt2img</string>
+    <string name="comfyui_lora_label">LoRA</string>
+    <string name="comfyui_controlnet_label">ControlNet</string>
+    <string name="comfyui_select_controlnet">Select ControlNet model…</string>
+    <string name="comfyui_edit_parameters_count">Edit Parameters (%1$d)</string>
+    <string name="comfyui_import_workflow_json">Import Workflow JSON</string>
+    <string name="comfyui_paste_workflow_json">Paste ComfyUI Workflow JSON</string>
+    <string name="comfyui_workflow_json_label">Workflow JSON</string>
+    <string name="comfyui_custom_workflow_json">Custom Workflow JSON</string>
+    <string name="comfyui_add_mask">Add Mask</string>
+    <string name="comfyui_inpainting_mask">Inpainting Mask</string>
+    <string name="comfyui_checkpoint_label">Checkpoint</string>
+    <string name="comfyui_seed_label">Seed (-1 = random)</string>
+    <string name="comfyui_width_label">Width</string>
+    <string name="comfyui_height_label">Height</string>
+    <string name="comfyui_result_generating">Generating…</string>
+    <string name="comfyui_output_gallery_title">Output Gallery</string>
+    <string name="comfyui_add_to_dataset">Add to Dataset</string>
+    <string name="comfyui_mask_editor_title">Mask Editor</string>
+    <string name="comfyui_no_loras">No LoRAs found on server</string>
+    <string name="comfyui_loading_parameters">Loading parameters…</string>
+    <string name="comfyui_image_saved">Image saved to gallery</string>
+    <string name="comfyui_image_save_failed">Failed to save image</string>
+    <string name="comfyui_status_connected">Connected</string>
+    <string name="comfyui_status_disconnected">Disconnected</string>
+    <string name="comfyui_status_testing">Testing…</string>
+    <string name="comfyui_status_error">Connection Error</string>
+    <string name="comfyui_status_not_configured">No server configured</string>
+
+    <!-- SD WebUI -->
+    <string name="sdwebui_title">SD WebUI</string>
+    <string name="sdwebui_open_generator">Open Generator</string>
+    <string name="sdwebui_generation_title">SD WebUI Generation</string>
+    <string name="sdwebui_steps_label">Steps</string>
+    <string name="sdwebui_cfg_scale_label">CFG Scale</string>
+    <string name="sdwebui_image_error">Image error</string>
+    <string name="sdwebui_generated_images">Generated Images</string>
+    <string name="sdwebui_port_placeholder">7860</string>
+
+    <!-- Civitai Link -->
+    <string name="civitai_link_title">Civitai Link</string>
+    <string name="civitai_link_key_label">Link Key</string>
+    <string name="civitai_link_key_placeholder">Paste your Civitai Link key here</string>
+
+    <!-- Workflow templates -->
+    <string name="template_editor_create">Create Template</string>
+    <string name="template_editor_edit">Edit Template</string>
+    <string name="template_name_label">Template Name</string>
+    <string name="template_display_label">Display Label</string>
+    <string name="template_default_label">Default</string>
+    <string name="template_min_label">Min</string>
+    <string name="template_max_label">Max</string>
+    <string name="template_step_label">Step</string>
+    <string name="template_variables">Variables</string>
+    <string name="template_picker_title">Pick Template</string>
+    <string name="template_list_title">Workflow Templates</string>
+    <string name="template_search_placeholder">Search templates…</string>
+    <string name="template_all_filter">All</string>
+    <string name="template_all_types_filter">All Types</string>
+    <string name="template_import_json">Import Template JSON</string>
+    <string name="template_paste_json">Paste template JSON</string>
+    <string name="template_json_title">Template JSON</string>
+    <string name="template_import_failed">Import failed: %1$s</string>
+    <string name="template_no_templates">No templates yet. Create one with the + button.</string>
+    <string name="template_no_match">No templates match your filters.</string>
+
+    <!-- Model files -->
+    <string name="model_files_title">Model Files</string>
+    <string name="model_files_scan_error">Scan Error</string>
+    <string name="model_files_remove_directory">Remove Directory</string>
+    <string name="model_files_remove_confirm">Remove this directory and all its scanned data?</string>
+    <string name="model_files_add_directory">Add Model Directory</string>
+    <string name="model_files_path_placeholder">/path/to/models</string>
+
+    <!-- Dataset -->
+    <string name="dataset_create_new">Create New Dataset</string>
+    <string name="dataset_caption_label">Caption</string>
+    <string name="dataset_caption_placeholder">Describe this image for training…</string>
+    <string name="dataset_list_title">Datasets</string>
+    <string name="dataset_name_label">Dataset name</string>
+    <string name="dataset_review_duplicates">Review Duplicates</string>
+    <string name="dataset_selected_count_label">%1$d selected</string>
+    <string name="dataset_export_cancel">Cancel</string>
+    <string name="dataset_export_complete">Export Complete</string>
+    <string name="dataset_export_failed">Export Failed</string>
+    <string name="dataset_export_anyway">Export Anyway</string>
+    <string name="dataset_license_warning">License Warning</string>
+    <string name="dataset_license_warning_message">%1$d images are non-trainable or have license restrictions. They will be excluded from the export.</string>
+
+    <!-- Gallery -->
+    <string name="gallery_title">Images</string>
+    <string name="gallery_copy_prompt">Copy Prompt</string>
+    <string name="gallery_save_prompt">Save Prompt</string>
+    <string name="gallery_comfyui_workflow">ComfyUI Workflow</string>
+    <string name="gallery_a1111_params">A1111 Params</string>
+
+    <!-- Discovery -->
+    <string name="discovery_title">Discover</string>
+
+    <!-- Plugin -->
+    <string name="plugin_enabled_label">Enabled</string>
+    <string name="plugin_json_config_label">JSON Config</string>
+    <string name="plugin_save_config">Save Config</string>
+    <string name="plugin_uninstall">Uninstall Plugin</string>
+    <string name="plugin_uninstall_confirm_title">Uninstall Plugin</string>
+    <string name="plugin_uninstall_confirm_message">Are you sure? This will remove the plugin and its data.</string>
+    <string name="plugin_uninstall_action">Uninstall</string>
+    <string name="plugin_list_title">Plugins</string>
+
+    <!-- QR Code -->
+    <string name="qr_scanner_title">Scan QR Code</string>
+    <string name="qr_share">Share QR Code</string>
+
+    <!-- Search -->
+    <string name="search_filter_reset">Reset</string>
+    <string name="search_save_filter_title">Save Filter</string>
+    <string name="search_filter_name_label">Filter name</string>
+    <string name="search_compare">Compare</string>
+    <string name="search_hide_model">Hide model</string>
+    <string name="search_placeholder">Search models…</string>
+
+    <!-- Detail -->
+    <string name="detail_find_similar">Find similar</string>
+    <string name="detail_add_to_collection">Add to collection</string>
+    <string name="detail_qr_code">QR code</string>
+    <string name="detail_view_community_images">View Community Images</string>
+    <string name="detail_send_to_pc">Send to PC</string>
+    <string name="detail_try_in_comfyui">Try in ComfyUI</string>
+    <string name="detail_note_placeholder">e.g. Works great with X LoRA</string>
+    <string name="detail_tag_placeholder">Tag name</string>
+    <string name="detail_review_details_label">Details (optional)</string>
+    <string name="detail_recommend">Recommend</string>
+    <string name="detail_not_recommended">Not recommended</string>
+    <string name="detail_compare_images">Compare Images</string>
+    <string name="detail_compare_models_title">Compare Models</string>
+
+    <!-- Notifications -->
+    <string name="notification_center_title">Notifications</string>
+
+    <!-- Feed -->
+    <string name="feed_title">Feed</string>
+
+    <!-- Browsing history -->
+    <string name="history_title">Browsing History</string>
+    <string name="history_clear_all_title">Clear All History</string>
+    <string name="history_clear_all_confirm">Are you sure? This cannot be undone.</string>
+
+    <!-- Prompts -->
+    <string name="prompts_search_placeholder">Search prompts…</string>
+    <string name="prompts_save_as_template">Save as Template</string>
+    <string name="prompts_template_name_label">Template name (optional)</string>
+
+    <!-- Backup -->
+    <string name="backup_title">Backup &amp; Restore</string>
+    <string name="backup_export">Export Backup</string>
+    <string name="backup_import">Import from File</string>
+    <string name="backup_restore_title">Restore Backup</string>
+    <string name="backup_restore_strategy">Restore Strategy:</string>
+    <string name="backup_categories_to_restore">Categories to restore:</string>
+    <string name="backup_found_categories">Found data for %1$d categories.</string>
+    <string name="backup_select_data">Select Data</string>
+
+    <!-- Collections -->
+    <string name="collection_all_types">All Types</string>
+    <string name="collection_new_title">New Collection</string>
+    <string name="collection_name_label">Collection name</string>
+    <string name="collection_delete_title">Delete Collection</string>
+    <string name="collection_delete_confirm">Are you sure you want to delete \"%1$s\"? This cannot be undone.</string>
+    <string name="collection_rename_title">Rename Collection</string>
+    <string name="collection_create_new">Create New Collection</string>
+
+    <!-- Create -->
+    <string name="create_hub_title">Create</string>
+
+    <!-- External server -->
+    <string name="external_server_title">Custom Server</string>
+    <string name="external_server_test_connection">Test Connection</string>
+    <string name="external_server_open_gallery">Open Gallery</string>
+    <string name="external_server_display_name_label">Display Name</string>
+    <string name="external_server_url_label">Server URL</string>
+    <string name="external_server_api_key_label">API Key (optional)</string>
+    <string name="external_server_search_label">Search</string>
+    <string name="external_server_character_label">Character</string>
+    <string name="external_server_scenario_label">Scenario</string>
+    <string name="external_server_start_generation">Start Generation</string>
+
+    <!-- Analytics -->
+    <string name="analytics_title">Usage Stats</string>
+
+    <!-- Share -->
+    <string name="share_add_hashtag_label">Add hashtag</string>
+    <string name="share_add_tag_label">Add tag</string>
 </resources>


### PR DESCRIPTION
## Summary
- Moved ~250 hardcoded user-facing strings from 58 Android UI files to `strings.xml`
- Added ~180 new string resources organized by feature (common actions, labels, ComfyUI, SD WebUI, templates, collections, backup, etc.)
- Replaced all `Text("...")` with `Text(stringResource(R.string.xxx))` throughout the Android app
- Converted `statusLabel()` functions in ComfyUI/SDWebUI settings to `@Composable` to enable `stringResource()` usage

Closes #852

## What was NOT changed
- Dynamic content (e.g. `"${server.ip}:${server.port}"`, `"$steps"`) remains inline -- these are runtime values, not localizable labels
- `ClipData.newPlainText()` labels -- internal clipboard labels, not user-visible
- Non-composable `LazyListScope` extension functions -- would require structural refactoring to access `stringResource()`
- Desktop app strings -- out of scope per issue instructions

## Test plan
- [ ] Verify Android app builds successfully (`./gradlew :androidApp:assembleDebug`)
- [ ] Run detekt lint (`./gradlew :androidApp:detekt`) -- both pass
- [ ] Spot-check key screens: ComfyUI settings, search, collections, backup, plugin management
- [ ] Verify no visual regressions (strings display identically to before)