### PR TITLE
Add VRAM compatibility badges and optimization suggestions

### DIFF
--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/CivitDeckApplication.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/CivitDeckApplication.kt
@@ -114,7 +114,7 @@ class CivitDeckApplication : Application(), SingletonImageLoader.Factory, KoinCo
 val androidModule = module {
     single<AppVersionProvider> { AndroidAppVersionProvider() }
     viewModel { params ->
-        ModelDetailViewModel(params.get(), get(), get(), get(), get(), get())
+        ModelDetailViewModel(params.get(), get(), get(), get(), get(), get(), get())
     }
     viewModel { params -> DuplicateReviewViewModel(params.get(), get(), get()) }
     // DownloadQueueViewModel now registered in shared Phase3ViewModelModule

--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/comfyui/ComfyUISettingsScreen.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/comfyui/ComfyUISettingsScreen.kt
@@ -17,6 +17,7 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.Edit
 import androidx.compose.material3.AlertDialog
@@ -53,6 +54,7 @@ import com.riox432.civitdeck.domain.model.ComfyUIConnectionStatus
 import com.riox432.civitdeck.domain.model.ConnectionSecurityLevel
 import com.riox432.civitdeck.domain.model.DiscoveredServer
 import com.riox432.civitdeck.domain.model.SystemStats
+import com.riox432.civitdeck.domain.util.OptimizationSuggestion
 import com.riox432.civitdeck.feature.comfyui.presentation.ComfyUISettingsUiState
 import com.riox432.civitdeck.feature.comfyui.presentation.ComfyUISettingsViewModel
 import com.riox432.civitdeck.ui.theme.CornerRadius
@@ -103,6 +105,7 @@ fun ComfyUISettingsScreen(
                 onDelete = viewModel::onDeleteConnection,
                 onScanLan = viewModel::onScanLan,
                 onSelectDiscovered = viewModel::onSelectDiscoveredServer,
+                onDismissSuggestion = viewModel::dismissSuggestion,
             )
         }
     }
@@ -127,12 +130,25 @@ private fun LazyListScope.settingsItems(
     onDelete: (Long) -> Unit,
     onScanLan: () -> Unit,
     onSelectDiscovered: (DiscoveredServer) -> Unit,
+    onDismissSuggestion: (String) -> Unit,
 ) {
     item { StatusSection(state, onTestConnection) }
 
     // Hardware info section
     state.systemStats?.let { stats ->
         item { ServerHardwareSection(stats) }
+    }
+
+    // Optimization suggestions
+    val visibleSuggestions = state.optimizationSuggestions
+        .filter { it.id !in state.dismissedSuggestionIds }
+    if (visibleSuggestions.isNotEmpty()) {
+        item {
+            OptimizationSuggestionsSection(
+                suggestions = visibleSuggestions,
+                onDismiss = onDismissSuggestion,
+            )
+        }
     }
 
     // Scan LAN section
@@ -293,6 +309,65 @@ private fun HardwareInfoRow(label: String, value: String) {
     ) {
         Text(label, style = MaterialTheme.typography.labelMedium)
         Text(value, style = MaterialTheme.typography.bodySmall)
+    }
+}
+
+@Composable
+private fun OptimizationSuggestionsSection(
+    suggestions: List<OptimizationSuggestion>,
+    onDismiss: (String) -> Unit,
+) {
+    Card(modifier = Modifier.fillMaxWidth()) {
+        Column(modifier = Modifier.padding(Spacing.md)) {
+            Text(
+                stringResource(R.string.vram_optimization_suggestions),
+                style = MaterialTheme.typography.titleSmall,
+            )
+            Spacer(modifier = Modifier.height(Spacing.sm))
+            suggestions.forEach { suggestion ->
+                SuggestionCard(suggestion = suggestion, onDismiss = onDismiss)
+                Spacer(modifier = Modifier.height(Spacing.xs))
+            }
+        }
+    }
+}
+
+@Composable
+private fun SuggestionCard(
+    suggestion: OptimizationSuggestion,
+    onDismiss: (String) -> Unit,
+) {
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.surfaceContainerHigh,
+        ),
+        shape = RoundedCornerShape(CornerRadius.card),
+    ) {
+        Row(
+            modifier = Modifier.fillMaxWidth().padding(Spacing.md),
+            verticalAlignment = Alignment.Top,
+        ) {
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    suggestion.title,
+                    style = MaterialTheme.typography.labelLarge,
+                )
+                Text(
+                    suggestion.description,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+            IconButton(onClick = { onDismiss(suggestion.id) }) {
+                Icon(
+                    Icons.Default.Close,
+                    contentDescription = stringResource(R.string.cd_dismiss),
+                    modifier = Modifier.size(Spacing.lg),
+                    tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+        }
     }
 }
 

--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/detail/FileDownloadRow.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/detail/FileDownloadRow.kt
@@ -1,11 +1,14 @@
 package com.riox432.civitdeck.ui.detail
 
+import androidx.compose.foundation.background
+import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Cancel
 import androidx.compose.material.icons.filled.CheckCircle
@@ -20,6 +23,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
@@ -28,7 +32,10 @@ import com.riox432.civitdeck.domain.model.DownloadStatus
 import com.riox432.civitdeck.domain.model.ModelDownload
 import com.riox432.civitdeck.domain.model.ModelFile
 import com.riox432.civitdeck.domain.util.FormatUtils
+import com.riox432.civitdeck.domain.util.VramCompatibility
+import com.riox432.civitdeck.ui.theme.CornerRadius
 import com.riox432.civitdeck.ui.theme.Spacing
+import com.riox432.civitdeck.ui.theme.VramColors
 
 @Composable
 fun FileDownloadRow(
@@ -37,6 +44,7 @@ fun FileDownloadRow(
     onDownload: (ModelFile) -> Unit,
     onCancel: (Long) -> Unit,
     onPause: (Long) -> Unit = {},
+    vramCompatibility: VramCompatibility = VramCompatibility.UNKNOWN,
 ) {
     Row(
         modifier = Modifier
@@ -51,7 +59,10 @@ fun FileDownloadRow(
                 maxLines = 1,
                 overflow = TextOverflow.Ellipsis,
             )
-            Row(horizontalArrangement = Arrangement.spacedBy(Spacing.sm)) {
+            Row(
+                horizontalArrangement = Arrangement.spacedBy(Spacing.sm),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
                 Text(
                     text = FormatUtils.formatFileSize(file.sizeKB),
                     style = MaterialTheme.typography.labelSmall,
@@ -79,6 +90,7 @@ fun FileDownloadRow(
                         color = MaterialTheme.colorScheme.primary,
                     )
                 }
+                VramBadge(compatibility = vramCompatibility)
             }
         }
         DownloadAction(
@@ -89,6 +101,46 @@ fun FileDownloadRow(
             onPause = onPause,
         )
     }
+}
+
+@Composable
+private fun VramBadge(compatibility: VramCompatibility) {
+    if (compatibility == VramCompatibility.UNKNOWN) return
+    val isDark = isSystemInDarkTheme()
+    val (bg, content, label) = vramBadgeColors(compatibility, isDark)
+    Text(
+        text = label,
+        style = MaterialTheme.typography.labelSmall,
+        color = content,
+        modifier = Modifier
+            .background(bg, RoundedCornerShape(CornerRadius.card))
+            .padding(horizontal = Spacing.sm, vertical = Spacing.xxs),
+    )
+}
+
+private data class BadgeStyle(val bg: Color, val content: Color, val label: String)
+
+@Composable
+private fun vramBadgeColors(
+    compatibility: VramCompatibility,
+    isDark: Boolean,
+): BadgeStyle = when (compatibility) {
+    VramCompatibility.FITS -> BadgeStyle(
+        bg = if (isDark) VramColors.fitsDarkBackground else VramColors.fitsBackground,
+        content = if (isDark) VramColors.fitsDarkContent else VramColors.fitsContent,
+        label = stringResource(R.string.vram_fits_gpu),
+    )
+    VramCompatibility.TIGHT -> BadgeStyle(
+        bg = if (isDark) VramColors.tightDarkBackground else VramColors.tightBackground,
+        content = if (isDark) VramColors.tightDarkContent else VramColors.tightContent,
+        label = stringResource(R.string.vram_tight_fit),
+    )
+    VramCompatibility.NEEDS_OFFLOADING -> BadgeStyle(
+        bg = if (isDark) VramColors.offloadDarkBackground else VramColors.offloadBackground,
+        content = if (isDark) VramColors.offloadDarkContent else VramColors.offloadContent,
+        label = stringResource(R.string.vram_needs_offloading),
+    )
+    VramCompatibility.UNKNOWN -> BadgeStyle(Color.Transparent, Color.Transparent, "")
 }
 
 @Composable

--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/detail/ModelDetailContent.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/detail/ModelDetailContent.kt
@@ -223,6 +223,7 @@ private fun LazyListScope.modelDetailActionItems(
             version = selectedVersion,
             powerUserMode = uiState.powerUserMode,
             downloads = uiState.downloads.associateBy { it.fileId },
+            fileVramCompatibility = uiState.fileVramCompatibility,
             onDownloadFile = callbacks.onDownloadFile,
             onCancelDownload = callbacks.onCancelDownload,
         )

--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/detail/VersionSection.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/detail/VersionSection.kt
@@ -26,6 +26,7 @@ import com.riox432.civitdeck.domain.model.HapticFeedbackType
 import com.riox432.civitdeck.domain.model.ModelDownload
 import com.riox432.civitdeck.domain.model.ModelFile
 import com.riox432.civitdeck.domain.model.ModelVersion
+import com.riox432.civitdeck.domain.util.VramCompatibility
 import com.riox432.civitdeck.ui.components.FilterChipRow
 import com.riox432.civitdeck.ui.components.SectionHeader
 import com.riox432.civitdeck.ui.components.rememberHapticFeedback
@@ -65,6 +66,7 @@ internal fun VersionDetail(
     version: ModelVersion,
     powerUserMode: Boolean = false,
     downloads: Map<Long, ModelDownload> = emptyMap(),
+    fileVramCompatibility: Map<Long, VramCompatibility> = emptyMap(),
     onDownloadFile: (ModelFile) -> Unit = {},
     onCancelDownload: (Long) -> Unit = {},
 ) {
@@ -94,6 +96,8 @@ internal fun VersionDetail(
                     downloadState = downloads[file.id],
                     onDownload = onDownloadFile,
                     onCancel = onCancelDownload,
+                    vramCompatibility = fileVramCompatibility[file.id]
+                        ?: VramCompatibility.UNKNOWN,
                 )
                 if (powerUserMode) {
                     AdvancedFileInfo(file = file)

--- a/androidApp/src/main/res/values/strings.xml
+++ b/androidApp/src/main/res/values/strings.xml
@@ -531,4 +531,11 @@
     <!-- Share -->
     <string name="share_add_hashtag_label">Add hashtag</string>
     <string name="share_add_tag_label">Add tag</string>
+
+    <!-- VRAM Compatibility -->
+    <string name="cd_dismiss">Dismiss</string>
+    <string name="vram_fits_gpu">Fits your GPU</string>
+    <string name="vram_tight_fit">Tight fit</string>
+    <string name="vram_needs_offloading">Needs offloading</string>
+    <string name="vram_optimization_suggestions">Optimization Suggestions</string>
 </resources>

--- a/androidApp/src/test/kotlin/com/riox432/civitdeck/ui/detail/ModelDetailViewModelTest.kt
+++ b/androidApp/src/test/kotlin/com/riox432/civitdeck/ui/detail/ModelDetailViewModelTest.kt
@@ -53,6 +53,7 @@ import com.riox432.civitdeck.domain.usecase.SaveModelNoteUseCase
 import com.riox432.civitdeck.domain.usecase.SubmitReviewUseCase
 import com.riox432.civitdeck.domain.usecase.ToggleFavoriteUseCase
 import com.riox432.civitdeck.domain.usecase.TrackModelViewUseCase
+import com.riox432.civitdeck.domain.util.SystemStatsProvider
 import com.riox432.civitdeck.feature.detail.presentation.CollectionUseCases
 import com.riox432.civitdeck.feature.detail.presentation.DownloadUseCases
 import com.riox432.civitdeck.feature.detail.presentation.ModelDetailViewModel
@@ -374,6 +375,7 @@ class ModelDetailViewModelTest {
             notesTagsUseCases = notesTagsUseCases,
             downloadUseCases = downloadUseCases,
             reviewUseCases = reviewUseCases,
+            systemStatsProvider = SystemStatsProvider { null },
         )
         return Triple(vm, modelRepo, favRepo)
     }

--- a/core/core-domain/src/commonMain/kotlin/com/riox432/civitdeck/domain/util/OptimizationSuggestions.kt
+++ b/core/core-domain/src/commonMain/kotlin/com/riox432/civitdeck/domain/util/OptimizationSuggestions.kt
@@ -1,0 +1,60 @@
+package com.riox432.civitdeck.domain.util
+
+import com.riox432.civitdeck.domain.model.SystemStats
+
+/**
+ * An actionable optimization suggestion based on the user's hardware.
+ */
+data class OptimizationSuggestion(
+    val id: String,
+    val title: String,
+    val description: String,
+)
+
+private const val LOW_VRAM_THRESHOLD_MB = 6 * 1024L
+private const val MID_VRAM_THRESHOLD_MB = 8 * 1024L
+private const val LOW_FREE_RATIO = 0.15
+
+/**
+ * Generates optimization suggestions based on the connected ComfyUI server's
+ * hardware capabilities.
+ */
+fun generateOptimizationSuggestions(stats: SystemStats): List<OptimizationSuggestion> {
+    val suggestions = mutableListOf<OptimizationSuggestion>()
+
+    if (stats.vramTotalMB in 1 until LOW_VRAM_THRESHOLD_MB) {
+        suggestions.add(
+            OptimizationSuggestion(
+                id = "fp16_tiling",
+                title = "Enable FP16 + Tiling",
+                description = "With ${stats.vramTotalMB} MB VRAM, enable FP16 precision " +
+                    "and tiled VAE decode to reduce memory usage.",
+            ),
+        )
+    } else if (stats.vramTotalMB in LOW_VRAM_THRESHOLD_MB until MID_VRAM_THRESHOLD_MB) {
+        suggestions.add(
+            OptimizationSuggestion(
+                id = "fp16",
+                title = "Use FP16 Precision",
+                description = "With ${stats.vramTotalMB} MB VRAM, FP16 models will give " +
+                    "the best balance of quality and performance.",
+            ),
+        )
+    }
+
+    if (stats.vramTotalMB > 0) {
+        val freeRatio = stats.vramFreeMB.toDouble() / stats.vramTotalMB
+        if (freeRatio < LOW_FREE_RATIO) {
+            suggestions.add(
+                OptimizationSuggestion(
+                    id = "low_free_vram",
+                    title = "Low Free VRAM",
+                    description = "Only ${stats.vramFreeMB} MB free of ${stats.vramTotalMB} MB. " +
+                        "Close GPU-intensive apps or use ComfyUI's /free endpoint to release cached models.",
+                ),
+            )
+        }
+    }
+
+    return suggestions
+}

--- a/core/core-domain/src/commonMain/kotlin/com/riox432/civitdeck/domain/util/SystemStatsProvider.kt
+++ b/core/core-domain/src/commonMain/kotlin/com/riox432/civitdeck/domain/util/SystemStatsProvider.kt
@@ -1,0 +1,15 @@
+package com.riox432.civitdeck.domain.util
+
+import com.riox432.civitdeck.domain.model.SystemStats
+
+/**
+ * Functional interface for fetching system stats from the connected
+ * ComfyUI server. Returns null when no server is connected or the
+ * endpoint is unavailable.
+ *
+ * This abstraction lives in core-domain so feature modules can
+ * consume system stats without depending on feature-comfyui.
+ */
+fun interface SystemStatsProvider {
+    suspend fun fetch(): SystemStats?
+}

--- a/core/core-domain/src/commonMain/kotlin/com/riox432/civitdeck/domain/util/VramCompatibility.kt
+++ b/core/core-domain/src/commonMain/kotlin/com/riox432/civitdeck/domain/util/VramCompatibility.kt
@@ -1,0 +1,46 @@
+package com.riox432.civitdeck.domain.util
+
+/**
+ * Indicates how well a model file fits the user's GPU VRAM.
+ */
+enum class VramCompatibility {
+    /** Model file fits in available VRAM with comfortable margin (>= 2 GB spare). */
+    FITS,
+
+    /** Model file fits but within the 2 GB safety margin. */
+    TIGHT,
+
+    /** Model file exceeds available VRAM; CPU offloading may be required. */
+    NEEDS_OFFLOADING,
+
+    /** No system stats available — cannot determine compatibility. */
+    UNKNOWN,
+}
+
+private const val KB_PER_MB = 1024.0
+private const val MARGIN_MB = 2048L
+
+/**
+ * Estimates VRAM compatibility for a model file.
+ *
+ * Heuristic: the VRAM needed to load a model is roughly proportional to its file
+ * size on disk. FP16/FP32 precision affects the actual runtime memory, but the
+ * file size already reflects the stored precision. We use total VRAM (not free)
+ * because the baseline VRAM usage of the inference runtime (~300-500 MB) is
+ * negligible compared to model weights.
+ *
+ * @param modelFileSizeKB file size in kilobytes (from CivitAI `sizeKB` field)
+ * @param vramTotalMB     total GPU VRAM in megabytes
+ */
+fun calculateVramCompatibility(
+    modelFileSizeKB: Double,
+    vramTotalMB: Long,
+): VramCompatibility {
+    if (vramTotalMB <= 0) return VramCompatibility.UNKNOWN
+    val fileSizeMB = (modelFileSizeKB / KB_PER_MB).toLong()
+    return when {
+        fileSizeMB + MARGIN_MB <= vramTotalMB -> VramCompatibility.FITS
+        fileSizeMB <= vramTotalMB -> VramCompatibility.TIGHT
+        else -> VramCompatibility.NEEDS_OFFLOADING
+    }
+}

--- a/core/core-domain/src/commonTest/kotlin/com/riox432/civitdeck/domain/util/OptimizationSuggestionsTest.kt
+++ b/core/core-domain/src/commonTest/kotlin/com/riox432/civitdeck/domain/util/OptimizationSuggestionsTest.kt
@@ -1,0 +1,68 @@
+package com.riox432.civitdeck.domain.util
+
+import com.riox432.civitdeck.domain.model.SystemStats
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class OptimizationSuggestionsTest {
+
+    private fun stats(
+        vramTotalMB: Long = 8_192L,
+        vramFreeMB: Long = 4_096L,
+    ) = SystemStats(
+        gpuName = "RTX 3060",
+        gpuType = "cuda",
+        vramTotalMB = vramTotalMB,
+        vramFreeMB = vramFreeMB,
+        ramTotalMB = 32_768L,
+        ramFreeMB = 16_384L,
+        os = "Linux",
+        comfyuiVersion = "0.2.0",
+        pytorchVersion = "2.3.0",
+    )
+
+    @Test
+    fun suggests_fp16_tiling_for_low_vram() {
+        val suggestions = generateOptimizationSuggestions(stats(vramTotalMB = 4_096L))
+        assertTrue(suggestions.any { it.id == "fp16_tiling" })
+    }
+
+    @Test
+    fun suggests_fp16_for_mid_vram() {
+        val suggestions = generateOptimizationSuggestions(stats(vramTotalMB = 7_168L))
+        assertTrue(suggestions.any { it.id == "fp16" })
+    }
+
+    @Test
+    fun no_precision_suggestion_for_high_vram() {
+        val suggestions = generateOptimizationSuggestions(stats(vramTotalMB = 24_576L))
+        assertTrue(suggestions.none { it.id == "fp16_tiling" || it.id == "fp16" })
+    }
+
+    @Test
+    fun suggests_low_free_vram() {
+        // 10% free = below 15% threshold
+        val suggestions = generateOptimizationSuggestions(
+            stats(vramTotalMB = 12_288L, vramFreeMB = 1_228L),
+        )
+        assertTrue(suggestions.any { it.id == "low_free_vram" })
+    }
+
+    @Test
+    fun no_low_free_vram_when_plenty_available() {
+        // 50% free
+        val suggestions = generateOptimizationSuggestions(
+            stats(vramTotalMB = 12_288L, vramFreeMB = 6_144L),
+        )
+        assertTrue(suggestions.none { it.id == "low_free_vram" })
+    }
+
+    @Test
+    fun empty_suggestions_for_high_vram_with_plenty_free() {
+        val suggestions = generateOptimizationSuggestions(
+            stats(vramTotalMB = 24_576L, vramFreeMB = 20_000L),
+        )
+        assertEquals(0, suggestions.size)
+    }
+}

--- a/core/core-domain/src/commonTest/kotlin/com/riox432/civitdeck/domain/util/VramCompatibilityTest.kt
+++ b/core/core-domain/src/commonTest/kotlin/com/riox432/civitdeck/domain/util/VramCompatibilityTest.kt
@@ -1,0 +1,84 @@
+package com.riox432.civitdeck.domain.util
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class VramCompatibilityTest {
+
+    @Test
+    fun fits_when_file_well_within_vram() {
+        // 2 GB file (2_097_152 KB) with 12 GB VRAM (12_288 MB)
+        // File = 2048 MB, VRAM = 12288 MB, margin = 2048 MB
+        // 2048 + 2048 = 4096 <= 12288 => FITS
+        val result = calculateVramCompatibility(
+            modelFileSizeKB = 2_097_152.0,
+            vramTotalMB = 12_288L,
+        )
+        assertEquals(VramCompatibility.FITS, result)
+    }
+
+    @Test
+    fun tight_when_file_within_vram_but_close() {
+        // 6 GB file (6_291_456 KB) with 8 GB VRAM (8_192 MB)
+        // File = 6144 MB, VRAM = 8192 MB, margin = 2048 MB
+        // 6144 + 2048 = 8192 <= 8192 => FITS (boundary)
+        // BUT 6.5 GB file should be TIGHT
+        val result = calculateVramCompatibility(
+            modelFileSizeKB = 6_815_744.0, // ~6.5 GB
+            vramTotalMB = 8_192L,
+        )
+        assertEquals(VramCompatibility.TIGHT, result)
+    }
+
+    @Test
+    fun needs_offloading_when_file_exceeds_vram() {
+        // 7 GB file with 4 GB VRAM
+        val result = calculateVramCompatibility(
+            modelFileSizeKB = 7_340_032.0, // 7 GB
+            vramTotalMB = 4_096L,
+        )
+        assertEquals(VramCompatibility.NEEDS_OFFLOADING, result)
+    }
+
+    @Test
+    fun unknown_when_no_vram() {
+        val result = calculateVramCompatibility(
+            modelFileSizeKB = 2_097_152.0,
+            vramTotalMB = 0L,
+        )
+        assertEquals(VramCompatibility.UNKNOWN, result)
+    }
+
+    @Test
+    fun fits_boundary_exact_margin() {
+        // File = 2048 MB, VRAM = 4096 MB, margin = 2048 MB
+        // 2048 + 2048 = 4096 <= 4096 => FITS (exact boundary)
+        val result = calculateVramCompatibility(
+            modelFileSizeKB = 2_097_152.0, // 2 GB
+            vramTotalMB = 4_096L,
+        )
+        assertEquals(VramCompatibility.FITS, result)
+    }
+
+    @Test
+    fun tight_just_over_margin() {
+        // File = 2049 MB, VRAM = 4096 MB
+        // 2049 + 2048 = 4097 > 4096 => TIGHT (not FITS)
+        // 2049 <= 4096 => TIGHT (not NEEDS_OFFLOADING)
+        val result = calculateVramCompatibility(
+            modelFileSizeKB = 2_098_176.0, // ~2049 MB
+            vramTotalMB = 4_096L,
+        )
+        assertEquals(VramCompatibility.TIGHT, result)
+    }
+
+    @Test
+    fun small_lora_fits_easily() {
+        // 150 MB LoRA with 8 GB VRAM => FITS
+        val result = calculateVramCompatibility(
+            modelFileSizeKB = 153_600.0, // 150 MB
+            vramTotalMB = 8_192L,
+        )
+        assertEquals(VramCompatibility.FITS, result)
+    }
+}

--- a/core/core-ui/src/commonMain/kotlin/com/riox432/civitdeck/ui/theme/Color.kt
+++ b/core/core-ui/src/commonMain/kotlin/com/riox432/civitdeck/ui/theme/Color.kt
@@ -230,3 +230,25 @@ object CivitDeckColors {
     val scrim = Color.Black
     val onScrim = Color.White
 }
+
+/** Semantic colors for VRAM compatibility badges. */
+object VramColors {
+    // FITS — green
+    val fitsBackground = Color(0xFFDCFCE7)
+    val fitsContent = Color(0xFF166534)
+    val fitsDarkBackground = Color(0xFF14532D)
+    val fitsDarkContent = Color(0xFF86EFAC)
+
+    // TIGHT — amber/warning
+    val tightBackground = Color(0xFFFEF9C3)
+    val tightContent = Color(0xFF854D0E)
+    val tightDarkBackground = Color(0xFF713F12)
+    val tightDarkContent = Color(0xFFFDE68A)
+
+    // NEEDS_OFFLOADING — red
+    val offloadBackground = Color(0xFFFEE2E2)
+    val offloadContent = Color(0xFF991B1B)
+    val offloadDarkBackground = Color(0xFF7F1D1D)
+    val offloadDarkContent = Color(0xFFFECACA)
+}
+

--- a/desktopApp/src/jvmMain/kotlin/com/riox432/civitdeck/di/DesktopModule.kt
+++ b/desktopApp/src/jvmMain/kotlin/com/riox432/civitdeck/di/DesktopModule.kt
@@ -12,7 +12,7 @@ val desktopModule = module {
     single<AppVersionProvider> { DesktopAppVersionProvider() }
     viewModel { DesktopUpdateViewModel(get(), get(), get()) }
     viewModel { params ->
-        ModelDetailViewModel(params.get(), get(), get(), get(), get(), get())
+        ModelDetailViewModel(params.get(), get(), get(), get(), get(), get(), get())
     }
     viewModel {
         DesktopDiscoveryViewModel(get(), get())

--- a/desktopApp/src/jvmMain/kotlin/com/riox432/civitdeck/ui/detail/InfoPanel.kt
+++ b/desktopApp/src/jvmMain/kotlin/com/riox432/civitdeck/ui/detail/InfoPanel.kt
@@ -31,6 +31,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.text.style.TextOverflow
 import coil3.PlatformContext
@@ -40,12 +41,14 @@ import coil3.size.Size
 import com.riox432.civitdeck.domain.model.Model
 import com.riox432.civitdeck.domain.model.ModelVersion
 import com.riox432.civitdeck.domain.util.FormatUtils
+import com.riox432.civitdeck.domain.util.VramCompatibility
 import com.riox432.civitdeck.feature.detail.presentation.ModelDetailUiState
 import com.riox432.civitdeck.ui.components.ImageErrorPlaceholder
 import com.riox432.civitdeck.ui.components.ModelStatsRow
 import com.riox432.civitdeck.ui.desktopFocusRing
 import com.riox432.civitdeck.ui.theme.CornerRadius
 import com.riox432.civitdeck.ui.theme.Spacing
+import com.riox432.civitdeck.ui.theme.VramColors
 import com.riox432.civitdeck.ui.theme.shimmer
 
 @Composable
@@ -86,7 +89,12 @@ internal fun InfoPanel(
             item { TagsSection(tags = model.tags) }
         }
         if (selectedVersion != null && selectedVersion.files.isNotEmpty()) {
-            item { FilesSection(files = selectedVersion.files) }
+            item {
+                FilesSection(
+                    files = selectedVersion.files,
+                    fileVramCompatibility = uiState.fileVramCompatibility,
+                )
+            }
         }
         model.description?.takeIf { it.isNotBlank() }?.let { description ->
             item { DescriptionSection(description = description) }
@@ -230,6 +238,7 @@ private fun TagsSection(tags: List<String>) {
 @Composable
 private fun FilesSection(
     files: List<com.riox432.civitdeck.domain.model.ModelFile>,
+    fileVramCompatibility: Map<Long, VramCompatibility> = emptyMap(),
 ) {
     Column(verticalArrangement = Arrangement.spacedBy(Spacing.xs)) {
         Text("Files", style = MaterialTheme.typography.titleSmall)
@@ -237,6 +246,7 @@ private fun FilesSection(
             Row(
                 modifier = Modifier.fillMaxWidth(),
                 horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically,
             ) {
                 Text(
                     text = file.name,
@@ -245,6 +255,9 @@ private fun FilesSection(
                     maxLines = 1,
                     overflow = TextOverflow.Ellipsis,
                 )
+                val compat = fileVramCompatibility[file.id] ?: VramCompatibility.UNKNOWN
+                DesktopVramBadge(compat)
+                Spacer(modifier = Modifier.width(Spacing.sm))
                 Text(
                     text = FormatUtils.formatFileSize(file.sizeKB),
                     style = MaterialTheme.typography.labelSmall,
@@ -253,6 +266,48 @@ private fun FilesSection(
             }
         }
     }
+}
+
+@Composable
+private fun DesktopVramBadge(compatibility: VramCompatibility) {
+    if (compatibility == VramCompatibility.UNKNOWN) return
+    val (bg, content, label) = desktopVramStyle(compatibility)
+    Text(
+        text = label,
+        style = MaterialTheme.typography.labelSmall,
+        color = content,
+        modifier = Modifier
+            .background(bg, RoundedCornerShape(CornerRadius.card))
+            .padding(horizontal = Spacing.sm, vertical = Spacing.xxs),
+    )
+}
+
+private data class VramBadgeStyle(
+    val bg: Color,
+    val content: Color,
+    val label: String,
+)
+
+@Composable
+private fun desktopVramStyle(
+    compatibility: VramCompatibility,
+): VramBadgeStyle = when (compatibility) {
+    VramCompatibility.FITS -> VramBadgeStyle(
+        bg = VramColors.fitsBackground,
+        content = VramColors.fitsContent,
+        label = "Fits your GPU",
+    )
+    VramCompatibility.TIGHT -> VramBadgeStyle(
+        bg = VramColors.tightBackground,
+        content = VramColors.tightContent,
+        label = "Tight fit",
+    )
+    VramCompatibility.NEEDS_OFFLOADING -> VramBadgeStyle(
+        bg = VramColors.offloadBackground,
+        content = VramColors.offloadContent,
+        label = "Needs offloading",
+    )
+    VramCompatibility.UNKNOWN -> VramBadgeStyle(Color.Transparent, Color.Transparent, "")
 }
 
 @Composable

--- a/feature/feature-comfyui/src/commonMain/kotlin/com/riox432/civitdeck/feature/comfyui/di/ComfyUIModule.kt
+++ b/feature/feature-comfyui/src/commonMain/kotlin/com/riox432/civitdeck/feature/comfyui/di/ComfyUIModule.kt
@@ -11,6 +11,7 @@ import com.riox432.civitdeck.domain.repository.SDWebUIAssetRepository
 import com.riox432.civitdeck.domain.repository.SDWebUIConnectionRepository
 import com.riox432.civitdeck.domain.repository.SDWebUIGenerationRepository
 import com.riox432.civitdeck.domain.repository.ServerDiscoveryRepository
+import com.riox432.civitdeck.domain.util.SystemStatsProvider
 import com.riox432.civitdeck.feature.comfyui.data.encoder.MaskPngEncoder
 import com.riox432.civitdeck.feature.comfyui.data.repository.CivitaiLinkRepositoryImpl
 import com.riox432.civitdeck.feature.comfyui.data.repository.ComfyHubRepositoryImpl
@@ -107,6 +108,10 @@ val comfyuiModule = module {
     factory { ActivateComfyUIConnectionUseCase(get()) }
     factory { TestComfyUIConnectionUseCase(get()) }
     factory { FetchSystemStatsUseCase(get()) }
+    factory<SystemStatsProvider> {
+        val useCase: FetchSystemStatsUseCase = get()
+        SystemStatsProvider { useCase() }
+    }
     factory { FetchComfyUICheckpointsUseCase(get()) }
     factory { FetchComfyUILorasUseCase(get()) }
     factory { FetchComfyUIControlNetsUseCase(get()) }

--- a/feature/feature-comfyui/src/commonMain/kotlin/com/riox432/civitdeck/feature/comfyui/presentation/ComfyUISettingsViewModel.kt
+++ b/feature/feature-comfyui/src/commonMain/kotlin/com/riox432/civitdeck/feature/comfyui/presentation/ComfyUISettingsViewModel.kt
@@ -8,6 +8,8 @@ import com.riox432.civitdeck.domain.model.ConnectionSecurityLevel
 import com.riox432.civitdeck.domain.model.DiscoveredServer
 import com.riox432.civitdeck.domain.model.SecurityLevelHelper
 import com.riox432.civitdeck.domain.model.SystemStats
+import com.riox432.civitdeck.domain.util.OptimizationSuggestion
+import com.riox432.civitdeck.domain.util.generateOptimizationSuggestions
 import com.riox432.civitdeck.feature.comfyui.domain.usecase.ActivateComfyUIConnectionUseCase
 import com.riox432.civitdeck.feature.comfyui.domain.usecase.DeleteComfyUIConnectionUseCase
 import com.riox432.civitdeck.feature.comfyui.domain.usecase.FetchSystemStatsUseCase
@@ -38,6 +40,8 @@ data class ComfyUISettingsUiState(
     val isScanning: Boolean = false,
     val discoveredServers: List<DiscoveredServer> = emptyList(),
     val systemStats: SystemStats? = null,
+    val optimizationSuggestions: List<OptimizationSuggestion> = emptyList(),
+    val dismissedSuggestionIds: Set<String> = emptySet(),
 )
 
 class ComfyUISettingsViewModel(
@@ -112,8 +116,14 @@ class ComfyUISettingsViewModel(
             val success = testConnection(active)
             if (success) {
                 val stats = fetchSystemStats()
+                val suggestions = stats?.let { generateOptimizationSuggestions(it) } ?: emptyList()
                 _mutableState.update {
-                    it.copy(isTesting = false, testError = null, systemStats = stats)
+                    it.copy(
+                        isTesting = false,
+                        testError = null,
+                        systemStats = stats,
+                        optimizationSuggestions = suggestions,
+                    )
                 }
             } else {
                 _mutableState.update {
@@ -155,6 +165,10 @@ class ComfyUISettingsViewModel(
 
     fun onDismissDialog() {
         _mutableState.update { it.copy(showAddDialog = false, editingConnection = null) }
+    }
+
+    fun dismissSuggestion(id: String) {
+        _mutableState.update { it.copy(dismissedSuggestionIds = it.dismissedSuggestionIds + id) }
     }
 
     private companion object {

--- a/feature/feature-detail/src/commonMain/kotlin/com/riox432/civitdeck/feature/detail/di/DetailModule.kt
+++ b/feature/feature-detail/src/commonMain/kotlin/com/riox432/civitdeck/feature/detail/di/DetailModule.kt
@@ -44,6 +44,6 @@ val detailModule = module {
     factory { DownloadUseCases(observeModelDownloads = get(), enqueueDownload = get(), cancelDownload = get()) }
     factory { ReviewUseCases(getModelReviews = get(), getRatingTotals = get(), submitReview = get()) }
     viewModel { params ->
-        ModelDetailViewModel(params.get(), get(), get(), get(), get(), get())
+        ModelDetailViewModel(params.get(), get(), get(), get(), get(), get(), get())
     }
 }

--- a/feature/feature-detail/src/commonMain/kotlin/com/riox432/civitdeck/feature/detail/presentation/ModelDetailViewModel.kt
+++ b/feature/feature-detail/src/commonMain/kotlin/com/riox432/civitdeck/feature/detail/presentation/ModelDetailViewModel.kt
@@ -14,7 +14,11 @@ import com.riox432.civitdeck.domain.model.PersonalTag
 import com.riox432.civitdeck.domain.model.RatingTotals
 import com.riox432.civitdeck.domain.model.ResourceReview
 import com.riox432.civitdeck.domain.model.ReviewSortOrder
+import com.riox432.civitdeck.domain.model.SystemStats
+import com.riox432.civitdeck.domain.util.SystemStatsProvider
 import com.riox432.civitdeck.domain.util.UiLoadingState
+import com.riox432.civitdeck.domain.util.VramCompatibility
+import com.riox432.civitdeck.domain.util.calculateVramCompatibility
 import com.riox432.civitdeck.domain.util.currentTimeMillis
 import com.riox432.civitdeck.domain.util.launchSafe
 import com.riox432.civitdeck.domain.util.suspendRunCatching
@@ -50,6 +54,8 @@ data class ModelDetailUiState(
     val reviewsError: String? = null,
     val isSubmittingReview: Boolean = false,
     val reviewSubmitSuccess: Boolean = false,
+    val systemStats: SystemStats? = null,
+    val fileVramCompatibility: Map<Long, VramCompatibility> = emptyMap(),
 ) : UiLoadingState
 
 class ModelDetailViewModel(
@@ -59,6 +65,7 @@ class ModelDetailViewModel(
     private val notesTagsUseCases: NotesTagsUseCases,
     private val downloadUseCases: DownloadUseCases,
     private val reviewUseCases: ReviewUseCases,
+    private val systemStatsProvider: SystemStatsProvider,
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow(ModelDetailUiState())
@@ -117,11 +124,13 @@ class ModelDetailViewModel(
         observeFavorite()
         startObservers()
         reviewDelegate.loadReviews()
+        fetchSystemStats()
     }
 
     fun onVersionSelected(index: Int) {
         _uiState.update { it.copy(selectedVersionIndex = index) }
         enrichCurrentVersion()
+        updateVramCompatibility()
     }
 
     override fun onCleared() {
@@ -197,6 +206,7 @@ class ModelDetailViewModel(
                 .onSuccess { model ->
                     _uiState.update { it.copy(model = model, isLoading = false) }
                     enrichCurrentVersion()
+                    updateVramCompatibility()
                     trackModelView(model)
                     triggerBackgroundEmbed(model)
                     viewStartTimeMs = currentTimeMillis()
@@ -309,6 +319,29 @@ class ModelDetailViewModel(
                 _uiState.update { it.copy(downloads = downloads) }
             }
         }
+    }
+
+    // endregion
+
+    // region Private — System Stats
+
+    private fun fetchSystemStats() {
+        viewModelScope.launch {
+            val stats = systemStatsProvider.fetch() ?: return@launch
+            _uiState.update { it.copy(systemStats = stats) }
+            updateVramCompatibility()
+        }
+    }
+
+    private fun updateVramCompatibility() {
+        val state = _uiState.value
+        val stats = state.systemStats ?: return
+        val model = state.model ?: return
+        val version = model.modelVersions.getOrNull(state.selectedVersionIndex) ?: return
+        val compatMap = version.files.associate { file ->
+            file.id to calculateVramCompatibility(file.sizeKB, stats.vramTotalMB)
+        }
+        _uiState.update { it.copy(fileVramCompatibility = compatMap) }
     }
 
     // endregion

--- a/iosApp/iosApp/DesignSystem/CivitDeckColors.swift
+++ b/iosApp/iosApp/DesignSystem/CivitDeckColors.swift
@@ -248,4 +248,53 @@ extension Color {
             blue: Double(value & 0xFF) / 255.0
         )
     }
+
+    // MARK: - VRAM Compatibility Badge Colors
+
+    static let vramFits = Color(light: .hex(0xDCFCE7), dark: .hex(0x14532D))
+    static let vramFitsContent = Color(light: .hex(0x166534), dark: .hex(0x86EFAC))
+    static let vramTight = Color(light: .hex(0xFEF9C3), dark: .hex(0x713F12))
+    static let vramTightContent = Color(light: .hex(0x854D0E), dark: .hex(0xFDE68A))
+    static let vramOffload = Color(light: .hex(0xFEE2E2), dark: .hex(0x7F1D1D))
+    static let vramOffloadContent = Color(light: .hex(0x991B1B), dark: .hex(0xFECACA))
+}
+
+// MARK: - VRAM Badge Style
+
+import Shared
+
+/// Visual style for VRAM compatibility badges (color + label).
+struct VramBadgeStyle {
+    let backgroundColor: Color
+    let contentColor: Color
+    let label: String
+
+    static func from(_ compatibility: VramCompatibility) -> VramBadgeStyle {
+        switch compatibility {
+        case .fits:
+            return VramBadgeStyle(
+                backgroundColor: .vramFits,
+                contentColor: .vramFitsContent,
+                label: "Fits your GPU"
+            )
+        case .tight:
+            return VramBadgeStyle(
+                backgroundColor: .vramTight,
+                contentColor: .vramTightContent,
+                label: "Tight fit"
+            )
+        case .needsOffloading:
+            return VramBadgeStyle(
+                backgroundColor: .vramOffload,
+                contentColor: .vramOffloadContent,
+                label: "Needs offloading"
+            )
+        case .unknown:
+            return VramBadgeStyle(
+                backgroundColor: .clear,
+                contentColor: .clear,
+                label: ""
+            )
+        }
+    }
 }

--- a/iosApp/iosApp/Features/ComfyUI/ComfyUISettingsView.swift
+++ b/iosApp/iosApp/Features/ComfyUI/ComfyUISettingsView.swift
@@ -11,6 +11,9 @@ struct ComfyUISettingsView: View {
             if let stats = viewModel.systemStats {
                 serverHardwareSection(stats)
             }
+            if !viewModel.visibleSuggestions.isEmpty {
+                optimizationSuggestionsSection
+            }
             scanLanSection
             if viewModel.isConnected {
                 NavigationLink("Open txt2img Generator") {
@@ -169,6 +172,31 @@ struct ComfyUISettingsView: View {
                 Text("\(vramUsed) / \(stats.vramTotalMB) MB")
                     .font(.civitBodySmall)
                     .foregroundColor(.civitOnSurfaceVariant)
+            }
+        }
+    }
+
+    private var optimizationSuggestionsSection: some View {
+        Section("Optimization Suggestions") {
+            ForEach(viewModel.visibleSuggestions, id: \.id) { suggestion in
+                HStack(alignment: .top) {
+                    VStack(alignment: .leading, spacing: Spacing.xs) {
+                        Text(suggestion.title)
+                            .font(.civitTitleSmall)
+                        Text(suggestion.description_)
+                            .font(.civitBodySmall)
+                            .foregroundColor(.civitOnSurfaceVariant)
+                    }
+                    Spacer()
+                    Button {
+                        viewModel.dismissSuggestion(id: suggestion.id)
+                    } label: {
+                        Image(systemName: "xmark.circle")
+                            .foregroundColor(.civitOnSurfaceVariant)
+                            .accessibilityLabel("Dismiss")
+                    }
+                    .buttonStyle(.plain)
+                }
             }
         }
     }

--- a/iosApp/iosApp/Features/ComfyUI/ComfyUISettingsViewModel.swift
+++ b/iosApp/iosApp/Features/ComfyUI/ComfyUISettingsViewModel.swift
@@ -16,6 +16,8 @@ final class ComfyUISettingsViewModelOwner: ObservableObject {
     @Published var isScanning = false
     @Published var discoveredServers: [DiscoveredServer] = []
     @Published var systemStats: Core_domainSystemStats?
+    @Published var optimizationSuggestions: [OptimizationSuggestion] = []
+    @Published var dismissedSuggestionIds: Set<String> = []
 
     init() {
         vm = KoinHelper.shared.createComfyUISettingsViewModel()
@@ -36,6 +38,10 @@ final class ComfyUISettingsViewModelOwner: ObservableObject {
             isScanning = state.isScanning
             discoveredServers = state.discoveredServers as? [DiscoveredServer] ?? []
             systemStats = state.systemStats
+            optimizationSuggestions = state.optimizationSuggestions as? [OptimizationSuggestion] ?? []
+            dismissedSuggestionIds = Set(
+                (state.dismissedSuggestionIds as? Set<String>) ?? []
+            )
         }
     }
 
@@ -71,6 +77,14 @@ final class ComfyUISettingsViewModelOwner: ObservableObject {
         showAddSheet = false
         editingConnection = nil
         vm.onDismissDialog()
+    }
+
+    func dismissSuggestion(id: String) {
+        vm.dismissSuggestion(id: id)
+    }
+
+    var visibleSuggestions: [OptimizationSuggestion] {
+        optimizationSuggestions.filter { !dismissedSuggestionIds.contains($0.id) }
     }
 
     var isConnected: Bool {

--- a/iosApp/iosApp/Features/Detail/ModelDetailScreen.swift
+++ b/iosApp/iosApp/Features/Detail/ModelDetailScreen.swift
@@ -401,6 +401,7 @@ struct ModelDetailScreen: View {
                 downloads: Dictionary(
                     uniqueKeysWithValues: viewModel.downloads.map { ($0.fileId, $0) }
                 ),
+                fileVramCompatibility: viewModel.fileVramCompatibility,
                 onDownload: { viewModel.downloadFile($0) },
                 onCancelDownload: { viewModel.cancelDownload($0) }
             )

--- a/iosApp/iosApp/Features/Detail/ModelDetailViewModel.swift
+++ b/iosApp/iosApp/Features/Detail/ModelDetailViewModel.swift
@@ -24,6 +24,7 @@ final class ModelDetailViewModelOwner: ObservableObject {
     @Published var isReviewsLoading: Bool = false
     @Published var isSubmittingReview: Bool = false
     @Published var reviewSubmitSuccess: Bool = false
+    @Published var fileVramCompatibility: [Int64: VramCompatibility] = [:]
 
     let modelId: Int64
 
@@ -62,6 +63,7 @@ final class ModelDetailViewModelOwner: ObservableObject {
             isReviewsLoading = state.isReviewsLoading
             isSubmittingReview = state.isSubmittingReview
             reviewSubmitSuccess = state.reviewSubmitSuccess
+            fileVramCompatibility = Self.mapVramCompatibility(state.fileVramCompatibility)
         }
     }
 
@@ -120,5 +122,17 @@ final class ModelDetailViewModelOwner: ObservableObject {
 
     func onDisappear() {
         // View cleanup is handled by shared VM's onCleared via ViewModelStore
+    }
+
+    // MARK: - Private Helpers
+
+    private static func mapVramCompatibility(
+        _ map: [KotlinLong: VramCompatibility]
+    ) -> [Int64: VramCompatibility] {
+        var result: [Int64: VramCompatibility] = [:]
+        for (key, value) in map {
+            result[key.int64Value] = value
+        }
+        return result
     }
 }

--- a/iosApp/iosApp/Features/Detail/VersionDetailSection.swift
+++ b/iosApp/iosApp/Features/Detail/VersionDetailSection.swift
@@ -5,6 +5,7 @@ struct VersionDetailSection: View {
     let version: ModelVersion
     let powerUserMode: Bool
     var downloads: [Int64: ModelDownload] = [:]
+    var fileVramCompatibility: [Int64: VramCompatibility] = [:]
     var onDownload: ((ModelFile) -> Void)?
     var onCancelDownload: ((Int64) -> Void)?
     @Environment(\.civitTheme) private var theme
@@ -97,12 +98,28 @@ struct VersionDetailSection: View {
                             .font(.civitLabelSmall)
                             .foregroundColor(theme.primary)
                     }
+                    vramBadge(for: file)
                 }
             }
             Spacer()
             downloadButton(for: file)
         }
         .padding(.vertical, Spacing.xs)
+    }
+
+    @ViewBuilder
+    private func vramBadge(for file: ModelFile) -> some View {
+        let compat = fileVramCompatibility[file.id]
+        if let compat, compat != .unknown {
+            let style = VramBadgeStyle.from(compat)
+            Text(style.label)
+                .font(.civitLabelSmall)
+                .foregroundColor(style.contentColor)
+                .padding(.horizontal, Spacing.sm)
+                .padding(.vertical, Spacing.xxs)
+                .background(style.backgroundColor)
+                .clipShape(Capsule())
+        }
     }
 
     @ViewBuilder

--- a/iosApp/iosApp/SharedTypeAliases.swift
+++ b/iosApp/iosApp/SharedTypeAliases.swift
@@ -237,6 +237,8 @@ typealias PluginState = Core_pluginPluginState
 typealias PluginManifest = Core_pluginPluginManifest
 
 typealias ReviewSortOrder = Core_domainReviewSortOrder
+typealias VramCompatibility = Core_domainVramCompatibility
+typealias OptimizationSuggestion = Core_domainOptimizationSuggestion
 
 // MARK: - Feature: Collections (shared use cases in core-domain)
 


### PR DESCRIPTION
## Summary
- Show VRAM compatibility badges (Fits your GPU / Tight fit / Needs offloading) next to model files on the detail screen when a ComfyUI server is connected
- Display dismissable optimization suggestion cards on the ComfyUI settings screen based on GPU VRAM capacity
- Cross-platform: Android, iOS, and Desktop

## Changes

### Domain layer (core-domain)
- `VramCompatibility` enum + `calculateVramCompatibility()` — estimates whether a model file fits in VRAM with a 2 GB safety margin
- `OptimizationSuggestion` data class + `generateOptimizationSuggestions()` — generates actionable tips (FP16+Tiling for <6 GB, FP16 for 6-8 GB, low free VRAM warning)
- `SystemStatsProvider` functional interface — allows feature-detail to access system stats without depending on feature-comfyui

### Presentation layer
- `ModelDetailViewModel` fetches system stats on init and computes per-file VRAM compatibility
- `ComfyUISettingsViewModel` generates optimization suggestions after successful connection test
- Both exposed via UI state for all platforms

### UI (Android / iOS / Desktop)
- Colored VRAM compatibility chip in `FileDownloadRow` / `VersionDetailSection` / `InfoPanel`
- `VramColors` semantic tokens (green/amber/red with light+dark variants)
- Suggestion cards with dismiss button on ComfyUI settings screen

### Tests
- `VramCompatibilityTest` — 7 tests covering fits, tight, offloading, unknown, boundary cases
- `OptimizationSuggestionsTest` — 6 tests covering low/mid/high VRAM and free VRAM ratio

## Test plan
- [ ] Connect to a ComfyUI server and verify system stats are fetched
- [ ] Open a model detail with large checkpoint files — verify VRAM badge appears
- [ ] Switch model versions — verify badge updates
- [ ] Open ComfyUI settings, test connection — verify optimization suggestions appear for low-VRAM GPUs
- [ ] Dismiss a suggestion — verify it stays dismissed
- [ ] Verify badges show correct colors in light and dark mode

Closes #895