### PR TITLE
Update ONNX Runtime Android from 1.20.0 to 1.25.0

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -22,7 +22,7 @@ glance = "1.1.1"
 detekt = "1.23.8"
 skie = "0.10.11"
 aboutlibraries = "12.1.2"
-onnxruntime-android = "1.20.0"
+onnxruntime-android = "1.25.0"
 
 [libraries]
 # QR Code


### PR DESCRIPTION
## Summary
- Update `onnxruntime-android` from 1.20.0 to 1.25.0 in `gradle/libs.versions.toml`
- No code changes required — the Java API (`OrtEnvironment`, `OrtSession`, `OnnxTensor`) is stable across these versions
- Breaking changes in 1.21-1.25 (CUDA 12 minimum, ArmNN EP removal, C++20 build requirement) do not affect the pre-built Android AAR

## Verification
- `./gradlew :androidApp:assembleDebug` — BUILD SUCCESSFUL
- `./gradlew detekt` — BUILD SUCCESSFUL
- `libonnxruntime.so` and `libonnxruntime4j_jni.so` packaged correctly

Closes #846