### PR TITLE
Group ModelDetailViewModel constructor params into aggregate use case classes

### DIFF
--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/CivitDeckApplication.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/CivitDeckApplication.kt
@@ -114,10 +114,7 @@ class CivitDeckApplication : Application(), SingletonImageLoader.Factory, KoinCo
 val androidModule = module {
     single<AppVersionProvider> { AndroidAppVersionProvider() }
     viewModel { params ->
-        ModelDetailViewModel(
-            params.get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get(),
-            get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get(),
-        )
+        ModelDetailViewModel(params.get(), get(), get(), get(), get(), get())
     }
     viewModel { params -> DuplicateReviewViewModel(params.get(), get(), get()) }
     // DownloadQueueViewModel now registered in shared Phase3ViewModelModule

--- a/androidApp/src/test/kotlin/com/riox432/civitdeck/ui/detail/ModelDetailViewModelTest.kt
+++ b/androidApp/src/test/kotlin/com/riox432/civitdeck/ui/detail/ModelDetailViewModelTest.kt
@@ -1,9 +1,12 @@
 package com.riox432.civitdeck.ui.detail
 
+import com.riox432.civitdeck.domain.ml.ImageEmbeddingModel
 import com.riox432.civitdeck.domain.model.BaseModel
 import com.riox432.civitdeck.domain.model.Creator
+import com.riox432.civitdeck.domain.model.DownloadStatus
 import com.riox432.civitdeck.domain.model.Model
 import com.riox432.civitdeck.domain.model.ModelCollection
+import com.riox432.civitdeck.domain.model.ModelDownload
 import com.riox432.civitdeck.domain.model.ModelImage
 import com.riox432.civitdeck.domain.model.ModelNote
 import com.riox432.civitdeck.domain.model.ModelStats
@@ -13,31 +16,51 @@ import com.riox432.civitdeck.domain.model.NsfwFilterLevel
 import com.riox432.civitdeck.domain.model.NsfwLevel
 import com.riox432.civitdeck.domain.model.PaginatedResult
 import com.riox432.civitdeck.domain.model.PersonalTag
+import com.riox432.civitdeck.domain.model.RatingTotals
 import com.riox432.civitdeck.domain.model.SortOrder
 import com.riox432.civitdeck.domain.model.TimePeriod
 import com.riox432.civitdeck.domain.repository.BrowsingHistoryRepository
 import com.riox432.civitdeck.domain.repository.ContentFilterPreferencesRepository
 import com.riox432.civitdeck.domain.repository.FavoriteRepository
+import com.riox432.civitdeck.domain.repository.ModelDownloadRepository
+import com.riox432.civitdeck.domain.repository.ModelEmbeddingRepository
 import com.riox432.civitdeck.domain.repository.ModelNoteRepository
 import com.riox432.civitdeck.domain.repository.ModelRepository
+import com.riox432.civitdeck.domain.repository.ReviewPage
+import com.riox432.civitdeck.domain.repository.ReviewRepository
+import com.riox432.civitdeck.domain.repository.ThumbnailDownloader
 import com.riox432.civitdeck.domain.usecase.AddModelToCollectionUseCase
 import com.riox432.civitdeck.domain.usecase.AddPersonalTagUseCase
+import com.riox432.civitdeck.domain.usecase.CancelDownloadUseCase
 import com.riox432.civitdeck.domain.usecase.CreateCollectionUseCase
 import com.riox432.civitdeck.domain.usecase.DeleteModelNoteUseCase
+import com.riox432.civitdeck.domain.usecase.EmbedImageUseCase
+import com.riox432.civitdeck.domain.usecase.EmbedOnBrowseUseCase
+import com.riox432.civitdeck.domain.usecase.EnqueueDownloadUseCase
 import com.riox432.civitdeck.domain.usecase.EnrichModelImagesUseCase
 import com.riox432.civitdeck.domain.usecase.GetModelDetailUseCase
+import com.riox432.civitdeck.domain.usecase.GetModelReviewsUseCase
+import com.riox432.civitdeck.domain.usecase.GetRatingTotalsUseCase
 import com.riox432.civitdeck.domain.usecase.ObserveCollectionsUseCase
 import com.riox432.civitdeck.domain.usecase.ObserveIsFavoriteUseCase
 import com.riox432.civitdeck.domain.usecase.ObserveModelCollectionsUseCase
+import com.riox432.civitdeck.domain.usecase.ObserveModelDownloadsUseCase
 import com.riox432.civitdeck.domain.usecase.ObserveModelNoteUseCase
 import com.riox432.civitdeck.domain.usecase.ObserveNsfwFilterUseCase
 import com.riox432.civitdeck.domain.usecase.ObservePersonalTagsUseCase
+import com.riox432.civitdeck.domain.usecase.ObservePowerUserModeUseCase
 import com.riox432.civitdeck.domain.usecase.RemoveModelFromCollectionUseCase
 import com.riox432.civitdeck.domain.usecase.RemovePersonalTagUseCase
 import com.riox432.civitdeck.domain.usecase.SaveModelNoteUseCase
+import com.riox432.civitdeck.domain.usecase.SubmitReviewUseCase
 import com.riox432.civitdeck.domain.usecase.ToggleFavoriteUseCase
 import com.riox432.civitdeck.domain.usecase.TrackModelViewUseCase
+import com.riox432.civitdeck.feature.detail.presentation.CollectionUseCases
+import com.riox432.civitdeck.feature.detail.presentation.DownloadUseCases
 import com.riox432.civitdeck.feature.detail.presentation.ModelDetailViewModel
+import com.riox432.civitdeck.feature.detail.presentation.ModelUseCases
+import com.riox432.civitdeck.feature.detail.presentation.NotesTagsUseCases
+import com.riox432.civitdeck.feature.detail.presentation.ReviewUseCases
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
@@ -100,6 +123,8 @@ class ModelDetailViewModelTest {
             ),
         ),
     )
+
+    // region Fake repositories
 
     private class FakeModelRepo(val model: Model) : ModelRepository {
         var getModelCalled = false
@@ -245,15 +270,66 @@ class ModelDetailViewModelTest {
         ) = Unit
     }
 
+    @Suppress("TooManyFunctions")
+    private class FakeDownloadRepo : ModelDownloadRepository {
+        override suspend fun enqueueDownload(download: ModelDownload) = 1L
+        override fun observeAllDownloads() = flowOf(emptyList<ModelDownload>())
+        override fun observeDownloadsForModel(modelId: Long) = flowOf(emptyList<ModelDownload>())
+        override suspend fun getDownloadById(id: Long): ModelDownload? = null
+        override suspend fun getDownloadByFileId(fileId: Long): ModelDownload? = null
+        override suspend fun updateStatus(id: Long, status: DownloadStatus, errorMessage: String?) = Unit
+        override suspend fun updateProgress(id: Long, downloadedBytes: Long) = Unit
+        override suspend fun updateDestinationPath(id: Long, path: String) = Unit
+        override suspend fun deleteDownload(id: Long) = Unit
+        override suspend fun updateHashVerified(id: Long, verified: Boolean) = Unit
+        override suspend fun clearCompletedDownloads() = Unit
+    }
+
+    private class FakeReviewRepo : ReviewRepository {
+        override suspend fun getReviews(
+            modelId: Long,
+            modelVersionId: Long?,
+            limit: Int,
+            cursor: Int?,
+        ) = ReviewPage(emptyList(), null)
+
+        override suspend fun getRatingTotals(modelId: Long, modelVersionId: Long?) =
+            RatingTotals(0, 0, 0, 0, 0, 0, 0)
+
+        override suspend fun submitReview(
+            modelId: Long,
+            modelVersionId: Long,
+            rating: Int,
+            recommended: Boolean,
+            details: String?,
+        ) = Unit
+    }
+
+    private class NoOpEmbeddingRepo : ModelEmbeddingRepository {
+        override suspend fun get(modelId: Long) = null
+        override suspend fun count(embeddingModel: String) = 0
+        override suspend fun cache(embedding: com.riox432.civitdeck.domain.model.ModelEmbedding) = Unit
+        override suspend fun findSimilar(
+            query: FloatArray,
+            embeddingModel: String,
+            limit: Int,
+            excludeModelId: Long?,
+        ) = emptyList<com.riox432.civitdeck.domain.model.SimilarModelHit>()
+        override suspend fun deleteStale(keepModel: String) = 0
+        override suspend fun clear() = Unit
+    }
+
+    private class NoOpDownloader : ThumbnailDownloader {
+        override suspend fun download(url: String) = byteArrayOf()
+    }
+
+    // endregion
+
     @Suppress("LongMethod")
     private fun createViewModel(
         model: Model = testModel(),
         isFavorite: Boolean = false,
-    ): Triple<
-        com.riox432.civitdeck.ui.detail.ModelDetailViewModel,
-        FakeModelRepo,
-        FakeFavoriteRepo,
-        > {
+    ): Triple<ModelDetailViewModel, FakeModelRepo, FakeFavoriteRepo> {
         val modelRepo = FakeModelRepo(model)
         val favRepo = FakeFavoriteRepo(MutableStateFlow(isFavorite))
         val browsingRepo = FakeBrowsingRepo()
@@ -261,29 +337,56 @@ class ModelDetailViewModelTest {
         val collectionRepo = FakeCollectionRepo()
         val noteRepo = FakeNoteRepo()
         val powerUserRepo = FakePowerUserRepo()
+        val downloadRepo = FakeDownloadRepo()
+        val reviewRepo = FakeReviewRepo()
 
-        val vm = com.riox432.civitdeck.ui.detail.ModelDetailViewModel(
-            modelId = model.id,
-            getModelDetailUseCase = GetModelDetailUseCase(modelRepo),
-            observeIsFavoriteUseCase = ObserveIsFavoriteUseCase(favRepo),
-            toggleFavoriteUseCase = ToggleFavoriteUseCase(favRepo),
-            trackModelViewUseCase = TrackModelViewUseCase(browsingRepo),
-            observeNsfwFilterUseCase = ObserveNsfwFilterUseCase(prefsRepo),
-            enrichModelImagesUseCase = EnrichModelImagesUseCase(modelRepo),
-            observeCollectionsUseCase = ObserveCollectionsUseCase(collectionRepo),
-            observeModelCollectionsUseCase = ObserveModelCollectionsUseCase(collectionRepo),
-            addModelToCollectionUseCase = AddModelToCollectionUseCase(collectionRepo),
-            removeModelFromCollectionUseCase = RemoveModelFromCollectionUseCase(collectionRepo),
-            createCollectionUseCase = CreateCollectionUseCase(collectionRepo),
-            observePowerUserModeUseCase = com.riox432.civitdeck.domain.usecase.ObservePowerUserModeUseCase(
-                powerUserRepo
+        val modelUseCases = ModelUseCases(
+            getModelDetail = GetModelDetailUseCase(modelRepo),
+            observeIsFavorite = ObserveIsFavoriteUseCase(favRepo),
+            toggleFavorite = ToggleFavoriteUseCase(favRepo),
+            trackModelView = TrackModelViewUseCase(browsingRepo),
+            enrichModelImages = EnrichModelImagesUseCase(modelRepo),
+            embedOnBrowse = EmbedOnBrowseUseCase(
+                NoOpEmbeddingRepo(),
+                EmbedImageUseCase(ImageEmbeddingModel()),
+                NoOpDownloader(),
             ),
-            observeModelNoteUseCase = ObserveModelNoteUseCase(noteRepo),
-            saveModelNoteUseCase = SaveModelNoteUseCase(noteRepo),
-            deleteModelNoteUseCase = DeleteModelNoteUseCase(noteRepo),
-            observePersonalTagsUseCase = ObservePersonalTagsUseCase(noteRepo),
-            addPersonalTagUseCase = AddPersonalTagUseCase(noteRepo),
-            removePersonalTagUseCase = RemovePersonalTagUseCase(noteRepo),
+            observeNsfwFilter = ObserveNsfwFilterUseCase(prefsRepo),
+            observePowerUserMode = ObservePowerUserModeUseCase(powerUserRepo),
+        )
+        val collectionUseCases = CollectionUseCases(
+            observeCollections = ObserveCollectionsUseCase(collectionRepo),
+            observeModelCollections = ObserveModelCollectionsUseCase(collectionRepo),
+            addModelToCollection = AddModelToCollectionUseCase(collectionRepo),
+            removeModelFromCollection = RemoveModelFromCollectionUseCase(collectionRepo),
+            createCollection = CreateCollectionUseCase(collectionRepo),
+        )
+        val notesTagsUseCases = NotesTagsUseCases(
+            observeModelNote = ObserveModelNoteUseCase(noteRepo),
+            saveModelNote = SaveModelNoteUseCase(noteRepo),
+            deleteModelNote = DeleteModelNoteUseCase(noteRepo),
+            observePersonalTags = ObservePersonalTagsUseCase(noteRepo),
+            addPersonalTag = AddPersonalTagUseCase(noteRepo),
+            removePersonalTag = RemovePersonalTagUseCase(noteRepo),
+        )
+        val downloadUseCases = DownloadUseCases(
+            observeModelDownloads = ObserveModelDownloadsUseCase(downloadRepo),
+            enqueueDownload = EnqueueDownloadUseCase(downloadRepo),
+            cancelDownload = CancelDownloadUseCase(downloadRepo),
+        )
+        val reviewUseCases = ReviewUseCases(
+            getModelReviews = GetModelReviewsUseCase(reviewRepo),
+            getRatingTotals = GetRatingTotalsUseCase(reviewRepo),
+            submitReview = SubmitReviewUseCase(reviewRepo),
+        )
+
+        val vm = ModelDetailViewModel(
+            modelId = model.id,
+            modelUseCases = modelUseCases,
+            collectionUseCases = collectionUseCases,
+            notesTagsUseCases = notesTagsUseCases,
+            downloadUseCases = downloadUseCases,
+            reviewUseCases = reviewUseCases,
         )
         return Triple(vm, modelRepo, favRepo)
     }

--- a/desktopApp/src/jvmMain/kotlin/com/riox432/civitdeck/di/DesktopModule.kt
+++ b/desktopApp/src/jvmMain/kotlin/com/riox432/civitdeck/di/DesktopModule.kt
@@ -12,10 +12,7 @@ val desktopModule = module {
     single<AppVersionProvider> { DesktopAppVersionProvider() }
     viewModel { DesktopUpdateViewModel(get(), get(), get()) }
     viewModel { params ->
-        ModelDetailViewModel(
-            params.get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get(),
-            get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get(),
-        )
+        ModelDetailViewModel(params.get(), get(), get(), get(), get(), get())
     }
     viewModel {
         DesktopDiscoveryViewModel(get(), get())

--- a/feature/feature-detail/src/commonMain/kotlin/com/riox432/civitdeck/feature/detail/di/DetailModule.kt
+++ b/feature/feature-detail/src/commonMain/kotlin/com/riox432/civitdeck/feature/detail/di/DetailModule.kt
@@ -1,14 +1,49 @@
 package com.riox432.civitdeck.feature.detail.di
 
+import com.riox432.civitdeck.feature.detail.presentation.CollectionUseCases
+import com.riox432.civitdeck.feature.detail.presentation.DownloadUseCases
 import com.riox432.civitdeck.feature.detail.presentation.ModelDetailViewModel
+import com.riox432.civitdeck.feature.detail.presentation.ModelUseCases
+import com.riox432.civitdeck.feature.detail.presentation.NotesTagsUseCases
+import com.riox432.civitdeck.feature.detail.presentation.ReviewUseCases
 import org.koin.core.module.dsl.viewModel
 import org.koin.dsl.module
 
 val detailModule = module {
-    viewModel { params ->
-        ModelDetailViewModel(
-            params.get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get(),
-            get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get(),
+    factory {
+        ModelUseCases(
+            getModelDetail = get(),
+            observeIsFavorite = get(),
+            toggleFavorite = get(),
+            trackModelView = get(),
+            enrichModelImages = get(),
+            embedOnBrowse = get(),
+            observeNsfwFilter = get(),
+            observePowerUserMode = get(),
         )
+    }
+    factory {
+        CollectionUseCases(
+            observeCollections = get(),
+            observeModelCollections = get(),
+            addModelToCollection = get(),
+            removeModelFromCollection = get(),
+            createCollection = get(),
+        )
+    }
+    factory {
+        NotesTagsUseCases(
+            observeModelNote = get(),
+            saveModelNote = get(),
+            deleteModelNote = get(),
+            observePersonalTags = get(),
+            addPersonalTag = get(),
+            removePersonalTag = get(),
+        )
+    }
+    factory { DownloadUseCases(observeModelDownloads = get(), enqueueDownload = get(), cancelDownload = get()) }
+    factory { ReviewUseCases(getModelReviews = get(), getRatingTotals = get(), submitReview = get()) }
+    viewModel { params ->
+        ModelDetailViewModel(params.get(), get(), get(), get(), get(), get())
     }
 }

--- a/feature/feature-detail/src/commonMain/kotlin/com/riox432/civitdeck/feature/detail/presentation/DetailUseCases.kt
+++ b/feature/feature-detail/src/commonMain/kotlin/com/riox432/civitdeck/feature/detail/presentation/DetailUseCases.kt
@@ -1,0 +1,82 @@
+package com.riox432.civitdeck.feature.detail.presentation
+
+import com.riox432.civitdeck.domain.usecase.AddModelToCollectionUseCase
+import com.riox432.civitdeck.domain.usecase.AddPersonalTagUseCase
+import com.riox432.civitdeck.domain.usecase.CancelDownloadUseCase
+import com.riox432.civitdeck.domain.usecase.CreateCollectionUseCase
+import com.riox432.civitdeck.domain.usecase.DeleteModelNoteUseCase
+import com.riox432.civitdeck.domain.usecase.EmbedOnBrowseUseCase
+import com.riox432.civitdeck.domain.usecase.EnqueueDownloadUseCase
+import com.riox432.civitdeck.domain.usecase.EnrichModelImagesUseCase
+import com.riox432.civitdeck.domain.usecase.GetModelDetailUseCase
+import com.riox432.civitdeck.domain.usecase.GetModelReviewsUseCase
+import com.riox432.civitdeck.domain.usecase.GetRatingTotalsUseCase
+import com.riox432.civitdeck.domain.usecase.ObserveCollectionsUseCase
+import com.riox432.civitdeck.domain.usecase.ObserveIsFavoriteUseCase
+import com.riox432.civitdeck.domain.usecase.ObserveModelCollectionsUseCase
+import com.riox432.civitdeck.domain.usecase.ObserveModelDownloadsUseCase
+import com.riox432.civitdeck.domain.usecase.ObserveModelNoteUseCase
+import com.riox432.civitdeck.domain.usecase.ObserveNsfwFilterUseCase
+import com.riox432.civitdeck.domain.usecase.ObservePersonalTagsUseCase
+import com.riox432.civitdeck.domain.usecase.ObservePowerUserModeUseCase
+import com.riox432.civitdeck.domain.usecase.RemoveModelFromCollectionUseCase
+import com.riox432.civitdeck.domain.usecase.RemovePersonalTagUseCase
+import com.riox432.civitdeck.domain.usecase.SaveModelNoteUseCase
+import com.riox432.civitdeck.domain.usecase.SubmitReviewUseCase
+import com.riox432.civitdeck.domain.usecase.ToggleFavoriteUseCase
+import com.riox432.civitdeck.domain.usecase.TrackModelViewUseCase
+
+/**
+ * Core model operations: loading, favorites, tracking, enrichment, and settings observers.
+ */
+data class ModelUseCases(
+    val getModelDetail: GetModelDetailUseCase,
+    val observeIsFavorite: ObserveIsFavoriteUseCase,
+    val toggleFavorite: ToggleFavoriteUseCase,
+    val trackModelView: TrackModelViewUseCase,
+    val enrichModelImages: EnrichModelImagesUseCase,
+    val embedOnBrowse: EmbedOnBrowseUseCase,
+    val observeNsfwFilter: ObserveNsfwFilterUseCase,
+    val observePowerUserMode: ObservePowerUserModeUseCase,
+)
+
+/**
+ * Collection management: observing, adding/removing models, creating collections.
+ */
+data class CollectionUseCases(
+    val observeCollections: ObserveCollectionsUseCase,
+    val observeModelCollections: ObserveModelCollectionsUseCase,
+    val addModelToCollection: AddModelToCollectionUseCase,
+    val removeModelFromCollection: RemoveModelFromCollectionUseCase,
+    val createCollection: CreateCollectionUseCase,
+)
+
+/**
+ * Notes and personal tags: observing, saving/deleting notes, adding/removing tags.
+ */
+data class NotesTagsUseCases(
+    val observeModelNote: ObserveModelNoteUseCase,
+    val saveModelNote: SaveModelNoteUseCase,
+    val deleteModelNote: DeleteModelNoteUseCase,
+    val observePersonalTags: ObservePersonalTagsUseCase,
+    val addPersonalTag: AddPersonalTagUseCase,
+    val removePersonalTag: RemovePersonalTagUseCase,
+)
+
+/**
+ * Download management: observing download status, enqueueing, and cancelling.
+ */
+data class DownloadUseCases(
+    val observeModelDownloads: ObserveModelDownloadsUseCase,
+    val enqueueDownload: EnqueueDownloadUseCase,
+    val cancelDownload: CancelDownloadUseCase,
+)
+
+/**
+ * Review operations: fetching reviews/ratings and submitting new reviews.
+ */
+data class ReviewUseCases(
+    val getModelReviews: GetModelReviewsUseCase,
+    val getRatingTotals: GetRatingTotalsUseCase,
+    val submitReview: SubmitReviewUseCase,
+)

--- a/feature/feature-detail/src/commonMain/kotlin/com/riox432/civitdeck/feature/detail/presentation/ModelDetailViewModel.kt
+++ b/feature/feature-detail/src/commonMain/kotlin/com/riox432/civitdeck/feature/detail/presentation/ModelDetailViewModel.kt
@@ -14,31 +14,6 @@ import com.riox432.civitdeck.domain.model.PersonalTag
 import com.riox432.civitdeck.domain.model.RatingTotals
 import com.riox432.civitdeck.domain.model.ResourceReview
 import com.riox432.civitdeck.domain.model.ReviewSortOrder
-import com.riox432.civitdeck.domain.usecase.AddModelToCollectionUseCase
-import com.riox432.civitdeck.domain.usecase.AddPersonalTagUseCase
-import com.riox432.civitdeck.domain.usecase.CancelDownloadUseCase
-import com.riox432.civitdeck.domain.usecase.CreateCollectionUseCase
-import com.riox432.civitdeck.domain.usecase.DeleteModelNoteUseCase
-import com.riox432.civitdeck.domain.usecase.EmbedOnBrowseUseCase
-import com.riox432.civitdeck.domain.usecase.EnqueueDownloadUseCase
-import com.riox432.civitdeck.domain.usecase.EnrichModelImagesUseCase
-import com.riox432.civitdeck.domain.usecase.GetModelDetailUseCase
-import com.riox432.civitdeck.domain.usecase.GetModelReviewsUseCase
-import com.riox432.civitdeck.domain.usecase.GetRatingTotalsUseCase
-import com.riox432.civitdeck.domain.usecase.ObserveCollectionsUseCase
-import com.riox432.civitdeck.domain.usecase.ObserveIsFavoriteUseCase
-import com.riox432.civitdeck.domain.usecase.ObserveModelCollectionsUseCase
-import com.riox432.civitdeck.domain.usecase.ObserveModelDownloadsUseCase
-import com.riox432.civitdeck.domain.usecase.ObserveModelNoteUseCase
-import com.riox432.civitdeck.domain.usecase.ObserveNsfwFilterUseCase
-import com.riox432.civitdeck.domain.usecase.ObservePersonalTagsUseCase
-import com.riox432.civitdeck.domain.usecase.ObservePowerUserModeUseCase
-import com.riox432.civitdeck.domain.usecase.RemoveModelFromCollectionUseCase
-import com.riox432.civitdeck.domain.usecase.RemovePersonalTagUseCase
-import com.riox432.civitdeck.domain.usecase.SaveModelNoteUseCase
-import com.riox432.civitdeck.domain.usecase.SubmitReviewUseCase
-import com.riox432.civitdeck.domain.usecase.ToggleFavoriteUseCase
-import com.riox432.civitdeck.domain.usecase.TrackModelViewUseCase
 import com.riox432.civitdeck.domain.util.UiLoadingState
 import com.riox432.civitdeck.domain.util.currentTimeMillis
 import com.riox432.civitdeck.domain.util.suspendRunCatching
@@ -76,34 +51,14 @@ data class ModelDetailUiState(
     val reviewSubmitSuccess: Boolean = false,
 ) : UiLoadingState
 
-@Suppress("LongParameterList", "TooManyFunctions")
+@Suppress("TooManyFunctions")
 class ModelDetailViewModel(
     private val modelId: Long,
-    private val getModelDetailUseCase: GetModelDetailUseCase,
-    private val observeIsFavoriteUseCase: ObserveIsFavoriteUseCase,
-    private val toggleFavoriteUseCase: ToggleFavoriteUseCase,
-    private val trackModelViewUseCase: TrackModelViewUseCase,
-    private val observeNsfwFilterUseCase: ObserveNsfwFilterUseCase,
-    private val enrichModelImagesUseCase: EnrichModelImagesUseCase,
-    observeCollectionsUseCase: ObserveCollectionsUseCase,
-    private val observeModelCollectionsUseCase: ObserveModelCollectionsUseCase,
-    private val addModelToCollectionUseCase: AddModelToCollectionUseCase,
-    private val removeModelFromCollectionUseCase: RemoveModelFromCollectionUseCase,
-    private val createCollectionUseCase: CreateCollectionUseCase,
-    private val observePowerUserModeUseCase: ObservePowerUserModeUseCase,
-    private val observeModelNoteUseCase: ObserveModelNoteUseCase,
-    private val saveModelNoteUseCase: SaveModelNoteUseCase,
-    private val deleteModelNoteUseCase: DeleteModelNoteUseCase,
-    private val observePersonalTagsUseCase: ObservePersonalTagsUseCase,
-    private val addPersonalTagUseCase: AddPersonalTagUseCase,
-    private val removePersonalTagUseCase: RemovePersonalTagUseCase,
-    private val observeModelDownloadsUseCase: ObserveModelDownloadsUseCase,
-    private val enqueueDownloadUseCase: EnqueueDownloadUseCase,
-    private val cancelDownloadUseCase: CancelDownloadUseCase,
-    private val getModelReviewsUseCase: GetModelReviewsUseCase,
-    private val getRatingTotalsUseCase: GetRatingTotalsUseCase,
-    private val submitReviewUseCase: SubmitReviewUseCase,
-    private val embedOnBrowseUseCase: EmbedOnBrowseUseCase,
+    private val modelUseCases: ModelUseCases,
+    private val collectionUseCases: CollectionUseCases,
+    private val notesTagsUseCases: NotesTagsUseCases,
+    private val downloadUseCases: DownloadUseCases,
+    private val reviewUseCases: ReviewUseCases,
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow(ModelDetailUiState())
@@ -115,45 +70,45 @@ class ModelDetailViewModel(
         modelId = modelId,
         scope = viewModelScope,
         uiState = _uiState,
-        getModelReviewsUseCase = getModelReviewsUseCase,
-        getRatingTotalsUseCase = getRatingTotalsUseCase,
-        submitReviewUseCase = submitReviewUseCase,
+        getModelReviewsUseCase = reviewUseCases.getModelReviews,
+        getRatingTotalsUseCase = reviewUseCases.getRatingTotals,
+        submitReviewUseCase = reviewUseCases.submitReview,
     )
 
     private val notesTagsDelegate = DetailNotesTagsDelegate(
         modelId = modelId,
         scope = viewModelScope,
-        saveModelNoteUseCase = saveModelNoteUseCase,
-        deleteModelNoteUseCase = deleteModelNoteUseCase,
-        addPersonalTagUseCase = addPersonalTagUseCase,
-        removePersonalTagUseCase = removePersonalTagUseCase,
+        saveModelNoteUseCase = notesTagsUseCases.saveModelNote,
+        deleteModelNoteUseCase = notesTagsUseCases.deleteModelNote,
+        addPersonalTagUseCase = notesTagsUseCases.addPersonalTag,
+        removePersonalTagUseCase = notesTagsUseCases.removePersonalTag,
     )
 
     private val _downloadEnqueuedEvent = MutableSharedFlow<Long>(extraBufferCapacity = 1)
     val downloadEnqueuedEvent: SharedFlow<Long> = _downloadEnqueuedEvent
 
     val collections: StateFlow<List<ModelCollection>> =
-        observeCollectionsUseCase()
+        collectionUseCases.observeCollections()
             .stateIn(viewModelScope, SharingStarted.WhileSubscribed(STOP_TIMEOUT), emptyList())
 
     val modelCollectionIds: StateFlow<List<Long>> =
-        observeModelCollectionsUseCase(modelId)
+        collectionUseCases.observeModelCollections(modelId)
             .stateIn(viewModelScope, SharingStarted.WhileSubscribed(STOP_TIMEOUT), emptyList())
 
     private val collectionDelegate = DetailCollectionDelegate(
         scope = viewModelScope,
         modelCollectionIds = modelCollectionIds,
-        addModelToCollectionUseCase = addModelToCollectionUseCase,
-        removeModelFromCollectionUseCase = removeModelFromCollectionUseCase,
-        createCollectionUseCase = createCollectionUseCase,
+        addModelToCollectionUseCase = collectionUseCases.addModelToCollection,
+        removeModelFromCollectionUseCase = collectionUseCases.removeModelFromCollection,
+        createCollectionUseCase = collectionUseCases.createCollection,
     )
 
     private val downloadDelegate = DetailDownloadDelegate(
         modelId = modelId,
         scope = viewModelScope,
-        enqueueDownloadUseCase = enqueueDownloadUseCase,
-        cancelDownloadUseCase = cancelDownloadUseCase,
-        trackModelViewUseCase = trackModelViewUseCase,
+        enqueueDownloadUseCase = downloadUseCases.enqueueDownload,
+        cancelDownloadUseCase = downloadUseCases.cancelDownload,
+        trackModelViewUseCase = modelUseCases.trackModelView,
         downloadEnqueuedEvent = _downloadEnqueuedEvent,
     )
 
@@ -177,8 +132,8 @@ class ModelDetailViewModel(
     fun onFavoriteToggle() {
         val model = _uiState.value.model ?: return
         launchCatching("Favorite toggle") {
-            toggleFavoriteUseCase(model)
-            trackModelViewUseCase.trackInteraction(modelId, InteractionType.FAVORITE)
+            modelUseCases.toggleFavorite(model)
+            modelUseCases.trackModelView.trackInteraction(modelId, InteractionType.FAVORITE)
         }
         triggerBackgroundEmbed(model)
     }
@@ -238,7 +193,7 @@ class ModelDetailViewModel(
     private fun loadModel() {
         viewModelScope.launch {
             _uiState.update { it.copy(isLoading = true, error = null) }
-            suspendRunCatching { getModelDetailUseCase(modelId) }
+            suspendRunCatching { modelUseCases.getModelDetail(modelId) }
                 .onSuccess { model ->
                     _uiState.update { it.copy(model = model, isLoading = false) }
                     enrichCurrentVersion()
@@ -260,7 +215,7 @@ class ModelDetailViewModel(
         val version = model.modelVersions.getOrNull(state.selectedVersionIndex) ?: return
         if (!markVersionForEnrichment(version.id)) return
         viewModelScope.launch {
-            suspendRunCatching { enrichModelImagesUseCase(version.id, version.images) }
+            suspendRunCatching { modelUseCases.enrichModelImages(version.id, version.images) }
                 .onSuccess { enriched -> applyEnrichedImages(version.id, enriched) }
                 .onFailure { e ->
                     Logger.w(TAG, "Enrich version images failed: ${e.message}")
@@ -310,7 +265,7 @@ class ModelDetailViewModel(
 
     private fun observeFavorite() {
         viewModelScope.launch {
-            observeIsFavoriteUseCase(modelId).collect { isFavorite ->
+            modelUseCases.observeIsFavorite(modelId).collect { isFavorite ->
                 _uiState.update { it.copy(isFavorite = isFavorite) }
             }
         }
@@ -318,7 +273,7 @@ class ModelDetailViewModel(
 
     private fun observeNsfwFilter() {
         viewModelScope.launch {
-            observeNsfwFilterUseCase().collect { level ->
+            modelUseCases.observeNsfwFilter().collect { level ->
                 _uiState.update { it.copy(nsfwFilterLevel = level) }
             }
         }
@@ -326,7 +281,7 @@ class ModelDetailViewModel(
 
     private fun observePowerUserMode() {
         viewModelScope.launch {
-            observePowerUserModeUseCase().collect { enabled ->
+            modelUseCases.observePowerUserMode().collect { enabled ->
                 _uiState.update { it.copy(powerUserMode = enabled) }
             }
         }
@@ -334,7 +289,7 @@ class ModelDetailViewModel(
 
     private fun observeNote() {
         viewModelScope.launch {
-            observeModelNoteUseCase(modelId).collect { note ->
+            notesTagsUseCases.observeModelNote(modelId).collect { note ->
                 _uiState.update { it.copy(note = note) }
             }
         }
@@ -342,7 +297,7 @@ class ModelDetailViewModel(
 
     private fun observePersonalTags() {
         viewModelScope.launch {
-            observePersonalTagsUseCase(modelId).collect { tags ->
+            notesTagsUseCases.observePersonalTags(modelId).collect { tags ->
                 _uiState.update { it.copy(personalTags = tags) }
             }
         }
@@ -350,7 +305,7 @@ class ModelDetailViewModel(
 
     private fun observeDownloads() {
         viewModelScope.launch {
-            observeModelDownloadsUseCase(modelId).collect { downloads ->
+            downloadUseCases.observeModelDownloads(modelId).collect { downloads ->
                 _uiState.update { it.copy(downloads = downloads) }
             }
         }
@@ -379,7 +334,7 @@ class ModelDetailViewModel(
         val url = model.modelVersions.firstOrNull()
             ?.images?.firstOrNull()?.url ?: return
         viewModelScope.launch {
-            suspendRunCatching { embedOnBrowseUseCase(model.id, url) }
+            suspendRunCatching { modelUseCases.embedOnBrowse(model.id, url) }
                 .onFailure { e -> Logger.d(TAG, "Background embed skipped: ${e.message}") }
         }
     }
@@ -392,7 +347,7 @@ class ModelDetailViewModel(
             withContext(NonCancellable) {
                 try {
                     withTimeoutOrNull(END_VIEW_TIMEOUT) {
-                        trackModelViewUseCase.endView(modelId, durationMs)
+                        modelUseCases.trackModelView.endView(modelId, durationMs)
                     }
                 } catch (e: Exception) {
                     Logger.w(TAG, "End view tracking failed: ${e.message}")
@@ -402,7 +357,7 @@ class ModelDetailViewModel(
     }
 
     private suspend fun trackModelView(model: Model) {
-        trackModelViewUseCase(
+        modelUseCases.trackModelView(
             modelId = model.id,
             modelName = model.name,
             modelType = model.type.name,


### PR DESCRIPTION
## Summary
- Created 5 aggregate data classes (`ModelUseCases`, `CollectionUseCases`, `NotesTagsUseCases`, `DownloadUseCases`, `ReviewUseCases`) in `DetailUseCases.kt` to group the 26 individual use case parameters
- Reduced `ModelDetailViewModel` constructor from 26 use case params + 1 modelId to 5 aggregate params + 1 modelId
- Removed `@Suppress("LongParameterList")` from the ViewModel
- Updated Koin DI in `DetailModule`, `CivitDeckApplication` (Android), and `DesktopModule`
- Updated test to use aggregate classes and added missing fake repos (downloads, reviews, embeddings) that the test was previously missing

## Test plan
- [x] `./gradlew :feature:feature-detail:detekt` passes
- [x] `./gradlew :androidApp:detekt` passes
- [x] `./gradlew :androidApp:assembleDebug` builds successfully
- [x] `./gradlew :desktopApp:compileKotlinJvm` builds successfully
- [x] `./gradlew :shared:compileKotlinIosArm64` builds successfully

Closes #810