### PR TITLE
Add ntfy.sh integration for cross-platform generation notifications

### DIFF
--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/comfyui/ComfyUISettingsScreen.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/comfyui/ComfyUISettingsScreen.kt
@@ -106,6 +106,7 @@ fun ComfyUISettingsScreen(
                 onScanLan = viewModel::onScanLan,
                 onSelectDiscovered = viewModel::onSelectDiscoveredServer,
                 onDismissSuggestion = viewModel::dismissSuggestion,
+                onTestNtfy = viewModel::onTestNtfy,
             )
         }
     }
@@ -113,7 +114,9 @@ fun ComfyUISettingsScreen(
     if (state.showAddDialog) {
         AddConnectionDialog(
             editing = state.editingConnection,
-            onSave = viewModel::onSaveConnection,
+            onSave = { name, hostname, port, https, selfSigned, ntfyUrl, ntfyTopic ->
+                viewModel.onSaveConnection(name, hostname, port, https, selfSigned, ntfyUrl, ntfyTopic)
+            },
             onDismiss = viewModel::onDismissDialog,
         )
     }
@@ -131,6 +134,7 @@ private fun LazyListScope.settingsItems(
     onScanLan: () -> Unit,
     onSelectDiscovered: (DiscoveredServer) -> Unit,
     onDismissSuggestion: (String) -> Unit,
+    onTestNtfy: () -> Unit,
 ) {
     item { StatusSection(state, onTestConnection) }
 
@@ -150,6 +154,9 @@ private fun LazyListScope.settingsItems(
             )
         }
     }
+
+    // ntfy push notifications section
+    item { NtfySection(state, onTestNtfy) }
 
     // Scan LAN section
     item { ScanLanSection(state, onScanLan, onSelectDiscovered) }
@@ -372,6 +379,105 @@ private fun SuggestionCard(
 }
 
 @Composable
+private fun NtfySection(
+    state: ComfyUISettingsUiState,
+    onTestNtfy: () -> Unit,
+) {
+    Card(modifier = Modifier.fillMaxWidth()) {
+        Column(modifier = Modifier.padding(Spacing.md)) {
+            NtfySectionHeader(state)
+            Spacer(modifier = Modifier.height(Spacing.sm))
+            NtfySectionContent(state, onTestNtfy)
+        }
+    }
+}
+
+@Composable
+private fun NtfySectionHeader(state: ComfyUISettingsUiState) {
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Text(
+            stringResource(R.string.ntfy_section_title),
+            style = MaterialTheme.typography.titleSmall,
+        )
+        Text(
+            text = if (state.isNtfySubscribed) {
+                stringResource(R.string.ntfy_status_subscribed)
+            } else {
+                stringResource(R.string.ntfy_status_not_configured)
+            },
+            style = MaterialTheme.typography.labelSmall,
+            color = if (state.isNtfySubscribed) {
+                MaterialTheme.colorScheme.primary
+            } else {
+                MaterialTheme.colorScheme.onSurfaceVariant
+            },
+        )
+    }
+}
+
+@Composable
+private fun NtfySectionContent(
+    state: ComfyUISettingsUiState,
+    onTestNtfy: () -> Unit,
+) {
+    val active = state.activeConnection
+    if (active?.isNtfyConfigured == true) {
+        Text(
+            "${active.resolvedNtfyServerUrl}/${active.ntfyTopic}",
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        Spacer(modifier = Modifier.height(Spacing.sm))
+        NtfyTestButton(state, onTestNtfy)
+    } else {
+        Text(
+            stringResource(R.string.ntfy_setup_guide),
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+    }
+}
+
+@Composable
+private fun NtfyTestButton(
+    state: ComfyUISettingsUiState,
+    onTestNtfy: () -> Unit,
+) {
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(Spacing.sm),
+    ) {
+        OutlinedButton(
+            onClick = onTestNtfy,
+            enabled = !state.isNtfyTestSending,
+        ) {
+            if (state.isNtfyTestSending) {
+                CircularProgressIndicator(modifier = Modifier.size(Spacing.lg))
+            } else {
+                Text(stringResource(R.string.ntfy_test_notification))
+            }
+        }
+        state.ntfyTestResult?.let { success ->
+            Text(
+                text = stringResource(
+                    if (success) R.string.ntfy_test_success else R.string.ntfy_test_failed,
+                ),
+                style = MaterialTheme.typography.bodySmall,
+                color = if (success) {
+                    MaterialTheme.colorScheme.primary
+                } else {
+                    MaterialTheme.colorScheme.error
+                },
+            )
+        }
+    }
+}
+
+@Composable
 private fun ScanLanSection(
     state: ComfyUISettingsUiState,
     onScan: () -> Unit,
@@ -465,9 +571,18 @@ private fun ConnectionCard(
 }
 
 @Composable
+@Suppress("LongMethod")
 private fun AddConnectionDialog(
     editing: ComfyUIConnection?,
-    onSave: (name: String, hostname: String, port: Int, useHttps: Boolean, acceptSelfSigned: Boolean) -> Unit,
+    onSave: (
+        name: String,
+        hostname: String,
+        port: Int,
+        useHttps: Boolean,
+        acceptSelfSigned: Boolean,
+        ntfyServerUrl: String?,
+        ntfyTopic: String?,
+    ) -> Unit,
     onDismiss: () -> Unit,
 ) {
     var name by rememberSaveable { mutableStateOf(editing?.name ?: "") }
@@ -475,6 +590,10 @@ private fun AddConnectionDialog(
     var portText by rememberSaveable { mutableStateOf(editing?.port?.toString() ?: "8188") }
     var useHttps by rememberSaveable { mutableStateOf(editing?.useHttps ?: false) }
     var acceptSelfSigned by rememberSaveable { mutableStateOf(editing?.acceptSelfSigned ?: false) }
+    var ntfyServerUrl by rememberSaveable {
+        mutableStateOf(editing?.ntfyServerUrl ?: "")
+    }
+    var ntfyTopic by rememberSaveable { mutableStateOf(editing?.ntfyTopic ?: "") }
 
     AlertDialog(
         onDismissRequest = onDismiss,
@@ -497,13 +616,28 @@ private fun AddConnectionDialog(
                 onHttpsChange = { useHttps = it },
                 acceptSelfSigned = acceptSelfSigned,
                 onSelfSignedChange = { acceptSelfSigned = it },
+                ntfyServerUrl = ntfyServerUrl,
+                onNtfyServerUrlChange = { ntfyServerUrl = it },
+                ntfyTopic = ntfyTopic,
+                onNtfyTopicChange = { ntfyTopic = it },
+                onGenerateNtfyTopic = {
+                    ntfyTopic = "civitdeck-${java.util.UUID.randomUUID().toString().take(TOPIC_ID_LENGTH)}"
+                },
             )
         },
         confirmButton = {
             TextButton(
                 onClick = {
                     val port = portText.toIntOrNull() ?: ComfyUIConnection.DEFAULT_COMFYUI_PORT
-                    onSave(name.ifBlank { hostname }, hostname, port, useHttps, acceptSelfSigned)
+                    onSave(
+                        name.ifBlank { hostname },
+                        hostname,
+                        port,
+                        useHttps,
+                        acceptSelfSigned,
+                        ntfyServerUrl.ifBlank { null },
+                        ntfyTopic.ifBlank { null },
+                    )
                 },
                 enabled = hostname.isNotBlank(),
             ) { Text(stringResource(R.string.action_save)) }
@@ -511,6 +645,8 @@ private fun AddConnectionDialog(
         dismissButton = { TextButton(onClick = onDismiss) { Text(stringResource(R.string.action_cancel)) } },
     )
 }
+
+private const val TOPIC_ID_LENGTH = 8
 
 @Composable
 @Suppress("LongParameterList")
@@ -525,50 +661,118 @@ private fun AddConnectionDialogContent(
     onHttpsChange: (Boolean) -> Unit,
     acceptSelfSigned: Boolean,
     onSelfSignedChange: (Boolean) -> Unit,
+    ntfyServerUrl: String,
+    onNtfyServerUrlChange: (String) -> Unit,
+    ntfyTopic: String,
+    onNtfyTopicChange: (String) -> Unit,
+    onGenerateNtfyTopic: () -> Unit,
 ) {
     Column(verticalArrangement = Arrangement.spacedBy(Spacing.sm)) {
-        OutlinedTextField(
-            value = name,
-            onValueChange = onNameChange,
-            label = { Text(stringResource(R.string.label_name)) },
-            placeholder = { Text(stringResource(R.string.comfyui_name_placeholder)) },
-            singleLine = true,
-            modifier = Modifier.fillMaxWidth(),
-        )
-        OutlinedTextField(
-            value = hostname,
-            onValueChange = onHostnameChange,
-            label = { Text(stringResource(R.string.comfyui_hostname_label)) },
-            placeholder = { Text(stringResource(R.string.comfyui_hostname_placeholder)) },
-            singleLine = true,
-            modifier = Modifier.fillMaxWidth(),
-        )
-        OutlinedTextField(
-            value = portText,
-            onValueChange = onPortChange,
-            label = { Text(stringResource(R.string.label_port)) },
-            singleLine = true,
-            modifier = Modifier.fillMaxWidth(),
-        )
+        ConnectionFields(name, onNameChange, hostname, onHostnameChange, portText, onPortChange)
+        SecurityToggles(useHttps, onHttpsChange, acceptSelfSigned, onSelfSignedChange)
+        NtfyFields(ntfyServerUrl, onNtfyServerUrlChange, ntfyTopic, onNtfyTopicChange, onGenerateNtfyTopic)
+    }
+}
+
+@Composable
+@Suppress("LongParameterList")
+private fun ConnectionFields(
+    name: String,
+    onNameChange: (String) -> Unit,
+    hostname: String,
+    onHostnameChange: (String) -> Unit,
+    portText: String,
+    onPortChange: (String) -> Unit,
+) {
+    OutlinedTextField(
+        value = name,
+        onValueChange = onNameChange,
+        label = { Text(stringResource(R.string.label_name)) },
+        placeholder = { Text(stringResource(R.string.comfyui_name_placeholder)) },
+        singleLine = true,
+        modifier = Modifier.fillMaxWidth(),
+    )
+    OutlinedTextField(
+        value = hostname,
+        onValueChange = onHostnameChange,
+        label = { Text(stringResource(R.string.comfyui_hostname_label)) },
+        placeholder = { Text(stringResource(R.string.comfyui_hostname_placeholder)) },
+        singleLine = true,
+        modifier = Modifier.fillMaxWidth(),
+    )
+    OutlinedTextField(
+        value = portText,
+        onValueChange = onPortChange,
+        label = { Text(stringResource(R.string.label_port)) },
+        singleLine = true,
+        modifier = Modifier.fillMaxWidth(),
+    )
+}
+
+@Composable
+private fun SecurityToggles(
+    useHttps: Boolean,
+    onHttpsChange: (Boolean) -> Unit,
+    acceptSelfSigned: Boolean,
+    onSelfSignedChange: (Boolean) -> Unit,
+) {
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Text(stringResource(R.string.comfyui_use_https), style = MaterialTheme.typography.bodyMedium)
+        Switch(checked = useHttps, onCheckedChange = onHttpsChange)
+    }
+    if (useHttps) {
         Row(
             modifier = Modifier.fillMaxWidth(),
             horizontalArrangement = Arrangement.SpaceBetween,
             verticalAlignment = Alignment.CenterVertically,
         ) {
-            Text(stringResource(R.string.comfyui_use_https), style = MaterialTheme.typography.bodyMedium)
-            Switch(checked = useHttps, onCheckedChange = onHttpsChange)
-        }
-        if (useHttps) {
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.SpaceBetween,
-                verticalAlignment = Alignment.CenterVertically,
-            ) {
-                Text(stringResource(R.string.comfyui_accept_self_signed), style = MaterialTheme.typography.bodySmall)
-                Switch(checked = acceptSelfSigned, onCheckedChange = onSelfSignedChange)
-            }
+            Text(stringResource(R.string.comfyui_accept_self_signed), style = MaterialTheme.typography.bodySmall)
+            Switch(checked = acceptSelfSigned, onCheckedChange = onSelfSignedChange)
         }
     }
+}
+
+@Composable
+private fun NtfyFields(
+    ntfyServerUrl: String,
+    onNtfyServerUrlChange: (String) -> Unit,
+    ntfyTopic: String,
+    onNtfyTopicChange: (String) -> Unit,
+    onGenerateNtfyTopic: () -> Unit,
+) {
+    Spacer(modifier = Modifier.height(Spacing.sm))
+    Text(
+        stringResource(R.string.ntfy_section_title),
+        style = MaterialTheme.typography.titleSmall,
+    )
+    OutlinedTextField(
+        value = ntfyServerUrl,
+        onValueChange = onNtfyServerUrlChange,
+        label = { Text(stringResource(R.string.ntfy_server_url_label)) },
+        placeholder = { Text(stringResource(R.string.ntfy_server_url_placeholder)) },
+        singleLine = true,
+        modifier = Modifier.fillMaxWidth(),
+    )
+    OutlinedTextField(
+        value = ntfyTopic,
+        onValueChange = onNtfyTopicChange,
+        label = { Text(stringResource(R.string.ntfy_topic_label)) },
+        placeholder = { Text(stringResource(R.string.ntfy_topic_placeholder)) },
+        singleLine = true,
+        modifier = Modifier.fillMaxWidth(),
+    )
+    TextButton(onClick = onGenerateNtfyTopic) {
+        Text(stringResource(R.string.ntfy_generate_topic))
+    }
+    Text(
+        stringResource(R.string.ntfy_setup_guide),
+        style = MaterialTheme.typography.bodySmall,
+        color = MaterialTheme.colorScheme.onSurfaceVariant,
+    )
 }
 
 @Composable

--- a/androidApp/src/main/res/values/strings.xml
+++ b/androidApp/src/main/res/values/strings.xml
@@ -370,6 +370,21 @@
     <string name="comfyui_pytorch_version">PyTorch Version</string>
     <string name="comfyui_os">OS</string>
 
+    <!-- ntfy.sh notifications -->
+    <string name="ntfy_section_title">Push Notifications (ntfy)</string>
+    <string name="ntfy_server_url_label">ntfy Server URL</string>
+    <string name="ntfy_server_url_placeholder">https://ntfy.sh</string>
+    <string name="ntfy_topic_label">Topic</string>
+    <string name="ntfy_topic_placeholder">my-comfyui-topic</string>
+    <string name="ntfy_generate_topic">Generate Random Topic</string>
+    <string name="ntfy_test_notification">Test Notification</string>
+    <string name="ntfy_test_sending">Sending…</string>
+    <string name="ntfy_test_success">Test notification sent successfully</string>
+    <string name="ntfy_test_failed">Failed to send test notification</string>
+    <string name="ntfy_status_subscribed">Subscribed</string>
+    <string name="ntfy_status_not_configured">Not configured</string>
+    <string name="ntfy_setup_guide">Install ComfyUI-ntfy custom node on your server and set the same topic there. Notifications will be received even when the app is closed.</string>
+
     <!-- SD WebUI -->
     <string name="sdwebui_title">SD WebUI</string>
     <string name="sdwebui_open_generator">Open Generator</string>

--- a/core/core-database/schemas/com.riox432.civitdeck.data.local.CivitDeckDatabase/46.json
+++ b/core/core-database/schemas/com.riox432.civitdeck.data.local.CivitDeckDatabase/46.json
@@ -1,0 +1,2034 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 46,
+    "identityHash": "513a16be8d48e3bcac71cb48ed69b2e3",
+    "entities": [
+      {
+        "tableName": "collections",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL, `isDefault` INTEGER NOT NULL, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isDefault",
+            "columnName": "isDefault",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "collection_model_entries",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`collectionId` INTEGER NOT NULL, `modelId` INTEGER NOT NULL, `name` TEXT NOT NULL, `type` TEXT NOT NULL, `nsfw` INTEGER NOT NULL, `thumbnailUrl` TEXT, `creatorName` TEXT, `downloadCount` INTEGER NOT NULL, `favoriteCount` INTEGER NOT NULL, `rating` REAL NOT NULL, `addedAt` INTEGER NOT NULL, PRIMARY KEY(`collectionId`, `modelId`), FOREIGN KEY(`collectionId`) REFERENCES `collections`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "collectionId",
+            "columnName": "collectionId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "modelId",
+            "columnName": "modelId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "nsfw",
+            "columnName": "nsfw",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "thumbnailUrl",
+            "columnName": "thumbnailUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "creatorName",
+            "columnName": "creatorName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "downloadCount",
+            "columnName": "downloadCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "favoriteCount",
+            "columnName": "favoriteCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "rating",
+            "columnName": "rating",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "addedAt",
+            "columnName": "addedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "collectionId",
+            "modelId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_collection_model_entries_modelId",
+            "unique": false,
+            "columnNames": [
+              "modelId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_collection_model_entries_modelId` ON `${TABLE_NAME}` (`modelId`)"
+          },
+          {
+            "name": "index_collection_model_entries_collectionId",
+            "unique": false,
+            "columnNames": [
+              "collectionId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_collection_model_entries_collectionId` ON `${TABLE_NAME}` (`collectionId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "collections",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "collectionId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "cached_api_responses",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`cacheKey` TEXT NOT NULL, `responseJson` TEXT NOT NULL, `cachedAt` INTEGER NOT NULL, `isOfflinePinned` INTEGER NOT NULL, PRIMARY KEY(`cacheKey`))",
+        "fields": [
+          {
+            "fieldPath": "cacheKey",
+            "columnName": "cacheKey",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "responseJson",
+            "columnName": "responseJson",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cachedAt",
+            "columnName": "cachedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isOfflinePinned",
+            "columnName": "isOfflinePinned",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "cacheKey"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_cached_api_responses_cachedAt",
+            "unique": false,
+            "columnNames": [
+              "cachedAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_cached_api_responses_cachedAt` ON `${TABLE_NAME}` (`cachedAt`)"
+          }
+        ]
+      },
+      {
+        "tableName": "user_preferences",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `nsfwFilterLevel` TEXT NOT NULL, `defaultSortOrder` TEXT NOT NULL, `defaultTimePeriod` TEXT NOT NULL, `gridColumns` INTEGER NOT NULL, `apiKey` TEXT, `powerUserMode` INTEGER NOT NULL, `notificationsEnabled` INTEGER NOT NULL, `pollingIntervalMinutes` INTEGER NOT NULL, `nsfwBlurSoft` INTEGER NOT NULL, `nsfwBlurMature` INTEGER NOT NULL, `nsfwBlurExplicit` INTEGER NOT NULL, `offlineCacheEnabled` INTEGER NOT NULL, `cacheSizeLimitMb` INTEGER NOT NULL, `accentColor` TEXT NOT NULL, `amoledDarkMode` INTEGER NOT NULL, `seenTutorialVersion` INTEGER NOT NULL, `civitaiLinkKey` TEXT, `themeMode` TEXT NOT NULL, `customNavShortcuts` TEXT NOT NULL, `feedQualityThreshold` INTEGER NOT NULL, `generationNotificationsEnabled` INTEGER NOT NULL, `autoUpdateCheckEnabled` INTEGER NOT NULL, `lastUpdateCheckTimestamp` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "nsfwFilterLevel",
+            "columnName": "nsfwFilterLevel",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "defaultSortOrder",
+            "columnName": "defaultSortOrder",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "defaultTimePeriod",
+            "columnName": "defaultTimePeriod",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "gridColumns",
+            "columnName": "gridColumns",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "apiKey",
+            "columnName": "apiKey",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "powerUserMode",
+            "columnName": "powerUserMode",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "notificationsEnabled",
+            "columnName": "notificationsEnabled",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "pollingIntervalMinutes",
+            "columnName": "pollingIntervalMinutes",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "nsfwBlurSoft",
+            "columnName": "nsfwBlurSoft",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "nsfwBlurMature",
+            "columnName": "nsfwBlurMature",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "nsfwBlurExplicit",
+            "columnName": "nsfwBlurExplicit",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "offlineCacheEnabled",
+            "columnName": "offlineCacheEnabled",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cacheSizeLimitMb",
+            "columnName": "cacheSizeLimitMb",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "accentColor",
+            "columnName": "accentColor",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "amoledDarkMode",
+            "columnName": "amoledDarkMode",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "seenTutorialVersion",
+            "columnName": "seenTutorialVersion",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "civitaiLinkKey",
+            "columnName": "civitaiLinkKey",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "themeMode",
+            "columnName": "themeMode",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "customNavShortcuts",
+            "columnName": "customNavShortcuts",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "feedQualityThreshold",
+            "columnName": "feedQualityThreshold",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "generationNotificationsEnabled",
+            "columnName": "generationNotificationsEnabled",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "autoUpdateCheckEnabled",
+            "columnName": "autoUpdateCheckEnabled",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastUpdateCheckTimestamp",
+            "columnName": "lastUpdateCheckTimestamp",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "saved_prompts",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `prompt` TEXT NOT NULL, `negativePrompt` TEXT, `sampler` TEXT, `steps` INTEGER, `cfgScale` REAL, `seed` INTEGER, `modelName` TEXT, `size` TEXT, `sourceImageUrl` TEXT, `savedAt` INTEGER NOT NULL, `isTemplate` INTEGER NOT NULL DEFAULT 0, `templateName` TEXT, `autoSaved` INTEGER NOT NULL DEFAULT 0, `templateVariables` TEXT, `templateType` TEXT, `templateMetadata` TEXT)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "prompt",
+            "columnName": "prompt",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "negativePrompt",
+            "columnName": "negativePrompt",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "sampler",
+            "columnName": "sampler",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "steps",
+            "columnName": "steps",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "cfgScale",
+            "columnName": "cfgScale",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "seed",
+            "columnName": "seed",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "modelName",
+            "columnName": "modelName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "size",
+            "columnName": "size",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "sourceImageUrl",
+            "columnName": "sourceImageUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "savedAt",
+            "columnName": "savedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isTemplate",
+            "columnName": "isTemplate",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "templateName",
+            "columnName": "templateName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "autoSaved",
+            "columnName": "autoSaved",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "templateVariables",
+            "columnName": "templateVariables",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "templateType",
+            "columnName": "templateType",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "templateMetadata",
+            "columnName": "templateMetadata",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "search_history",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `query` TEXT NOT NULL, `searchedAt` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "query",
+            "columnName": "query",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "searchedAt",
+            "columnName": "searchedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "browsing_history",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `modelId` INTEGER NOT NULL, `modelName` TEXT NOT NULL, `modelType` TEXT NOT NULL, `creatorName` TEXT, `thumbnailUrl` TEXT, `tags` TEXT NOT NULL, `viewedAt` INTEGER NOT NULL, `durationMs` INTEGER, `interactionType` TEXT)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "modelId",
+            "columnName": "modelId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "modelName",
+            "columnName": "modelName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "modelType",
+            "columnName": "modelType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "creatorName",
+            "columnName": "creatorName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "thumbnailUrl",
+            "columnName": "thumbnailUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "tags",
+            "columnName": "tags",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "viewedAt",
+            "columnName": "viewedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "durationMs",
+            "columnName": "durationMs",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "interactionType",
+            "columnName": "interactionType",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_browsing_history_modelId",
+            "unique": false,
+            "columnNames": [
+              "modelId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_browsing_history_modelId` ON `${TABLE_NAME}` (`modelId`)"
+          },
+          {
+            "name": "index_browsing_history_viewedAt",
+            "unique": false,
+            "columnNames": [
+              "viewedAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_browsing_history_viewedAt` ON `${TABLE_NAME}` (`viewedAt`)"
+          }
+        ]
+      },
+      {
+        "tableName": "excluded_tags",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`tag` TEXT NOT NULL, `addedAt` INTEGER NOT NULL, PRIMARY KEY(`tag`))",
+        "fields": [
+          {
+            "fieldPath": "tag",
+            "columnName": "tag",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "addedAt",
+            "columnName": "addedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "tag"
+          ]
+        }
+      },
+      {
+        "tableName": "hidden_models",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`modelId` INTEGER NOT NULL, `modelName` TEXT NOT NULL, `hiddenAt` INTEGER NOT NULL, PRIMARY KEY(`modelId`))",
+        "fields": [
+          {
+            "fieldPath": "modelId",
+            "columnName": "modelId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "modelName",
+            "columnName": "modelName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "hiddenAt",
+            "columnName": "hiddenAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "modelId"
+          ]
+        }
+      },
+      {
+        "tableName": "model_directories",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `path` TEXT NOT NULL, `label` TEXT, `lastScannedAt` INTEGER, `isEnabled` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "path",
+            "columnName": "path",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "label",
+            "columnName": "label",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "lastScannedAt",
+            "columnName": "lastScannedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "isEnabled",
+            "columnName": "isEnabled",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "local_model_files",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `directoryId` INTEGER NOT NULL, `filePath` TEXT NOT NULL, `fileName` TEXT NOT NULL, `sha256Hash` TEXT NOT NULL, `sizeBytes` INTEGER NOT NULL, `scannedAt` INTEGER NOT NULL, `matchedModelId` INTEGER, `matchedModelName` TEXT, `matchedVersionId` INTEGER, `matchedVersionName` TEXT, `latestVersionId` INTEGER, `hasUpdate` INTEGER NOT NULL, FOREIGN KEY(`directoryId`) REFERENCES `model_directories`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "directoryId",
+            "columnName": "directoryId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "filePath",
+            "columnName": "filePath",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fileName",
+            "columnName": "fileName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sha256Hash",
+            "columnName": "sha256Hash",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sizeBytes",
+            "columnName": "sizeBytes",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "scannedAt",
+            "columnName": "scannedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "matchedModelId",
+            "columnName": "matchedModelId",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "matchedModelName",
+            "columnName": "matchedModelName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "matchedVersionId",
+            "columnName": "matchedVersionId",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "matchedVersionName",
+            "columnName": "matchedVersionName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "latestVersionId",
+            "columnName": "latestVersionId",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "hasUpdate",
+            "columnName": "hasUpdate",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_local_model_files_directoryId",
+            "unique": false,
+            "columnNames": [
+              "directoryId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_local_model_files_directoryId` ON `${TABLE_NAME}` (`directoryId`)"
+          },
+          {
+            "name": "index_local_model_files_sha256Hash",
+            "unique": false,
+            "columnNames": [
+              "sha256Hash"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_local_model_files_sha256Hash` ON `${TABLE_NAME}` (`sha256Hash`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "model_directories",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "directoryId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "model_version_checkpoints",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`modelId` INTEGER NOT NULL, `lastKnownVersionId` INTEGER NOT NULL, `lastCheckedAt` INTEGER NOT NULL, PRIMARY KEY(`modelId`))",
+        "fields": [
+          {
+            "fieldPath": "modelId",
+            "columnName": "modelId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastKnownVersionId",
+            "columnName": "lastKnownVersionId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastCheckedAt",
+            "columnName": "lastCheckedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "modelId"
+          ]
+        }
+      },
+      {
+        "tableName": "comfyui_connections",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL, `hostname` TEXT NOT NULL, `port` INTEGER NOT NULL, `isActive` INTEGER NOT NULL, `lastTestedAt` INTEGER, `lastTestSuccess` INTEGER, `createdAt` INTEGER NOT NULL, `useHttps` INTEGER NOT NULL, `acceptSelfSigned` INTEGER NOT NULL, `ntfyServerUrl` TEXT, `ntfyTopic` TEXT)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "hostname",
+            "columnName": "hostname",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "port",
+            "columnName": "port",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isActive",
+            "columnName": "isActive",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastTestedAt",
+            "columnName": "lastTestedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "lastTestSuccess",
+            "columnName": "lastTestSuccess",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "useHttps",
+            "columnName": "useHttps",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "acceptSelfSigned",
+            "columnName": "acceptSelfSigned",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ntfyServerUrl",
+            "columnName": "ntfyServerUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "ntfyTopic",
+            "columnName": "ntfyTopic",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "sdwebui_connections",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL, `hostname` TEXT NOT NULL, `port` INTEGER NOT NULL, `isActive` INTEGER NOT NULL, `lastTestedAt` INTEGER, `lastTestSuccess` INTEGER, `createdAt` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "hostname",
+            "columnName": "hostname",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "port",
+            "columnName": "port",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isActive",
+            "columnName": "isActive",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastTestedAt",
+            "columnName": "lastTestedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "lastTestSuccess",
+            "columnName": "lastTestSuccess",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "dataset_collections",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL, `description` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "dataset_images",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `datasetId` INTEGER NOT NULL, `imageUrl` TEXT NOT NULL, `sourceType` TEXT NOT NULL, `trainable` INTEGER NOT NULL, `addedAt` INTEGER NOT NULL, `licenseNote` TEXT, `pHash` TEXT, `excluded` INTEGER NOT NULL, `width` INTEGER, `height` INTEGER, FOREIGN KEY(`datasetId`) REFERENCES `dataset_collections`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "datasetId",
+            "columnName": "datasetId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "imageUrl",
+            "columnName": "imageUrl",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceType",
+            "columnName": "sourceType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "trainable",
+            "columnName": "trainable",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "addedAt",
+            "columnName": "addedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "licenseNote",
+            "columnName": "licenseNote",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "pHash",
+            "columnName": "pHash",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "excluded",
+            "columnName": "excluded",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "width",
+            "columnName": "width",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "height",
+            "columnName": "height",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_dataset_images_datasetId",
+            "unique": false,
+            "columnNames": [
+              "datasetId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_dataset_images_datasetId` ON `${TABLE_NAME}` (`datasetId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "dataset_collections",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "datasetId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "image_tags",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `datasetImageId` INTEGER NOT NULL, `tag` TEXT NOT NULL, FOREIGN KEY(`datasetImageId`) REFERENCES `dataset_images`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "datasetImageId",
+            "columnName": "datasetImageId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "tag",
+            "columnName": "tag",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_image_tags_datasetImageId",
+            "unique": false,
+            "columnNames": [
+              "datasetImageId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_image_tags_datasetImageId` ON `${TABLE_NAME}` (`datasetImageId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "dataset_images",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "datasetImageId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "captions",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`datasetImageId` INTEGER NOT NULL, `text` TEXT NOT NULL, PRIMARY KEY(`datasetImageId`), FOREIGN KEY(`datasetImageId`) REFERENCES `dataset_images`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "datasetImageId",
+            "columnName": "datasetImageId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "text",
+            "columnName": "text",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "datasetImageId"
+          ]
+        },
+        "foreignKeys": [
+          {
+            "table": "dataset_images",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "datasetImageId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "saved_search_filters",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL, `query` TEXT NOT NULL, `selectedType` TEXT, `selectedSort` TEXT NOT NULL, `selectedPeriod` TEXT NOT NULL, `selectedBaseModels` TEXT NOT NULL, `nsfwFilterLevel` TEXT NOT NULL, `isFreshFindEnabled` INTEGER NOT NULL, `excludedTags` TEXT NOT NULL, `includedTags` TEXT NOT NULL, `selectedSources` TEXT NOT NULL, `savedAt` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "query",
+            "columnName": "query",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "selectedType",
+            "columnName": "selectedType",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "selectedSort",
+            "columnName": "selectedSort",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "selectedPeriod",
+            "columnName": "selectedPeriod",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "selectedBaseModels",
+            "columnName": "selectedBaseModels",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "nsfwFilterLevel",
+            "columnName": "nsfwFilterLevel",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isFreshFindEnabled",
+            "columnName": "isFreshFindEnabled",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "excludedTags",
+            "columnName": "excludedTags",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "includedTags",
+            "columnName": "includedTags",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "selectedSources",
+            "columnName": "selectedSources",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "savedAt",
+            "columnName": "savedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "external_server_configs",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL, `baseUrl` TEXT NOT NULL, `apiKey` TEXT NOT NULL, `isActive` INTEGER NOT NULL, `lastTestedAt` INTEGER, `lastTestSuccess` INTEGER, `createdAt` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "baseUrl",
+            "columnName": "baseUrl",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "apiKey",
+            "columnName": "apiKey",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isActive",
+            "columnName": "isActive",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastTestedAt",
+            "columnName": "lastTestedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "lastTestSuccess",
+            "columnName": "lastTestSuccess",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "model_notes",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `modelId` INTEGER NOT NULL, `noteText` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "modelId",
+            "columnName": "modelId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "noteText",
+            "columnName": "noteText",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_model_notes_modelId",
+            "unique": false,
+            "columnNames": [
+              "modelId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_model_notes_modelId` ON `${TABLE_NAME}` (`modelId`)"
+          }
+        ]
+      },
+      {
+        "tableName": "personal_tags",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `modelId` INTEGER NOT NULL, `tag` TEXT NOT NULL, `addedAt` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "modelId",
+            "columnName": "modelId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "tag",
+            "columnName": "tag",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "addedAt",
+            "columnName": "addedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_personal_tags_modelId",
+            "unique": false,
+            "columnNames": [
+              "modelId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_personal_tags_modelId` ON `${TABLE_NAME}` (`modelId`)"
+          },
+          {
+            "name": "index_personal_tags_tag",
+            "unique": false,
+            "columnNames": [
+              "tag"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_personal_tags_tag` ON `${TABLE_NAME}` (`tag`)"
+          }
+        ]
+      },
+      {
+        "tableName": "followed_creators",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`username` TEXT NOT NULL, `displayName` TEXT NOT NULL, `avatarUrl` TEXT, `followedAt` INTEGER NOT NULL, `lastCheckedAt` INTEGER NOT NULL, PRIMARY KEY(`username`))",
+        "fields": [
+          {
+            "fieldPath": "username",
+            "columnName": "username",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayName",
+            "columnName": "displayName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "avatarUrl",
+            "columnName": "avatarUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "followedAt",
+            "columnName": "followedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastCheckedAt",
+            "columnName": "lastCheckedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "username"
+          ]
+        }
+      },
+      {
+        "tableName": "feed_cache",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`modelId` INTEGER NOT NULL, `creatorUsername` TEXT NOT NULL, `title` TEXT NOT NULL, `thumbnailUrl` TEXT, `type` TEXT NOT NULL, `publishedAt` TEXT NOT NULL, `cachedAt` INTEGER NOT NULL, `downloadCount` INTEGER NOT NULL, `favoriteCount` INTEGER NOT NULL, `commentCount` INTEGER NOT NULL, `ratingCount` INTEGER NOT NULL, `rating` REAL NOT NULL, PRIMARY KEY(`modelId`))",
+        "fields": [
+          {
+            "fieldPath": "modelId",
+            "columnName": "modelId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "creatorUsername",
+            "columnName": "creatorUsername",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "thumbnailUrl",
+            "columnName": "thumbnailUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "publishedAt",
+            "columnName": "publishedAt",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cachedAt",
+            "columnName": "cachedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "downloadCount",
+            "columnName": "downloadCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "favoriteCount",
+            "columnName": "favoriteCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "commentCount",
+            "columnName": "commentCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ratingCount",
+            "columnName": "ratingCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "rating",
+            "columnName": "rating",
+            "affinity": "REAL",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "modelId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_feed_cache_creatorUsername",
+            "unique": false,
+            "columnNames": [
+              "creatorUsername"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_feed_cache_creatorUsername` ON `${TABLE_NAME}` (`creatorUsername`)"
+          },
+          {
+            "name": "index_feed_cache_publishedAt",
+            "unique": false,
+            "columnNames": [
+              "publishedAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_feed_cache_publishedAt` ON `${TABLE_NAME}` (`publishedAt`)"
+          }
+        ]
+      },
+      {
+        "tableName": "model_downloads",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `modelId` INTEGER NOT NULL, `modelName` TEXT NOT NULL, `versionId` INTEGER NOT NULL, `versionName` TEXT NOT NULL, `fileId` INTEGER NOT NULL, `fileName` TEXT NOT NULL, `fileUrl` TEXT NOT NULL, `fileSizeBytes` INTEGER NOT NULL, `downloadedBytes` INTEGER NOT NULL, `status` TEXT NOT NULL, `modelType` TEXT NOT NULL, `destinationPath` TEXT, `errorMessage` TEXT, `expectedSha256` TEXT, `hashVerified` INTEGER, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "modelId",
+            "columnName": "modelId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "modelName",
+            "columnName": "modelName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "versionId",
+            "columnName": "versionId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "versionName",
+            "columnName": "versionName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fileId",
+            "columnName": "fileId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fileName",
+            "columnName": "fileName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fileUrl",
+            "columnName": "fileUrl",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fileSizeBytes",
+            "columnName": "fileSizeBytes",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "downloadedBytes",
+            "columnName": "downloadedBytes",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "modelType",
+            "columnName": "modelType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "destinationPath",
+            "columnName": "destinationPath",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "errorMessage",
+            "columnName": "errorMessage",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "expectedSha256",
+            "columnName": "expectedSha256",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "hashVerified",
+            "columnName": "hashVerified",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_model_downloads_modelId",
+            "unique": false,
+            "columnNames": [
+              "modelId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_model_downloads_modelId` ON `${TABLE_NAME}` (`modelId`)"
+          },
+          {
+            "name": "index_model_downloads_status",
+            "unique": false,
+            "columnNames": [
+              "status"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_model_downloads_status` ON `${TABLE_NAME}` (`status`)"
+          },
+          {
+            "name": "index_model_downloads_createdAt",
+            "unique": false,
+            "columnNames": [
+              "createdAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_model_downloads_createdAt` ON `${TABLE_NAME}` (`createdAt`)"
+          }
+        ]
+      },
+      {
+        "tableName": "plugins",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `name` TEXT NOT NULL, `version` TEXT NOT NULL, `author` TEXT NOT NULL, `description` TEXT NOT NULL, `pluginType` TEXT NOT NULL, `capabilities` TEXT NOT NULL, `minAppVersion` TEXT NOT NULL, `state` TEXT NOT NULL, `configJson` TEXT NOT NULL, `installedAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "version",
+            "columnName": "version",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "author",
+            "columnName": "author",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "pluginType",
+            "columnName": "pluginType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "capabilities",
+            "columnName": "capabilities",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "minAppVersion",
+            "columnName": "minAppVersion",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "state",
+            "columnName": "state",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "configJson",
+            "columnName": "configJson",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "installedAt",
+            "columnName": "installedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "share_hashtags",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`tag` TEXT NOT NULL, `isEnabled` INTEGER NOT NULL, `isCustom` INTEGER NOT NULL, `addedAt` INTEGER NOT NULL, PRIMARY KEY(`tag`))",
+        "fields": [
+          {
+            "fieldPath": "tag",
+            "columnName": "tag",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isEnabled",
+            "columnName": "isEnabled",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isCustom",
+            "columnName": "isCustom",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "addedAt",
+            "columnName": "addedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "tag"
+          ]
+        }
+      },
+      {
+        "tableName": "model_update_notifications",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `modelId` INTEGER NOT NULL, `modelName` TEXT NOT NULL, `newVersionName` TEXT NOT NULL, `newVersionId` INTEGER NOT NULL, `source` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, `isRead` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "modelId",
+            "columnName": "modelId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "modelName",
+            "columnName": "modelName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "newVersionName",
+            "columnName": "newVersionName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "newVersionId",
+            "columnName": "newVersionId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "source",
+            "columnName": "source",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isRead",
+            "columnName": "isRead",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_model_update_notifications_createdAt",
+            "unique": false,
+            "columnNames": [
+              "createdAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_model_update_notifications_createdAt` ON `${TABLE_NAME}` (`createdAt`)"
+          },
+          {
+            "name": "index_model_update_notifications_isRead",
+            "unique": false,
+            "columnNames": [
+              "isRead"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_model_update_notifications_isRead` ON `${TABLE_NAME}` (`isRead`)"
+          }
+        ]
+      },
+      {
+        "tableName": "quality_score_cache",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`modelId` INTEGER NOT NULL, `score` INTEGER NOT NULL, `downloadCount` INTEGER NOT NULL, `favoriteCount` INTEGER NOT NULL, `ratingCount` INTEGER NOT NULL, `cachedAt` INTEGER NOT NULL, PRIMARY KEY(`modelId`))",
+        "fields": [
+          {
+            "fieldPath": "modelId",
+            "columnName": "modelId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "score",
+            "columnName": "score",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "downloadCount",
+            "columnName": "downloadCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "favoriteCount",
+            "columnName": "favoriteCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ratingCount",
+            "columnName": "ratingCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cachedAt",
+            "columnName": "cachedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "modelId"
+          ]
+        }
+      },
+      {
+        "tableName": "model_embeddings",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`modelId` INTEGER NOT NULL, `embeddingModel` TEXT NOT NULL, `dim` INTEGER NOT NULL, `embedding` BLOB NOT NULL, `cachedAt` INTEGER NOT NULL, PRIMARY KEY(`modelId`))",
+        "fields": [
+          {
+            "fieldPath": "modelId",
+            "columnName": "modelId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "embeddingModel",
+            "columnName": "embeddingModel",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "dim",
+            "columnName": "dim",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "embedding",
+            "columnName": "embedding",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cachedAt",
+            "columnName": "cachedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "modelId"
+          ]
+        }
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '513a16be8d48e3bcac71cb48ed69b2e3')"
+    ]
+  }
+}

--- a/core/core-database/src/commonMain/kotlin/com/riox432/civitdeck/data/local/CivitDeckDatabase.kt
+++ b/core/core-database/src/commonMain/kotlin/com/riox432/civitdeck/data/local/CivitDeckDatabase.kt
@@ -99,6 +99,7 @@ import com.riox432.civitdeck.data.local.migrations.MIGRATION_41_42
 import com.riox432.civitdeck.data.local.migrations.MIGRATION_42_43
 import com.riox432.civitdeck.data.local.migrations.MIGRATION_43_44
 import com.riox432.civitdeck.data.local.migrations.MIGRATION_44_45
+import com.riox432.civitdeck.data.local.migrations.MIGRATION_45_46
 import com.riox432.civitdeck.data.local.migrations.MIGRATION_4_5
 import com.riox432.civitdeck.data.local.migrations.MIGRATION_5_6
 import com.riox432.civitdeck.data.local.migrations.MIGRATION_6_7
@@ -142,7 +143,7 @@ import kotlinx.coroutines.IO
         QualityScoreCacheEntity::class,
         ModelEmbeddingEntity::class,
     ],
-    version = 45,
+    version = 46,
 )
 @ConstructedBy(CivitDeckDatabaseConstructor::class)
 abstract class CivitDeckDatabase : RoomDatabase() {
@@ -224,6 +225,7 @@ fun getRoomDatabase(builder: RoomDatabase.Builder<CivitDeckDatabase>): CivitDeck
             MIGRATION_42_43,
             MIGRATION_43_44,
             MIGRATION_44_45,
+            MIGRATION_45_46,
         )
         .fallbackToDestructiveMigrationOnDowngrade(dropAllTables = true)
         .addCallback(defaultCollectionCallback)

--- a/core/core-database/src/commonMain/kotlin/com/riox432/civitdeck/data/local/entity/ComfyUIConnectionEntity.kt
+++ b/core/core-database/src/commonMain/kotlin/com/riox432/civitdeck/data/local/entity/ComfyUIConnectionEntity.kt
@@ -15,6 +15,8 @@ data class ComfyUIConnectionEntity(
     val createdAt: Long,
     val useHttps: Boolean = false,
     val acceptSelfSigned: Boolean = false,
+    val ntfyServerUrl: String? = null,
+    val ntfyTopic: String? = null,
 ) {
     companion object {
         const val DEFAULT_PORT = 8188

--- a/core/core-database/src/commonMain/kotlin/com/riox432/civitdeck/data/local/migrations/Migration45to46.kt
+++ b/core/core-database/src/commonMain/kotlin/com/riox432/civitdeck/data/local/migrations/Migration45to46.kt
@@ -1,0 +1,16 @@
+package com.riox432.civitdeck.data.local.migrations
+
+import androidx.room.migration.Migration
+import androidx.sqlite.SQLiteConnection
+import androidx.sqlite.execSQL
+
+val MIGRATION_45_46 = object : Migration(45, 46) {
+    override fun migrate(connection: SQLiteConnection) {
+        connection.execSQL(
+            "ALTER TABLE comfyui_connections ADD COLUMN ntfyServerUrl TEXT DEFAULT NULL",
+        )
+        connection.execSQL(
+            "ALTER TABLE comfyui_connections ADD COLUMN ntfyTopic TEXT DEFAULT NULL",
+        )
+    }
+}

--- a/core/core-domain/src/commonMain/kotlin/com/riox432/civitdeck/domain/model/ComfyUIConnection.kt
+++ b/core/core-domain/src/commonMain/kotlin/com/riox432/civitdeck/domain/model/ComfyUIConnection.kt
@@ -10,6 +10,8 @@ data class ComfyUIConnection(
     val lastTestSuccess: Boolean? = null,
     val useHttps: Boolean = false,
     val acceptSelfSigned: Boolean = false,
+    val ntfyServerUrl: String? = null,
+    val ntfyTopic: String? = null,
 ) {
     /** HTTP base URL with the correct scheme. */
     val baseUrl: String get() {
@@ -23,8 +25,16 @@ data class ComfyUIConnection(
     /** Whether this connection uses a secure transport (HTTPS/WSS). */
     val isSecure: Boolean get() = useHttps
 
+    /** Whether ntfy push notifications are configured for this connection. */
+    val isNtfyConfigured: Boolean get() = !ntfyTopic.isNullOrBlank()
+
+    /** Resolved ntfy server URL, defaulting to the public ntfy.sh instance. */
+    val resolvedNtfyServerUrl: String get() =
+        ntfyServerUrl?.takeIf { it.isNotBlank() } ?: DEFAULT_NTFY_SERVER_URL
+
     companion object {
         const val DEFAULT_COMFYUI_PORT = 8188
+        const val DEFAULT_NTFY_SERVER_URL = "https://ntfy.sh"
     }
 }
 

--- a/desktopApp/src/jvmMain/kotlin/com/riox432/civitdeck/ui/settings/DesktopComfyUIConnectionSection.kt
+++ b/desktopApp/src/jvmMain/kotlin/com/riox432/civitdeck/ui/settings/DesktopComfyUIConnectionSection.kt
@@ -36,6 +36,8 @@ fun ComfyUISettingsSection(viewModel: ComfyUISettingsViewModel) {
     var hostInput by remember { mutableStateOf("127.0.0.1") }
     var portInput by remember { mutableStateOf(ComfyUIConnection.DEFAULT_COMFYUI_PORT.toString()) }
     var useHttpsInput by remember { mutableStateOf(false) }
+    var ntfyServerUrlInput by remember { mutableStateOf("") }
+    var ntfyTopicInput by remember { mutableStateOf("") }
 
     SettingsCard(title = "ComfyUI Server") {
         ConnectionStatusBadge(
@@ -48,6 +50,8 @@ fun ComfyUISettingsSection(viewModel: ComfyUISettingsViewModel) {
             Spacer(modifier = Modifier.height(Spacing.sm))
             DesktopServerHardwareSection(stats)
         }
+        Spacer(modifier = Modifier.height(Spacing.sm))
+        DesktopNtfySection(state = state, onTestNtfy = viewModel::onTestNtfy)
         Spacer(modifier = Modifier.height(Spacing.sm))
         LanScanSection(
             isScanning = state.isScanning,
@@ -72,16 +76,22 @@ fun ComfyUISettingsSection(viewModel: ComfyUISettingsViewModel) {
             hostInput = hostInput,
             portInput = portInput,
             useHttpsInput = useHttpsInput,
+            ntfyServerUrlInput = ntfyServerUrlInput,
+            ntfyTopicInput = ntfyTopicInput,
             onNameChanged = { nameInput = it },
             onHostChanged = { hostInput = it },
             onPortChanged = { portInput = it },
             onHttpsChanged = { useHttpsInput = it },
-            onSave = { name, host, port, https ->
-                viewModel.onSaveConnection(name, host, port, https, false)
+            onNtfyServerUrlChanged = { ntfyServerUrlInput = it },
+            onNtfyTopicChanged = { ntfyTopicInput = it },
+            onSave = { name, host, port, https, ntfyUrl, ntfyTopic ->
+                viewModel.onSaveConnection(name, host, port, https, false, ntfyUrl, ntfyTopic)
                 nameInput = ""
                 hostInput = "127.0.0.1"
                 portInput = ComfyUIConnection.DEFAULT_COMFYUI_PORT.toString()
                 useHttpsInput = false
+                ntfyServerUrlInput = ""
+                ntfyTopicInput = ""
             },
         )
     }
@@ -259,16 +269,83 @@ private fun DesktopHardwareRow(label: String, value: String) {
 }
 
 @Composable
+private fun DesktopNtfySection(
+    state: com.riox432.civitdeck.feature.comfyui.presentation.ComfyUISettingsUiState,
+    onTestNtfy: () -> Unit,
+) {
+    Text("Push Notifications (ntfy)", style = MaterialTheme.typography.labelMedium)
+    Spacer(modifier = Modifier.height(Spacing.xs))
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Text("Status", style = MaterialTheme.typography.labelSmall)
+        Text(
+            if (state.isNtfySubscribed) "Subscribed" else "Not configured",
+            style = MaterialTheme.typography.bodySmall,
+            color = if (state.isNtfySubscribed) {
+                MaterialTheme.colorScheme.primary
+            } else {
+                MaterialTheme.colorScheme.onSurfaceVariant
+            },
+        )
+    }
+    val active = state.activeConnection
+    if (active?.isNtfyConfigured == true) {
+        Text(
+            "${active.resolvedNtfyServerUrl}/${active.ntfyTopic}",
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        Spacer(modifier = Modifier.height(Spacing.xs))
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(Spacing.sm),
+        ) {
+            OutlinedButton(
+                onClick = onTestNtfy,
+                enabled = !state.isNtfyTestSending,
+            ) {
+                Text(if (state.isNtfyTestSending) "Sending..." else "Test Notification")
+            }
+            state.ntfyTestResult?.let { success ->
+                Text(
+                    if (success) "Sent successfully" else "Failed to send",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = if (success) {
+                        MaterialTheme.colorScheme.primary
+                    } else {
+                        MaterialTheme.colorScheme.error
+                    },
+                )
+            }
+        }
+    } else {
+        Text(
+            "Configure ntfy topic in your connection to receive push notifications.",
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+    }
+}
+
+@Composable
+@Suppress("LongParameterList")
 private fun AddConnectionForm(
     nameInput: String,
     hostInput: String,
     portInput: String,
     useHttpsInput: Boolean,
+    ntfyServerUrlInput: String,
+    ntfyTopicInput: String,
     onNameChanged: (String) -> Unit,
     onHostChanged: (String) -> Unit,
     onPortChanged: (String) -> Unit,
     onHttpsChanged: (Boolean) -> Unit,
-    onSave: (String, String, Int, Boolean) -> Unit,
+    onNtfyServerUrlChanged: (String) -> Unit,
+    onNtfyTopicChanged: (String) -> Unit,
+    onSave: (String, String, Int, Boolean, String?, String?) -> Unit,
 ) {
     Spacer(modifier = Modifier.height(Spacing.sm))
     Text("Add Connection:", style = MaterialTheme.typography.labelMedium)
@@ -308,14 +385,69 @@ private fun AddConnectionForm(
         )
         Text("Use HTTPS", style = MaterialTheme.typography.bodySmall)
     }
+    DesktopNtfyFormFields(
+        ntfyServerUrlInput = ntfyServerUrlInput,
+        ntfyTopicInput = ntfyTopicInput,
+        onNtfyServerUrlChanged = onNtfyServerUrlChanged,
+        onNtfyTopicChanged = onNtfyTopicChanged,
+    )
     Spacer(modifier = Modifier.height(Spacing.sm))
     Button(
         onClick = {
             val port = portInput.toIntOrNull() ?: return@Button
-            onSave(nameInput, hostInput, port, useHttpsInput)
+            onSave(
+                nameInput, hostInput, port, useHttpsInput,
+                ntfyServerUrlInput.ifBlank { null },
+                ntfyTopicInput.ifBlank { null },
+            )
         },
         enabled = nameInput.isNotBlank() && hostInput.isNotBlank(),
     ) {
         Text("Save Connection")
     }
 }
+
+@Composable
+private fun DesktopNtfyFormFields(
+    ntfyServerUrlInput: String,
+    ntfyTopicInput: String,
+    onNtfyServerUrlChanged: (String) -> Unit,
+    onNtfyTopicChanged: (String) -> Unit,
+) {
+    Spacer(modifier = Modifier.height(Spacing.sm))
+    Text("ntfy Push Notifications:", style = MaterialTheme.typography.labelMedium)
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.spacedBy(Spacing.sm),
+    ) {
+        OutlinedTextField(
+            value = ntfyServerUrlInput,
+            onValueChange = onNtfyServerUrlChanged,
+            label = { Text("ntfy Server URL") },
+            placeholder = { Text("https://ntfy.sh") },
+            singleLine = true,
+            modifier = Modifier.weight(1f),
+        )
+        OutlinedTextField(
+            value = ntfyTopicInput,
+            onValueChange = onNtfyTopicChanged,
+            label = { Text("Topic") },
+            placeholder = { Text("my-comfyui-topic") },
+            singleLine = true,
+            modifier = Modifier.weight(1f),
+        )
+    }
+    Row(horizontalArrangement = Arrangement.spacedBy(Spacing.sm)) {
+        TextButton(
+            onClick = {
+                onNtfyTopicChanged(
+                    "civitdeck-${java.util.UUID.randomUUID().toString().take(TOPIC_ID_LENGTH)}",
+                )
+            },
+        ) {
+            Text("Generate Random Topic")
+        }
+    }
+}
+
+private const val TOPIC_ID_LENGTH = 8

--- a/feature/feature-comfyui/src/commonMain/kotlin/com/riox432/civitdeck/feature/comfyui/data/NtfySubscriptionService.kt
+++ b/feature/feature-comfyui/src/commonMain/kotlin/com/riox432/civitdeck/feature/comfyui/data/NtfySubscriptionService.kt
@@ -1,0 +1,178 @@
+package com.riox432.civitdeck.feature.comfyui.data
+
+import com.riox432.civitdeck.domain.service.GenerationNotificationService
+import com.riox432.civitdeck.util.Logger
+import io.ktor.client.HttpClient
+import io.ktor.client.request.post
+import io.ktor.client.request.prepareGet
+import io.ktor.client.request.setBody
+import io.ktor.client.statement.bodyAsChannel
+import io.ktor.http.ContentType
+import io.ktor.http.contentType
+import io.ktor.utils.io.readUTF8Line
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+
+/**
+ * Subscribes to an ntfy.sh topic via the JSON streaming endpoint and fires
+ * local notifications when generation-complete messages arrive.
+ *
+ * ntfy.sh JSON stream format (one JSON object per line):
+ * ```
+ * {"id":"abc","time":1635528757,"event":"open","topic":"mytopic"}
+ * {"id":"def","time":1635528741,"event":"message","topic":"mytopic","message":"Generation complete"}
+ * {"id":"ghi","time":1635528787,"event":"keepalive","topic":"mytopic"}
+ * ```
+ *
+ * @see <a href="https://docs.ntfy.sh/subscribe/api/">ntfy subscribe API</a>
+ */
+class NtfySubscriptionService(
+    private val httpClient: HttpClient,
+    private val notificationService: GenerationNotificationService,
+    private val scope: CoroutineScope,
+) {
+    private var subscriptionJob: Job? = null
+    private var currentTopic: String? = null
+    private var currentServerUrl: String? = null
+
+    /** Whether the service is currently subscribed to a topic. */
+    val isSubscribed: Boolean get() = subscriptionJob?.isActive == true
+
+    /**
+     * Start subscribing to the given ntfy topic. Cancels any existing subscription first.
+     * Reconnects automatically with exponential backoff on connection failures.
+     */
+    fun subscribe(serverUrl: String, topic: String) {
+        if (currentTopic == topic && currentServerUrl == serverUrl && isSubscribed) {
+            Logger.d(TAG, "Already subscribed to $topic on $serverUrl")
+            return
+        }
+        unsubscribe()
+        currentTopic = topic
+        currentServerUrl = serverUrl
+        subscriptionJob = scope.launch {
+            subscribeWithReconnect(serverUrl, topic)
+        }
+        Logger.d(TAG, "Started subscription to $serverUrl/$topic")
+    }
+
+    /** Stop the current subscription. */
+    fun unsubscribe() {
+        subscriptionJob?.cancel()
+        subscriptionJob = null
+        currentTopic = null
+        currentServerUrl = null
+        Logger.d(TAG, "Unsubscribed from ntfy")
+    }
+
+    /**
+     * Send a test message to the configured ntfy topic to verify the setup.
+     * Returns true if the publish request succeeded.
+     */
+    suspend fun sendTestNotification(serverUrl: String, topic: String): Boolean {
+        return try {
+            val url = "${serverUrl.trimEnd('/')}/$topic"
+            val response = httpClient.post(url) {
+                contentType(ContentType.Text.Plain)
+                setBody("CivitDeck test notification")
+            }
+            response.status.value in SUCCESS_STATUS_RANGE
+        } catch (@Suppress("TooGenericExceptionCaught") e: Exception) {
+            Logger.w(TAG, "Test notification failed: ${e.message}")
+            false
+        }
+    }
+
+    private suspend fun subscribeWithReconnect(serverUrl: String, topic: String) {
+        var backoffMs = INITIAL_BACKOFF_MS
+        while (scope.isActive) {
+            try {
+                connectAndListen(serverUrl, topic)
+                // If connectAndListen returns normally, the stream ended — reconnect
+                backoffMs = INITIAL_BACKOFF_MS
+            } catch (e: CancellationException) {
+                throw e
+            } catch (@Suppress("TooGenericExceptionCaught") e: Exception) {
+                Logger.w(TAG, "Connection error, retrying in ${backoffMs}ms: ${e.message}")
+            }
+            delay(backoffMs)
+            backoffMs = (backoffMs * BACKOFF_MULTIPLIER).toLong().coerceAtMost(MAX_BACKOFF_MS)
+        }
+    }
+
+    private suspend fun connectAndListen(serverUrl: String, topic: String) {
+        val url = "${serverUrl.trimEnd('/')}/$topic/json"
+        Logger.d(TAG, "Connecting to $url")
+        httpClient.prepareGet(url).execute { response ->
+            val channel = response.bodyAsChannel()
+            while (!channel.isClosedForRead) {
+                val line = channel.readUTF8Line() ?: break
+                if (line.isBlank()) continue
+                processLine(line)
+            }
+        }
+    }
+
+    private fun processLine(line: String) {
+        try {
+            val message = json.decodeFromString<NtfyMessage>(line)
+            when (message.event) {
+                EVENT_MESSAGE -> handleMessage(message)
+                EVENT_OPEN -> Logger.d(TAG, "Stream opened for topic: ${message.topic}")
+                EVENT_KEEPALIVE -> { /* ignore keepalive */ }
+                else -> Logger.d(TAG, "Unknown event: ${message.event}")
+            }
+        } catch (@Suppress("TooGenericExceptionCaught") e: Exception) {
+            Logger.w(TAG, "Failed to parse ntfy message: ${e.message}")
+        }
+    }
+
+    private fun handleMessage(message: NtfyMessage) {
+        val text = message.message ?: return
+        Logger.d(TAG, "Received ntfy message: $text")
+        // Fire a local notification with the message content
+        notificationService.notifyGenerationComplete(
+            promptId = message.id,
+            imageCount = 0,
+            elapsedMs = 0L,
+        )
+    }
+
+    companion object {
+        private const val TAG = "NtfySubscription"
+        private const val INITIAL_BACKOFF_MS = 1_000L
+        private const val MAX_BACKOFF_MS = 60_000L
+        private const val BACKOFF_MULTIPLIER = 2.0
+        private const val EVENT_MESSAGE = "message"
+        private const val EVENT_OPEN = "open"
+        private const val EVENT_KEEPALIVE = "keepalive"
+        private val SUCCESS_STATUS_RANGE = 200..299
+        private val json = Json {
+            ignoreUnknownKeys = true
+            isLenient = true
+        }
+    }
+}
+
+/**
+ * Represents a message from the ntfy.sh JSON stream.
+ *
+ * @see <a href="https://docs.ntfy.sh/subscribe/api/">ntfy subscribe API</a>
+ */
+@Serializable
+private data class NtfyMessage(
+    val id: String = "",
+    val time: Long = 0L,
+    val event: String = "",
+    val topic: String = "",
+    val message: String? = null,
+    val title: String? = null,
+    val priority: Int? = null,
+    val tags: List<String>? = null,
+)

--- a/feature/feature-comfyui/src/commonMain/kotlin/com/riox432/civitdeck/feature/comfyui/data/repository/ComfyUIConnectionRepositoryImpl.kt
+++ b/feature/feature-comfyui/src/commonMain/kotlin/com/riox432/civitdeck/feature/comfyui/data/repository/ComfyUIConnectionRepositoryImpl.kt
@@ -73,6 +73,8 @@ class ComfyUIConnectionRepositoryImpl(
         lastTestSuccess = lastTestSuccess,
         useHttps = useHttps,
         acceptSelfSigned = acceptSelfSigned,
+        ntfyServerUrl = ntfyServerUrl,
+        ntfyTopic = ntfyTopic,
     )
 
     private fun ComfyUIConnection.toEntity() = ComfyUIConnectionEntity(
@@ -86,5 +88,7 @@ class ComfyUIConnectionRepositoryImpl(
         createdAt = currentTimeMillis(),
         useHttps = useHttps,
         acceptSelfSigned = acceptSelfSigned,
+        ntfyServerUrl = ntfyServerUrl,
+        ntfyTopic = ntfyTopic,
     )
 }

--- a/feature/feature-comfyui/src/commonMain/kotlin/com/riox432/civitdeck/feature/comfyui/di/ComfyUIModule.kt
+++ b/feature/feature-comfyui/src/commonMain/kotlin/com/riox432/civitdeck/feature/comfyui/di/ComfyUIModule.kt
@@ -12,6 +12,7 @@ import com.riox432.civitdeck.domain.repository.SDWebUIConnectionRepository
 import com.riox432.civitdeck.domain.repository.SDWebUIGenerationRepository
 import com.riox432.civitdeck.domain.repository.ServerDiscoveryRepository
 import com.riox432.civitdeck.domain.util.SystemStatsProvider
+import com.riox432.civitdeck.feature.comfyui.data.NtfySubscriptionService
 import com.riox432.civitdeck.feature.comfyui.data.encoder.MaskPngEncoder
 import com.riox432.civitdeck.feature.comfyui.data.repository.CivitaiLinkRepositoryImpl
 import com.riox432.civitdeck.feature.comfyui.data.repository.ComfyHubRepositoryImpl
@@ -75,6 +76,9 @@ import com.riox432.civitdeck.feature.comfyui.domain.usecase.TestComfyUIConnectio
 import com.riox432.civitdeck.feature.comfyui.domain.usecase.TestSDWebUIConnectionUseCase
 import com.riox432.civitdeck.feature.comfyui.domain.usecase.UploadMaskUseCase
 import com.riox432.civitdeck.feature.comfyui.plugin.ComfyUIWorkflowPlugin
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
 import com.riox432.civitdeck.feature.comfyui.presentation.CivitaiLinkSendViewModel
 import com.riox432.civitdeck.feature.comfyui.presentation.CivitaiLinkSettingsViewModel
 import com.riox432.civitdeck.feature.comfyui.presentation.ComfyUIGenerationViewModel
@@ -171,11 +175,20 @@ val comfyuiModule = module {
     factory { SendResourceToPCUseCase(get()) }
     factory { CancelLinkActivityUseCase(get()) }
 
+    // ntfy.sh subscription service (uses the standard ComfyUI HttpClient)
+    single {
+        NtfySubscriptionService(
+            httpClient = get(named("comfyui")),
+            notificationService = get(),
+            scope = CoroutineScope(SupervisorJob() + Dispatchers.Default),
+        )
+    }
+
     // Plugin adapter
     single { ComfyUIWorkflowPlugin(get()) }
 
     // ViewModels
-    viewModel { ComfyUISettingsViewModel(get(), get(), get(), get(), get(), get(), get(), get()) }
+    viewModel { ComfyUISettingsViewModel(get(), get(), get(), get(), get(), get(), get(), get(), get()) }
     viewModel {
         ComfyUIGenerationViewModel(
             get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get(),

--- a/feature/feature-comfyui/src/commonMain/kotlin/com/riox432/civitdeck/feature/comfyui/presentation/ComfyUISettingsViewModel.kt
+++ b/feature/feature-comfyui/src/commonMain/kotlin/com/riox432/civitdeck/feature/comfyui/presentation/ComfyUISettingsViewModel.kt
@@ -10,6 +10,7 @@ import com.riox432.civitdeck.domain.model.SecurityLevelHelper
 import com.riox432.civitdeck.domain.model.SystemStats
 import com.riox432.civitdeck.domain.util.OptimizationSuggestion
 import com.riox432.civitdeck.domain.util.generateOptimizationSuggestions
+import com.riox432.civitdeck.feature.comfyui.data.NtfySubscriptionService
 import com.riox432.civitdeck.feature.comfyui.domain.usecase.ActivateComfyUIConnectionUseCase
 import com.riox432.civitdeck.feature.comfyui.domain.usecase.DeleteComfyUIConnectionUseCase
 import com.riox432.civitdeck.feature.comfyui.domain.usecase.FetchSystemStatsUseCase
@@ -42,6 +43,9 @@ data class ComfyUISettingsUiState(
     val systemStats: SystemStats? = null,
     val optimizationSuggestions: List<OptimizationSuggestion> = emptyList(),
     val dismissedSuggestionIds: Set<String> = emptySet(),
+    val isNtfySubscribed: Boolean = false,
+    val isNtfyTestSending: Boolean = false,
+    val ntfyTestResult: Boolean? = null,
 )
 
 class ComfyUISettingsViewModel(
@@ -53,6 +57,7 @@ class ComfyUISettingsViewModel(
     private val testConnection: TestComfyUIConnectionUseCase,
     private val scanForServers: ScanForServersUseCase,
     private val fetchSystemStats: FetchSystemStatsUseCase,
+    private val ntfyService: NtfySubscriptionService,
 ) : ViewModel() {
 
     private val _mutableState = MutableStateFlow(ComfyUISettingsUiState())
@@ -71,20 +76,28 @@ class ComfyUISettingsViewModel(
             else -> ComfyUIConnectionStatus.Disconnected
         }
         val security = active?.let { SecurityLevelHelper.getSecurityLevel(it) }
+
+        // Manage ntfy subscription lifecycle based on active connection
+        manageNtfySubscription(active, status)
+
         mutable.copy(
             connections = connections,
             activeConnection = active,
             connectionStatus = status,
             securityLevel = security,
+            isNtfySubscribed = ntfyService.isSubscribed,
         )
     }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(SUBSCRIBE_TIMEOUT), ComfyUISettingsUiState())
 
+    @Suppress("LongParameterList")
     fun onSaveConnection(
         name: String,
         hostname: String,
         port: Int,
         useHttps: Boolean = false,
         acceptSelfSigned: Boolean = false,
+        ntfyServerUrl: String? = null,
+        ntfyTopic: String? = null,
     ) {
         viewModelScope.launch {
             val editing = _mutableState.value.editingConnection
@@ -95,6 +108,8 @@ class ComfyUISettingsViewModel(
                 port = port,
                 useHttps = useHttps,
                 acceptSelfSigned = acceptSelfSigned,
+                ntfyServerUrl = ntfyServerUrl?.takeIf { it.isNotBlank() },
+                ntfyTopic = ntfyTopic?.takeIf { it.isNotBlank() },
             )
             saveConnection(connection)
             _mutableState.update { it.copy(showAddDialog = false, editingConnection = null) }
@@ -169,6 +184,40 @@ class ComfyUISettingsViewModel(
 
     fun dismissSuggestion(id: String) {
         _mutableState.update { it.copy(dismissedSuggestionIds = it.dismissedSuggestionIds + id) }
+    }
+
+    fun onTestNtfy() {
+        val active = uiState.value.activeConnection ?: return
+        val topic = active.ntfyTopic ?: return
+        _mutableState.update { it.copy(isNtfyTestSending = true, ntfyTestResult = null) }
+        viewModelScope.launch {
+            val success = ntfyService.sendTestNotification(
+                active.resolvedNtfyServerUrl,
+                topic,
+            )
+            _mutableState.update { it.copy(isNtfyTestSending = false, ntfyTestResult = success) }
+        }
+    }
+
+    fun clearNtfyTestResult() {
+        _mutableState.update { it.copy(ntfyTestResult = null) }
+    }
+
+    private fun manageNtfySubscription(
+        active: ComfyUIConnection?,
+        status: ComfyUIConnectionStatus,
+    ) {
+        if (active != null &&
+            active.isNtfyConfigured &&
+            status == ComfyUIConnectionStatus.Connected
+        ) {
+            ntfyService.subscribe(
+                active.resolvedNtfyServerUrl,
+                active.ntfyTopic.orEmpty(),
+            )
+        } else {
+            ntfyService.unsubscribe()
+        }
     }
 
     private companion object {

--- a/iosApp/iosApp/Features/ComfyUI/ComfyUISettingsView.swift
+++ b/iosApp/iosApp/Features/ComfyUI/ComfyUISettingsView.swift
@@ -14,6 +14,7 @@ struct ComfyUISettingsView: View {
             if !viewModel.visibleSuggestions.isEmpty {
                 optimizationSuggestionsSection
             }
+            ntfySection
             scanLanSection
             if viewModel.isConnected {
                 NavigationLink("Open txt2img Generator") {
@@ -201,6 +202,45 @@ struct ComfyUISettingsView: View {
         }
     }
 
+    private var ntfySection: some View {
+        Section("Push Notifications (ntfy)") {
+            HStack {
+                Text("Status")
+                    .font(.civitBodyMedium)
+                Spacer()
+                Text(viewModel.isNtfySubscribed ? "Subscribed" : "Not configured")
+                    .font(.civitLabelSmall)
+                    .foregroundColor(viewModel.isNtfySubscribed ? theme.primary : .civitOnSurfaceVariant)
+            }
+            if let active = viewModel.activeConnection, active.isNtfyConfigured {
+                Text("\(active.resolvedNtfyServerUrl)/\(active.ntfyTopic ?? "")")
+                    .font(.civitBodySmall)
+                    .foregroundColor(.civitOnSurfaceVariant)
+                HStack(spacing: Spacing.sm) {
+                    Button {
+                        viewModel.onTestNtfy()
+                    } label: {
+                        if viewModel.isNtfyTestSending {
+                            ProgressView()
+                        } else {
+                            Text("Test Notification")
+                        }
+                    }
+                    .disabled(viewModel.isNtfyTestSending)
+                    if let result = viewModel.ntfyTestResult {
+                        Text(result ? "Sent successfully" : "Failed to send")
+                            .font(.civitBodySmall)
+                            .foregroundColor(result ? theme.primary : .civitError)
+                    }
+                }
+            } else {
+                Text("Install ComfyUI-ntfy custom node on your server and set the same topic there. Notifications will be received even when the app is closed.")
+                    .font(.civitBodySmall)
+                    .foregroundColor(.civitOnSurfaceVariant)
+            }
+        }
+    }
+
     private var scanLanSection: some View {
         Section("LAN Discovery") {
             HStack {
@@ -289,17 +329,19 @@ struct ComfyUISettingsView: View {
 
 struct AddConnectionSheet: View {
     let editing: ComfyUIConnection?
-    let onSave: (String, String, Int32, Bool, Bool) -> Void
+    let onSave: (String, String, Int32, Bool, Bool, String?, String?) -> Void
     @Environment(\.dismiss) private var dismiss
     @State private var name: String
     @State private var hostname: String
     @State private var portText: String
     @State private var useHttps: Bool
     @State private var acceptSelfSigned: Bool
+    @State private var ntfyServerUrl: String
+    @State private var ntfyTopic: String
 
     init(
         editing: ComfyUIConnection?,
-        onSave: @escaping (String, String, Int32, Bool, Bool) -> Void
+        onSave: @escaping (String, String, Int32, Bool, Bool, String?, String?) -> Void
     ) {
         self.editing = editing
         self.onSave = onSave
@@ -308,25 +350,16 @@ struct AddConnectionSheet: View {
         _portText = State(initialValue: editing.map { String($0.port) } ?? "8188")
         _useHttps = State(initialValue: editing?.useHttps ?? false)
         _acceptSelfSigned = State(initialValue: editing?.acceptSelfSigned ?? false)
+        _ntfyServerUrl = State(initialValue: editing?.ntfyServerUrl ?? "")
+        _ntfyTopic = State(initialValue: editing?.ntfyTopic ?? "")
     }
 
     var body: some View {
         NavigationStack {
             Form {
-                Section {
-                    TextField("Name (e.g. Home PC)", text: $name)
-                    TextField("Hostname / IP", text: $hostname)
-                        .autocapitalization(.none)
-                        .disableAutocorrection(true)
-                    TextField("Port", text: $portText)
-                        .keyboardType(.numberPad)
-                }
-                Section("Security") {
-                    Toggle("Use HTTPS", isOn: $useHttps)
-                    if useHttps {
-                        Toggle("Accept self-signed certificates", isOn: $acceptSelfSigned)
-                    }
-                }
+                connectionSection
+                securitySection
+                ntfySection
             }
             .navigationTitle(editing != nil ? "Edit Connection" : "Add Connection")
             .navigationBarTitleDisplayMode(.inline)
@@ -339,16 +372,53 @@ struct AddConnectionSheet: View {
                         let port = Int32(portText) ?? 8188
                         onSave(
                             name.isEmpty ? hostname : name,
-                            hostname,
-                            port,
-                            useHttps,
-                            acceptSelfSigned
+                            hostname, port, useHttps, acceptSelfSigned,
+                            ntfyServerUrl.isEmpty ? nil : ntfyServerUrl,
+                            ntfyTopic.isEmpty ? nil : ntfyTopic
                         )
                         dismiss()
                     }
                     .disabled(hostname.isEmpty)
                 }
             }
+        }
+    }
+
+    private var connectionSection: some View {
+        Section {
+            TextField("Name (e.g. Home PC)", text: $name)
+            TextField("Hostname / IP", text: $hostname)
+                .autocapitalization(.none)
+                .disableAutocorrection(true)
+            TextField("Port", text: $portText)
+                .keyboardType(.numberPad)
+        }
+    }
+
+    private var securitySection: some View {
+        Section("Security") {
+            Toggle("Use HTTPS", isOn: $useHttps)
+            if useHttps {
+                Toggle("Accept self-signed certificates", isOn: $acceptSelfSigned)
+            }
+        }
+    }
+
+    private var ntfySection: some View {
+        Section("Push Notifications (ntfy)") {
+            TextField("Server URL (default: https://ntfy.sh)", text: $ntfyServerUrl)
+                .autocapitalization(.none)
+                .disableAutocorrection(true)
+                .keyboardType(.URL)
+            TextField("Topic (e.g. my-comfyui-topic)", text: $ntfyTopic)
+                .autocapitalization(.none)
+                .disableAutocorrection(true)
+            Button("Generate Random Topic") {
+                ntfyTopic = "civitdeck-\(UUID().uuidString.prefix(8).lowercased())"
+            }
+            Text("Install ComfyUI-ntfy custom node on your server and set the same topic there.")
+                .font(.civitBodySmall)
+                .foregroundColor(.civitOnSurfaceVariant)
         }
     }
 }

--- a/iosApp/iosApp/Features/ComfyUI/ComfyUISettingsViewModel.swift
+++ b/iosApp/iosApp/Features/ComfyUI/ComfyUISettingsViewModel.swift
@@ -18,6 +18,9 @@ final class ComfyUISettingsViewModelOwner: ObservableObject {
     @Published var systemStats: Core_domainSystemStats?
     @Published var optimizationSuggestions: [OptimizationSuggestion] = []
     @Published var dismissedSuggestionIds: Set<String> = []
+    @Published var isNtfySubscribed = false
+    @Published var isNtfyTestSending = false
+    @Published var ntfyTestResult: Bool?
 
     init() {
         vm = KoinHelper.shared.createComfyUISettingsViewModel()
@@ -42,16 +45,25 @@ final class ComfyUISettingsViewModelOwner: ObservableObject {
             dismissedSuggestionIds = Set(
                 (state.dismissedSuggestionIds as? Set<String>) ?? []
             )
+            isNtfySubscribed = state.isNtfySubscribed
+            isNtfyTestSending = state.isNtfyTestSending
+            ntfyTestResult = state.ntfyTestResult?.boolValue
         }
     }
 
-    func onSave(name: String, hostname: String, port: Int32, useHttps: Bool, acceptSelfSigned: Bool) {
+    func onSave(
+        name: String, hostname: String, port: Int32,
+        useHttps: Bool, acceptSelfSigned: Bool,
+        ntfyServerUrl: String?, ntfyTopic: String?
+    ) {
         vm.onSaveConnection(
             name: name,
             hostname: hostname,
             port: port,
             useHttps: useHttps,
-            acceptSelfSigned: acceptSelfSigned
+            acceptSelfSigned: acceptSelfSigned,
+            ntfyServerUrl: ntfyServerUrl,
+            ntfyTopic: ntfyTopic
         )
     }
 
@@ -81,6 +93,14 @@ final class ComfyUISettingsViewModelOwner: ObservableObject {
 
     func dismissSuggestion(id: String) {
         vm.dismissSuggestion(id: id)
+    }
+
+    func onTestNtfy() {
+        vm.onTestNtfy()
+    }
+
+    func clearNtfyTestResult() {
+        vm.clearNtfyTestResult()
     }
 
     var visibleSuggestions: [OptimizationSuggestion] {


### PR DESCRIPTION
## Summary

- Add ntfy.sh topic subscription service (`NtfySubscriptionService`) using Ktor JSON streaming with auto-reconnect and exponential backoff
- Extend `ComfyUIConnection` domain model and database entity with `ntfyServerUrl` and `ntfyTopic` fields (Room migration 45 → 46)
- Add ntfy configuration UI to connection dialogs and status sections on all 3 platforms (Android, iOS, Desktop)
- Manage subscription lifecycle: auto-subscribe when connection is active + ntfy configured, auto-unsubscribe on disconnect
- Include "Test Notification" button to verify setup and "Generate Random Topic" for easy onboarding

## How it works

1. User installs [ComfyUI-ntfy](https://github.com/boredofnames/ComfyUI-ntfy) custom node on their ComfyUI server
2. User configures the same ntfy topic in both ComfyUI-ntfy and CivitDeck connection settings
3. CivitDeck subscribes to `{server}/topic/json` via Ktor HTTP streaming
4. When ComfyUI-ntfy publishes a message on generation complete, CivitDeck fires a local notification via `GenerationNotificationService`

## Test plan

- [ ] Add a ComfyUI connection with ntfy topic configured
- [ ] Verify "Subscribed" status shows when connection is active
- [ ] Tap "Test Notification" and confirm success message
- [ ] Verify ntfy subscription reconnects after network drop
- [ ] Edit connection to remove ntfy topic, verify unsubscribe
- [ ] Verify migration 45→46 works (fresh install and upgrade)

Closes #890