### PR TITLE
Extract shared ComfyUI parameter components into core-ui

### DIFF
--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/comfyui/ComfyUIGenerationScreen.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/comfyui/ComfyUIGenerationScreen.kt
@@ -46,6 +46,7 @@ import com.riox432.civitdeck.domain.model.GenerationStatus
 import com.riox432.civitdeck.domain.model.LoraSelection
 import com.riox432.civitdeck.feature.comfyui.presentation.ComfyUIGenerationViewModel
 import com.riox432.civitdeck.feature.comfyui.presentation.GenerationUiState
+import com.riox432.civitdeck.ui.components.comfyui.ParameterSliderRow
 import com.riox432.civitdeck.ui.theme.Spacing
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -216,12 +217,13 @@ private fun LoraRow(lora: LoraSelection, viewModel: ComfyUIGenerationViewModel) 
                 Icon(Icons.Default.Close, contentDescription = stringResource(R.string.cd_remove_lora))
             }
         }
-        SliderRow(
-            label = "Strength: ${"%.2f".format(lora.strengthModel)}",
-            value = lora.strengthModel.toDouble(),
-            min = 0.0,
-            max = 2.0,
-        ) { v -> viewModel.onLoraStrengthChanged(lora.name, v.toFloat(), v.toFloat()) }
+        ParameterSliderRow(
+            label = "Strength",
+            valueLabel = "%.2f".format(lora.strengthModel),
+            value = lora.strengthModel,
+            valueRange = 0f..2f,
+            onValueChange = { v -> viewModel.onLoraStrengthChanged(lora.name, v, v) },
+        )
     }
 }
 
@@ -253,9 +255,13 @@ private fun ControlNetSection(state: GenerationUiState, viewModel: ComfyUIGenera
                         )
                     }
                 }
-                SliderRow("Strength", state.controlNetStrength.toDouble(), 0.0, 2.0) { v ->
-                    viewModel.onControlNetStrengthChanged(v.toFloat())
-                }
+                ParameterSliderRow(
+                    label = "Strength",
+                    valueLabel = "%.2f".format(state.controlNetStrength),
+                    value = state.controlNetStrength,
+                    valueRange = 0f..2f,
+                    onValueChange = { viewModel.onControlNetStrengthChanged(it) },
+                )
             }
         }
     }
@@ -411,12 +417,13 @@ private fun InpaintingMaskContent(
                 Text(stringResource(R.string.action_clear))
             }
         }
-        SliderRow(
-            "Denoise",
-            state.denoiseStrength,
-            0.0,
-            1.0,
-        ) { viewModel.onDenoiseStrengthChanged(it) }
+        ParameterSliderRow(
+            label = "Denoise",
+            valueLabel = "%.2f".format(state.denoiseStrength),
+            value = state.denoiseStrength.toFloat(),
+            valueRange = 0f..1f,
+            onValueChange = { viewModel.onDenoiseStrengthChanged(it.toDouble()) },
+        )
     } else {
         Button(
             onClick = {

--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/comfyui/ComfyUIParameterSection.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/comfyui/ComfyUIParameterSection.kt
@@ -1,16 +1,12 @@
 package com.riox432.civitdeck.ui.comfyui
 
-import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Card
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.OutlinedTextField
-import androidx.compose.material3.Slider
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
@@ -18,13 +14,16 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import com.riox432.civitdeck.R
 import com.riox432.civitdeck.feature.comfyui.presentation.ComfyUIGenerationViewModel
 import com.riox432.civitdeck.feature.comfyui.presentation.GenerationUiState
 import com.riox432.civitdeck.ui.components.LoadingStateOverlay
+import com.riox432.civitdeck.ui.components.comfyui.DimensionInputRow
+import com.riox432.civitdeck.ui.components.comfyui.ParameterSliderRow
+import com.riox432.civitdeck.ui.components.comfyui.PromptInputFields
+import com.riox432.civitdeck.ui.components.comfyui.SeedInputField
 import com.riox432.civitdeck.ui.theme.Spacing
 
 @Composable
@@ -61,21 +60,13 @@ internal fun CheckpointSelector(
 
 @Composable
 internal fun PromptInputs(state: GenerationUiState, viewModel: ComfyUIGenerationViewModel) {
-    OutlinedTextField(
-        value = state.prompt,
-        onValueChange = viewModel::onPromptChanged,
-        label = { Text(stringResource(R.string.label_prompt)) },
-        modifier = Modifier.fillMaxWidth(),
-        minLines = 3,
-        maxLines = 6,
-    )
-    OutlinedTextField(
-        value = state.negativePrompt,
-        onValueChange = viewModel::onNegativePromptChanged,
-        label = { Text(stringResource(R.string.label_negative_prompt)) },
-        modifier = Modifier.fillMaxWidth(),
-        minLines = 2,
-        maxLines = 4,
+    PromptInputFields(
+        prompt = state.prompt,
+        negativePrompt = state.negativePrompt,
+        onPromptChanged = viewModel::onPromptChanged,
+        onNegativePromptChanged = viewModel::onNegativePromptChanged,
+        promptLabel = stringResource(R.string.label_prompt),
+        negativePromptLabel = stringResource(R.string.label_negative_prompt),
     )
 }
 
@@ -83,92 +74,38 @@ internal fun PromptInputs(state: GenerationUiState, viewModel: ComfyUIGeneration
 internal fun ParameterControls(state: GenerationUiState, viewModel: ComfyUIGenerationViewModel) {
     Card(modifier = Modifier.fillMaxWidth()) {
         Column(modifier = Modifier.padding(Spacing.md)) {
-            SliderRow("Steps", state.steps, 1, 150) { viewModel.onStepsChanged(it) }
-            SliderRow(
-                "CFG Scale",
-                state.cfgScale,
-                1.0,
-                30.0,
-            ) { viewModel.onCfgScaleChanged(it) }
-            ResolutionRow(state.width, state.height, viewModel)
-            SeedInput(state.seed, viewModel::onSeedChanged)
+            ParameterSliderRow(
+                label = "Steps",
+                valueLabel = state.steps.toString(),
+                value = state.steps.toFloat(),
+                valueRange = STEPS_MIN..STEPS_MAX,
+                onValueChange = { viewModel.onStepsChanged(it.toInt()) },
+            )
+            ParameterSliderRow(
+                label = "CFG Scale",
+                valueLabel = "%.1f".format(state.cfgScale),
+                value = state.cfgScale.toFloat(),
+                valueRange = CFG_MIN..CFG_MAX,
+                onValueChange = { viewModel.onCfgScaleChanged(it.toDouble()) },
+            )
+            DimensionInputRow(
+                width = state.width,
+                height = state.height,
+                onWidthChanged = viewModel::onWidthChanged,
+                onHeightChanged = viewModel::onHeightChanged,
+                widthLabel = stringResource(R.string.comfyui_width_label),
+                heightLabel = stringResource(R.string.comfyui_height_label),
+            )
+            SeedInputField(
+                seed = state.seed,
+                onSeedChanged = viewModel::onSeedChanged,
+                label = stringResource(R.string.comfyui_seed_label),
+            )
         }
     }
 }
 
-@Composable
-internal fun SliderRow(label: String, value: Int, min: Int, max: Int, onChange: (Int) -> Unit) {
-    Row(
-        modifier = Modifier.fillMaxWidth(),
-        verticalAlignment = Alignment.CenterVertically,
-    ) {
-        Text("$label: $value", modifier = Modifier.weight(0.3f), style = MaterialTheme.typography.bodySmall)
-        Slider(
-            value = value.toFloat(),
-            onValueChange = { onChange(it.toInt()) },
-            valueRange = min.toFloat()..max.toFloat(),
-            modifier = Modifier.weight(0.7f),
-        )
-    }
-}
-
-@Composable
-internal fun SliderRow(label: String, value: Double, min: Double, max: Double, onChange: (Double) -> Unit) {
-    Row(
-        modifier = Modifier.fillMaxWidth(),
-        verticalAlignment = Alignment.CenterVertically,
-    ) {
-        Text(
-            "$label: ${"%.1f".format(value)}",
-            modifier = Modifier.weight(0.3f),
-            style = MaterialTheme.typography.bodySmall,
-        )
-        Slider(
-            value = value.toFloat(),
-            onValueChange = { onChange(it.toDouble()) },
-            valueRange = min.toFloat()..max.toFloat(),
-            modifier = Modifier.weight(0.7f),
-        )
-    }
-}
-
-@Composable
-private fun ResolutionRow(
-    width: Int,
-    height: Int,
-    viewModel: ComfyUIGenerationViewModel,
-) {
-    Row(
-        modifier = Modifier.fillMaxWidth(),
-        horizontalArrangement = Arrangement.spacedBy(Spacing.sm),
-    ) {
-        OutlinedTextField(
-            value = width.toString(),
-            onValueChange = { it.toIntOrNull()?.let(viewModel::onWidthChanged) },
-            label = { Text(stringResource(R.string.comfyui_width_label)) },
-            modifier = Modifier.weight(1f),
-            singleLine = true,
-        )
-        OutlinedTextField(
-            value = height.toString(),
-            onValueChange = { it.toIntOrNull()?.let(viewModel::onHeightChanged) },
-            label = { Text(stringResource(R.string.comfyui_height_label)) },
-            modifier = Modifier.weight(1f),
-            singleLine = true,
-        )
-    }
-}
-
-@Composable
-private fun SeedInput(seed: Long, onChanged: (Long) -> Unit) {
-    OutlinedTextField(
-        value = if (seed == -1L) "" else seed.toString(),
-        onValueChange = {
-            val parsed = it.toLongOrNull() ?: -1L
-            onChanged(parsed)
-        },
-        label = { Text(stringResource(R.string.comfyui_seed_label)) },
-        modifier = Modifier.fillMaxWidth(),
-        singleLine = true,
-    )
-}
+private const val STEPS_MIN = 1f
+private const val STEPS_MAX = 150f
+private const val CFG_MIN = 1f
+private const val CFG_MAX = 30f

--- a/core/core-ui/src/commonMain/kotlin/com/riox432/civitdeck/ui/components/comfyui/DimensionInputRow.kt
+++ b/core/core-ui/src/commonMain/kotlin/com/riox432/civitdeck/ui/components/comfyui/DimensionInputRow.kt
@@ -1,0 +1,52 @@
+package com.riox432.civitdeck.ui.components.comfyui
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import com.riox432.civitdeck.ui.theme.Spacing
+
+/**
+ * Width and height text fields for image dimension input.
+ *
+ * @param width Current width value
+ * @param height Current height value
+ * @param onWidthChanged Callback when width changes
+ * @param onHeightChanged Callback when height changes
+ * @param widthLabel Label for the width field
+ * @param heightLabel Label for the height field
+ * @param modifier Optional modifier for the row
+ */
+@Composable
+fun DimensionInputRow(
+    width: Int,
+    height: Int,
+    onWidthChanged: (Int) -> Unit,
+    onHeightChanged: (Int) -> Unit,
+    widthLabel: String = "Width",
+    heightLabel: String = "Height",
+    modifier: Modifier = Modifier,
+) {
+    Row(
+        modifier = modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.spacedBy(Spacing.sm),
+    ) {
+        OutlinedTextField(
+            value = width.toString(),
+            onValueChange = { it.toIntOrNull()?.let(onWidthChanged) },
+            label = { Text(widthLabel) },
+            modifier = Modifier.weight(1f),
+            singleLine = true,
+        )
+        OutlinedTextField(
+            value = height.toString(),
+            onValueChange = { it.toIntOrNull()?.let(onHeightChanged) },
+            label = { Text(heightLabel) },
+            modifier = Modifier.weight(1f),
+            singleLine = true,
+        )
+    }
+}

--- a/core/core-ui/src/commonMain/kotlin/com/riox432/civitdeck/ui/components/comfyui/ParameterSliderRow.kt
+++ b/core/core-ui/src/commonMain/kotlin/com/riox432/civitdeck/ui/components/comfyui/ParameterSliderRow.kt
@@ -1,0 +1,52 @@
+package com.riox432.civitdeck.ui.components.comfyui
+
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Slider
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+
+/**
+ * Slider row for generation parameters (steps, CFG scale, etc.).
+ *
+ * Displays a label with the current value on the left and a slider on the right.
+ *
+ * @param label Display name for the parameter (e.g. "Steps", "CFG Scale")
+ * @param valueLabel Formatted string of the current value (e.g. "20", "7.5")
+ * @param value Current slider value as Float
+ * @param valueRange Allowed range for the slider
+ * @param onValueChange Callback when the slider value changes
+ * @param modifier Optional modifier for the row
+ */
+@Composable
+fun ParameterSliderRow(
+    label: String,
+    valueLabel: String,
+    value: Float,
+    valueRange: ClosedFloatingPointRange<Float>,
+    onValueChange: (Float) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Row(
+        modifier = modifier.fillMaxWidth(),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Text(
+            "$label: $valueLabel",
+            modifier = Modifier.weight(LABEL_WEIGHT),
+            style = MaterialTheme.typography.bodySmall,
+        )
+        Slider(
+            value = value,
+            onValueChange = onValueChange,
+            valueRange = valueRange,
+            modifier = Modifier.weight(SLIDER_WEIGHT),
+        )
+    }
+}
+
+private const val LABEL_WEIGHT = 0.3f
+private const val SLIDER_WEIGHT = 0.7f

--- a/core/core-ui/src/commonMain/kotlin/com/riox432/civitdeck/ui/components/comfyui/PromptInputFields.kt
+++ b/core/core-ui/src/commonMain/kotlin/com/riox432/civitdeck/ui/components/comfyui/PromptInputFields.kt
@@ -1,0 +1,58 @@
+package com.riox432.civitdeck.ui.components.comfyui
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import com.riox432.civitdeck.ui.theme.Spacing
+
+/**
+ * Positive and negative prompt text fields for image generation.
+ *
+ * @param prompt Current positive prompt text
+ * @param negativePrompt Current negative prompt text
+ * @param onPromptChanged Callback when positive prompt changes
+ * @param onNegativePromptChanged Callback when negative prompt changes
+ * @param promptLabel Label for the positive prompt field
+ * @param negativePromptLabel Label for the negative prompt field
+ * @param modifier Optional modifier for the column
+ */
+@Composable
+fun PromptInputFields(
+    prompt: String,
+    negativePrompt: String,
+    onPromptChanged: (String) -> Unit,
+    onNegativePromptChanged: (String) -> Unit,
+    promptLabel: String = "Prompt",
+    negativePromptLabel: String = "Negative Prompt",
+    modifier: Modifier = Modifier,
+) {
+    Column(modifier = modifier) {
+        OutlinedTextField(
+            value = prompt,
+            onValueChange = onPromptChanged,
+            label = { Text(promptLabel) },
+            modifier = Modifier.fillMaxWidth(),
+            minLines = PROMPT_MIN_LINES,
+            maxLines = PROMPT_MAX_LINES,
+        )
+        Spacer(modifier = Modifier.height(Spacing.sm))
+        OutlinedTextField(
+            value = negativePrompt,
+            onValueChange = onNegativePromptChanged,
+            label = { Text(negativePromptLabel) },
+            modifier = Modifier.fillMaxWidth(),
+            minLines = NEGATIVE_PROMPT_MIN_LINES,
+            maxLines = NEGATIVE_PROMPT_MAX_LINES,
+        )
+    }
+}
+
+private const val PROMPT_MIN_LINES = 3
+private const val PROMPT_MAX_LINES = 6
+private const val NEGATIVE_PROMPT_MIN_LINES = 2
+private const val NEGATIVE_PROMPT_MAX_LINES = 4

--- a/core/core-ui/src/commonMain/kotlin/com/riox432/civitdeck/ui/components/comfyui/SeedInputField.kt
+++ b/core/core-ui/src/commonMain/kotlin/com/riox432/civitdeck/ui/components/comfyui/SeedInputField.kt
@@ -1,0 +1,36 @@
+package com.riox432.civitdeck.ui.components.comfyui
+
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+
+private const val RANDOM_SEED = -1L
+
+/**
+ * Text field for seed input with -1 representing a random seed.
+ *
+ * When the seed is -1, the field is displayed as empty. Invalid input
+ * (non-numeric) falls back to -1 (random).
+ *
+ * @param seed Current seed value (-1 for random)
+ * @param onSeedChanged Callback when the seed changes
+ * @param label Label for the text field
+ * @param modifier Optional modifier for the field
+ */
+@Composable
+fun SeedInputField(
+    seed: Long,
+    onSeedChanged: (Long) -> Unit,
+    label: String = "Seed (-1 = random)",
+    modifier: Modifier = Modifier,
+) {
+    OutlinedTextField(
+        value = if (seed == RANDOM_SEED) "" else seed.toString(),
+        onValueChange = { onSeedChanged(it.toLongOrNull() ?: RANDOM_SEED) },
+        label = { Text(label) },
+        modifier = modifier.fillMaxWidth(),
+        singleLine = true,
+    )
+}

--- a/desktopApp/src/jvmMain/kotlin/com/riox432/civitdeck/ui/settings/DesktopComfyUIGenerationSection.kt
+++ b/desktopApp/src/jvmMain/kotlin/com/riox432/civitdeck/ui/settings/DesktopComfyUIGenerationSection.kt
@@ -1,20 +1,19 @@
 package com.riox432.civitdeck.ui.settings
 
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.material3.Button
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import com.riox432.civitdeck.feature.comfyui.presentation.ComfyUIGenerationViewModel
+import com.riox432.civitdeck.ui.components.comfyui.DimensionInputRow
+import com.riox432.civitdeck.ui.components.comfyui.ParameterSliderRow
+import com.riox432.civitdeck.ui.components.comfyui.PromptInputFields
+import com.riox432.civitdeck.ui.components.comfyui.SeedInputField
 import com.riox432.civitdeck.ui.theme.Spacing
 
 @Composable
@@ -30,7 +29,7 @@ fun ComfyUIGenerationSection(viewModel: ComfyUIGenerationViewModel) {
                 selectedCheckpoint = state.selectedCheckpoint,
                 onCheckpointSelected = viewModel::onCheckpointSelected,
             )
-            PromptInputs(
+            PromptInputFields(
                 prompt = state.prompt,
                 negativePrompt = state.negativePrompt,
                 onPromptChanged = viewModel::onPromptChanged,
@@ -93,60 +92,26 @@ private fun CheckpointSelector(
 }
 
 @Composable
-private fun PromptInputs(
-    prompt: String,
-    negativePrompt: String,
-    onPromptChanged: (String) -> Unit,
-    onNegativePromptChanged: (String) -> Unit,
-) {
-    OutlinedTextField(
-        value = prompt,
-        onValueChange = onPromptChanged,
-        label = { Text("Prompt") },
-        modifier = Modifier.fillMaxWidth(),
-        minLines = 3,
-        maxLines = 5,
-    )
-    Spacer(modifier = Modifier.height(Spacing.sm))
-    OutlinedTextField(
-        value = negativePrompt,
-        onValueChange = onNegativePromptChanged,
-        label = { Text("Negative Prompt") },
-        modifier = Modifier.fillMaxWidth(),
-        minLines = 2,
-        maxLines = 3,
-    )
-}
-
-@Composable
 private fun GenerationSliders(
     steps: Int,
     cfgScale: Double,
     onStepsChanged: (Float) -> Unit,
     onCfgScaleChanged: (Float) -> Unit,
 ) {
-    Row(horizontalArrangement = Arrangement.spacedBy(Spacing.md)) {
-        Column(modifier = Modifier.weight(1f)) {
-            SliderSetting(
-                label = "Steps",
-                value = steps.toFloat(),
-                valueRange = 1f..150f,
-                steps = 148,
-                valueLabel = steps.toString(),
-                onValueChange = onStepsChanged,
-            )
-        }
-        Column(modifier = Modifier.weight(1f)) {
-            SliderSetting(
-                label = "CFG Scale",
-                value = cfgScale.toFloat(),
-                valueRange = 1f..30f,
-                steps = 28,
-                valueLabel = "%.1f".format(cfgScale),
-                onValueChange = onCfgScaleChanged,
-            )
-        }
-    }
+    ParameterSliderRow(
+        label = "Steps",
+        valueLabel = steps.toString(),
+        value = steps.toFloat(),
+        valueRange = STEPS_MIN..STEPS_MAX,
+        onValueChange = onStepsChanged,
+    )
+    ParameterSliderRow(
+        label = "CFG Scale",
+        valueLabel = "%.1f".format(cfgScale),
+        value = cfgScale.toFloat(),
+        valueRange = CFG_MIN..CFG_MAX,
+        onValueChange = onCfgScaleChanged,
+    )
 }
 
 @Composable
@@ -158,29 +123,16 @@ private fun DimensionInputs(
     onHeightChanged: (Int) -> Unit,
     onSeedChanged: (Long) -> Unit,
 ) {
-    Row(horizontalArrangement = Arrangement.spacedBy(Spacing.md)) {
-        OutlinedTextField(
-            value = width.toString(),
-            onValueChange = { it.toIntOrNull()?.let(onWidthChanged) },
-            label = { Text("Width") },
-            singleLine = true,
-            modifier = Modifier.weight(1f),
-        )
-        OutlinedTextField(
-            value = height.toString(),
-            onValueChange = { it.toIntOrNull()?.let(onHeightChanged) },
-            label = { Text("Height") },
-            singleLine = true,
-            modifier = Modifier.weight(1f),
-        )
-        OutlinedTextField(
-            value = if (seed == -1L) "" else seed.toString(),
-            onValueChange = { onSeedChanged(it.toLongOrNull() ?: -1L) },
-            label = { Text("Seed (-1 = random)") },
-            singleLine = true,
-            modifier = Modifier.weight(1f),
-        )
-    }
+    DimensionInputRow(
+        width = width,
+        height = height,
+        onWidthChanged = onWidthChanged,
+        onHeightChanged = onHeightChanged,
+    )
+    SeedInputField(
+        seed = seed,
+        onSeedChanged = onSeedChanged,
+    )
 }
 
 @Composable
@@ -201,3 +153,8 @@ private fun GenerationResult(
         )
     }
 }
+
+private const val STEPS_MIN = 1f
+private const val STEPS_MAX = 150f
+private const val CFG_MIN = 1f
+private const val CFG_MAX = 30f


### PR DESCRIPTION
## Summary
- Extracted 4 shared composable components (`ParameterSliderRow`, `PromptInputFields`, `DimensionInputRow`, `SeedInputField`) into `:core:core-ui` module under `ui/components/comfyui/` package
- Updated Android `ComfyUIParameterSection.kt` and `ComfyUIGenerationScreen.kt` to use shared components, removing duplicate `SliderRow` overloads (Int/Double), `ResolutionRow`, and `SeedInput`
- Updated Desktop `DesktopComfyUIGenerationSection.kt` to use shared components, replacing inline `PromptInputs`, `GenerationSliders` (which used Desktop-local `SliderSetting`), and `DimensionInputs`

## Test plan
- [ ] Verify Android ComfyUI generation screen renders correctly (steps/CFG sliders, dimension inputs, seed field, LoRA strength, ControlNet strength, denoise sliders)
- [ ] Verify Desktop ComfyUI generation section renders correctly (prompts, sliders, dimension/seed inputs)
- [ ] Verify both platforms compile cleanly (`./gradlew :androidApp:assembleDebug`, `./gradlew :desktopApp:compileKotlinJvm`)
- [ ] Verify detekt passes without violations

Closes #821