### PR TITLE
Add Android foreground service for background ComfyUI WebSocket monitoring

### DIFF
--- a/androidApp/src/main/AndroidManifest.xml
+++ b/androidApp/src/main/AndroidManifest.xml
@@ -5,6 +5,7 @@
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_DATA_SYNC" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_SPECIAL_USE" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <uses-permission android:name="android.permission.CAMERA" />
 
@@ -45,6 +46,14 @@
             android:name="androidx.work.impl.foreground.SystemForegroundService"
             android:foregroundServiceType="dataSync"
             tools:node="merge" />
+        <service
+            android:name=".service.GenerationMonitorService"
+            android:foregroundServiceType="specialUse"
+            android:exported="false">
+            <property
+                android:name="android.app.PROPERTY_SPECIAL_USE_FGS_SUBTYPE"
+                android:value="Maintains WebSocket connection to local ComfyUI server to track image generation progress and deliver completion notifications" />
+        </service>
         <receiver
             android:name=".widget.TrendingModelWidgetReceiver"
             android:exported="true">

--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/service/GenerationMonitorService.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/service/GenerationMonitorService.kt
@@ -1,0 +1,208 @@
+package com.riox432.civitdeck.service
+
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.app.Service
+import android.content.Intent
+import android.content.pm.ServiceInfo
+import android.os.Build
+import android.os.IBinder
+import androidx.annotation.RequiresApi
+import androidx.core.app.NotificationCompat
+import androidx.core.app.ServiceCompat
+import com.riox432.civitdeck.R
+import com.riox432.civitdeck.data.api.comfyui.ComfyUIWebSocketApi
+import com.riox432.civitdeck.data.api.comfyui.ComfyUIWebSocketMessage
+import com.riox432.civitdeck.domain.service.BackgroundMonitorStarter.Companion.ACTION_START
+import com.riox432.civitdeck.domain.service.BackgroundMonitorStarter.Companion.ACTION_STOP
+import com.riox432.civitdeck.domain.service.BackgroundMonitorStarter.Companion.EXTRA_BASE_URL
+import com.riox432.civitdeck.domain.service.BackgroundMonitorStarter.Companion.EXTRA_PROMPT_ID
+import com.riox432.civitdeck.domain.service.BackgroundMonitorStarter.Companion.EXTRA_WS_SCHEME
+import com.riox432.civitdeck.domain.service.GenerationNotificationService
+import com.riox432.civitdeck.domain.util.currentTimeMillis
+import com.riox432.civitdeck.util.Logger
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.launch
+import org.koin.android.ext.android.inject
+
+/**
+ * Android foreground service that maintains a WebSocket connection to a ComfyUI server
+ * in the background. Shows a persistent notification with generation progress and
+ * fires a completion/error notification when the job finishes.
+ *
+ * Lifecycle:
+ * - Started by [BackgroundMonitorStarter] after generation is submitted
+ * - Stops itself when [ComfyUIWebSocketMessage.ExecutionSuccess] or
+ *   [ComfyUIWebSocketMessage.ExecutionError] is received
+ * - Can be stopped externally via [ACTION_STOP] intent
+ */
+class GenerationMonitorService : Service() {
+
+    private val webSocketApi: ComfyUIWebSocketApi by inject()
+    private val notificationService: GenerationNotificationService by inject()
+
+    private val serviceScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+    private var monitorJob: Job? = null
+    private var startTimeMs: Long = 0L
+
+    override fun onBind(intent: Intent?): IBinder? = null
+
+    override fun onCreate() {
+        super.onCreate()
+        ensureChannel()
+    }
+
+    override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
+        when (intent?.action) {
+            ACTION_START -> handleStart(intent)
+            ACTION_STOP -> stopSelfCleanly()
+            else -> stopSelfCleanly()
+        }
+        return START_NOT_STICKY
+    }
+
+    override fun onDestroy() {
+        monitorJob?.cancel()
+        serviceScope.cancel()
+        super.onDestroy()
+    }
+
+    private fun handleStart(intent: Intent) {
+        val promptId = intent.getStringExtra(EXTRA_PROMPT_ID) ?: return stopSelfCleanly()
+        val baseUrl = intent.getStringExtra(EXTRA_BASE_URL) ?: return stopSelfCleanly()
+        val wsScheme = intent.getStringExtra(EXTRA_WS_SCHEME) ?: "ws"
+
+        startTimeMs = currentTimeMillis()
+
+        // Cancel any existing monitor before starting a new one
+        monitorJob?.cancel()
+
+        startForegroundNotification()
+        monitorJob = serviceScope.launch {
+            collectWebSocket(promptId, baseUrl, wsScheme)
+        }
+    }
+
+    private fun startForegroundNotification() {
+        val notification = buildProgressNotification(
+            getString(R.string.generation_monitor_waiting),
+            progress = 0,
+            maxProgress = 0,
+            indeterminate = true,
+        )
+        ServiceCompat.startForeground(
+            this,
+            NOTIFICATION_ID,
+            notification.build(),
+            foregroundServiceType(),
+        )
+    }
+
+    private fun foregroundServiceType(): Int {
+        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+            ServiceInfo.FOREGROUND_SERVICE_TYPE_SPECIAL_USE
+        } else {
+            0
+        }
+    }
+
+    private suspend fun collectWebSocket(
+        promptId: String,
+        baseUrl: String,
+        wsScheme: String,
+    ) {
+        val clientId = "civitdeck-monitor-${currentTimeMillis()}"
+        try {
+            webSocketApi.observeProgress(baseUrl, wsScheme, clientId, promptId)
+                .collect { message -> handleMessage(message, promptId) }
+        } catch (@Suppress("TooGenericExceptionCaught") e: Exception) {
+            Logger.e(TAG, "WebSocket monitor failed: ${e.message}")
+            notificationService.notifyGenerationError(promptId, e.message ?: "Connection lost")
+        }
+        stopSelfCleanly()
+    }
+
+    private fun handleMessage(message: ComfyUIWebSocketMessage, promptId: String) {
+        when (message) {
+            is ComfyUIWebSocketMessage.Progress -> updateProgress(message)
+            is ComfyUIWebSocketMessage.ExecutionSuccess -> onComplete(promptId)
+            is ComfyUIWebSocketMessage.ExecutionError -> onError(promptId, message)
+            else -> { /* Status, Executing, etc. — no notification update needed */ }
+        }
+    }
+
+    private fun updateProgress(progress: ComfyUIWebSocketMessage.Progress) {
+        val contentText = getString(
+            R.string.generation_monitor_progress,
+            progress.value,
+            progress.max,
+        )
+        val notification = buildProgressNotification(
+            contentText,
+            progress = progress.value,
+            maxProgress = progress.max,
+            indeterminate = false,
+        )
+        val manager = getSystemService(NotificationManager::class.java)
+        manager.notify(NOTIFICATION_ID, notification.build())
+    }
+
+    private fun onComplete(promptId: String) {
+        val elapsed = currentTimeMillis() - startTimeMs
+        notificationService.notifyGenerationComplete(promptId, imageCount = 1, elapsed)
+    }
+
+    private fun onError(promptId: String, error: ComfyUIWebSocketMessage.ExecutionError) {
+        notificationService.notifyGenerationError(promptId, error.exceptionMessage)
+    }
+
+    private fun buildProgressNotification(
+        contentText: String,
+        progress: Int,
+        maxProgress: Int,
+        indeterminate: Boolean,
+    ): NotificationCompat.Builder {
+        return NotificationCompat.Builder(this, CHANNEL_ID)
+            .setSmallIcon(R.drawable.ic_notification)
+            .setContentTitle(getString(R.string.generation_monitor_title))
+            .setContentText(contentText)
+            .setProgress(maxProgress, progress, indeterminate)
+            .setOngoing(true)
+            .setSilent(true)
+            .setForegroundServiceBehavior(NotificationCompat.FOREGROUND_SERVICE_IMMEDIATE)
+    }
+
+    private fun stopSelfCleanly() {
+        monitorJob?.cancel()
+        ServiceCompat.stopForeground(this, ServiceCompat.STOP_FOREGROUND_REMOVE)
+        stopSelf()
+    }
+
+    private fun ensureChannel() {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) return
+        createChannel()
+    }
+
+    @RequiresApi(Build.VERSION_CODES.O)
+    private fun createChannel() {
+        val channel = NotificationChannel(
+            CHANNEL_ID,
+            getString(R.string.generation_monitor_channel_name),
+            NotificationManager.IMPORTANCE_LOW,
+        ).apply {
+            description = getString(R.string.generation_monitor_channel_description)
+        }
+        val manager = getSystemService(NotificationManager::class.java)
+        manager.createNotificationChannel(channel)
+    }
+
+    companion object {
+        private const val TAG = "GenerationMonitorSvc"
+        private const val CHANNEL_ID = "generation_monitor"
+        private const val NOTIFICATION_ID = 3001
+    }
+}

--- a/androidApp/src/main/res/values/strings.xml
+++ b/androidApp/src/main/res/values/strings.xml
@@ -540,4 +540,11 @@
     <string name="vram_tight_fit">Tight fit</string>
     <string name="vram_needs_offloading">Needs offloading</string>
     <string name="vram_optimization_suggestions">Optimization Suggestions</string>
+
+    <!-- Generation Monitor Service -->
+    <string name="generation_monitor_channel_name">Generation Monitor</string>
+    <string name="generation_monitor_channel_description">Persistent notification while monitoring ComfyUI generation progress</string>
+    <string name="generation_monitor_title">Monitoring ComfyUI generation</string>
+    <string name="generation_monitor_progress">Step %1$d/%2$d</string>
+    <string name="generation_monitor_waiting">Waiting for progress…</string>
 </resources>

--- a/core/core-domain/src/androidMain/kotlin/com/riox432/civitdeck/domain/service/BackgroundMonitorStarter.android.kt
+++ b/core/core-domain/src/androidMain/kotlin/com/riox432/civitdeck/domain/service/BackgroundMonitorStarter.android.kt
@@ -1,0 +1,52 @@
+package com.riox432.civitdeck.domain.service
+
+import android.content.Context
+import android.content.Intent
+import android.os.Build
+import com.riox432.civitdeck.util.Logger
+
+actual class BackgroundMonitorStarter(
+    private val context: Context,
+) {
+    actual fun startMonitoring(promptId: String, baseUrl: String, wsScheme: String) {
+        val intent = Intent().apply {
+            setClassName(context, SERVICE_CLASS_NAME)
+            action = ACTION_START
+            putExtra(EXTRA_PROMPT_ID, promptId)
+            putExtra(EXTRA_BASE_URL, baseUrl)
+            putExtra(EXTRA_WS_SCHEME, wsScheme)
+        }
+        try {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                context.startForegroundService(intent)
+            } else {
+                context.startService(intent)
+            }
+        } catch (@Suppress("TooGenericExceptionCaught") e: Exception) {
+            Logger.w(TAG, "Failed to start monitor service: ${e.message}")
+        }
+    }
+
+    actual fun stopMonitoring() {
+        val intent = Intent().apply {
+            setClassName(context, SERVICE_CLASS_NAME)
+            action = ACTION_STOP
+        }
+        try {
+            context.startService(intent)
+        } catch (@Suppress("TooGenericExceptionCaught") e: Exception) {
+            Logger.w(TAG, "Failed to stop monitor service: ${e.message}")
+        }
+    }
+
+    companion object {
+        private const val TAG = "BackgroundMonitorStarter"
+        private const val SERVICE_CLASS_NAME =
+            "com.riox432.civitdeck.service.GenerationMonitorService"
+        const val ACTION_START = "com.riox432.civitdeck.action.START_MONITOR"
+        const val ACTION_STOP = "com.riox432.civitdeck.action.STOP_MONITOR"
+        const val EXTRA_PROMPT_ID = "extra_prompt_id"
+        const val EXTRA_BASE_URL = "extra_base_url"
+        const val EXTRA_WS_SCHEME = "extra_ws_scheme"
+    }
+}

--- a/core/core-domain/src/commonMain/kotlin/com/riox432/civitdeck/domain/service/BackgroundMonitorStarter.kt
+++ b/core/core-domain/src/commonMain/kotlin/com/riox432/civitdeck/domain/service/BackgroundMonitorStarter.kt
@@ -1,0 +1,23 @@
+package com.riox432.civitdeck.domain.service
+
+/**
+ * Platform-specific mechanism to start a background monitor that keeps
+ * the WebSocket connection alive when the app is backgrounded.
+ *
+ * On Android this starts a foreground service with a persistent notification.
+ * On iOS and Desktop this is a no-op (iOS cannot maintain background WebSocket
+ * reliably, and Desktop apps are always in the foreground).
+ */
+expect class BackgroundMonitorStarter {
+    /**
+     * Start monitoring a generation job in the background.
+     *
+     * @param promptId the ComfyUI prompt ID being monitored
+     * @param baseUrl the ComfyUI server base URL (e.g. "http://192.168.1.100:8188")
+     * @param wsScheme the WebSocket scheme ("ws" or "wss")
+     */
+    fun startMonitoring(promptId: String, baseUrl: String, wsScheme: String)
+
+    /** Stop the background monitor. Called when generation completes or is interrupted. */
+    fun stopMonitoring()
+}

--- a/core/core-domain/src/iosMain/kotlin/com/riox432/civitdeck/domain/service/BackgroundMonitorStarter.ios.kt
+++ b/core/core-domain/src/iosMain/kotlin/com/riox432/civitdeck/domain/service/BackgroundMonitorStarter.ios.kt
@@ -1,0 +1,15 @@
+package com.riox432.civitdeck.domain.service
+
+/**
+ * iOS no-op implementation. iOS cannot maintain a background WebSocket connection
+ * reliably, so background monitoring is not supported.
+ */
+actual class BackgroundMonitorStarter {
+    actual fun startMonitoring(promptId: String, baseUrl: String, wsScheme: String) {
+        // No-op on iOS
+    }
+
+    actual fun stopMonitoring() {
+        // No-op on iOS
+    }
+}

--- a/core/core-domain/src/jvmMain/kotlin/com/riox432/civitdeck/domain/service/BackgroundMonitorStarter.jvm.kt
+++ b/core/core-domain/src/jvmMain/kotlin/com/riox432/civitdeck/domain/service/BackgroundMonitorStarter.jvm.kt
@@ -1,0 +1,15 @@
+package com.riox432.civitdeck.domain.service
+
+/**
+ * JVM/Desktop no-op implementation. Desktop apps are always in the foreground,
+ * so background monitoring is not needed.
+ */
+actual class BackgroundMonitorStarter {
+    actual fun startMonitoring(promptId: String, baseUrl: String, wsScheme: String) {
+        // No-op on Desktop
+    }
+
+    actual fun stopMonitoring() {
+        // No-op on Desktop
+    }
+}

--- a/feature/feature-comfyui/src/commonMain/kotlin/com/riox432/civitdeck/feature/comfyui/di/ComfyUIModule.kt
+++ b/feature/feature-comfyui/src/commonMain/kotlin/com/riox432/civitdeck/feature/comfyui/di/ComfyUIModule.kt
@@ -179,7 +179,7 @@ val comfyuiModule = module {
     viewModel {
         ComfyUIGenerationViewModel(
             get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get(),
-            get(), get(), get(),
+            get(), get(), get(), get(),
         )
     }
     viewModel { ComfyUIHistoryViewModel(get(), get(), get(), get(), get(), get(), get(), get(), get()) }

--- a/feature/feature-comfyui/src/commonMain/kotlin/com/riox432/civitdeck/feature/comfyui/presentation/ComfyUIGenerationViewModel.kt
+++ b/feature/feature-comfyui/src/commonMain/kotlin/com/riox432/civitdeck/feature/comfyui/presentation/ComfyUIGenerationViewModel.kt
@@ -9,6 +9,7 @@ import com.riox432.civitdeck.domain.model.GenerationStatus
 import com.riox432.civitdeck.domain.model.LoraSelection
 import com.riox432.civitdeck.domain.repository.ComfyUIConnectionRepository
 import com.riox432.civitdeck.domain.service.AppLifecycleTracker
+import com.riox432.civitdeck.domain.service.BackgroundMonitorStarter
 import com.riox432.civitdeck.domain.service.GenerationNotificationService
 import com.riox432.civitdeck.domain.usecase.ObserveGenerationNotificationsEnabledUseCase
 import com.riox432.civitdeck.feature.comfyui.domain.model.ExtractedParameter
@@ -96,6 +97,7 @@ class ComfyUIGenerationViewModel(
     repository: ComfyUIConnectionRepository,
     notificationService: GenerationNotificationService,
     lifecycleTracker: AppLifecycleTracker,
+    backgroundMonitorStarter: BackgroundMonitorStarter,
     observeGenNotifEnabled: ObserveGenerationNotificationsEnabledUseCase,
 ) : ViewModel() {
 
@@ -113,6 +115,7 @@ class ComfyUIGenerationViewModel(
         repository = repository,
         notificationService = notificationService,
         lifecycleTracker = lifecycleTracker,
+        backgroundMonitorStarter = backgroundMonitorStarter,
         observeGenNotifEnabled = observeGenNotifEnabled,
     )
 

--- a/feature/feature-comfyui/src/commonMain/kotlin/com/riox432/civitdeck/feature/comfyui/presentation/GenerationExecutionDelegate.kt
+++ b/feature/feature-comfyui/src/commonMain/kotlin/com/riox432/civitdeck/feature/comfyui/presentation/GenerationExecutionDelegate.kt
@@ -6,6 +6,7 @@ import com.riox432.civitdeck.domain.model.ComfyUIGenerationParams
 import com.riox432.civitdeck.domain.model.GenerationStatus
 import com.riox432.civitdeck.domain.repository.ComfyUIConnectionRepository
 import com.riox432.civitdeck.domain.service.AppLifecycleTracker
+import com.riox432.civitdeck.domain.service.BackgroundMonitorStarter
 import com.riox432.civitdeck.domain.service.GenerationNotificationService
 import com.riox432.civitdeck.domain.usecase.ObserveGenerationNotificationsEnabledUseCase
 import com.riox432.civitdeck.feature.comfyui.domain.usecase.InterruptComfyUIGenerationUseCase
@@ -41,6 +42,7 @@ internal class GenerationExecutionDelegate(
     private val repository: ComfyUIConnectionRepository,
     private val notificationService: GenerationNotificationService,
     private val lifecycleTracker: AppLifecycleTracker,
+    private val backgroundMonitorStarter: BackgroundMonitorStarter,
     observeGenNotifEnabled: ObserveGenerationNotificationsEnabledUseCase,
 ) {
     private var progressJob: Job? = null
@@ -77,6 +79,11 @@ internal class GenerationExecutionDelegate(
             uiState.update { it.copy(generationStatus = GenerationStatus.Running) }
             val connection = repository.getActiveConnection()
             if (connection != null) {
+                backgroundMonitorStarter.startMonitoring(
+                    promptId,
+                    connection.baseUrl,
+                    connection.wsScheme,
+                )
                 startWebSocketProgress(promptId, connection)
             } else {
                 pollForResult(promptId)
@@ -86,6 +93,7 @@ internal class GenerationExecutionDelegate(
 
     fun onInterrupt() {
         progressJob?.cancel()
+        backgroundMonitorStarter.stopMonitoring()
         launchWithErrorHandling(
             tag = "Interrupt failed",
             onError = { e -> uiState.update { it.copy(error = e.message) } },
@@ -144,6 +152,7 @@ internal class GenerationExecutionDelegate(
     }
 
     private suspend fun fetchFinalResult(promptId: String) {
+        backgroundMonitorStarter.stopMonitoring()
         val onError = { e: Exception ->
             notifyErrorIfNeeded(promptId, e.message ?: "Unknown error")
             uiState.update { it.copy(generationStatus = GenerationStatus.Error, error = e.message) }

--- a/shared/src/androidMain/kotlin/com/riox432/civitdeck/di/PlatformModule.android.kt
+++ b/shared/src/androidMain/kotlin/com/riox432/civitdeck/di/PlatformModule.android.kt
@@ -4,6 +4,7 @@ import com.riox432.civitdeck.data.local.AndroidNetworkMonitor
 import com.riox432.civitdeck.data.local.getDatabaseBuilder
 import com.riox432.civitdeck.domain.repository.NetworkRepository
 import com.riox432.civitdeck.domain.service.AppLifecycleTracker
+import com.riox432.civitdeck.domain.service.BackgroundMonitorStarter
 import com.riox432.civitdeck.domain.service.GenerationNotificationService
 import org.koin.core.module.Module
 import org.koin.dsl.module
@@ -13,4 +14,5 @@ actual val platformModule: Module = module {
     single<NetworkRepository> { AndroidNetworkMonitor(get()) }
     single { GenerationNotificationService(get()) }
     single { AppLifecycleTracker() }
+    single { BackgroundMonitorStarter(get()) }
 }

--- a/shared/src/iosMain/kotlin/com/riox432/civitdeck/di/PlatformModule.ios.kt
+++ b/shared/src/iosMain/kotlin/com/riox432/civitdeck/di/PlatformModule.ios.kt
@@ -5,6 +5,7 @@ import com.riox432.civitdeck.data.local.getDatabaseBuilder
 import com.riox432.civitdeck.domain.download.DownloadScheduler
 import com.riox432.civitdeck.domain.repository.NetworkRepository
 import com.riox432.civitdeck.domain.service.AppLifecycleTracker
+import com.riox432.civitdeck.domain.service.BackgroundMonitorStarter
 import com.riox432.civitdeck.domain.service.GenerationNotificationService
 import com.riox432.civitdeck.download.IosDownloadScheduler
 import org.koin.core.module.Module
@@ -16,4 +17,5 @@ actual val platformModule: Module = module {
     single<DownloadScheduler> { IosDownloadScheduler() }
     single { GenerationNotificationService() }
     single { AppLifecycleTracker() }
+    single { BackgroundMonitorStarter() }
 }

--- a/shared/src/jvmMain/kotlin/com/riox432/civitdeck/di/PlatformModule.jvm.kt
+++ b/shared/src/jvmMain/kotlin/com/riox432/civitdeck/di/PlatformModule.jvm.kt
@@ -5,6 +5,7 @@ import com.riox432.civitdeck.data.local.getDatabaseBuilder
 import com.riox432.civitdeck.domain.download.DownloadScheduler
 import com.riox432.civitdeck.domain.repository.NetworkRepository
 import com.riox432.civitdeck.domain.service.AppLifecycleTracker
+import com.riox432.civitdeck.domain.service.BackgroundMonitorStarter
 import com.riox432.civitdeck.domain.service.GenerationNotificationService
 import com.riox432.civitdeck.download.DesktopDownloadScheduler
 import org.koin.core.module.Module
@@ -16,4 +17,5 @@ actual val platformModule: Module = module {
     single<DownloadScheduler> { DesktopDownloadScheduler() }
     single { GenerationNotificationService() }
     single { AppLifecycleTracker() }
+    single { BackgroundMonitorStarter() }
 }


### PR DESCRIPTION
## Summary

- Add `GenerationMonitorService` Android foreground service that maintains a WebSocket connection to ComfyUI when the app is backgrounded, tracking generation progress with a persistent notification and firing completion/error notifications
- Add `BackgroundMonitorStarter` expect/actual interface in `core-domain` — Android actual starts/stops the foreground service via Intent, iOS and JVM actuals are no-ops
- Wire `BackgroundMonitorStarter` into `GenerationExecutionDelegate` to automatically start monitoring after generation submission and stop on completion/interrupt

Closes #889

## Changes

### New files
- `core/core-domain/.../service/BackgroundMonitorStarter.kt` — expect class with `startMonitoring()` / `stopMonitoring()`
- `core/core-domain/.../service/BackgroundMonitorStarter.android.kt` — starts/stops `GenerationMonitorService` via explicit Intent
- `core/core-domain/.../service/BackgroundMonitorStarter.ios.kt` — no-op (iOS cannot maintain background WebSocket)
- `core/core-domain/.../service/BackgroundMonitorStarter.jvm.kt` — no-op (Desktop is always foreground)
- `androidApp/.../service/GenerationMonitorService.kt` — foreground service with `FOREGROUND_SERVICE_TYPE_SPECIAL_USE`, persistent progress notification, WebSocket collection, auto-stop on terminal message

### Modified files
- `AndroidManifest.xml` — register service with `specialUse` type and `PROPERTY_SPECIAL_USE_FGS_SUBTYPE`, add `FOREGROUND_SERVICE_SPECIAL_USE` permission
- `GenerationExecutionDelegate.kt` — start monitor after generation submission, stop on completion/interrupt
- `ComfyUIGenerationViewModel.kt` — pass `BackgroundMonitorStarter` to delegate
- `ComfyUIModule.kt` — add extra `get()` for new VM parameter
- `PlatformModule.{android,ios,jvm}.kt` — register `BackgroundMonitorStarter` in Koin
- `strings.xml` — add foreground notification strings

## Test plan
- [ ] Submit a generation, background the app, verify persistent notification appears with progress updates
- [ ] Verify completion notification fires when generation finishes while app is backgrounded
- [ ] Verify service stops itself after completion (notification dismissed)
- [ ] Verify interrupt from the app stops the foreground service
- [ ] Verify Desktop build still compiles (`./gradlew :desktopApp:compileKotlinJvm`)
- [ ] Verify detekt passes