### PR TITLE
Extract launchSafe to deduplicate delegate boilerplate

### DIFF
--- a/core/core-domain/src/commonMain/kotlin/com/riox432/civitdeck/domain/util/SuspendRunCatching.kt
+++ b/core/core-domain/src/commonMain/kotlin/com/riox432/civitdeck/domain/util/SuspendRunCatching.kt
@@ -1,5 +1,8 @@
 package com.riox432.civitdeck.domain.util
 
+import com.riox432.civitdeck.util.Logger
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
 import kotlin.coroutines.cancellation.CancellationException
 
 /**
@@ -12,4 +15,20 @@ inline fun <T> suspendRunCatching(block: () -> T): Result<T> = try {
     throw e
 } catch (e: Exception) {
     Result.failure(e)
+}
+
+/**
+ * Launch a coroutine that wraps [block] in [suspendRunCatching] and logs
+ * failures via [Logger.w]. Useful for fire-and-forget operations where
+ * the caller only needs to log errors.
+ */
+fun CoroutineScope.launchSafe(
+    tag: String,
+    operationName: String,
+    block: suspend () -> Unit,
+) {
+    launch {
+        suspendRunCatching { block() }
+            .onFailure { e -> Logger.w(tag, "$operationName failed: ${e.message}") }
+    }
 }

--- a/feature/feature-detail/src/commonMain/kotlin/com/riox432/civitdeck/feature/detail/presentation/DetailCollectionDelegate.kt
+++ b/feature/feature-detail/src/commonMain/kotlin/com/riox432/civitdeck/feature/detail/presentation/DetailCollectionDelegate.kt
@@ -4,11 +4,9 @@ import com.riox432.civitdeck.domain.model.Model
 import com.riox432.civitdeck.domain.usecase.AddModelToCollectionUseCase
 import com.riox432.civitdeck.domain.usecase.CreateCollectionUseCase
 import com.riox432.civitdeck.domain.usecase.RemoveModelFromCollectionUseCase
-import com.riox432.civitdeck.domain.util.suspendRunCatching
-import com.riox432.civitdeck.util.Logger
+import com.riox432.civitdeck.domain.util.launchSafe
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.launch
 
 private const val TAG = "DetailCollectionDelegate"
 
@@ -22,24 +20,20 @@ internal class DetailCollectionDelegate(
 
     fun toggleCollection(collectionId: Long, model: Model?) {
         model ?: return
-        scope.launch {
-            suspendRunCatching {
-                if (collectionId in modelCollectionIds.value) {
-                    removeModelFromCollectionUseCase(collectionId, model.id)
-                } else {
-                    addModelToCollectionUseCase(collectionId, model)
-                }
-            }.onFailure { e -> Logger.w(TAG, "Collection toggle failed: ${e.message}") }
+        scope.launchSafe(TAG, "Collection toggle") {
+            if (collectionId in modelCollectionIds.value) {
+                removeModelFromCollectionUseCase(collectionId, model.id)
+            } else {
+                addModelToCollectionUseCase(collectionId, model)
+            }
         }
     }
 
     fun createCollectionAndAdd(name: String, model: Model?) {
         model ?: return
-        scope.launch {
-            suspendRunCatching {
-                val newId = createCollectionUseCase(name)
-                addModelToCollectionUseCase(newId, model)
-            }.onFailure { e -> Logger.w(TAG, "Create collection and add failed: ${e.message}") }
+        scope.launchSafe(TAG, "Create collection and add") {
+            val newId = createCollectionUseCase(name)
+            addModelToCollectionUseCase(newId, model)
         }
     }
 }

--- a/feature/feature-detail/src/commonMain/kotlin/com/riox432/civitdeck/feature/detail/presentation/DetailDownloadDelegate.kt
+++ b/feature/feature-detail/src/commonMain/kotlin/com/riox432/civitdeck/feature/detail/presentation/DetailDownloadDelegate.kt
@@ -9,11 +9,9 @@ import com.riox432.civitdeck.domain.model.ModelVersion
 import com.riox432.civitdeck.domain.usecase.CancelDownloadUseCase
 import com.riox432.civitdeck.domain.usecase.EnqueueDownloadUseCase
 import com.riox432.civitdeck.domain.usecase.TrackModelViewUseCase
-import com.riox432.civitdeck.domain.util.suspendRunCatching
-import com.riox432.civitdeck.util.Logger
+import com.riox432.civitdeck.domain.util.launchSafe
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.MutableSharedFlow
-import kotlinx.coroutines.launch
 
 private const val TAG = "DetailDownloadDelegate"
 private const val KB_TO_BYTES = 1024.0
@@ -30,21 +28,16 @@ internal class DetailDownloadDelegate(
     fun downloadFile(file: ModelFile, model: Model?, version: ModelVersion?) {
         model ?: return
         version ?: return
-        scope.launch {
-            suspendRunCatching {
-                val download = buildModelDownload(model, version, file)
-                val id = enqueueDownloadUseCase(download)
-                downloadEnqueuedEvent.tryEmit(id)
-                trackModelViewUseCase.trackInteraction(modelId, InteractionType.DOWNLOAD)
-            }.onFailure { e -> Logger.w(TAG, "Download enqueue failed: ${e.message}") }
+        scope.launchSafe(TAG, "Download enqueue") {
+            val download = buildModelDownload(model, version, file)
+            val id = enqueueDownloadUseCase(download)
+            downloadEnqueuedEvent.tryEmit(id)
+            trackModelViewUseCase.trackInteraction(modelId, InteractionType.DOWNLOAD)
         }
     }
 
     fun cancelDownload(downloadId: Long) {
-        scope.launch {
-            suspendRunCatching { cancelDownloadUseCase(downloadId) }
-                .onFailure { e -> Logger.w(TAG, "Cancel download failed: ${e.message}") }
-        }
+        scope.launchSafe(TAG, "Cancel download") { cancelDownloadUseCase(downloadId) }
     }
 
     companion object {

--- a/feature/feature-detail/src/commonMain/kotlin/com/riox432/civitdeck/feature/detail/presentation/DetailNotesTagsDelegate.kt
+++ b/feature/feature-detail/src/commonMain/kotlin/com/riox432/civitdeck/feature/detail/presentation/DetailNotesTagsDelegate.kt
@@ -4,10 +4,8 @@ import com.riox432.civitdeck.domain.usecase.AddPersonalTagUseCase
 import com.riox432.civitdeck.domain.usecase.DeleteModelNoteUseCase
 import com.riox432.civitdeck.domain.usecase.RemovePersonalTagUseCase
 import com.riox432.civitdeck.domain.usecase.SaveModelNoteUseCase
-import com.riox432.civitdeck.domain.util.suspendRunCatching
-import com.riox432.civitdeck.util.Logger
+import com.riox432.civitdeck.domain.util.launchSafe
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.launch
 
 private const val TAG = "DetailNotesTagsDelegate"
 
@@ -21,30 +19,22 @@ internal class DetailNotesTagsDelegate(
 ) {
 
     fun saveNote(text: String) {
-        scope.launch {
-            suspendRunCatching {
-                if (text.isBlank()) {
-                    deleteModelNoteUseCase(modelId)
-                } else {
-                    saveModelNoteUseCase(modelId, text)
-                }
-            }.onFailure { e -> Logger.w(TAG, "Note save failed: ${e.message}") }
+        scope.launchSafe(TAG, "Note save") {
+            if (text.isBlank()) {
+                deleteModelNoteUseCase(modelId)
+            } else {
+                saveModelNoteUseCase(modelId, text)
+            }
         }
     }
 
     fun addTag(tag: String) {
         val trimmed = tag.trim().lowercase()
         if (trimmed.isBlank()) return
-        scope.launch {
-            suspendRunCatching { addPersonalTagUseCase(modelId, trimmed) }
-                .onFailure { e -> Logger.w(TAG, "Add tag failed: ${e.message}") }
-        }
+        scope.launchSafe(TAG, "Add tag") { addPersonalTagUseCase(modelId, trimmed) }
     }
 
     fun removeTag(tag: String) {
-        scope.launch {
-            suspendRunCatching { removePersonalTagUseCase(modelId, tag) }
-                .onFailure { e -> Logger.w(TAG, "Remove tag failed: ${e.message}") }
-        }
+        scope.launchSafe(TAG, "Remove tag") { removePersonalTagUseCase(modelId, tag) }
     }
 }

--- a/feature/feature-detail/src/commonMain/kotlin/com/riox432/civitdeck/feature/detail/presentation/ModelDetailViewModel.kt
+++ b/feature/feature-detail/src/commonMain/kotlin/com/riox432/civitdeck/feature/detail/presentation/ModelDetailViewModel.kt
@@ -16,6 +16,7 @@ import com.riox432.civitdeck.domain.model.ResourceReview
 import com.riox432.civitdeck.domain.model.ReviewSortOrder
 import com.riox432.civitdeck.domain.util.UiLoadingState
 import com.riox432.civitdeck.domain.util.currentTimeMillis
+import com.riox432.civitdeck.domain.util.launchSafe
 import com.riox432.civitdeck.domain.util.suspendRunCatching
 import com.riox432.civitdeck.util.Logger
 import kotlinx.coroutines.NonCancellable
@@ -130,7 +131,7 @@ class ModelDetailViewModel(
 
     fun onFavoriteToggle() {
         val model = _uiState.value.model ?: return
-        launchCatching("Favorite toggle") {
+        viewModelScope.launchSafe(TAG, "Favorite toggle") {
             modelUseCases.toggleFavorite(model)
             modelUseCases.trackModelView.trackInteraction(modelId, InteractionType.FAVORITE)
         }
@@ -313,17 +314,6 @@ class ModelDetailViewModel(
     // endregion
 
     // region Private — Helpers
-
-    /**
-     * Common pattern: launch a coroutine, run [block] inside suspendRunCatching,
-     * and log failures with [operationName].
-     */
-    private fun launchCatching(operationName: String, block: suspend () -> Unit) {
-        viewModelScope.launch {
-            suspendRunCatching { block() }
-                .onFailure { e -> Logger.w(TAG, "$operationName failed: ${e.message}") }
-        }
-    }
 
     /**
      * Fire-and-forget background embed of the model's first thumbnail.


### PR DESCRIPTION
## Summary
- Added `CoroutineScope.launchSafe(tag, operationName, block)` extension in `SuspendRunCatching.kt` — wraps `suspendRunCatching` + `Logger.w` for fire-and-forget coroutine operations
- Refactored `DetailCollectionDelegate`, `DetailNotesTagsDelegate`, and `DetailDownloadDelegate` to use `launchSafe` instead of manual `scope.launch { suspendRunCatching { ... }.onFailure { ... } }` pattern
- Replaced `ModelDetailViewModel.launchCatching` private method with the shared `launchSafe`
- `DetailReviewDelegate` unchanged — its methods use `.onSuccess` with state updates, which doesn't fit the simple fire-and-forget pattern

Net: -14 lines, consistent error handling across all delegates.

Closes #822