### PR TITLE
Add local notification on ComfyUI generation completion

### DIFF
--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/settings/ContentFilterSettingsScreen.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/settings/ContentFilterSettingsScreen.kt
@@ -98,6 +98,12 @@ internal fun LazyListScope.notificationItems(
     if (state.notificationsEnabled) {
         item { PollingIntervalRow(state.pollingInterval, viewModel::onPollingIntervalChanged) }
     }
+    item {
+        GenerationNotificationsToggleRow(
+            enabled = state.generationNotificationsEnabled,
+            onToggle = viewModel::onGenerationNotificationsEnabledChanged,
+        )
+    }
 }
 
 internal fun LazyListScope.feedQualityItems(

--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/settings/NotificationComponents.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/settings/NotificationComponents.kt
@@ -55,6 +55,30 @@ internal fun NotificationsToggleRow(enabled: Boolean, onToggle: (Boolean) -> Uni
 }
 
 @Composable
+internal fun GenerationNotificationsToggleRow(enabled: Boolean, onToggle: (Boolean) -> Unit) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = Spacing.lg, vertical = Spacing.md),
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Column(modifier = Modifier.weight(1f)) {
+            Text(
+                stringResource(R.string.settings_generation_notifications),
+                style = MaterialTheme.typography.bodyLarge,
+            )
+            Text(
+                stringResource(R.string.settings_generation_notifications_description),
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+        Switch(checked = enabled, onCheckedChange = onToggle)
+    }
+}
+
+@Composable
 internal fun PollingIntervalRow(selected: PollingInterval, onChanged: (PollingInterval) -> Unit) {
     val options = PollingInterval.entries.filter { it != PollingInterval.Off }
     DropdownSettingRow(

--- a/androidApp/src/main/res/values/strings.xml
+++ b/androidApp/src/main/res/values/strings.xml
@@ -183,6 +183,8 @@
     <string name="settings_quality_threshold_description">Filter low-quality models from your creator feed</string>
     <string name="settings_model_update_alerts">Model Update Alerts</string>
     <string name="settings_model_update_alerts_description">Notify when favorited models get new versions</string>
+    <string name="settings_generation_notifications">Generation Complete Alerts</string>
+    <string name="settings_generation_notifications_description">Notify when ComfyUI generation finishes while app is in background</string>
     <string name="settings_check_frequency">Check Frequency</string>
     <string name="settings_color_scheme">Color Scheme</string>
     <string name="settings_theme_light">Light</string>

--- a/core/core-database/schemas/com.riox432.civitdeck.data.local.CivitDeckDatabase/45.json
+++ b/core/core-database/schemas/com.riox432.civitdeck.data.local.CivitDeckDatabase/45.json
@@ -1,0 +1,2024 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 45,
+    "identityHash": "4418185262368d0397acd8251f52d2b7",
+    "entities": [
+      {
+        "tableName": "collections",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL, `isDefault` INTEGER NOT NULL, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isDefault",
+            "columnName": "isDefault",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "collection_model_entries",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`collectionId` INTEGER NOT NULL, `modelId` INTEGER NOT NULL, `name` TEXT NOT NULL, `type` TEXT NOT NULL, `nsfw` INTEGER NOT NULL, `thumbnailUrl` TEXT, `creatorName` TEXT, `downloadCount` INTEGER NOT NULL, `favoriteCount` INTEGER NOT NULL, `rating` REAL NOT NULL, `addedAt` INTEGER NOT NULL, PRIMARY KEY(`collectionId`, `modelId`), FOREIGN KEY(`collectionId`) REFERENCES `collections`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "collectionId",
+            "columnName": "collectionId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "modelId",
+            "columnName": "modelId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "nsfw",
+            "columnName": "nsfw",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "thumbnailUrl",
+            "columnName": "thumbnailUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "creatorName",
+            "columnName": "creatorName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "downloadCount",
+            "columnName": "downloadCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "favoriteCount",
+            "columnName": "favoriteCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "rating",
+            "columnName": "rating",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "addedAt",
+            "columnName": "addedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "collectionId",
+            "modelId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_collection_model_entries_modelId",
+            "unique": false,
+            "columnNames": [
+              "modelId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_collection_model_entries_modelId` ON `${TABLE_NAME}` (`modelId`)"
+          },
+          {
+            "name": "index_collection_model_entries_collectionId",
+            "unique": false,
+            "columnNames": [
+              "collectionId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_collection_model_entries_collectionId` ON `${TABLE_NAME}` (`collectionId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "collections",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "collectionId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "cached_api_responses",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`cacheKey` TEXT NOT NULL, `responseJson` TEXT NOT NULL, `cachedAt` INTEGER NOT NULL, `isOfflinePinned` INTEGER NOT NULL, PRIMARY KEY(`cacheKey`))",
+        "fields": [
+          {
+            "fieldPath": "cacheKey",
+            "columnName": "cacheKey",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "responseJson",
+            "columnName": "responseJson",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cachedAt",
+            "columnName": "cachedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isOfflinePinned",
+            "columnName": "isOfflinePinned",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "cacheKey"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_cached_api_responses_cachedAt",
+            "unique": false,
+            "columnNames": [
+              "cachedAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_cached_api_responses_cachedAt` ON `${TABLE_NAME}` (`cachedAt`)"
+          }
+        ]
+      },
+      {
+        "tableName": "user_preferences",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `nsfwFilterLevel` TEXT NOT NULL, `defaultSortOrder` TEXT NOT NULL, `defaultTimePeriod` TEXT NOT NULL, `gridColumns` INTEGER NOT NULL, `apiKey` TEXT, `powerUserMode` INTEGER NOT NULL, `notificationsEnabled` INTEGER NOT NULL, `pollingIntervalMinutes` INTEGER NOT NULL, `nsfwBlurSoft` INTEGER NOT NULL, `nsfwBlurMature` INTEGER NOT NULL, `nsfwBlurExplicit` INTEGER NOT NULL, `offlineCacheEnabled` INTEGER NOT NULL, `cacheSizeLimitMb` INTEGER NOT NULL, `accentColor` TEXT NOT NULL, `amoledDarkMode` INTEGER NOT NULL, `seenTutorialVersion` INTEGER NOT NULL, `civitaiLinkKey` TEXT, `themeMode` TEXT NOT NULL, `customNavShortcuts` TEXT NOT NULL, `feedQualityThreshold` INTEGER NOT NULL, `generationNotificationsEnabled` INTEGER NOT NULL, `autoUpdateCheckEnabled` INTEGER NOT NULL, `lastUpdateCheckTimestamp` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "nsfwFilterLevel",
+            "columnName": "nsfwFilterLevel",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "defaultSortOrder",
+            "columnName": "defaultSortOrder",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "defaultTimePeriod",
+            "columnName": "defaultTimePeriod",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "gridColumns",
+            "columnName": "gridColumns",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "apiKey",
+            "columnName": "apiKey",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "powerUserMode",
+            "columnName": "powerUserMode",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "notificationsEnabled",
+            "columnName": "notificationsEnabled",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "pollingIntervalMinutes",
+            "columnName": "pollingIntervalMinutes",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "nsfwBlurSoft",
+            "columnName": "nsfwBlurSoft",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "nsfwBlurMature",
+            "columnName": "nsfwBlurMature",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "nsfwBlurExplicit",
+            "columnName": "nsfwBlurExplicit",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "offlineCacheEnabled",
+            "columnName": "offlineCacheEnabled",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cacheSizeLimitMb",
+            "columnName": "cacheSizeLimitMb",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "accentColor",
+            "columnName": "accentColor",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "amoledDarkMode",
+            "columnName": "amoledDarkMode",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "seenTutorialVersion",
+            "columnName": "seenTutorialVersion",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "civitaiLinkKey",
+            "columnName": "civitaiLinkKey",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "themeMode",
+            "columnName": "themeMode",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "customNavShortcuts",
+            "columnName": "customNavShortcuts",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "feedQualityThreshold",
+            "columnName": "feedQualityThreshold",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "generationNotificationsEnabled",
+            "columnName": "generationNotificationsEnabled",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "autoUpdateCheckEnabled",
+            "columnName": "autoUpdateCheckEnabled",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastUpdateCheckTimestamp",
+            "columnName": "lastUpdateCheckTimestamp",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "saved_prompts",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `prompt` TEXT NOT NULL, `negativePrompt` TEXT, `sampler` TEXT, `steps` INTEGER, `cfgScale` REAL, `seed` INTEGER, `modelName` TEXT, `size` TEXT, `sourceImageUrl` TEXT, `savedAt` INTEGER NOT NULL, `isTemplate` INTEGER NOT NULL DEFAULT 0, `templateName` TEXT, `autoSaved` INTEGER NOT NULL DEFAULT 0, `templateVariables` TEXT, `templateType` TEXT, `templateMetadata` TEXT)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "prompt",
+            "columnName": "prompt",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "negativePrompt",
+            "columnName": "negativePrompt",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "sampler",
+            "columnName": "sampler",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "steps",
+            "columnName": "steps",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "cfgScale",
+            "columnName": "cfgScale",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "seed",
+            "columnName": "seed",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "modelName",
+            "columnName": "modelName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "size",
+            "columnName": "size",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "sourceImageUrl",
+            "columnName": "sourceImageUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "savedAt",
+            "columnName": "savedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isTemplate",
+            "columnName": "isTemplate",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "templateName",
+            "columnName": "templateName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "autoSaved",
+            "columnName": "autoSaved",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "templateVariables",
+            "columnName": "templateVariables",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "templateType",
+            "columnName": "templateType",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "templateMetadata",
+            "columnName": "templateMetadata",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "search_history",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `query` TEXT NOT NULL, `searchedAt` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "query",
+            "columnName": "query",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "searchedAt",
+            "columnName": "searchedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "browsing_history",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `modelId` INTEGER NOT NULL, `modelName` TEXT NOT NULL, `modelType` TEXT NOT NULL, `creatorName` TEXT, `thumbnailUrl` TEXT, `tags` TEXT NOT NULL, `viewedAt` INTEGER NOT NULL, `durationMs` INTEGER, `interactionType` TEXT)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "modelId",
+            "columnName": "modelId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "modelName",
+            "columnName": "modelName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "modelType",
+            "columnName": "modelType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "creatorName",
+            "columnName": "creatorName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "thumbnailUrl",
+            "columnName": "thumbnailUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "tags",
+            "columnName": "tags",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "viewedAt",
+            "columnName": "viewedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "durationMs",
+            "columnName": "durationMs",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "interactionType",
+            "columnName": "interactionType",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_browsing_history_modelId",
+            "unique": false,
+            "columnNames": [
+              "modelId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_browsing_history_modelId` ON `${TABLE_NAME}` (`modelId`)"
+          },
+          {
+            "name": "index_browsing_history_viewedAt",
+            "unique": false,
+            "columnNames": [
+              "viewedAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_browsing_history_viewedAt` ON `${TABLE_NAME}` (`viewedAt`)"
+          }
+        ]
+      },
+      {
+        "tableName": "excluded_tags",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`tag` TEXT NOT NULL, `addedAt` INTEGER NOT NULL, PRIMARY KEY(`tag`))",
+        "fields": [
+          {
+            "fieldPath": "tag",
+            "columnName": "tag",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "addedAt",
+            "columnName": "addedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "tag"
+          ]
+        }
+      },
+      {
+        "tableName": "hidden_models",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`modelId` INTEGER NOT NULL, `modelName` TEXT NOT NULL, `hiddenAt` INTEGER NOT NULL, PRIMARY KEY(`modelId`))",
+        "fields": [
+          {
+            "fieldPath": "modelId",
+            "columnName": "modelId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "modelName",
+            "columnName": "modelName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "hiddenAt",
+            "columnName": "hiddenAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "modelId"
+          ]
+        }
+      },
+      {
+        "tableName": "model_directories",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `path` TEXT NOT NULL, `label` TEXT, `lastScannedAt` INTEGER, `isEnabled` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "path",
+            "columnName": "path",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "label",
+            "columnName": "label",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "lastScannedAt",
+            "columnName": "lastScannedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "isEnabled",
+            "columnName": "isEnabled",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "local_model_files",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `directoryId` INTEGER NOT NULL, `filePath` TEXT NOT NULL, `fileName` TEXT NOT NULL, `sha256Hash` TEXT NOT NULL, `sizeBytes` INTEGER NOT NULL, `scannedAt` INTEGER NOT NULL, `matchedModelId` INTEGER, `matchedModelName` TEXT, `matchedVersionId` INTEGER, `matchedVersionName` TEXT, `latestVersionId` INTEGER, `hasUpdate` INTEGER NOT NULL, FOREIGN KEY(`directoryId`) REFERENCES `model_directories`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "directoryId",
+            "columnName": "directoryId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "filePath",
+            "columnName": "filePath",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fileName",
+            "columnName": "fileName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sha256Hash",
+            "columnName": "sha256Hash",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sizeBytes",
+            "columnName": "sizeBytes",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "scannedAt",
+            "columnName": "scannedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "matchedModelId",
+            "columnName": "matchedModelId",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "matchedModelName",
+            "columnName": "matchedModelName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "matchedVersionId",
+            "columnName": "matchedVersionId",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "matchedVersionName",
+            "columnName": "matchedVersionName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "latestVersionId",
+            "columnName": "latestVersionId",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "hasUpdate",
+            "columnName": "hasUpdate",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_local_model_files_directoryId",
+            "unique": false,
+            "columnNames": [
+              "directoryId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_local_model_files_directoryId` ON `${TABLE_NAME}` (`directoryId`)"
+          },
+          {
+            "name": "index_local_model_files_sha256Hash",
+            "unique": false,
+            "columnNames": [
+              "sha256Hash"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_local_model_files_sha256Hash` ON `${TABLE_NAME}` (`sha256Hash`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "model_directories",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "directoryId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "model_version_checkpoints",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`modelId` INTEGER NOT NULL, `lastKnownVersionId` INTEGER NOT NULL, `lastCheckedAt` INTEGER NOT NULL, PRIMARY KEY(`modelId`))",
+        "fields": [
+          {
+            "fieldPath": "modelId",
+            "columnName": "modelId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastKnownVersionId",
+            "columnName": "lastKnownVersionId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastCheckedAt",
+            "columnName": "lastCheckedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "modelId"
+          ]
+        }
+      },
+      {
+        "tableName": "comfyui_connections",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL, `hostname` TEXT NOT NULL, `port` INTEGER NOT NULL, `isActive` INTEGER NOT NULL, `lastTestedAt` INTEGER, `lastTestSuccess` INTEGER, `createdAt` INTEGER NOT NULL, `useHttps` INTEGER NOT NULL, `acceptSelfSigned` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "hostname",
+            "columnName": "hostname",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "port",
+            "columnName": "port",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isActive",
+            "columnName": "isActive",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastTestedAt",
+            "columnName": "lastTestedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "lastTestSuccess",
+            "columnName": "lastTestSuccess",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "useHttps",
+            "columnName": "useHttps",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "acceptSelfSigned",
+            "columnName": "acceptSelfSigned",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "sdwebui_connections",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL, `hostname` TEXT NOT NULL, `port` INTEGER NOT NULL, `isActive` INTEGER NOT NULL, `lastTestedAt` INTEGER, `lastTestSuccess` INTEGER, `createdAt` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "hostname",
+            "columnName": "hostname",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "port",
+            "columnName": "port",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isActive",
+            "columnName": "isActive",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastTestedAt",
+            "columnName": "lastTestedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "lastTestSuccess",
+            "columnName": "lastTestSuccess",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "dataset_collections",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL, `description` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "dataset_images",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `datasetId` INTEGER NOT NULL, `imageUrl` TEXT NOT NULL, `sourceType` TEXT NOT NULL, `trainable` INTEGER NOT NULL, `addedAt` INTEGER NOT NULL, `licenseNote` TEXT, `pHash` TEXT, `excluded` INTEGER NOT NULL, `width` INTEGER, `height` INTEGER, FOREIGN KEY(`datasetId`) REFERENCES `dataset_collections`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "datasetId",
+            "columnName": "datasetId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "imageUrl",
+            "columnName": "imageUrl",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceType",
+            "columnName": "sourceType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "trainable",
+            "columnName": "trainable",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "addedAt",
+            "columnName": "addedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "licenseNote",
+            "columnName": "licenseNote",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "pHash",
+            "columnName": "pHash",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "excluded",
+            "columnName": "excluded",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "width",
+            "columnName": "width",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "height",
+            "columnName": "height",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_dataset_images_datasetId",
+            "unique": false,
+            "columnNames": [
+              "datasetId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_dataset_images_datasetId` ON `${TABLE_NAME}` (`datasetId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "dataset_collections",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "datasetId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "image_tags",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `datasetImageId` INTEGER NOT NULL, `tag` TEXT NOT NULL, FOREIGN KEY(`datasetImageId`) REFERENCES `dataset_images`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "datasetImageId",
+            "columnName": "datasetImageId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "tag",
+            "columnName": "tag",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_image_tags_datasetImageId",
+            "unique": false,
+            "columnNames": [
+              "datasetImageId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_image_tags_datasetImageId` ON `${TABLE_NAME}` (`datasetImageId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "dataset_images",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "datasetImageId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "captions",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`datasetImageId` INTEGER NOT NULL, `text` TEXT NOT NULL, PRIMARY KEY(`datasetImageId`), FOREIGN KEY(`datasetImageId`) REFERENCES `dataset_images`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "datasetImageId",
+            "columnName": "datasetImageId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "text",
+            "columnName": "text",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "datasetImageId"
+          ]
+        },
+        "foreignKeys": [
+          {
+            "table": "dataset_images",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "datasetImageId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "saved_search_filters",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL, `query` TEXT NOT NULL, `selectedType` TEXT, `selectedSort` TEXT NOT NULL, `selectedPeriod` TEXT NOT NULL, `selectedBaseModels` TEXT NOT NULL, `nsfwFilterLevel` TEXT NOT NULL, `isFreshFindEnabled` INTEGER NOT NULL, `excludedTags` TEXT NOT NULL, `includedTags` TEXT NOT NULL, `selectedSources` TEXT NOT NULL, `savedAt` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "query",
+            "columnName": "query",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "selectedType",
+            "columnName": "selectedType",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "selectedSort",
+            "columnName": "selectedSort",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "selectedPeriod",
+            "columnName": "selectedPeriod",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "selectedBaseModels",
+            "columnName": "selectedBaseModels",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "nsfwFilterLevel",
+            "columnName": "nsfwFilterLevel",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isFreshFindEnabled",
+            "columnName": "isFreshFindEnabled",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "excludedTags",
+            "columnName": "excludedTags",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "includedTags",
+            "columnName": "includedTags",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "selectedSources",
+            "columnName": "selectedSources",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "savedAt",
+            "columnName": "savedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "external_server_configs",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL, `baseUrl` TEXT NOT NULL, `apiKey` TEXT NOT NULL, `isActive` INTEGER NOT NULL, `lastTestedAt` INTEGER, `lastTestSuccess` INTEGER, `createdAt` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "baseUrl",
+            "columnName": "baseUrl",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "apiKey",
+            "columnName": "apiKey",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isActive",
+            "columnName": "isActive",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastTestedAt",
+            "columnName": "lastTestedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "lastTestSuccess",
+            "columnName": "lastTestSuccess",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "model_notes",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `modelId` INTEGER NOT NULL, `noteText` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "modelId",
+            "columnName": "modelId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "noteText",
+            "columnName": "noteText",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_model_notes_modelId",
+            "unique": false,
+            "columnNames": [
+              "modelId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_model_notes_modelId` ON `${TABLE_NAME}` (`modelId`)"
+          }
+        ]
+      },
+      {
+        "tableName": "personal_tags",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `modelId` INTEGER NOT NULL, `tag` TEXT NOT NULL, `addedAt` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "modelId",
+            "columnName": "modelId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "tag",
+            "columnName": "tag",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "addedAt",
+            "columnName": "addedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_personal_tags_modelId",
+            "unique": false,
+            "columnNames": [
+              "modelId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_personal_tags_modelId` ON `${TABLE_NAME}` (`modelId`)"
+          },
+          {
+            "name": "index_personal_tags_tag",
+            "unique": false,
+            "columnNames": [
+              "tag"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_personal_tags_tag` ON `${TABLE_NAME}` (`tag`)"
+          }
+        ]
+      },
+      {
+        "tableName": "followed_creators",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`username` TEXT NOT NULL, `displayName` TEXT NOT NULL, `avatarUrl` TEXT, `followedAt` INTEGER NOT NULL, `lastCheckedAt` INTEGER NOT NULL, PRIMARY KEY(`username`))",
+        "fields": [
+          {
+            "fieldPath": "username",
+            "columnName": "username",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayName",
+            "columnName": "displayName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "avatarUrl",
+            "columnName": "avatarUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "followedAt",
+            "columnName": "followedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastCheckedAt",
+            "columnName": "lastCheckedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "username"
+          ]
+        }
+      },
+      {
+        "tableName": "feed_cache",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`modelId` INTEGER NOT NULL, `creatorUsername` TEXT NOT NULL, `title` TEXT NOT NULL, `thumbnailUrl` TEXT, `type` TEXT NOT NULL, `publishedAt` TEXT NOT NULL, `cachedAt` INTEGER NOT NULL, `downloadCount` INTEGER NOT NULL, `favoriteCount` INTEGER NOT NULL, `commentCount` INTEGER NOT NULL, `ratingCount` INTEGER NOT NULL, `rating` REAL NOT NULL, PRIMARY KEY(`modelId`))",
+        "fields": [
+          {
+            "fieldPath": "modelId",
+            "columnName": "modelId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "creatorUsername",
+            "columnName": "creatorUsername",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "thumbnailUrl",
+            "columnName": "thumbnailUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "publishedAt",
+            "columnName": "publishedAt",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cachedAt",
+            "columnName": "cachedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "downloadCount",
+            "columnName": "downloadCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "favoriteCount",
+            "columnName": "favoriteCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "commentCount",
+            "columnName": "commentCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ratingCount",
+            "columnName": "ratingCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "rating",
+            "columnName": "rating",
+            "affinity": "REAL",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "modelId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_feed_cache_creatorUsername",
+            "unique": false,
+            "columnNames": [
+              "creatorUsername"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_feed_cache_creatorUsername` ON `${TABLE_NAME}` (`creatorUsername`)"
+          },
+          {
+            "name": "index_feed_cache_publishedAt",
+            "unique": false,
+            "columnNames": [
+              "publishedAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_feed_cache_publishedAt` ON `${TABLE_NAME}` (`publishedAt`)"
+          }
+        ]
+      },
+      {
+        "tableName": "model_downloads",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `modelId` INTEGER NOT NULL, `modelName` TEXT NOT NULL, `versionId` INTEGER NOT NULL, `versionName` TEXT NOT NULL, `fileId` INTEGER NOT NULL, `fileName` TEXT NOT NULL, `fileUrl` TEXT NOT NULL, `fileSizeBytes` INTEGER NOT NULL, `downloadedBytes` INTEGER NOT NULL, `status` TEXT NOT NULL, `modelType` TEXT NOT NULL, `destinationPath` TEXT, `errorMessage` TEXT, `expectedSha256` TEXT, `hashVerified` INTEGER, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "modelId",
+            "columnName": "modelId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "modelName",
+            "columnName": "modelName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "versionId",
+            "columnName": "versionId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "versionName",
+            "columnName": "versionName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fileId",
+            "columnName": "fileId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fileName",
+            "columnName": "fileName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fileUrl",
+            "columnName": "fileUrl",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fileSizeBytes",
+            "columnName": "fileSizeBytes",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "downloadedBytes",
+            "columnName": "downloadedBytes",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "modelType",
+            "columnName": "modelType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "destinationPath",
+            "columnName": "destinationPath",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "errorMessage",
+            "columnName": "errorMessage",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "expectedSha256",
+            "columnName": "expectedSha256",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "hashVerified",
+            "columnName": "hashVerified",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_model_downloads_modelId",
+            "unique": false,
+            "columnNames": [
+              "modelId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_model_downloads_modelId` ON `${TABLE_NAME}` (`modelId`)"
+          },
+          {
+            "name": "index_model_downloads_status",
+            "unique": false,
+            "columnNames": [
+              "status"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_model_downloads_status` ON `${TABLE_NAME}` (`status`)"
+          },
+          {
+            "name": "index_model_downloads_createdAt",
+            "unique": false,
+            "columnNames": [
+              "createdAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_model_downloads_createdAt` ON `${TABLE_NAME}` (`createdAt`)"
+          }
+        ]
+      },
+      {
+        "tableName": "plugins",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `name` TEXT NOT NULL, `version` TEXT NOT NULL, `author` TEXT NOT NULL, `description` TEXT NOT NULL, `pluginType` TEXT NOT NULL, `capabilities` TEXT NOT NULL, `minAppVersion` TEXT NOT NULL, `state` TEXT NOT NULL, `configJson` TEXT NOT NULL, `installedAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "version",
+            "columnName": "version",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "author",
+            "columnName": "author",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "pluginType",
+            "columnName": "pluginType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "capabilities",
+            "columnName": "capabilities",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "minAppVersion",
+            "columnName": "minAppVersion",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "state",
+            "columnName": "state",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "configJson",
+            "columnName": "configJson",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "installedAt",
+            "columnName": "installedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "share_hashtags",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`tag` TEXT NOT NULL, `isEnabled` INTEGER NOT NULL, `isCustom` INTEGER NOT NULL, `addedAt` INTEGER NOT NULL, PRIMARY KEY(`tag`))",
+        "fields": [
+          {
+            "fieldPath": "tag",
+            "columnName": "tag",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isEnabled",
+            "columnName": "isEnabled",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isCustom",
+            "columnName": "isCustom",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "addedAt",
+            "columnName": "addedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "tag"
+          ]
+        }
+      },
+      {
+        "tableName": "model_update_notifications",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `modelId` INTEGER NOT NULL, `modelName` TEXT NOT NULL, `newVersionName` TEXT NOT NULL, `newVersionId` INTEGER NOT NULL, `source` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, `isRead` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "modelId",
+            "columnName": "modelId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "modelName",
+            "columnName": "modelName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "newVersionName",
+            "columnName": "newVersionName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "newVersionId",
+            "columnName": "newVersionId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "source",
+            "columnName": "source",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isRead",
+            "columnName": "isRead",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_model_update_notifications_createdAt",
+            "unique": false,
+            "columnNames": [
+              "createdAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_model_update_notifications_createdAt` ON `${TABLE_NAME}` (`createdAt`)"
+          },
+          {
+            "name": "index_model_update_notifications_isRead",
+            "unique": false,
+            "columnNames": [
+              "isRead"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_model_update_notifications_isRead` ON `${TABLE_NAME}` (`isRead`)"
+          }
+        ]
+      },
+      {
+        "tableName": "quality_score_cache",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`modelId` INTEGER NOT NULL, `score` INTEGER NOT NULL, `downloadCount` INTEGER NOT NULL, `favoriteCount` INTEGER NOT NULL, `ratingCount` INTEGER NOT NULL, `cachedAt` INTEGER NOT NULL, PRIMARY KEY(`modelId`))",
+        "fields": [
+          {
+            "fieldPath": "modelId",
+            "columnName": "modelId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "score",
+            "columnName": "score",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "downloadCount",
+            "columnName": "downloadCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "favoriteCount",
+            "columnName": "favoriteCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ratingCount",
+            "columnName": "ratingCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cachedAt",
+            "columnName": "cachedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "modelId"
+          ]
+        }
+      },
+      {
+        "tableName": "model_embeddings",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`modelId` INTEGER NOT NULL, `embeddingModel` TEXT NOT NULL, `dim` INTEGER NOT NULL, `embedding` BLOB NOT NULL, `cachedAt` INTEGER NOT NULL, PRIMARY KEY(`modelId`))",
+        "fields": [
+          {
+            "fieldPath": "modelId",
+            "columnName": "modelId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "embeddingModel",
+            "columnName": "embeddingModel",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "dim",
+            "columnName": "dim",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "embedding",
+            "columnName": "embedding",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cachedAt",
+            "columnName": "cachedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "modelId"
+          ]
+        }
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '4418185262368d0397acd8251f52d2b7')"
+    ]
+  }
+}

--- a/core/core-database/src/commonMain/kotlin/com/riox432/civitdeck/data/local/CivitDeckDatabase.kt
+++ b/core/core-database/src/commonMain/kotlin/com/riox432/civitdeck/data/local/CivitDeckDatabase.kt
@@ -98,6 +98,7 @@ import com.riox432.civitdeck.data.local.migrations.MIGRATION_40_41
 import com.riox432.civitdeck.data.local.migrations.MIGRATION_41_42
 import com.riox432.civitdeck.data.local.migrations.MIGRATION_42_43
 import com.riox432.civitdeck.data.local.migrations.MIGRATION_43_44
+import com.riox432.civitdeck.data.local.migrations.MIGRATION_44_45
 import com.riox432.civitdeck.data.local.migrations.MIGRATION_4_5
 import com.riox432.civitdeck.data.local.migrations.MIGRATION_5_6
 import com.riox432.civitdeck.data.local.migrations.MIGRATION_6_7
@@ -141,7 +142,7 @@ import kotlinx.coroutines.IO
         QualityScoreCacheEntity::class,
         ModelEmbeddingEntity::class,
     ],
-    version = 44,
+    version = 45,
 )
 @ConstructedBy(CivitDeckDatabaseConstructor::class)
 abstract class CivitDeckDatabase : RoomDatabase() {
@@ -222,6 +223,7 @@ fun getRoomDatabase(builder: RoomDatabase.Builder<CivitDeckDatabase>): CivitDeck
             MIGRATION_41_42,
             MIGRATION_42_43,
             MIGRATION_43_44,
+            MIGRATION_44_45,
         )
         .fallbackToDestructiveMigrationOnDowngrade(dropAllTables = true)
         .addCallback(defaultCollectionCallback)

--- a/core/core-database/src/commonMain/kotlin/com/riox432/civitdeck/data/local/entity/UserPreferencesEntity.kt
+++ b/core/core-database/src/commonMain/kotlin/com/riox432/civitdeck/data/local/entity/UserPreferencesEntity.kt
@@ -26,6 +26,7 @@ data class UserPreferencesEntity(
     val themeMode: String = "SYSTEM",
     val customNavShortcuts: String = "",
     val feedQualityThreshold: Int = DEFAULT_FEED_QUALITY_THRESHOLD,
+    val generationNotificationsEnabled: Boolean = true,
     val autoUpdateCheckEnabled: Boolean = true,
     val lastUpdateCheckTimestamp: Long = 0L,
 ) {

--- a/core/core-database/src/commonMain/kotlin/com/riox432/civitdeck/data/local/migrations/Migration44to45.kt
+++ b/core/core-database/src/commonMain/kotlin/com/riox432/civitdeck/data/local/migrations/Migration44to45.kt
@@ -1,0 +1,13 @@
+package com.riox432.civitdeck.data.local.migrations
+
+import androidx.room.migration.Migration
+import androidx.sqlite.SQLiteConnection
+import androidx.sqlite.execSQL
+
+val MIGRATION_44_45 = object : Migration(44, 45) {
+    override fun migrate(connection: SQLiteConnection) {
+        connection.execSQL(
+            "ALTER TABLE user_preferences ADD COLUMN generationNotificationsEnabled INTEGER NOT NULL DEFAULT 1",
+        )
+    }
+}

--- a/core/core-domain/build.gradle.kts
+++ b/core/core-domain/build.gradle.kts
@@ -13,6 +13,8 @@ kotlin {
 
         androidMain.dependencies {
             implementation(libs.onnxruntime.android)
+            implementation(libs.androidx.lifecycle.process)
+            implementation(libs.androidx.core.ktx)
         }
 
         commonTest.dependencies {

--- a/core/core-domain/src/androidMain/kotlin/com/riox432/civitdeck/domain/service/AppLifecycleTracker.android.kt
+++ b/core/core-domain/src/androidMain/kotlin/com/riox432/civitdeck/domain/service/AppLifecycleTracker.android.kt
@@ -1,0 +1,11 @@
+package com.riox432.civitdeck.domain.service
+
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.ProcessLifecycleOwner
+
+actual class AppLifecycleTracker {
+    actual val isInForeground: Boolean
+        get() = ProcessLifecycleOwner.get().lifecycle.currentState.isAtLeast(
+            Lifecycle.State.RESUMED,
+        )
+}

--- a/core/core-domain/src/androidMain/kotlin/com/riox432/civitdeck/domain/service/GenerationNotificationService.android.kt
+++ b/core/core-domain/src/androidMain/kotlin/com/riox432/civitdeck/domain/service/GenerationNotificationService.android.kt
@@ -1,0 +1,91 @@
+package com.riox432.civitdeck.domain.service
+
+import android.Manifest
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.content.Context
+import android.content.pm.PackageManager
+import android.os.Build
+import androidx.annotation.RequiresApi
+import androidx.core.app.NotificationCompat
+import androidx.core.app.NotificationManagerCompat
+import androidx.core.content.ContextCompat
+
+actual class GenerationNotificationService(
+    private val context: Context,
+) {
+
+    init {
+        ensureChannel()
+    }
+
+    actual fun notifyGenerationComplete(promptId: String, imageCount: Int, elapsedMs: Long) {
+        if (!hasNotificationPermission()) return
+
+        val elapsedSec = elapsedMs / MILLIS_PER_SECOND
+        val title = "Generation Complete"
+        val body = buildString {
+            append("$imageCount image")
+            if (imageCount != 1) append("s")
+            append(" generated in ${elapsedSec}s")
+        }
+
+        val notification = NotificationCompat.Builder(context, CHANNEL_ID)
+            .setSmallIcon(android.R.drawable.ic_menu_gallery)
+            .setContentTitle(title)
+            .setContentText(body)
+            .setPriority(NotificationCompat.PRIORITY_HIGH)
+            .setAutoCancel(true)
+            .build()
+
+        NotificationManagerCompat.from(context)
+            .notify(promptId.hashCode(), notification)
+    }
+
+    actual fun notifyGenerationError(promptId: String, errorMessage: String) {
+        if (!hasNotificationPermission()) return
+
+        val notification = NotificationCompat.Builder(context, CHANNEL_ID)
+            .setSmallIcon(android.R.drawable.ic_dialog_alert)
+            .setContentTitle("Generation Failed")
+            .setContentText(errorMessage)
+            .setPriority(NotificationCompat.PRIORITY_HIGH)
+            .setAutoCancel(true)
+            .build()
+
+        NotificationManagerCompat.from(context)
+            .notify(promptId.hashCode(), notification)
+    }
+
+    private fun hasNotificationPermission(): Boolean {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) return true
+        return ContextCompat.checkSelfPermission(
+            context,
+            Manifest.permission.POST_NOTIFICATIONS,
+        ) == PackageManager.PERMISSION_GRANTED
+    }
+
+    private fun ensureChannel() {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) return
+        createChannel()
+    }
+
+    @RequiresApi(Build.VERSION_CODES.O)
+    private fun createChannel() {
+        val channel = NotificationChannel(
+            CHANNEL_ID,
+            CHANNEL_NAME,
+            NotificationManager.IMPORTANCE_HIGH,
+        ).apply {
+            description = "Notifications when ComfyUI generation completes or fails"
+        }
+        val manager = context.getSystemService(NotificationManager::class.java)
+        manager.createNotificationChannel(channel)
+    }
+
+    private companion object {
+        private const val CHANNEL_ID = "generation_complete"
+        private const val CHANNEL_NAME = "Generation Complete"
+        private const val MILLIS_PER_SECOND = 1000L
+    }
+}

--- a/core/core-domain/src/commonMain/kotlin/com/riox432/civitdeck/di/SettingsDomainModule.kt
+++ b/core/core-domain/src/commonMain/kotlin/com/riox432/civitdeck/di/SettingsDomainModule.kt
@@ -2,12 +2,14 @@ package com.riox432.civitdeck.di
 
 import com.riox432.civitdeck.domain.usecase.ObserveCustomNavShortcutsUseCase
 import com.riox432.civitdeck.domain.usecase.ObserveDefaultSortOrderUseCase
+import com.riox432.civitdeck.domain.usecase.ObserveGenerationNotificationsEnabledUseCase
 import com.riox432.civitdeck.domain.usecase.ObserveDefaultTimePeriodUseCase
 import com.riox432.civitdeck.domain.usecase.ObserveGridColumnsUseCase
 import com.riox432.civitdeck.domain.usecase.ObservePowerUserModeUseCase
 import com.riox432.civitdeck.domain.usecase.ObserveQualityThresholdUseCase
 import com.riox432.civitdeck.domain.usecase.SetCustomNavShortcutsUseCase
 import com.riox432.civitdeck.domain.usecase.SetDefaultSortOrderUseCase
+import com.riox432.civitdeck.domain.usecase.SetGenerationNotificationsEnabledUseCase
 import com.riox432.civitdeck.domain.usecase.SetDefaultTimePeriodUseCase
 import com.riox432.civitdeck.domain.usecase.SetGridColumnsUseCase
 import com.riox432.civitdeck.domain.usecase.SetPowerUserModeUseCase
@@ -27,4 +29,6 @@ val settingsDomainModule = module {
     factory { SetCustomNavShortcutsUseCase(get()) }
     factory { ObserveQualityThresholdUseCase(get()) }
     factory { SetQualityThresholdUseCase(get()) }
+    factory { ObserveGenerationNotificationsEnabledUseCase(get()) }
+    factory { SetGenerationNotificationsEnabledUseCase(get()) }
 }

--- a/core/core-domain/src/commonMain/kotlin/com/riox432/civitdeck/domain/repository/AppBehaviorPreferencesRepository.kt
+++ b/core/core-domain/src/commonMain/kotlin/com/riox432/civitdeck/domain/repository/AppBehaviorPreferencesRepository.kt
@@ -17,4 +17,6 @@ interface AppBehaviorPreferencesRepository {
     suspend fun setCustomNavShortcuts(items: List<NavShortcut>)
     fun observeFeedQualityThreshold(): Flow<Int>
     suspend fun setFeedQualityThreshold(threshold: Int)
+    fun observeGenerationNotificationsEnabled(): Flow<Boolean>
+    suspend fun setGenerationNotificationsEnabled(enabled: Boolean)
 }

--- a/core/core-domain/src/commonMain/kotlin/com/riox432/civitdeck/domain/service/AppLifecycleTracker.kt
+++ b/core/core-domain/src/commonMain/kotlin/com/riox432/civitdeck/domain/service/AppLifecycleTracker.kt
@@ -1,0 +1,10 @@
+package com.riox432.civitdeck.domain.service
+
+/**
+ * Platform-specific tracker that reports whether the app is currently in the foreground.
+ * Used to suppress local notifications when the user is already looking at the app.
+ */
+expect class AppLifecycleTracker {
+    /** Returns true when the app is in the foreground (visible to the user). */
+    val isInForeground: Boolean
+}

--- a/core/core-domain/src/commonMain/kotlin/com/riox432/civitdeck/domain/service/GenerationNotificationService.kt
+++ b/core/core-domain/src/commonMain/kotlin/com/riox432/civitdeck/domain/service/GenerationNotificationService.kt
@@ -1,0 +1,25 @@
+package com.riox432.civitdeck.domain.service
+
+/**
+ * Platform-specific local notification service for ComfyUI generation events.
+ * Fires heads-up / banner notifications when generation completes or fails
+ * while the app is in the background.
+ */
+expect class GenerationNotificationService {
+    /**
+     * Show a "generation complete" local notification.
+     *
+     * @param promptId the ComfyUI prompt ID
+     * @param imageCount number of generated images
+     * @param elapsedMs wall-clock time from submission to completion
+     */
+    fun notifyGenerationComplete(promptId: String, imageCount: Int, elapsedMs: Long)
+
+    /**
+     * Show a "generation failed" local notification.
+     *
+     * @param promptId the ComfyUI prompt ID
+     * @param errorMessage human-readable error description
+     */
+    fun notifyGenerationError(promptId: String, errorMessage: String)
+}

--- a/core/core-domain/src/commonMain/kotlin/com/riox432/civitdeck/domain/usecase/ObserveGenerationNotificationsEnabledUseCase.kt
+++ b/core/core-domain/src/commonMain/kotlin/com/riox432/civitdeck/domain/usecase/ObserveGenerationNotificationsEnabledUseCase.kt
@@ -1,0 +1,10 @@
+package com.riox432.civitdeck.domain.usecase
+
+import com.riox432.civitdeck.domain.repository.AppBehaviorPreferencesRepository
+import kotlinx.coroutines.flow.Flow
+
+class ObserveGenerationNotificationsEnabledUseCase(
+    private val repository: AppBehaviorPreferencesRepository,
+) {
+    operator fun invoke(): Flow<Boolean> = repository.observeGenerationNotificationsEnabled()
+}

--- a/core/core-domain/src/commonMain/kotlin/com/riox432/civitdeck/domain/usecase/SetGenerationNotificationsEnabledUseCase.kt
+++ b/core/core-domain/src/commonMain/kotlin/com/riox432/civitdeck/domain/usecase/SetGenerationNotificationsEnabledUseCase.kt
@@ -1,0 +1,10 @@
+package com.riox432.civitdeck.domain.usecase
+
+import com.riox432.civitdeck.domain.repository.AppBehaviorPreferencesRepository
+
+class SetGenerationNotificationsEnabledUseCase(
+    private val repository: AppBehaviorPreferencesRepository,
+) {
+    suspend operator fun invoke(enabled: Boolean) =
+        repository.setGenerationNotificationsEnabled(enabled)
+}

--- a/core/core-domain/src/iosMain/kotlin/com/riox432/civitdeck/domain/service/AppLifecycleTracker.ios.kt
+++ b/core/core-domain/src/iosMain/kotlin/com/riox432/civitdeck/domain/service/AppLifecycleTracker.ios.kt
@@ -1,0 +1,9 @@
+package com.riox432.civitdeck.domain.service
+
+import platform.UIKit.UIApplication
+import platform.UIKit.UIApplicationState
+
+actual class AppLifecycleTracker {
+    actual val isInForeground: Boolean
+        get() = UIApplication.sharedApplication.applicationState == UIApplicationState.UIApplicationStateActive
+}

--- a/core/core-domain/src/iosMain/kotlin/com/riox432/civitdeck/domain/service/GenerationNotificationService.ios.kt
+++ b/core/core-domain/src/iosMain/kotlin/com/riox432/civitdeck/domain/service/GenerationNotificationService.ios.kt
@@ -1,0 +1,46 @@
+package com.riox432.civitdeck.domain.service
+
+import platform.Foundation.NSDate
+import platform.Foundation.timeIntervalSince1970
+import platform.UserNotifications.UNMutableNotificationContent
+import platform.UserNotifications.UNNotificationRequest
+import platform.UserNotifications.UNNotificationSound
+import platform.UserNotifications.UNUserNotificationCenter
+
+actual class GenerationNotificationService {
+
+    actual fun notifyGenerationComplete(promptId: String, imageCount: Int, elapsedMs: Long) {
+        val elapsedSec = elapsedMs / MILLIS_PER_SECOND
+        val content = UNMutableNotificationContent().apply {
+            setTitle("Generation Complete")
+            val suffix = if (imageCount == 1) "" else "s"
+            setBody("$imageCount image$suffix generated in ${elapsedSec}s")
+            setSound(UNNotificationSound.defaultSound)
+        }
+        scheduleNotification(promptId, content)
+    }
+
+    actual fun notifyGenerationError(promptId: String, errorMessage: String) {
+        val content = UNMutableNotificationContent().apply {
+            setTitle("Generation Failed")
+            setBody(errorMessage)
+            setSound(UNNotificationSound.defaultSound)
+        }
+        scheduleNotification(promptId, content)
+    }
+
+    private fun scheduleNotification(promptId: String, content: UNMutableNotificationContent) {
+        val center = UNUserNotificationCenter.currentNotificationCenter()
+        val identifier = "generation-$promptId-${NSDate().timeIntervalSince1970}"
+        val request = UNNotificationRequest.requestWithIdentifier(
+            identifier = identifier,
+            content = content,
+            trigger = null,
+        )
+        center.addNotificationRequest(request, withCompletionHandler = null)
+    }
+
+    private companion object {
+        private const val MILLIS_PER_SECOND = 1000L
+    }
+}

--- a/core/core-domain/src/jvmMain/kotlin/com/riox432/civitdeck/domain/service/AppLifecycleTracker.jvm.kt
+++ b/core/core-domain/src/jvmMain/kotlin/com/riox432/civitdeck/domain/service/AppLifecycleTracker.jvm.kt
@@ -1,0 +1,9 @@
+package com.riox432.civitdeck.domain.service
+
+/**
+ * JVM/Desktop implementation. Desktop is always considered foreground
+ * since the window is directly accessible to the user.
+ */
+actual class AppLifecycleTracker {
+    actual val isInForeground: Boolean = true
+}

--- a/core/core-domain/src/jvmMain/kotlin/com/riox432/civitdeck/domain/service/GenerationNotificationService.jvm.kt
+++ b/core/core-domain/src/jvmMain/kotlin/com/riox432/civitdeck/domain/service/GenerationNotificationService.jvm.kt
@@ -1,0 +1,22 @@
+package com.riox432.civitdeck.domain.service
+
+import com.riox432.civitdeck.util.Logger
+
+/**
+ * JVM/Desktop no-op implementation. Desktop apps are always in the foreground,
+ * so system-level notifications are not needed.
+ */
+actual class GenerationNotificationService {
+
+    actual fun notifyGenerationComplete(promptId: String, imageCount: Int, elapsedMs: Long) {
+        Logger.d(TAG, "Generation complete: promptId=$promptId, images=$imageCount, elapsed=${elapsedMs}ms")
+    }
+
+    actual fun notifyGenerationError(promptId: String, errorMessage: String) {
+        Logger.d(TAG, "Generation error: promptId=$promptId, error=$errorMessage")
+    }
+
+    private companion object {
+        private const val TAG = "GenerationNotification"
+    }
+}

--- a/feature/feature-comfyui/src/commonMain/kotlin/com/riox432/civitdeck/feature/comfyui/di/ComfyUIModule.kt
+++ b/feature/feature-comfyui/src/commonMain/kotlin/com/riox432/civitdeck/feature/comfyui/di/ComfyUIModule.kt
@@ -179,6 +179,7 @@ val comfyuiModule = module {
     viewModel {
         ComfyUIGenerationViewModel(
             get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get(),
+            get(), get(), get(),
         )
     }
     viewModel { ComfyUIHistoryViewModel(get(), get(), get(), get(), get(), get(), get(), get(), get()) }

--- a/feature/feature-comfyui/src/commonMain/kotlin/com/riox432/civitdeck/feature/comfyui/presentation/ComfyUIGenerationViewModel.kt
+++ b/feature/feature-comfyui/src/commonMain/kotlin/com/riox432/civitdeck/feature/comfyui/presentation/ComfyUIGenerationViewModel.kt
@@ -8,6 +8,9 @@ import com.riox432.civitdeck.domain.model.GenerationResult
 import com.riox432.civitdeck.domain.model.GenerationStatus
 import com.riox432.civitdeck.domain.model.LoraSelection
 import com.riox432.civitdeck.domain.repository.ComfyUIConnectionRepository
+import com.riox432.civitdeck.domain.service.AppLifecycleTracker
+import com.riox432.civitdeck.domain.service.GenerationNotificationService
+import com.riox432.civitdeck.domain.usecase.ObserveGenerationNotificationsEnabledUseCase
 import com.riox432.civitdeck.feature.comfyui.domain.model.ExtractedParameter
 import com.riox432.civitdeck.feature.comfyui.domain.usecase.ExtractWorkflowParametersUseCase
 import com.riox432.civitdeck.feature.comfyui.domain.usecase.FetchComfyUICheckpointsUseCase
@@ -91,6 +94,9 @@ class ComfyUIGenerationViewModel(
     interruptGeneration: InterruptComfyUIGenerationUseCase,
     saveImage: SaveGeneratedImageUseCase,
     repository: ComfyUIConnectionRepository,
+    notificationService: GenerationNotificationService,
+    lifecycleTracker: AppLifecycleTracker,
+    observeGenNotifEnabled: ObserveGenerationNotificationsEnabledUseCase,
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow(GenerationUiState())
@@ -105,6 +111,9 @@ class ComfyUIGenerationViewModel(
         interruptGeneration = interruptGeneration,
         saveImage = saveImage,
         repository = repository,
+        notificationService = notificationService,
+        lifecycleTracker = lifecycleTracker,
+        observeGenNotifEnabled = observeGenNotifEnabled,
     )
 
     init {

--- a/feature/feature-comfyui/src/commonMain/kotlin/com/riox432/civitdeck/feature/comfyui/presentation/GenerationExecutionDelegate.kt
+++ b/feature/feature-comfyui/src/commonMain/kotlin/com/riox432/civitdeck/feature/comfyui/presentation/GenerationExecutionDelegate.kt
@@ -5,10 +5,14 @@ import com.riox432.civitdeck.domain.model.ComfyUIConnection
 import com.riox432.civitdeck.domain.model.ComfyUIGenerationParams
 import com.riox432.civitdeck.domain.model.GenerationStatus
 import com.riox432.civitdeck.domain.repository.ComfyUIConnectionRepository
+import com.riox432.civitdeck.domain.service.AppLifecycleTracker
+import com.riox432.civitdeck.domain.service.GenerationNotificationService
+import com.riox432.civitdeck.domain.usecase.ObserveGenerationNotificationsEnabledUseCase
 import com.riox432.civitdeck.feature.comfyui.domain.usecase.InterruptComfyUIGenerationUseCase
 import com.riox432.civitdeck.feature.comfyui.domain.usecase.ObserveGenerationProgressUseCase
 import com.riox432.civitdeck.feature.comfyui.domain.usecase.PollComfyUIResultUseCase
 import com.riox432.civitdeck.feature.comfyui.domain.usecase.SubmitComfyUIGenerationUseCase
+import com.riox432.civitdeck.domain.util.currentTimeMillis
 import com.riox432.civitdeck.util.Logger
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
@@ -16,6 +20,8 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 
@@ -23,6 +29,7 @@ import kotlinx.coroutines.launch
  * Handles generation submission, progress tracking (WebSocket + polling), interruption, and
  * image saving. Extracted from [ComfyUIGenerationViewModel] to reduce function count.
  */
+@Suppress("LongParameterList")
 internal class GenerationExecutionDelegate(
     private val scope: CoroutineScope,
     private val uiState: MutableStateFlow<GenerationUiState>,
@@ -32,11 +39,23 @@ internal class GenerationExecutionDelegate(
     private val interruptGeneration: InterruptComfyUIGenerationUseCase,
     private val saveImage: SaveGeneratedImageUseCase,
     private val repository: ComfyUIConnectionRepository,
+    private val notificationService: GenerationNotificationService,
+    private val lifecycleTracker: AppLifecycleTracker,
+    observeGenNotifEnabled: ObserveGenerationNotificationsEnabledUseCase,
 ) {
     private var progressJob: Job? = null
+    private var generationStartTimeMs: Long = 0L
+    private var notificationsEnabled: Boolean = true
+
+    init {
+        observeGenNotifEnabled()
+            .onEach { notificationsEnabled = it }
+            .launchIn(scope)
+    }
 
     fun onGenerate(params: ComfyUIGenerationParams) {
         progressJob?.cancel()
+        generationStartTimeMs = currentTimeMs()
         uiState.update {
             it.copy(
                 generationStatus = GenerationStatus.Submitting,
@@ -126,14 +145,19 @@ internal class GenerationExecutionDelegate(
 
     private suspend fun fetchFinalResult(promptId: String) {
         val onError = { e: Exception ->
+            notifyErrorIfNeeded(promptId, e.message ?: "Unknown error")
             uiState.update { it.copy(generationStatus = GenerationStatus.Error, error = e.message) }
         }
         runCatchingLogged("Failed to fetch final result", onError) {
             val result = pollResult(promptId)
-            uiState.update {
-                if (result.status == GenerationStatus.Completed) {
+            if (result.status == GenerationStatus.Completed) {
+                notifyCompleteIfNeeded(promptId, result.imageUrls.size)
+                uiState.update {
                     it.copy(generationStatus = GenerationStatus.Completed, result = result)
-                } else {
+                }
+            } else {
+                notifyErrorIfNeeded(promptId, result.error ?: "Unknown error")
+                uiState.update {
                     it.copy(generationStatus = GenerationStatus.Error, error = result.error)
                 }
             }
@@ -142,6 +166,7 @@ internal class GenerationExecutionDelegate(
 
     private suspend fun pollForResult(promptId: String) {
         val onError = { e: Exception ->
+            notifyErrorIfNeeded(promptId, e.message ?: "Unknown error")
             uiState.update { it.copy(generationStatus = GenerationStatus.Error, error = e.message) }
         }
         var attempts = 0
@@ -152,12 +177,14 @@ internal class GenerationExecutionDelegate(
                 val result = pollResult(promptId)
                 when (result.status) {
                     GenerationStatus.Completed -> {
+                        notifyCompleteIfNeeded(promptId, result.imageUrls.size)
                         uiState.update {
                             it.copy(generationStatus = GenerationStatus.Completed, result = result)
                         }
                         done = true
                     }
                     GenerationStatus.Error -> {
+                        notifyErrorIfNeeded(promptId, result.error ?: "Unknown error")
                         uiState.update {
                             it.copy(generationStatus = GenerationStatus.Error, error = result.error)
                         }
@@ -168,10 +195,28 @@ internal class GenerationExecutionDelegate(
             }
             if (!success || done) return
         }
+        notifyErrorIfNeeded(promptId, "Generation timed out")
         uiState.update {
             it.copy(generationStatus = GenerationStatus.Error, error = "Generation timed out")
         }
     }
+
+    // region Notification helpers
+
+    private fun notifyCompleteIfNeeded(promptId: String, imageCount: Int) {
+        if (!notificationsEnabled || lifecycleTracker.isInForeground) return
+        val elapsed = currentTimeMs() - generationStartTimeMs
+        notificationService.notifyGenerationComplete(promptId, imageCount, elapsed)
+    }
+
+    private fun notifyErrorIfNeeded(promptId: String, errorMessage: String) {
+        if (!notificationsEnabled || lifecycleTracker.isInForeground) return
+        notificationService.notifyGenerationError(promptId, errorMessage)
+    }
+
+    private fun currentTimeMs(): Long = currentTimeMillis()
+
+    // endregion
 
     private inline fun launchWithErrorHandling(
         tag: String,

--- a/feature/feature-settings/src/commonMain/kotlin/com/riox432/civitdeck/feature/settings/data/repository/UserPreferencesRepositoryImpl.kt
+++ b/feature/feature-settings/src/commonMain/kotlin/com/riox432/civitdeck/feature/settings/data/repository/UserPreferencesRepositoryImpl.kt
@@ -216,4 +216,12 @@ class UserPreferencesRepositoryImpl(
         val existing = dao.getPreferences() ?: UserPreferencesEntity()
         dao.upsert(existing.copy(feedQualityThreshold = threshold.coerceIn(0, 100)))
     }
+
+    override fun observeGenerationNotificationsEnabled(): Flow<Boolean> =
+        dao.observePreferences().map { it?.generationNotificationsEnabled ?: true }
+
+    override suspend fun setGenerationNotificationsEnabled(enabled: Boolean) {
+        val existing = dao.getPreferences() ?: UserPreferencesEntity()
+        dao.upsert(existing.copy(generationNotificationsEnabled = enabled))
+    }
 }

--- a/feature/feature-settings/src/commonMain/kotlin/com/riox432/civitdeck/feature/settings/presentation/AppBehaviorSettingsViewModel.kt
+++ b/feature/feature-settings/src/commonMain/kotlin/com/riox432/civitdeck/feature/settings/presentation/AppBehaviorSettingsViewModel.kt
@@ -3,10 +3,12 @@ package com.riox432.civitdeck.feature.settings.presentation
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.riox432.civitdeck.domain.model.PollingInterval
+import com.riox432.civitdeck.domain.usecase.ObserveGenerationNotificationsEnabledUseCase
 import com.riox432.civitdeck.domain.usecase.ObserveNotificationsEnabledUseCase
 import com.riox432.civitdeck.domain.usecase.ObservePollingIntervalUseCase
 import com.riox432.civitdeck.domain.usecase.ObservePowerUserModeUseCase
 import com.riox432.civitdeck.domain.usecase.ObserveQualityThresholdUseCase
+import com.riox432.civitdeck.domain.usecase.SetGenerationNotificationsEnabledUseCase
 import com.riox432.civitdeck.domain.usecase.SetNotificationsEnabledUseCase
 import com.riox432.civitdeck.domain.usecase.SetPollingIntervalUseCase
 import com.riox432.civitdeck.domain.usecase.SetPowerUserModeUseCase
@@ -22,6 +24,7 @@ data class AppBehaviorSettingsUiState(
     val notificationsEnabled: Boolean = false,
     val pollingInterval: PollingInterval = PollingInterval.Off,
     val feedQualityThreshold: Int = 30,
+    val generationNotificationsEnabled: Boolean = true,
 )
 
 @Suppress("LongParameterList")
@@ -34,6 +37,8 @@ class AppBehaviorSettingsViewModel(
     private val setPollingIntervalUseCase: SetPollingIntervalUseCase,
     observeQualityThresholdUseCase: ObserveQualityThresholdUseCase,
     private val setQualityThresholdUseCase: SetQualityThresholdUseCase,
+    observeGenNotifUseCase: ObserveGenerationNotificationsEnabledUseCase,
+    private val setGenNotifUseCase: SetGenerationNotificationsEnabledUseCase,
 ) : ViewModel() {
 
     val uiState: StateFlow<AppBehaviorSettingsUiState> = combine(
@@ -41,12 +46,14 @@ class AppBehaviorSettingsViewModel(
         observeNotificationsEnabledUseCase(),
         observePollingIntervalUseCase(),
         observeQualityThresholdUseCase(),
-    ) { powerUser, notifications, polling, qualityThreshold ->
+        observeGenNotifUseCase(),
+    ) { powerUser, notifications, polling, qualityThreshold, genNotif ->
         AppBehaviorSettingsUiState(
             powerUserMode = powerUser,
             notificationsEnabled = notifications,
             pollingInterval = polling,
             feedQualityThreshold = qualityThreshold,
+            generationNotificationsEnabled = genNotif,
         )
     }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), AppBehaviorSettingsUiState())
 
@@ -69,5 +76,9 @@ class AppBehaviorSettingsViewModel(
 
     fun onFeedQualityThresholdChanged(threshold: Int) {
         viewModelScope.launch { setQualityThresholdUseCase(threshold) }
+    }
+
+    fun onGenerationNotificationsEnabledChanged(enabled: Boolean) {
+        viewModelScope.launch { setGenNotifUseCase(enabled) }
     }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -23,6 +23,7 @@ detekt = "1.23.8"
 skie = "0.10.11"
 aboutlibraries = "12.1.2"
 onnxruntime-android = "1.25.0"
+androidx-core = "1.16.0"
 
 [libraries]
 # QR Code
@@ -70,10 +71,12 @@ paging-common = { module = "androidx.paging:paging-common", version.ref = "pagin
 paging-compose = { module = "androidx.paging:paging-compose", version.ref = "paging" }
 
 # AndroidX
+androidx-core-ktx = { module = "androidx.core:core-ktx", version.ref = "androidx-core" }
 androidx-activity-compose = { module = "androidx.activity:activity-compose", version.ref = "androidx-activity-compose" }
 androidx-work-runtime = { module = "androidx.work:work-runtime-ktx", version.ref = "androidx-work" }
 androidx-lifecycle-viewmodel = { module = "androidx.lifecycle:lifecycle-viewmodel", version.ref = "androidx-lifecycle" }
 androidx-lifecycle-viewmodel-compose = { module = "androidx.lifecycle:lifecycle-viewmodel-compose", version.ref = "androidx-lifecycle" }
+androidx-lifecycle-process = { module = "androidx.lifecycle:lifecycle-process", version.ref = "androidx-lifecycle" }
 androidx-lifecycle-runtime-compose = { module = "androidx.lifecycle:lifecycle-runtime-compose", version.ref = "androidx-lifecycle" }
 androidx-navigation3-runtime = { module = "androidx.navigation3:navigation3-runtime", version.ref = "androidx-navigation3" }
 androidx-navigation3-ui = { module = "androidx.navigation3:navigation3-ui", version.ref = "androidx-navigation3" }

--- a/iosApp/iosApp/Features/Settings/ContentFilterSettingsView.swift
+++ b/iosApp/iosApp/Features/Settings/ContentFilterSettingsView.swift
@@ -123,6 +123,7 @@ struct ContentFilterSettingsView: View {
             if state.notificationsEnabled {
                 pollingIntervalPicker(state: state)
             }
+            generationNotificationsToggle(state: state)
         }
     }
 
@@ -135,6 +136,21 @@ struct ContentFilterSettingsView: View {
                 Text("Model Update Alerts")
                     .font(.civitBodyMedium)
                 Text("Notify when favorited models get new versions")
+                    .font(.civitBodySmall)
+                    .foregroundColor(.civitOnSurfaceVariant)
+            }
+        }
+    }
+
+    private func generationNotificationsToggle(state: AppBehaviorSettingsUiState) -> some View {
+        Toggle(isOn: Binding(
+            get: { state.generationNotificationsEnabled },
+            set: { appBehaviorViewModel.onGenerationNotificationsEnabledChanged(enabled: $0) }
+        )) {
+            VStack(alignment: .leading, spacing: Spacing.xs) {
+                Text("Generation Complete Alerts")
+                    .font(.civitBodyMedium)
+                Text("Notify when ComfyUI generation finishes while app is in background")
                     .font(.civitBodySmall)
                     .foregroundColor(.civitOnSurfaceVariant)
             }

--- a/shared/src/androidMain/kotlin/com/riox432/civitdeck/di/PlatformModule.android.kt
+++ b/shared/src/androidMain/kotlin/com/riox432/civitdeck/di/PlatformModule.android.kt
@@ -3,10 +3,14 @@ package com.riox432.civitdeck.di
 import com.riox432.civitdeck.data.local.AndroidNetworkMonitor
 import com.riox432.civitdeck.data.local.getDatabaseBuilder
 import com.riox432.civitdeck.domain.repository.NetworkRepository
+import com.riox432.civitdeck.domain.service.AppLifecycleTracker
+import com.riox432.civitdeck.domain.service.GenerationNotificationService
 import org.koin.core.module.Module
 import org.koin.dsl.module
 
 actual val platformModule: Module = module {
     single { getDatabaseBuilder(get()) }
     single<NetworkRepository> { AndroidNetworkMonitor(get()) }
+    single { GenerationNotificationService(get()) }
+    single { AppLifecycleTracker() }
 }

--- a/shared/src/commonMain/kotlin/com/riox432/civitdeck/di/SettingsViewModelModule.kt
+++ b/shared/src/commonMain/kotlin/com/riox432/civitdeck/di/SettingsViewModelModule.kt
@@ -14,6 +14,7 @@ import com.riox432.civitdeck.domain.usecase.ObserveApiKeyUseCase
 import com.riox432.civitdeck.domain.usecase.ObserveCacheSizeLimitUseCase
 import com.riox432.civitdeck.domain.usecase.ObserveCustomNavShortcutsUseCase
 import com.riox432.civitdeck.domain.usecase.ObserveDefaultSortOrderUseCase
+import com.riox432.civitdeck.domain.usecase.ObserveGenerationNotificationsEnabledUseCase
 import com.riox432.civitdeck.domain.usecase.ObserveDefaultTimePeriodUseCase
 import com.riox432.civitdeck.domain.usecase.ObserveGridColumnsUseCase
 import com.riox432.civitdeck.domain.usecase.ObserveNetworkStatusUseCase
@@ -32,6 +33,7 @@ import com.riox432.civitdeck.domain.usecase.SetApiKeyUseCase
 import com.riox432.civitdeck.domain.usecase.SetCacheSizeLimitUseCase
 import com.riox432.civitdeck.domain.usecase.SetCustomNavShortcutsUseCase
 import com.riox432.civitdeck.domain.usecase.SetDefaultSortOrderUseCase
+import com.riox432.civitdeck.domain.usecase.SetGenerationNotificationsEnabledUseCase
 import com.riox432.civitdeck.domain.usecase.SetDefaultTimePeriodUseCase
 import com.riox432.civitdeck.domain.usecase.SetGridColumnsUseCase
 import com.riox432.civitdeck.domain.usecase.SetNotificationsEnabledUseCase
@@ -95,6 +97,8 @@ val settingsViewModelModule = module {
             setPollingIntervalUseCase = get<SetPollingIntervalUseCase>(),
             observeQualityThresholdUseCase = get<ObserveQualityThresholdUseCase>(),
             setQualityThresholdUseCase = get<SetQualityThresholdUseCase>(),
+            observeGenNotifUseCase = get<ObserveGenerationNotificationsEnabledUseCase>(),
+            setGenNotifUseCase = get<SetGenerationNotificationsEnabledUseCase>(),
         )
     }
     viewModel {

--- a/shared/src/iosMain/kotlin/com/riox432/civitdeck/di/PlatformModule.ios.kt
+++ b/shared/src/iosMain/kotlin/com/riox432/civitdeck/di/PlatformModule.ios.kt
@@ -4,6 +4,8 @@ import com.riox432.civitdeck.data.local.IosNetworkMonitor
 import com.riox432.civitdeck.data.local.getDatabaseBuilder
 import com.riox432.civitdeck.domain.download.DownloadScheduler
 import com.riox432.civitdeck.domain.repository.NetworkRepository
+import com.riox432.civitdeck.domain.service.AppLifecycleTracker
+import com.riox432.civitdeck.domain.service.GenerationNotificationService
 import com.riox432.civitdeck.download.IosDownloadScheduler
 import org.koin.core.module.Module
 import org.koin.dsl.module
@@ -12,4 +14,6 @@ actual val platformModule: Module = module {
     single { getDatabaseBuilder() }
     single<NetworkRepository> { IosNetworkMonitor() }
     single<DownloadScheduler> { IosDownloadScheduler() }
+    single { GenerationNotificationService() }
+    single { AppLifecycleTracker() }
 }

--- a/shared/src/jvmMain/kotlin/com/riox432/civitdeck/di/PlatformModule.jvm.kt
+++ b/shared/src/jvmMain/kotlin/com/riox432/civitdeck/di/PlatformModule.jvm.kt
@@ -4,6 +4,8 @@ import com.riox432.civitdeck.data.local.JvmNetworkMonitor
 import com.riox432.civitdeck.data.local.getDatabaseBuilder
 import com.riox432.civitdeck.domain.download.DownloadScheduler
 import com.riox432.civitdeck.domain.repository.NetworkRepository
+import com.riox432.civitdeck.domain.service.AppLifecycleTracker
+import com.riox432.civitdeck.domain.service.GenerationNotificationService
 import com.riox432.civitdeck.download.DesktopDownloadScheduler
 import org.koin.core.module.Module
 import org.koin.dsl.module
@@ -12,4 +14,6 @@ actual val platformModule: Module = module {
     single { getDatabaseBuilder() }
     single<NetworkRepository> { JvmNetworkMonitor() }
     single<DownloadScheduler> { DesktopDownloadScheduler() }
+    single { GenerationNotificationService() }
+    single { AppLifecycleTracker() }
 }


### PR DESCRIPTION
## Summary
- Add `GenerationNotificationService` (expect/actual) that fires local notifications when ComfyUI generation completes or fails while the app is in the background
- Add `AppLifecycleTracker` (expect/actual) to check foreground state — suppresses notifications when user is looking at the app
- Add `generationNotificationsEnabled` settings toggle (default: on) in the Notifications section on both Android and iOS
- Hook notification dispatch into `GenerationExecutionDelegate` at completion/error points with elapsed time tracking

## Platform implementations
- **Android**: `NotificationChannel` (IMPORTANCE_HIGH for heads-up), `ProcessLifecycleOwner` for lifecycle
- **iOS**: `UNMutableNotificationContent` with default sound, `UIApplication.sharedApplication.applicationState` for lifecycle
- **Desktop/JVM**: No-op (always foreground)

## Database
- Migration 44→45: adds `generationNotificationsEnabled` column to `user_preferences`

## Build verification
- [x] `./gradlew :androidApp:detekt` — PASSED
- [x] `./gradlew :androidApp:assembleDebug` — PASSED
- [x] `./gradlew :desktopApp:compileKotlinJvm` — PASSED
- [x] iOS xcodebuild — no new errors (pre-existing KMP framework build order errors only)

Closes #888