### PR TITLE
Add ComfyUI /system_stats API and server hardware info display

### DIFF
--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/comfyui/ComfyUISettingsScreen.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/comfyui/ComfyUISettingsScreen.kt
@@ -27,6 +27,7 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
+import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.OutlinedTextField
@@ -51,6 +52,7 @@ import com.riox432.civitdeck.domain.model.ComfyUIConnection
 import com.riox432.civitdeck.domain.model.ComfyUIConnectionStatus
 import com.riox432.civitdeck.domain.model.ConnectionSecurityLevel
 import com.riox432.civitdeck.domain.model.DiscoveredServer
+import com.riox432.civitdeck.domain.model.SystemStats
 import com.riox432.civitdeck.feature.comfyui.presentation.ComfyUISettingsUiState
 import com.riox432.civitdeck.feature.comfyui.presentation.ComfyUISettingsViewModel
 import com.riox432.civitdeck.ui.theme.CornerRadius
@@ -127,6 +129,11 @@ private fun LazyListScope.settingsItems(
     onSelectDiscovered: (DiscoveredServer) -> Unit,
 ) {
     item { StatusSection(state, onTestConnection) }
+
+    // Hardware info section
+    state.systemStats?.let { stats ->
+        item { ServerHardwareSection(stats) }
+    }
 
     // Scan LAN section
     item { ScanLanSection(state, onScanLan, onSelectDiscovered) }
@@ -221,6 +228,72 @@ private fun SecurityBadge(level: ConnectionSecurityLevel, modifier: Modifier = M
         color = color,
         modifier = modifier,
     )
+}
+
+@Composable
+private fun ServerHardwareSection(stats: SystemStats) {
+    Card(modifier = Modifier.fillMaxWidth()) {
+        Column(modifier = Modifier.padding(Spacing.md)) {
+            Text(
+                stringResource(R.string.comfyui_server_hardware),
+                style = MaterialTheme.typography.titleSmall,
+            )
+            Spacer(modifier = Modifier.height(Spacing.sm))
+            HardwareGpuRow(stats)
+            VramProgressRow(stats)
+            HardwareInfoRows(stats)
+        }
+    }
+}
+
+@Composable
+private fun HardwareGpuRow(stats: SystemStats) {
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.SpaceBetween,
+    ) {
+        Text(stringResource(R.string.comfyui_gpu), style = MaterialTheme.typography.labelMedium)
+        Text(stats.gpuName, style = MaterialTheme.typography.bodySmall)
+    }
+}
+
+@Composable
+private fun VramProgressRow(stats: SystemStats) {
+    val vramUsed = stats.vramTotalMB - stats.vramFreeMB
+    val progress = if (stats.vramTotalMB > 0) vramUsed.toFloat() / stats.vramTotalMB else 0f
+    Spacer(modifier = Modifier.height(Spacing.xs))
+    Text(stringResource(R.string.comfyui_vram_usage), style = MaterialTheme.typography.labelMedium)
+    Spacer(modifier = Modifier.height(Spacing.xs))
+    LinearProgressIndicator(
+        progress = { progress },
+        modifier = Modifier.fillMaxWidth().height(Spacing.sm),
+        trackColor = MaterialTheme.colorScheme.surfaceVariant,
+    )
+    Text(
+        stringResource(R.string.comfyui_vram_format, vramUsed, stats.vramTotalMB),
+        style = MaterialTheme.typography.bodySmall,
+        color = MaterialTheme.colorScheme.onSurfaceVariant,
+    )
+}
+
+@Composable
+private fun HardwareInfoRows(stats: SystemStats) {
+    Spacer(modifier = Modifier.height(Spacing.xs))
+    HardwareInfoRow(stringResource(R.string.comfyui_ram), stringResource(R.string.comfyui_ram_format, stats.ramTotalMB))
+    stats.comfyuiVersion?.let { HardwareInfoRow(stringResource(R.string.comfyui_comfyui_version), it) }
+    stats.pytorchVersion?.let { HardwareInfoRow(stringResource(R.string.comfyui_pytorch_version), it) }
+    HardwareInfoRow(stringResource(R.string.comfyui_os), stats.os)
+}
+
+@Composable
+private fun HardwareInfoRow(label: String, value: String) {
+    Row(
+        modifier = Modifier.fillMaxWidth().padding(vertical = Spacing.xs),
+        horizontalArrangement = Arrangement.SpaceBetween,
+    ) {
+        Text(label, style = MaterialTheme.typography.labelMedium)
+        Text(value, style = MaterialTheme.typography.bodySmall)
+    }
 }
 
 @Composable

--- a/androidApp/src/main/res/values/strings.xml
+++ b/androidApp/src/main/res/values/strings.xml
@@ -358,6 +358,15 @@
     <string name="comfyui_status_testing">Testing…</string>
     <string name="comfyui_status_error">Connection Error</string>
     <string name="comfyui_status_not_configured">No server configured</string>
+    <string name="comfyui_server_hardware">Server Hardware</string>
+    <string name="comfyui_gpu">GPU</string>
+    <string name="comfyui_vram_usage">VRAM Usage</string>
+    <string name="comfyui_vram_format">%1$d / %2$d MB</string>
+    <string name="comfyui_ram">RAM</string>
+    <string name="comfyui_ram_format">%1$d MB total</string>
+    <string name="comfyui_comfyui_version">ComfyUI Version</string>
+    <string name="comfyui_pytorch_version">PyTorch Version</string>
+    <string name="comfyui_os">OS</string>
 
     <!-- SD WebUI -->
     <string name="sdwebui_title">SD WebUI</string>

--- a/core/core-domain/src/commonMain/kotlin/com/riox432/civitdeck/domain/model/SystemStats.kt
+++ b/core/core-domain/src/commonMain/kotlin/com/riox432/civitdeck/domain/model/SystemStats.kt
@@ -1,0 +1,17 @@
+package com.riox432.civitdeck.domain.model
+
+/**
+ * Hardware and system information from a connected ComfyUI server.
+ * Memory values are in megabytes for display convenience.
+ */
+data class SystemStats(
+    val gpuName: String,
+    val gpuType: String,
+    val vramTotalMB: Long,
+    val vramFreeMB: Long,
+    val ramTotalMB: Long,
+    val ramFreeMB: Long,
+    val os: String,
+    val comfyuiVersion: String?,
+    val pytorchVersion: String?,
+)

--- a/core/core-network/src/commonMain/kotlin/com/riox432/civitdeck/data/api/comfyui/ComfyUIApi.kt
+++ b/core/core-network/src/commonMain/kotlin/com/riox432/civitdeck/data/api/comfyui/ComfyUIApi.kt
@@ -209,6 +209,18 @@ class ComfyUIApi(
     }
 
     /**
+     * Fetch system stats: GET /system_stats
+     * Returns hardware info (GPU, VRAM, RAM) and software versions.
+     * Available in ComfyUI 0.1.0+.
+     * @throws ResponseException on HTTP error response
+     * @throws SerializationException on deserialization failure
+     * @throws HttpRequestTimeoutException on request timeout
+     * @throws ConnectTimeoutException on connection timeout
+     */
+    suspend fun getSystemStats(): SystemStatsResponse =
+        logAndRethrow("getSystemStats") { client.get("${_baseUrl.value}/system_stats").body() }
+
+    /**
      * Build image URL for viewing: GET /view?filename=...&type=output[&subfolder=...]
      * Omits subfolder when empty to avoid ComfyUI rejecting the request.
      */

--- a/core/core-network/src/commonMain/kotlin/com/riox432/civitdeck/data/api/comfyui/SystemStatsDto.kt
+++ b/core/core-network/src/commonMain/kotlin/com/riox432/civitdeck/data/api/comfyui/SystemStatsDto.kt
@@ -1,0 +1,34 @@
+package com.riox432.civitdeck.data.api.comfyui
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * Response from GET /system_stats.
+ * Available in ComfyUI 0.1.0+.
+ */
+@Serializable
+data class SystemStatsResponse(
+    val system: SystemInfo,
+    val devices: List<DeviceInfo>,
+)
+
+@Serializable
+data class SystemInfo(
+    @SerialName("os") val os: String,
+    @SerialName("ram_total") val ramTotal: Long,
+    @SerialName("ram_free") val ramFree: Long,
+    @SerialName("comfyui_version") val comfyuiVersion: String? = null,
+    @SerialName("python_version") val pythonVersion: String? = null,
+    @SerialName("pytorch_version") val pytorchVersion: String? = null,
+    @SerialName("embedded_python") val embeddedPython: Boolean? = null,
+)
+
+@Serializable
+data class DeviceInfo(
+    val name: String,
+    val type: String,
+    @SerialName("vram_total") val vramTotal: Long,
+    @SerialName("vram_free") val vramFree: Long,
+    val index: Int = 0,
+)

--- a/desktopApp/src/jvmMain/kotlin/com/riox432/civitdeck/ui/settings/DesktopComfyUIConnectionSection.kt
+++ b/desktopApp/src/jvmMain/kotlin/com/riox432/civitdeck/ui/settings/DesktopComfyUIConnectionSection.kt
@@ -1,12 +1,14 @@
 package com.riox432.civitdeck.ui.settings
 
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.width
 import androidx.compose.material3.Button
+import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.OutlinedTextField
@@ -23,6 +25,7 @@ import androidx.compose.ui.Modifier
 import com.riox432.civitdeck.domain.model.ComfyUIConnection
 import com.riox432.civitdeck.domain.model.ComfyUIConnectionStatus
 import com.riox432.civitdeck.domain.model.ConnectionSecurityLevel
+import com.riox432.civitdeck.domain.model.SystemStats
 import com.riox432.civitdeck.feature.comfyui.presentation.ComfyUISettingsViewModel
 import com.riox432.civitdeck.ui.theme.Spacing
 
@@ -41,6 +44,10 @@ fun ComfyUISettingsSection(viewModel: ComfyUISettingsViewModel) {
             isConnected = state.connectionStatus == ComfyUIConnectionStatus.Connected,
         )
         SecurityLevelIndicator(securityLevel = state.securityLevel)
+        state.systemStats?.let { stats ->
+            Spacer(modifier = Modifier.height(Spacing.sm))
+            DesktopServerHardwareSection(stats)
+        }
         Spacer(modifier = Modifier.height(Spacing.sm))
         LanScanSection(
             isScanning = state.isScanning,
@@ -205,6 +212,49 @@ private fun SavedConnectionsList(
                 }
             }
         }
+    }
+}
+
+@Composable
+private fun DesktopServerHardwareSection(stats: SystemStats) {
+    Text("Server Hardware", style = MaterialTheme.typography.labelMedium)
+    Spacer(modifier = Modifier.height(Spacing.xs))
+    DesktopHardwareRow("GPU", stats.gpuName)
+    DesktopVramProgressRow(stats)
+    DesktopHardwareRow("RAM", "${stats.ramTotalMB} MB total")
+    stats.comfyuiVersion?.let { DesktopHardwareRow("ComfyUI", it) }
+    stats.pytorchVersion?.let { DesktopHardwareRow("PyTorch", it) }
+    DesktopHardwareRow("OS", stats.os)
+}
+
+@Composable
+private fun DesktopVramProgressRow(stats: SystemStats) {
+    val vramUsed = stats.vramTotalMB - stats.vramFreeMB
+    val progress = if (stats.vramTotalMB > 0) vramUsed.toFloat() / stats.vramTotalMB else 0f
+    Column {
+        Text("VRAM Usage", style = MaterialTheme.typography.labelSmall)
+        Spacer(modifier = Modifier.height(Spacing.xs))
+        LinearProgressIndicator(
+            progress = { progress },
+            modifier = Modifier.fillMaxWidth().height(Spacing.sm),
+            trackColor = MaterialTheme.colorScheme.surfaceVariant,
+        )
+        Text(
+            "$vramUsed / ${stats.vramTotalMB} MB",
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+    }
+}
+
+@Composable
+private fun DesktopHardwareRow(label: String, value: String) {
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.SpaceBetween,
+    ) {
+        Text(label, style = MaterialTheme.typography.labelSmall)
+        Text(value, style = MaterialTheme.typography.bodySmall)
     }
 }
 

--- a/feature/feature-comfyui/src/commonMain/kotlin/com/riox432/civitdeck/feature/comfyui/di/ComfyUIModule.kt
+++ b/feature/feature-comfyui/src/commonMain/kotlin/com/riox432/civitdeck/feature/comfyui/di/ComfyUIModule.kt
@@ -34,6 +34,7 @@ import com.riox432.civitdeck.feature.comfyui.domain.usecase.DisconnectCivitaiLin
 import com.riox432.civitdeck.feature.comfyui.domain.usecase.ExportWorkflowTemplateUseCase
 import com.riox432.civitdeck.feature.comfyui.domain.usecase.ExtractWorkflowParametersUseCase
 import com.riox432.civitdeck.feature.comfyui.domain.usecase.FetchComfyUICheckpointsUseCase
+import com.riox432.civitdeck.feature.comfyui.domain.usecase.FetchSystemStatsUseCase
 import com.riox432.civitdeck.feature.comfyui.domain.usecase.FetchComfyUIControlNetsUseCase
 import com.riox432.civitdeck.feature.comfyui.domain.usecase.FetchComfyUIHistoryItemUseCase
 import com.riox432.civitdeck.feature.comfyui.domain.usecase.FetchComfyUIHistoryUseCase
@@ -105,6 +106,7 @@ val comfyuiModule = module {
     factory { DeleteComfyUIConnectionUseCase(get()) }
     factory { ActivateComfyUIConnectionUseCase(get()) }
     factory { TestComfyUIConnectionUseCase(get()) }
+    factory { FetchSystemStatsUseCase(get()) }
     factory { FetchComfyUICheckpointsUseCase(get()) }
     factory { FetchComfyUILorasUseCase(get()) }
     factory { FetchComfyUIControlNetsUseCase(get()) }
@@ -168,7 +170,7 @@ val comfyuiModule = module {
     single { ComfyUIWorkflowPlugin(get()) }
 
     // ViewModels
-    viewModel { ComfyUISettingsViewModel(get(), get(), get(), get(), get(), get(), get()) }
+    viewModel { ComfyUISettingsViewModel(get(), get(), get(), get(), get(), get(), get(), get()) }
     viewModel {
         ComfyUIGenerationViewModel(
             get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get(),

--- a/feature/feature-comfyui/src/commonMain/kotlin/com/riox432/civitdeck/feature/comfyui/domain/usecase/FetchSystemStatsUseCase.kt
+++ b/feature/feature-comfyui/src/commonMain/kotlin/com/riox432/civitdeck/feature/comfyui/domain/usecase/FetchSystemStatsUseCase.kt
@@ -1,0 +1,40 @@
+package com.riox432.civitdeck.feature.comfyui.domain.usecase
+
+import com.riox432.civitdeck.data.api.comfyui.ComfyUIApi
+import com.riox432.civitdeck.data.api.comfyui.SystemStatsResponse
+import com.riox432.civitdeck.domain.model.SystemStats
+import com.riox432.civitdeck.util.Logger
+
+private const val TAG = "FetchSystemStats"
+private const val BYTES_PER_MB = 1_048_576L
+
+/**
+ * Fetches hardware and system information from the connected ComfyUI server.
+ * Returns null if the server does not support /system_stats (older versions)
+ * or if the request fails for any reason.
+ */
+class FetchSystemStatsUseCase(private val api: ComfyUIApi) {
+
+    suspend operator fun invoke(): SystemStats? = try {
+        val response = api.getSystemStats()
+        mapToSystemStats(response)
+    } catch (@Suppress("TooGenericExceptionCaught") e: Exception) {
+        Logger.w(TAG, "Failed to fetch system stats: ${e.message}")
+        null
+    }
+
+    private fun mapToSystemStats(response: SystemStatsResponse): SystemStats {
+        val device = response.devices.firstOrNull()
+        return SystemStats(
+            gpuName = device?.name ?: "Unknown",
+            gpuType = device?.type ?: "Unknown",
+            vramTotalMB = (device?.vramTotal ?: 0L) / BYTES_PER_MB,
+            vramFreeMB = (device?.vramFree ?: 0L) / BYTES_PER_MB,
+            ramTotalMB = response.system.ramTotal / BYTES_PER_MB,
+            ramFreeMB = response.system.ramFree / BYTES_PER_MB,
+            os = response.system.os,
+            comfyuiVersion = response.system.comfyuiVersion,
+            pytorchVersion = response.system.pytorchVersion,
+        )
+    }
+}

--- a/feature/feature-comfyui/src/commonMain/kotlin/com/riox432/civitdeck/feature/comfyui/presentation/ComfyUISettingsViewModel.kt
+++ b/feature/feature-comfyui/src/commonMain/kotlin/com/riox432/civitdeck/feature/comfyui/presentation/ComfyUISettingsViewModel.kt
@@ -7,8 +7,10 @@ import com.riox432.civitdeck.domain.model.ComfyUIConnectionStatus
 import com.riox432.civitdeck.domain.model.ConnectionSecurityLevel
 import com.riox432.civitdeck.domain.model.DiscoveredServer
 import com.riox432.civitdeck.domain.model.SecurityLevelHelper
+import com.riox432.civitdeck.domain.model.SystemStats
 import com.riox432.civitdeck.feature.comfyui.domain.usecase.ActivateComfyUIConnectionUseCase
 import com.riox432.civitdeck.feature.comfyui.domain.usecase.DeleteComfyUIConnectionUseCase
+import com.riox432.civitdeck.feature.comfyui.domain.usecase.FetchSystemStatsUseCase
 import com.riox432.civitdeck.feature.comfyui.domain.usecase.ObserveActiveComfyUIConnectionUseCase
 import com.riox432.civitdeck.feature.comfyui.domain.usecase.ObserveComfyUIConnectionsUseCase
 import com.riox432.civitdeck.feature.comfyui.domain.usecase.SaveComfyUIConnectionUseCase
@@ -35,6 +37,7 @@ data class ComfyUISettingsUiState(
     val editingConnection: ComfyUIConnection? = null,
     val isScanning: Boolean = false,
     val discoveredServers: List<DiscoveredServer> = emptyList(),
+    val systemStats: SystemStats? = null,
 )
 
 class ComfyUISettingsViewModel(
@@ -45,6 +48,7 @@ class ComfyUISettingsViewModel(
     private val activateConnection: ActivateComfyUIConnectionUseCase,
     private val testConnection: TestComfyUIConnectionUseCase,
     private val scanForServers: ScanForServersUseCase,
+    private val fetchSystemStats: FetchSystemStatsUseCase,
 ) : ViewModel() {
 
     private val _mutableState = MutableStateFlow(ComfyUISettingsUiState())
@@ -103,14 +107,18 @@ class ComfyUISettingsViewModel(
 
     fun onTestConnection() {
         val active = uiState.value.activeConnection ?: return
-        _mutableState.update { it.copy(isTesting = true, testError = null) }
+        _mutableState.update { it.copy(isTesting = true, testError = null, systemStats = null) }
         viewModelScope.launch {
             val success = testConnection(active)
-            _mutableState.update {
-                it.copy(
-                    isTesting = false,
-                    testError = if (success) null else "Connection failed",
-                )
+            if (success) {
+                val stats = fetchSystemStats()
+                _mutableState.update {
+                    it.copy(isTesting = false, testError = null, systemStats = stats)
+                }
+            } else {
+                _mutableState.update {
+                    it.copy(isTesting = false, testError = "Connection failed", systemStats = null)
+                }
             }
         }
     }

--- a/iosApp/iosApp/Features/ComfyUI/ComfyUISettingsView.swift
+++ b/iosApp/iosApp/Features/ComfyUI/ComfyUISettingsView.swift
@@ -8,6 +8,9 @@ struct ComfyUISettingsView: View {
     var body: some View {
         List {
             statusSection
+            if let stats = viewModel.systemStats {
+                serverHardwareSection(stats)
+            }
             scanLanSection
             if viewModel.isConnected {
                 NavigationLink("Open txt2img Generator") {
@@ -122,6 +125,52 @@ struct ComfyUISettingsView: View {
             return "Connection Error"
         }
         return "Disconnected"
+    }
+
+    private func serverHardwareSection(_ stats: Core_domainSystemStats) -> some View {
+        Section("Server Hardware") {
+            LabeledContent("GPU") {
+                Text(stats.gpuName)
+                    .font(.civitBodySmall)
+            }
+            vramProgressRow(stats)
+            LabeledContent("RAM") {
+                Text("\(stats.ramTotalMB) MB total")
+                    .font(.civitBodySmall)
+            }
+            if let version = stats.comfyuiVersion {
+                LabeledContent("ComfyUI") {
+                    Text(version)
+                        .font(.civitBodySmall)
+                }
+            }
+            if let pytorch = stats.pytorchVersion {
+                LabeledContent("PyTorch") {
+                    Text(pytorch)
+                        .font(.civitBodySmall)
+                }
+            }
+            LabeledContent("OS") {
+                Text(stats.os)
+                    .font(.civitBodySmall)
+            }
+        }
+    }
+
+    private func vramProgressRow(_ stats: Core_domainSystemStats) -> some View {
+        let vramUsed = stats.vramTotalMB - stats.vramFreeMB
+        let progress = stats.vramTotalMB > 0
+            ? Double(vramUsed) / Double(stats.vramTotalMB)
+            : 0.0
+        return VStack(alignment: .leading, spacing: Spacing.xs) {
+            Text("VRAM Usage")
+                .font(.civitLabelMedium)
+            ProgressView(value: progress) {
+                Text("\(vramUsed) / \(stats.vramTotalMB) MB")
+                    .font(.civitBodySmall)
+                    .foregroundColor(.civitOnSurfaceVariant)
+            }
+        }
     }
 
     private var scanLanSection: some View {

--- a/iosApp/iosApp/Features/ComfyUI/ComfyUISettingsViewModel.swift
+++ b/iosApp/iosApp/Features/ComfyUI/ComfyUISettingsViewModel.swift
@@ -15,6 +15,7 @@ final class ComfyUISettingsViewModelOwner: ObservableObject {
     @Published var editingConnection: ComfyUIConnection?
     @Published var isScanning = false
     @Published var discoveredServers: [DiscoveredServer] = []
+    @Published var systemStats: Core_domainSystemStats?
 
     init() {
         vm = KoinHelper.shared.createComfyUISettingsViewModel()
@@ -34,6 +35,7 @@ final class ComfyUISettingsViewModelOwner: ObservableObject {
             editingConnection = state.editingConnection
             isScanning = state.isScanning
             discoveredServers = state.discoveredServers as? [DiscoveredServer] ?? []
+            systemStats = state.systemStats
         }
     }
 


### PR DESCRIPTION
## Summary
- Add `SystemStatsDto` (DTO) and `SystemStats` (domain model) for ComfyUI `/system_stats` endpoint
- Add `getSystemStats()` to `ComfyUIApi` using existing `logAndRethrow` error pattern
- Add `FetchSystemStatsUseCase` with graceful fallback (returns null for older ComfyUI servers)
- Fetch system stats automatically after successful connection test in `ComfyUISettingsViewModel`
- Display GPU name, VRAM usage progress bar, RAM, ComfyUI/PyTorch versions, and OS on all 3 platforms:
  - **Android**: `ServerHardwareSection` card with `LinearProgressIndicator`
  - **iOS**: `Section("Server Hardware")` with `LabeledContent` rows and `ProgressView`
  - **Desktop**: `DesktopServerHardwareSection` with `LinearProgressIndicator`

Closes #894

## Test plan
- [ ] Connect to a ComfyUI server and tap "Test" — hardware info card should appear after success
- [ ] Verify VRAM progress bar shows correct used/total ratio
- [ ] Test with a server that does not support `/system_stats` — hardware card should not appear (graceful fallback)
- [ ] Verify all 3 platforms display correct data (Android, iOS, Desktop)
- [ ] Verify detekt passes on Android
- [ ] Verify desktop JVM compiles cleanly