### PR TITLE
Add APP mode metadata parser and extend workflow parameter extraction

### DIFF
--- a/core/core-domain/src/commonMain/kotlin/com/riox432/civitdeck/domain/model/AppModeMetadata.kt
+++ b/core/core-domain/src/commonMain/kotlin/com/riox432/civitdeck/domain/model/AppModeMetadata.kt
@@ -1,0 +1,59 @@
+package com.riox432.civitdeck.domain.model
+
+/**
+ * Represents ComfyUI APP mode metadata parsed from workflow JSON.
+ *
+ * APP mode (ComfyUI frontend v1.41.13+) allows workflows to define which node inputs
+ * are user-facing and which node outputs are visible, stored in `extra.linearData`.
+ *
+ * See: https://docs.comfy.org/interface/app-mode
+ */
+data class AppModeMetadata(
+    val inputs: List<AppModeInput>,
+    val outputs: List<AppModeOutput>,
+    val defaultView: AppModeView,
+)
+
+/**
+ * A single user-facing input designated by APP mode.
+ *
+ * In the ComfyUI frontend, this is stored as a tuple: [nodeId, paramName, config?]
+ * where config is an optional object with widget configuration like height.
+ *
+ * @param nodeId The workflow node ID containing this input.
+ * @param paramName The input parameter name on the node.
+ * @param label Optional display label (derived from node _meta.title if available).
+ * @param group Optional grouping key for UI organization.
+ * @param order Position in the input list (0-based, preserves original ordering).
+ * @param widgetHeight Optional height hint for the input widget (from config.height).
+ */
+data class AppModeInput(
+    val nodeId: String,
+    val paramName: String,
+    val label: String? = null,
+    val group: String? = null,
+    val order: Int = 0,
+    val widgetHeight: Int? = null,
+)
+
+/**
+ * A node output designated as visible in APP mode.
+ *
+ * @param nodeId The workflow node ID whose output is visible.
+ * @param label Optional display label (derived from node _meta.title if available).
+ */
+data class AppModeOutput(
+    val nodeId: String,
+    val label: String? = null,
+)
+
+/**
+ * Default view mode for a workflow with APP mode metadata.
+ */
+enum class AppModeView {
+    /** Show the simplified APP mode interface. */
+    APP,
+
+    /** Show the traditional node graph editor. */
+    GRAPH,
+}

--- a/feature/feature-comfyui/src/commonMain/kotlin/com/riox432/civitdeck/feature/comfyui/di/ComfyUIModule.kt
+++ b/feature/feature-comfyui/src/commonMain/kotlin/com/riox432/civitdeck/feature/comfyui/di/ComfyUIModule.kt
@@ -35,6 +35,7 @@ import com.riox432.civitdeck.feature.comfyui.domain.usecase.DeleteWorkflowTempla
 import com.riox432.civitdeck.feature.comfyui.domain.usecase.DisconnectCivitaiLinkUseCase
 import com.riox432.civitdeck.feature.comfyui.domain.usecase.ExportWorkflowTemplateUseCase
 import com.riox432.civitdeck.feature.comfyui.domain.usecase.ExtractWorkflowParametersUseCase
+import com.riox432.civitdeck.feature.comfyui.domain.usecase.ParseAppModeMetadataUseCase
 import com.riox432.civitdeck.feature.comfyui.domain.usecase.FetchComfyUICheckpointsUseCase
 import com.riox432.civitdeck.feature.comfyui.domain.usecase.FetchSystemStatsUseCase
 import com.riox432.civitdeck.feature.comfyui.domain.usecase.FetchComfyUIControlNetsUseCase
@@ -120,7 +121,8 @@ val comfyuiModule = module {
     factory { FetchComfyUILorasUseCase(get()) }
     factory { FetchComfyUIControlNetsUseCase(get()) }
     factory { ImportWorkflowUseCase() }
-    factory { ExtractWorkflowParametersUseCase() }
+    factory { ParseAppModeMetadataUseCase() }
+    factory { ExtractWorkflowParametersUseCase(get()) }
     factory { InjectWorkflowParametersUseCase() }
     factory { FetchObjectInfoUseCase(get(), get()) }
     factory { SubmitComfyUIGenerationUseCase(get()) }

--- a/feature/feature-comfyui/src/commonMain/kotlin/com/riox432/civitdeck/feature/comfyui/domain/model/ExtractedParameter.kt
+++ b/feature/feature-comfyui/src/commonMain/kotlin/com/riox432/civitdeck/feature/comfyui/domain/model/ExtractedParameter.kt
@@ -2,6 +2,10 @@ package com.riox432.civitdeck.feature.comfyui.domain.model
 
 /**
  * Represents a single editable parameter extracted from a ComfyUI workflow JSON.
+ *
+ * @param group Optional grouping key for APP mode parameters (null for legacy extraction).
+ * @param order Sort order within group (0-based). APP mode preserves the original input order;
+ *              legacy extraction uses priority-based ordering.
  */
 data class ExtractedParameter(
     val nodeId: String,
@@ -14,6 +18,8 @@ data class ExtractedParameter(
     val max: Double? = null,
     val step: Double? = null,
     val options: List<String> = emptyList(),
+    val group: String? = null,
+    val order: Int = 0,
 )
 
 /**

--- a/feature/feature-comfyui/src/commonMain/kotlin/com/riox432/civitdeck/feature/comfyui/domain/usecase/ExtractWorkflowParametersUseCase.kt
+++ b/feature/feature-comfyui/src/commonMain/kotlin/com/riox432/civitdeck/feature/comfyui/domain/usecase/ExtractWorkflowParametersUseCase.kt
@@ -1,5 +1,7 @@
 package com.riox432.civitdeck.feature.comfyui.domain.usecase
 
+import com.riox432.civitdeck.domain.model.AppModeInput
+import com.riox432.civitdeck.domain.model.AppModeMetadata
 import com.riox432.civitdeck.feature.comfyui.domain.model.ExtractedParameter
 import com.riox432.civitdeck.feature.comfyui.domain.model.ParameterType
 import com.riox432.civitdeck.util.Logger
@@ -12,15 +14,22 @@ import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
 
 /**
- * Parses a ComfyUI workflow JSON and extracts editable parameters from priority node types.
- * Optionally uses /object_info data to enrich parameter metadata (options, ranges).
+ * Parses a ComfyUI workflow JSON and extracts editable parameters.
+ *
+ * Extraction strategy:
+ * 1. Try APP mode: parse `extra.linearData` for designated inputs (official ComfyUI standard).
+ * 2. Fallback: extract from hardcoded PRIORITY_NODES when no APP mode metadata is present.
+ *
+ * Both paths are optionally enriched with /object_info schema data.
  */
-class ExtractWorkflowParametersUseCase {
+class ExtractWorkflowParametersUseCase(
+    private val parseAppModeMetadata: ParseAppModeMetadataUseCase,
+) {
 
     /**
      * @param workflowJson The raw workflow JSON string.
      * @param objectInfoJson Optional /object_info response JSON for enriching param metadata.
-     * @return List of extracted parameters sorted by node priority then param order.
+     * @return List of extracted parameters sorted by APP mode order or node priority.
      */
     operator fun invoke(
         workflowJson: String,
@@ -33,15 +42,76 @@ class ExtractWorkflowParametersUseCase {
             return emptyList()
         }
 
-        val objectInfo = objectInfoJson?.let {
-            try {
-                Json.parseToJsonElement(it).jsonObject
-            } catch (@Suppress("TooGenericExceptionCaught") e: Exception) {
-                Logger.w(TAG, "Failed to parse object_info JSON: ${e.message}")
-                null
-            }
+        val objectInfo = parseObjectInfo(objectInfoJson)
+        val appMode = parseAppModeMetadata(workflowJson)
+
+        return if (appMode != null) {
+            Logger.d(TAG, "APP mode detected: ${appMode.inputs.size} inputs")
+            extractAppModeParameters(appMode, workflow, objectInfo)
+        } else {
+            extractLegacyParameters(workflow, objectInfo)
+        }
+    }
+
+    /**
+     * Extract parameters designated by APP mode metadata.
+     * Only inputs explicitly listed in linearData.inputs are extracted.
+     */
+    private fun extractAppModeParameters(
+        appMode: AppModeMetadata,
+        workflow: JsonObject,
+        objectInfo: JsonObject?,
+    ): List<ExtractedParameter> {
+        return appMode.inputs.mapNotNull { input ->
+            extractAppModeInput(input, workflow, objectInfo)
+        }
+    }
+
+    private fun extractAppModeInput(
+        input: AppModeInput,
+        workflow: JsonObject,
+        objectInfo: JsonObject?,
+    ): ExtractedParameter? {
+        val node = workflow[input.nodeId] as? JsonObject ?: return null
+        val classType = (node["class_type"] as? JsonPrimitive)?.content ?: return null
+        val inputs = node["inputs"] as? JsonObject ?: return null
+
+        val rawValue = inputs[input.paramName] ?: return null
+        // Skip node link references (arrays like ["3", 0])
+        if (rawValue is JsonArray) return null
+
+        val currentValue = when (rawValue) {
+            is JsonPrimitive -> rawValue.content
+            else -> rawValue.toString()
         }
 
+        val title = input.label ?: extractNodeTitle(node, classType, input.nodeId)
+        val nodeSchema = objectInfo?.get(classType) as? JsonObject
+        val schemaInfo = resolveSchemaInfo(input.paramName, nodeSchema)
+        val paramType = resolveParameterType(input.paramName, schemaInfo)
+
+        return ExtractedParameter(
+            nodeId = input.nodeId,
+            nodeTitle = title,
+            nodeClassType = classType,
+            paramName = input.paramName,
+            paramType = paramType,
+            currentValue = currentValue,
+            min = schemaInfo?.min,
+            max = schemaInfo?.max,
+            step = schemaInfo?.step,
+            options = schemaInfo?.options ?: emptyList(),
+            group = input.group,
+            order = input.order,
+        )
+    }
+
+    // region Legacy extraction (PRIORITY_NODES fallback)
+
+    private fun extractLegacyParameters(
+        workflow: JsonObject,
+        objectInfo: JsonObject?,
+    ): List<ExtractedParameter> {
         return workflow.entries
             .mapNotNull { (nodeId, nodeElement) ->
                 val node = nodeElement as? JsonObject ?: return@mapNotNull null
@@ -106,6 +176,21 @@ class ExtractWorkflowParametersUseCase {
         )
     }
 
+    // endregion
+
+    // region Shared helpers
+
+    private fun parseObjectInfo(objectInfoJson: String?): JsonObject? {
+        return objectInfoJson?.let {
+            try {
+                Json.parseToJsonElement(it).jsonObject
+            } catch (@Suppress("TooGenericExceptionCaught") e: Exception) {
+                Logger.w(TAG, "Failed to parse object_info JSON: ${e.message}")
+                null
+            }
+        }
+    }
+
     private fun extractNodeTitle(node: JsonObject, classType: String, nodeId: String): String {
         // ComfyUI workflows may have _meta.title
         val meta = node["_meta"] as? JsonObject
@@ -135,7 +220,7 @@ class ExtractWorkflowParametersUseCase {
         return ParameterType.TEXT
     }
 
-    private data class SchemaInfo(
+    internal data class SchemaInfo(
         val min: Double? = null,
         val max: Double? = null,
         val step: Double? = null,
@@ -147,7 +232,7 @@ class ExtractWorkflowParametersUseCase {
      * Object info structure: { NodeType: { input: { required: { paramName: [...] } } } }
      */
     @Suppress("ReturnCount")
-    private fun resolveSchemaInfo(paramName: String, nodeSchema: JsonObject?): SchemaInfo? {
+    internal fun resolveSchemaInfo(paramName: String, nodeSchema: JsonObject?): SchemaInfo? {
         if (nodeSchema == null) return null
 
         val inputObj = nodeSchema["input"] as? JsonObject ?: return null
@@ -194,6 +279,8 @@ class ExtractWorkflowParametersUseCase {
         "EmptyLatentImage" -> 4
         else -> 5
     }
+
+    // endregion
 
     companion object {
         private const val TAG = "ExtractWorkflowParams"

--- a/feature/feature-comfyui/src/commonMain/kotlin/com/riox432/civitdeck/feature/comfyui/domain/usecase/ParseAppModeMetadataUseCase.kt
+++ b/feature/feature-comfyui/src/commonMain/kotlin/com/riox432/civitdeck/feature/comfyui/domain/usecase/ParseAppModeMetadataUseCase.kt
@@ -1,0 +1,152 @@
+package com.riox432.civitdeck.feature.comfyui.domain.usecase
+
+import com.riox432.civitdeck.domain.model.AppModeInput
+import com.riox432.civitdeck.domain.model.AppModeMetadata
+import com.riox432.civitdeck.domain.model.AppModeOutput
+import com.riox432.civitdeck.domain.model.AppModeView
+import com.riox432.civitdeck.util.Logger
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.booleanOrNull
+import kotlinx.serialization.json.intOrNull
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+
+/**
+ * Parses ComfyUI APP mode metadata from a workflow JSON.
+ *
+ * APP mode metadata is stored in the workflow's `extra` field:
+ * - `extra.linearData.inputs`: Array of [nodeId, paramName, config?] tuples
+ * - `extra.linearData.outputs`: Array of nodeId strings
+ * - `extra.linearMode`: Boolean (true = app view, false = graph view)
+ *
+ * Returns null if the workflow does not contain APP mode metadata.
+ */
+class ParseAppModeMetadataUseCase {
+
+    /**
+     * @param workflowJson The full workflow JSON string (not API format).
+     * @return Parsed APP mode metadata, or null if not present.
+     */
+    operator fun invoke(workflowJson: String): AppModeMetadata? {
+        val root = try {
+            Json.parseToJsonElement(workflowJson).jsonObject
+        } catch (@Suppress("TooGenericExceptionCaught") e: Exception) {
+            Logger.w(TAG, "Failed to parse workflow JSON: ${e.message}")
+            return null
+        }
+
+        val extra = root["extra"] as? JsonObject ?: return null
+        val linearData = extra["linearData"] as? JsonObject ?: return null
+
+        val inputs = parseInputs(linearData, root)
+        val outputs = parseOutputs(linearData, root)
+        val defaultView = parseDefaultView(extra)
+
+        // If there are no inputs and no outputs, treat as no APP mode
+        if (inputs.isEmpty() && outputs.isEmpty()) return null
+
+        return AppModeMetadata(
+            inputs = inputs,
+            outputs = outputs,
+            defaultView = defaultView,
+        )
+    }
+
+    private fun parseInputs(
+        linearData: JsonObject,
+        root: JsonObject,
+    ): List<AppModeInput> {
+        val inputsArray = linearData["inputs"] as? JsonArray ?: return emptyList()
+        return inputsArray.mapIndexedNotNull { index, element ->
+            parseSingleInput(element, index, root)
+        }
+    }
+
+    /**
+     * Parse a single input entry.
+     * Format: [nodeId, paramName] or [nodeId, paramName, {height?: number}]
+     */
+    private fun parseSingleInput(
+        element: kotlinx.serialization.json.JsonElement,
+        index: Int,
+        root: JsonObject,
+    ): AppModeInput? {
+        val tuple = element as? JsonArray ?: return null
+        if (tuple.size < INPUT_TUPLE_MIN_SIZE) return null
+
+        val nodeId = (tuple[0] as? JsonPrimitive)?.content ?: return null
+        val paramName = (tuple[1] as? JsonPrimitive)?.content ?: return null
+
+        val config = if (tuple.size > INPUT_TUPLE_MIN_SIZE) {
+            tuple[INPUT_TUPLE_MIN_SIZE] as? JsonObject
+        } else {
+            null
+        }
+        val widgetHeight = config?.get("height")?.jsonPrimitive?.intOrNull
+
+        // Derive label from node's _meta.title if available
+        val label = resolveNodeTitle(root, nodeId)
+
+        return AppModeInput(
+            nodeId = nodeId,
+            paramName = paramName,
+            label = label,
+            group = null,
+            order = index,
+            widgetHeight = widgetHeight,
+        )
+    }
+
+    private fun parseOutputs(
+        linearData: JsonObject,
+        root: JsonObject,
+    ): List<AppModeOutput> {
+        val outputsArray = linearData["outputs"] as? JsonArray ?: return emptyList()
+        return outputsArray.mapNotNull { element ->
+            val nodeId = (element as? JsonPrimitive)?.content ?: return@mapNotNull null
+            val label = resolveNodeTitle(root, nodeId)
+            AppModeOutput(nodeId = nodeId, label = label)
+        }
+    }
+
+    private fun parseDefaultView(extra: JsonObject): AppModeView {
+        val linearMode = extra["linearMode"]?.jsonPrimitive?.booleanOrNull
+        return if (linearMode == true) AppModeView.APP else AppModeView.GRAPH
+    }
+
+    /**
+     * Looks up the node's _meta.title from the workflow JSON.
+     * Workflow nodes are stored as top-level entries (nodeId -> nodeObject)
+     * or inside a "nodes" array with "id" fields.
+     */
+    private fun resolveNodeTitle(root: JsonObject, nodeId: String): String? {
+        // API format: top-level nodeId keys
+        val nodeObj = root[nodeId] as? JsonObject
+        if (nodeObj != null) {
+            return extractMetaTitle(nodeObj)
+        }
+
+        // UI workflow format: "nodes" array with "id" field
+        val nodesArray = root["nodes"] as? JsonArray ?: return null
+        val node = nodesArray.firstOrNull { entry ->
+            val obj = entry as? JsonObject ?: return@firstOrNull false
+            val id = (obj["id"] as? JsonPrimitive)?.content
+            id == nodeId
+        } as? JsonObject
+        return node?.let { extractMetaTitle(it) }
+            ?: node?.let { (it["title"] as? JsonPrimitive)?.content }
+    }
+
+    private fun extractMetaTitle(node: JsonObject): String? {
+        val meta = node["_meta"] as? JsonObject ?: return null
+        return (meta["title"] as? JsonPrimitive)?.content
+    }
+
+    companion object {
+        private const val TAG = "ParseAppModeMetadata"
+        private const val INPUT_TUPLE_MIN_SIZE = 2
+    }
+}

--- a/feature/feature-comfyui/src/commonTest/kotlin/com/riox432/civitdeck/feature/comfyui/domain/usecase/ExtractWorkflowParametersUseCaseTest.kt
+++ b/feature/feature-comfyui/src/commonTest/kotlin/com/riox432/civitdeck/feature/comfyui/domain/usecase/ExtractWorkflowParametersUseCaseTest.kt
@@ -1,0 +1,283 @@
+package com.riox432.civitdeck.feature.comfyui.domain.usecase
+
+import com.riox432.civitdeck.feature.comfyui.domain.model.ParameterType
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class ExtractWorkflowParametersUseCaseTest {
+
+    private val useCase = ExtractWorkflowParametersUseCase(ParseAppModeMetadataUseCase())
+
+    // region APP mode extraction
+
+    @Test
+    fun extractsOnlyAppModeDesignatedInputs() {
+        val workflow = buildAppModeWorkflow()
+
+        val params = useCase(workflow)
+
+        // APP mode designates only seed and text — should NOT extract steps, cfg, etc.
+        assertEquals(2, params.size)
+        assertEquals("seed", params[0].paramName)
+        assertEquals("text", params[1].paramName)
+    }
+
+    @Test
+    fun appModePreservesOriginalOrder() {
+        val workflow = buildAppModeWorkflow()
+
+        val params = useCase(workflow)
+
+        assertEquals(0, params[0].order)
+        assertEquals(1, params[1].order)
+    }
+
+    @Test
+    fun appModeResolvesNodeTitleFromMeta() {
+        val workflow = buildAppModeWorkflow()
+
+        val params = useCase(workflow)
+
+        assertEquals("KSampler", params[0].nodeTitle)
+        assertEquals("Positive Prompt", params[1].nodeTitle)
+    }
+
+    @Test
+    fun appModeEnrichesWithObjectInfo() {
+        val workflow = buildAppModeWorkflow()
+        val objectInfo = """
+        {
+            "KSampler": {
+                "input": {
+                    "required": {
+                        "seed": ["INT", {"min": 0, "max": 999999}]
+                    }
+                }
+            }
+        }
+        """.trimIndent()
+
+        val params = useCase(workflow, objectInfo)
+
+        val seedParam = params.first { it.paramName == "seed" }
+        assertEquals(0.0, seedParam.min)
+        assertEquals(999999.0, seedParam.max)
+        assertEquals(ParameterType.SEED, seedParam.paramType)
+    }
+
+    @Test
+    fun appModeSkipsLinkedInputs() {
+        // "clip" input is a link reference ["4", 0] — should be skipped even if designated
+        val workflow = """
+        {
+            "6": {
+                "class_type": "CLIPTextEncode",
+                "inputs": {"text": "a photo", "clip": ["4", 0]},
+                "_meta": {"title": "Prompt"}
+            },
+            "extra": {
+                "linearData": {
+                    "inputs": [["6", "text"], ["6", "clip"]],
+                    "outputs": []
+                },
+                "linearMode": true
+            }
+        }
+        """.trimIndent()
+
+        val params = useCase(workflow)
+
+        assertEquals(1, params.size)
+        assertEquals("text", params[0].paramName)
+    }
+
+    @Test
+    fun appModeHandlesUnknownNodeTypes() {
+        // A custom node type not in PRIORITY_NODES should still be extracted via APP mode
+        val workflow = """
+        {
+            "10": {
+                "class_type": "CustomStyleTransfer",
+                "inputs": {"style_strength": 0.8, "style_name": "anime"},
+                "_meta": {"title": "Style Transfer"}
+            },
+            "extra": {
+                "linearData": {
+                    "inputs": [["10", "style_strength"], ["10", "style_name"]],
+                    "outputs": []
+                },
+                "linearMode": true
+            }
+        }
+        """.trimIndent()
+
+        val params = useCase(workflow)
+
+        assertEquals(2, params.size)
+        assertEquals("CustomStyleTransfer", params[0].nodeClassType)
+        assertEquals("style_strength", params[0].paramName)
+        assertEquals("style_name", params[1].paramName)
+    }
+
+    // endregion
+
+    // region Legacy fallback
+
+    @Test
+    fun fallsBackToLegacyWhenNoAppMode() {
+        val workflow = """
+        {
+            "3": {
+                "class_type": "KSampler",
+                "inputs": {
+                    "seed": 42,
+                    "steps": 20,
+                    "cfg": 7.0,
+                    "sampler_name": "euler",
+                    "scheduler": "normal",
+                    "denoise": 1.0,
+                    "model": ["1", 0],
+                    "positive": ["6", 0],
+                    "negative": ["7", 0],
+                    "latent_image": ["5", 0]
+                },
+                "_meta": {"title": "KSampler"}
+            }
+        }
+        """.trimIndent()
+
+        val params = useCase(workflow)
+
+        // Legacy mode extracts all PRIORITY_NODES params from KSampler
+        assertTrue(params.any { it.paramName == "seed" })
+        assertTrue(params.any { it.paramName == "steps" })
+        assertTrue(params.any { it.paramName == "cfg" })
+    }
+
+    @Test
+    fun legacyIgnoresNonPriorityNodes() {
+        val workflow = """
+        {
+            "10": {
+                "class_type": "CustomNode",
+                "inputs": {"my_param": "value"},
+                "_meta": {"title": "Custom"}
+            }
+        }
+        """.trimIndent()
+
+        val params = useCase(workflow)
+
+        assertTrue(params.isEmpty())
+    }
+
+    @Test
+    fun legacyGroupAndOrderAreDefaults() {
+        val workflow = """
+        {
+            "3": {
+                "class_type": "KSampler",
+                "inputs": {"seed": 42},
+                "_meta": {"title": "KSampler"}
+            }
+        }
+        """.trimIndent()
+
+        val params = useCase(workflow)
+
+        assertEquals(1, params.size)
+        assertNull(params[0].group)
+        assertEquals(0, params[0].order)
+    }
+
+    // endregion
+
+    // region Mixed workflow
+
+    @Test
+    fun appModeTakesPriorityOverLegacy() {
+        // Workflow has both KSampler (would be extracted by legacy)
+        // and APP mode metadata designating only "text"
+        val workflow = """
+        {
+            "3": {
+                "class_type": "KSampler",
+                "inputs": {"seed": 42, "steps": 20, "cfg": 7.0},
+                "_meta": {"title": "KSampler"}
+            },
+            "6": {
+                "class_type": "CLIPTextEncode",
+                "inputs": {"text": "a cat"},
+                "_meta": {"title": "Prompt"}
+            },
+            "extra": {
+                "linearData": {
+                    "inputs": [["6", "text"]],
+                    "outputs": []
+                },
+                "linearMode": true
+            }
+        }
+        """.trimIndent()
+
+        val params = useCase(workflow)
+
+        // Only APP mode designated input, not legacy KSampler params
+        assertEquals(1, params.size)
+        assertEquals("text", params[0].paramName)
+    }
+
+    // endregion
+
+    // region Error handling
+
+    @Test
+    fun returnsEmptyForInvalidJson() {
+        val params = useCase("not json")
+        assertTrue(params.isEmpty())
+    }
+
+    @Test
+    fun returnsEmptyForEmptyObject() {
+        val params = useCase("{}")
+        assertTrue(params.isEmpty())
+    }
+
+    // endregion
+
+    private fun buildAppModeWorkflow(): String = """
+        {
+            "3": {
+                "class_type": "KSampler",
+                "inputs": {
+                    "seed": 42,
+                    "steps": 20,
+                    "cfg": 7.0,
+                    "sampler_name": "euler",
+                    "scheduler": "normal",
+                    "denoise": 1.0
+                },
+                "_meta": {"title": "KSampler"}
+            },
+            "6": {
+                "class_type": "CLIPTextEncode",
+                "inputs": {"text": "a photo of a cat"},
+                "_meta": {"title": "Positive Prompt"}
+            },
+            "9": {
+                "class_type": "SaveImage",
+                "inputs": {"images": ["8", 0]},
+                "_meta": {"title": "Save Image"}
+            },
+            "extra": {
+                "linearData": {
+                    "inputs": [["3", "seed"], ["6", "text"]],
+                    "outputs": ["9"]
+                },
+                "linearMode": true
+            }
+        }
+    """.trimIndent()
+}

--- a/feature/feature-comfyui/src/commonTest/kotlin/com/riox432/civitdeck/feature/comfyui/domain/usecase/ParseAppModeMetadataUseCaseTest.kt
+++ b/feature/feature-comfyui/src/commonTest/kotlin/com/riox432/civitdeck/feature/comfyui/domain/usecase/ParseAppModeMetadataUseCaseTest.kt
@@ -1,0 +1,262 @@
+package com.riox432.civitdeck.feature.comfyui.domain.usecase
+
+import com.riox432.civitdeck.domain.model.AppModeView
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+
+class ParseAppModeMetadataUseCaseTest {
+
+    private val useCase = ParseAppModeMetadataUseCase()
+
+    @Test
+    fun parsesAppModeInputsFromLinearData() {
+        val json = buildAppModeWorkflow(
+            inputs = """[["3", "seed"], ["6", "text"]]""",
+            outputs = """["9"]""",
+        )
+
+        val result = useCase(json)
+
+        assertNotNull(result)
+        assertEquals(2, result.inputs.size)
+        assertEquals("3", result.inputs[0].nodeId)
+        assertEquals("seed", result.inputs[0].paramName)
+        assertEquals(0, result.inputs[0].order)
+        assertEquals("6", result.inputs[1].nodeId)
+        assertEquals("text", result.inputs[1].paramName)
+        assertEquals(1, result.inputs[1].order)
+    }
+
+    @Test
+    fun parsesOutputNodeIds() {
+        val json = buildAppModeWorkflow(
+            inputs = """[["3", "seed"]]""",
+            outputs = """["9", "12"]""",
+        )
+
+        val result = useCase(json)
+
+        assertNotNull(result)
+        assertEquals(2, result.outputs.size)
+        assertEquals("9", result.outputs[0].nodeId)
+        assertEquals("12", result.outputs[1].nodeId)
+    }
+
+    @Test
+    fun parsesWidgetHeightFromConfig() {
+        val json = buildAppModeWorkflow(
+            inputs = """[["6", "text", {"height": 200}]]""",
+            outputs = """["9"]""",
+        )
+
+        val result = useCase(json)
+
+        assertNotNull(result)
+        assertEquals(200, result.inputs[0].widgetHeight)
+    }
+
+    @Test
+    fun returnsNullForWorkflowWithoutExtra() {
+        val json = """
+        {
+            "3": {
+                "class_type": "KSampler",
+                "inputs": {"seed": 12345}
+            }
+        }
+        """.trimIndent()
+
+        assertNull(useCase(json))
+    }
+
+    @Test
+    fun returnsNullForWorkflowWithoutLinearData() {
+        val json = """
+        {
+            "3": {
+                "class_type": "KSampler",
+                "inputs": {"seed": 12345}
+            },
+            "extra": {"ds": {"scale": 1.0}}
+        }
+        """.trimIndent()
+
+        assertNull(useCase(json))
+    }
+
+    @Test
+    fun returnsNullWhenBothInputsAndOutputsEmpty() {
+        val json = buildAppModeWorkflow(
+            inputs = """[]""",
+            outputs = """[]""",
+        )
+
+        assertNull(useCase(json))
+    }
+
+    @Test
+    fun parsesDefaultViewApp() {
+        val json = buildAppModeWorkflow(
+            inputs = """[["3", "seed"]]""",
+            outputs = """["9"]""",
+            linearMode = true,
+        )
+
+        val result = useCase(json)
+
+        assertNotNull(result)
+        assertEquals(AppModeView.APP, result.defaultView)
+    }
+
+    @Test
+    fun parsesDefaultViewGraph() {
+        val json = buildAppModeWorkflow(
+            inputs = """[["3", "seed"]]""",
+            outputs = """["9"]""",
+            linearMode = false,
+        )
+
+        val result = useCase(json)
+
+        assertNotNull(result)
+        assertEquals(AppModeView.GRAPH, result.defaultView)
+    }
+
+    @Test
+    fun defaultViewIsGraphWhenLinearModeAbsent() {
+        val json = """
+        {
+            "3": {
+                "class_type": "KSampler",
+                "inputs": {"seed": 12345},
+                "_meta": {"title": "Sampler"}
+            },
+            "extra": {
+                "linearData": {
+                    "inputs": [["3", "seed"]],
+                    "outputs": []
+                }
+            }
+        }
+        """.trimIndent()
+
+        val result = useCase(json)
+
+        assertNotNull(result)
+        assertEquals(AppModeView.GRAPH, result.defaultView)
+    }
+
+    @Test
+    fun resolvesNodeTitleFromMeta() {
+        val json = """
+        {
+            "3": {
+                "class_type": "KSampler",
+                "inputs": {"seed": 12345},
+                "_meta": {"title": "My Sampler"}
+            },
+            "extra": {
+                "linearData": {
+                    "inputs": [["3", "seed"]],
+                    "outputs": []
+                },
+                "linearMode": true
+            }
+        }
+        """.trimIndent()
+
+        val result = useCase(json)
+
+        assertNotNull(result)
+        assertEquals("My Sampler", result.inputs[0].label)
+    }
+
+    @Test
+    fun returnsNullForInvalidJson() {
+        assertNull(useCase("not valid json"))
+    }
+
+    @Test
+    fun handlesPartialInputTuples() {
+        // Input with only 1 element should be skipped
+        val json = buildAppModeWorkflow(
+            inputs = """[["3"], ["6", "text"]]""",
+            outputs = """["9"]""",
+        )
+
+        val result = useCase(json)
+
+        assertNotNull(result)
+        assertEquals(1, result.inputs.size)
+        assertEquals("6", result.inputs[0].nodeId)
+    }
+
+    @Test
+    fun handlesNodeInNodesArray() {
+        // UI workflow format stores nodes in a "nodes" array instead of top-level keys
+        val json = """
+        {
+            "nodes": [
+                {
+                    "id": "3",
+                    "type": "KSampler",
+                    "title": "My Sampler Node"
+                }
+            ],
+            "extra": {
+                "linearData": {
+                    "inputs": [["3", "seed"]],
+                    "outputs": ["3"]
+                },
+                "linearMode": true
+            }
+        }
+        """.trimIndent()
+
+        val result = useCase(json)
+
+        assertNotNull(result)
+        assertEquals("My Sampler Node", result.inputs[0].label)
+        assertEquals("My Sampler Node", result.outputs[0].label)
+    }
+
+    private fun buildAppModeWorkflow(
+        inputs: String,
+        outputs: String,
+        linearMode: Boolean = true,
+    ): String {
+        return """
+        {
+            "3": {
+                "class_type": "KSampler",
+                "inputs": {"seed": 12345, "steps": 20, "cfg": 7.0},
+                "_meta": {"title": "KSampler"}
+            },
+            "6": {
+                "class_type": "CLIPTextEncode",
+                "inputs": {"text": "a photo", "clip": ["4", 0]},
+                "_meta": {"title": "Positive Prompt"}
+            },
+            "9": {
+                "class_type": "SaveImage",
+                "inputs": {"images": ["8", 0]},
+                "_meta": {"title": "Save Image"}
+            },
+            "12": {
+                "class_type": "PreviewImage",
+                "inputs": {"images": ["8", 0]},
+                "_meta": {"title": "Preview"}
+            },
+            "extra": {
+                "linearData": {
+                    "inputs": $inputs,
+                    "outputs": $outputs
+                },
+                "linearMode": $linearMode
+            }
+        }
+        """.trimIndent()
+    }
+}


### PR DESCRIPTION
## Summary
- Add `AppModeMetadata` domain model (`AppModeInput`, `AppModeOutput`, `AppModeView`) based on ComfyUI frontend's `extra.linearData` format
- Add `ParseAppModeMetadataUseCase` to parse APP mode inputs/outputs from workflow JSON
- Extend `ExtractWorkflowParametersUseCase` with APP mode priority: try `linearData` first, fall back to `PRIORITY_NODES`
- Add `group` and `order` fields to `ExtractedParameter` for APP mode grouping/ordering
- Register new use case in Koin `ComfyUIModule`

## Implementation Notes
Researched the actual ComfyUI APP mode JSON format from the official frontend source code (`Comfy-Org/ComfyUI_frontend`). The metadata lives in:
- `workflow.extra.linearData.inputs` — array of `[nodeId, paramName, config?]` tuples
- `workflow.extra.linearData.outputs` — array of node ID strings
- `workflow.extra.linearMode` — boolean for default view (app vs graph)

This is the official standard from ComfyUI frontend v1.41.13+.

## Test plan
- [x] Unit tests for `ParseAppModeMetadataUseCase` (12 tests): valid parsing, edge cases, error handling
- [x] Unit tests for `ExtractWorkflowParametersUseCase` (10 tests): APP mode extraction, legacy fallback, mixed workflows
- [x] Android assembleDebug passes
- [x] Desktop compileKotlinJvm passes
- [x] Detekt passes

Closes #891