### PR TITLE
Add IMAGE/BOOLEAN types, grouped sections, collapsible Advanced

### DIFF
--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/comfyui/TemplateParameterScreen.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/comfyui/TemplateParameterScreen.kt
@@ -10,8 +10,10 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Casino
 import androidx.compose.material3.Button
 import androidx.compose.material3.Card
 import androidx.compose.material3.DropdownMenu
@@ -23,6 +25,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Slider
+import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
@@ -32,14 +35,17 @@ import androidx.compose.runtime.mutableStateMapOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.input.KeyboardType
 import com.riox432.civitdeck.R
 import com.riox432.civitdeck.domain.model.TemplateVariable
 import com.riox432.civitdeck.domain.model.TemplateVariableType
 import com.riox432.civitdeck.domain.model.WorkflowTemplate
 import com.riox432.civitdeck.ui.theme.Spacing
 import kotlin.math.roundToInt
+import kotlin.random.Random
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -131,7 +137,11 @@ private fun ParameterInput(
                 TemplateVariableType.SLIDER -> SliderInput(variable, value, onValueChange)
                 TemplateVariableType.SELECT -> SelectInput(variable, value, onValueChange)
                 TemplateVariableType.NUMBER -> NumberInput(variable, value, onValueChange)
-                TemplateVariableType.TEXT -> TextInput(variable, value, onValueChange)
+                TemplateVariableType.BOOLEAN -> BooleanInput(variable, value, onValueChange)
+                TemplateVariableType.SEED -> SeedInput(variable, value, onValueChange)
+                TemplateVariableType.TEXT, TemplateVariableType.IMAGE -> {
+                    TextInput(variable, value, onValueChange)
+                }
             }
         }
     }
@@ -241,6 +251,59 @@ private fun TextInput(
             }
         },
     )
+}
+
+@Composable
+private fun BooleanInput(
+    variable: TemplateVariable,
+    value: String,
+    onValueChange: (String) -> Unit,
+) {
+    val isChecked = value.equals("true", ignoreCase = true) || value == "1"
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.SpaceBetween,
+    ) {
+        Text(
+            variable.label.ifBlank { variable.name },
+            style = MaterialTheme.typography.bodyMedium,
+        )
+        Switch(
+            checked = isChecked,
+            onCheckedChange = { onValueChange(it.toString()) },
+        )
+    }
+}
+
+@Composable
+private fun SeedInput(
+    variable: TemplateVariable,
+    value: String,
+    onValueChange: (String) -> Unit,
+) {
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(Spacing.sm),
+    ) {
+        OutlinedTextField(
+            value = value,
+            onValueChange = onValueChange,
+            label = { Text(variable.label.ifBlank { variable.name }) },
+            modifier = Modifier.weight(1f),
+            singleLine = true,
+            keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+        )
+        IconButton(onClick = {
+            val randomSeed = Random.nextLong(0, Long.MAX_VALUE)
+            onValueChange(randomSeed.toString())
+        }) {
+            Icon(
+                Icons.Default.Casino,
+                contentDescription = stringResource(R.string.cd_randomize_seed),
+            )
+        }
+    }
 }
 
 private fun formatSliderValue(value: Float, step: Float): String {

--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/comfyui/WorkflowParameterSheet.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/comfyui/WorkflowParameterSheet.kt
@@ -1,18 +1,23 @@
+@file:Suppress("TooManyFunctions")
+
 package com.riox432.civitdeck.ui.comfyui
 
-import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Casino
 import androidx.compose.material.icons.filled.ExpandLess
 import androidx.compose.material.icons.filled.ExpandMore
+import androidx.compose.material.icons.filled.Image
 import androidx.compose.material.icons.filled.Refresh
 import androidx.compose.material3.Card
 import androidx.compose.material3.DropdownMenu
@@ -22,14 +27,15 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Slider
+import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateMapOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
@@ -37,11 +43,16 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.unit.dp
 import com.riox432.civitdeck.R
 import com.riox432.civitdeck.feature.comfyui.domain.model.ExtractedParameter
 import com.riox432.civitdeck.feature.comfyui.domain.model.ParameterType
+import com.riox432.civitdeck.ui.components.SectionHeader
 import com.riox432.civitdeck.ui.theme.Spacing
 import kotlin.random.Random
+
+private const val IMAGE_PREVIEW_SIZE = 64
+private const val MAX_SLIDER_STEPS = 1000
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -50,10 +61,16 @@ fun WorkflowParameterSheet(
     onParameterChanged: (nodeId: String, paramName: String, newValue: String) -> Unit,
     onRefresh: () -> Unit,
     onDismiss: () -> Unit,
+    onImagePickRequested: ((nodeId: String, paramName: String) -> Unit)? = null,
 ) {
     val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
     ModalBottomSheet(onDismissRequest = onDismiss, sheetState = sheetState) {
-        ParameterSheetContent(parameters, onParameterChanged, onRefresh)
+        ParameterSheetContent(
+            parameters = parameters,
+            onParameterChanged = onParameterChanged,
+            onRefresh = onRefresh,
+            onImagePickRequested = onImagePickRequested,
+        )
     }
 }
 
@@ -62,32 +79,54 @@ private fun ParameterSheetContent(
     parameters: List<ExtractedParameter>,
     onParameterChanged: (nodeId: String, paramName: String, newValue: String) -> Unit,
     onRefresh: () -> Unit,
+    onImagePickRequested: ((nodeId: String, paramName: String) -> Unit)?,
 ) {
-    // Group parameters by nodeId + nodeTitle
-    val grouped = remember(parameters) {
-        parameters.groupBy { it.nodeId to it.nodeTitle }
+    val (grouped, advancedParams) = remember(parameters) {
+        buildGroupedParameters(parameters)
     }
+    var showAdvanced by remember { mutableStateOf(false) }
 
     LazyColumn(
         contentPadding = PaddingValues(horizontal = Spacing.lg, vertical = Spacing.md),
         verticalArrangement = Arrangement.spacedBy(Spacing.md),
     ) {
-        item {
-            SheetHeader(onRefresh)
-        }
-        grouped.forEach { (nodeKey, nodeParams) ->
-            item(key = nodeKey.first) {
-                NodeSection(
-                    nodeId = nodeKey.first,
-                    nodeTitle = nodeKey.second,
-                    classType = nodeParams.first().nodeClassType,
-                    parameters = nodeParams,
-                    onParameterChanged = onParameterChanged,
-                )
+        item { SheetHeader(onRefresh) }
+        renderGroupedSections(grouped, onParameterChanged, onImagePickRequested)
+        if (advancedParams.isNotEmpty()) {
+            renderAdvancedSection(advancedParams, showAdvanced, onParameterChanged, onImagePickRequested) {
+                showAdvanced = !showAdvanced
             }
         }
     }
 }
+
+/**
+ * Splits parameters into grouped (APP mode) sections and advanced (ungrouped) sections.
+ * If no groups are present, all parameters go into node-based groups.
+ */
+private fun buildGroupedParameters(
+    parameters: List<ExtractedParameter>,
+): Pair<List<ParameterGroup>, List<ExtractedParameter>> {
+    val hasGroups = parameters.any { it.group != null }
+    if (!hasGroups) {
+        // Legacy: group by node, no advanced section
+        val groups = parameters
+            .groupBy { it.nodeId to it.nodeTitle }
+            .map { (key, params) -> ParameterGroup(key.second, params.sortedBy { it.order }) }
+        return groups to emptyList()
+    }
+    // APP mode: grouped params go into named sections, ungrouped become "advanced"
+    val grouped = parameters.filter { it.group != null }
+        .groupBy { it.group!! }
+        .map { (name, params) -> ParameterGroup(name, params.sortedBy { it.order }) }
+    val advanced = parameters.filter { it.group == null }
+    return grouped to advanced
+}
+
+private data class ParameterGroup(
+    val title: String,
+    val parameters: List<ExtractedParameter>,
+)
 
 @Composable
 private fun SheetHeader(onRefresh: () -> Unit) {
@@ -109,30 +148,52 @@ private fun SheetHeader(onRefresh: () -> Unit) {
     }
 }
 
-@Composable
-private fun NodeSection(
-    nodeId: String,
-    nodeTitle: String,
-    classType: String,
-    parameters: List<ExtractedParameter>,
-    onParameterChanged: (nodeId: String, paramName: String, newValue: String) -> Unit,
+// Extension functions on LazyListScope for rendering sections
+private fun androidx.compose.foundation.lazy.LazyListScope.renderGroupedSections(
+    groups: List<ParameterGroup>,
+    onParameterChanged: (String, String, String) -> Unit,
+    onImagePickRequested: ((String, String) -> Unit)?,
 ) {
-    val expandedNodes = remember { mutableStateMapOf<String, Boolean>() }
-    val isExpanded = expandedNodes.getOrPut(nodeId) { true }
+    groups.forEach { group ->
+        item(key = "group_${group.title}") {
+            GroupSection(group, onParameterChanged, onImagePickRequested)
+        }
+    }
+}
 
+@Suppress("LongParameterList")
+private fun androidx.compose.foundation.lazy.LazyListScope.renderAdvancedSection(
+    advancedParams: List<ExtractedParameter>,
+    showAdvanced: Boolean,
+    onParameterChanged: (String, String, String) -> Unit,
+    onImagePickRequested: ((String, String) -> Unit)?,
+    onToggle: () -> Unit,
+) {
+    item(key = "advanced_header") {
+        AdvancedSectionHeader(isExpanded = showAdvanced, onToggle = onToggle)
+    }
+    if (showAdvanced) {
+        item(key = "advanced_content") {
+            AdvancedSectionContent(advancedParams, onParameterChanged, onImagePickRequested)
+        }
+    }
+}
+
+@Composable
+private fun GroupSection(
+    group: ParameterGroup,
+    onParameterChanged: (String, String, String) -> Unit,
+    onImagePickRequested: ((String, String) -> Unit)?,
+) {
     Card(modifier = Modifier.fillMaxWidth()) {
         Column(modifier = Modifier.padding(Spacing.md)) {
-            NodeSectionHeader(
-                nodeTitle = nodeTitle,
-                classType = classType,
-                isExpanded = isExpanded,
-                onToggle = { expandedNodes[nodeId] = !isExpanded },
-            )
-            AnimatedVisibility(visible = isExpanded) {
-                Column(verticalArrangement = Arrangement.spacedBy(Spacing.sm)) {
-                    parameters.forEach { param ->
-                        ParameterWidget(param, onParameterChanged)
-                    }
+            SectionHeader(title = group.title, showDivider = false)
+            Column(
+                modifier = Modifier.padding(top = Spacing.sm),
+                verticalArrangement = Arrangement.spacedBy(Spacing.sm),
+            ) {
+                group.parameters.forEach { param ->
+                    ParameterWidget(param, onParameterChanged, onImagePickRequested)
                 }
             }
         }
@@ -140,29 +201,67 @@ private fun NodeSection(
 }
 
 @Composable
-private fun NodeSectionHeader(
-    nodeTitle: String,
-    classType: String,
-    isExpanded: Boolean,
-    onToggle: () -> Unit,
-) {
+private fun AdvancedSectionHeader(isExpanded: Boolean, onToggle: () -> Unit) {
     Row(
         modifier = Modifier.fillMaxWidth(),
         verticalAlignment = Alignment.CenterVertically,
     ) {
-        Column(modifier = Modifier.weight(1f)) {
-            Text(nodeTitle, style = MaterialTheme.typography.labelLarge)
-            Text(
-                classType,
-                style = MaterialTheme.typography.bodySmall,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-            )
-        }
+        Text(
+            stringResource(R.string.label_advanced_parameters),
+            style = MaterialTheme.typography.titleSmall,
+            modifier = Modifier.weight(1f),
+        )
         IconButton(onClick = onToggle) {
             Icon(
                 if (isExpanded) Icons.Default.ExpandLess else Icons.Default.ExpandMore,
-                contentDescription = if (isExpanded) "Collapse" else "Expand",
+                contentDescription = if (isExpanded) {
+                    stringResource(R.string.cd_collapse_section)
+                } else {
+                    stringResource(R.string.cd_expand_section)
+                },
             )
+        }
+    }
+}
+
+@Composable
+private fun AdvancedSectionContent(
+    params: List<ExtractedParameter>,
+    onParameterChanged: (String, String, String) -> Unit,
+    onImagePickRequested: ((String, String) -> Unit)?,
+) {
+    // Group advanced params by node
+    val nodeGroups = params.groupBy { it.nodeId to it.nodeTitle }
+    Column(verticalArrangement = Arrangement.spacedBy(Spacing.sm)) {
+        nodeGroups.forEach { (nodeKey, nodeParams) ->
+            NodeSection(
+                nodeTitle = nodeKey.second,
+                parameters = nodeParams,
+                onParameterChanged = onParameterChanged,
+                onImagePickRequested = onImagePickRequested,
+            )
+        }
+    }
+}
+
+@Composable
+private fun NodeSection(
+    nodeTitle: String,
+    parameters: List<ExtractedParameter>,
+    onParameterChanged: (String, String, String) -> Unit,
+    onImagePickRequested: ((String, String) -> Unit)?,
+) {
+    Card(modifier = Modifier.fillMaxWidth()) {
+        Column(modifier = Modifier.padding(Spacing.md)) {
+            Text(nodeTitle, style = MaterialTheme.typography.labelLarge)
+            Column(
+                modifier = Modifier.padding(top = Spacing.xs),
+                verticalArrangement = Arrangement.spacedBy(Spacing.sm),
+            ) {
+                parameters.forEach { param ->
+                    ParameterWidget(param, onParameterChanged, onImagePickRequested)
+                }
+            }
         }
     }
 }
@@ -170,20 +269,87 @@ private fun NodeSectionHeader(
 @Composable
 private fun ParameterWidget(
     param: ExtractedParameter,
-    onParameterChanged: (nodeId: String, paramName: String, newValue: String) -> Unit,
+    onParameterChanged: (String, String, String) -> Unit,
+    onImagePickRequested: ((String, String) -> Unit)?,
 ) {
     when (param.paramType) {
         ParameterType.TEXT -> TextParameterWidget(param, onParameterChanged)
         ParameterType.NUMBER -> NumberParameterWidget(param, onParameterChanged)
         ParameterType.SELECT -> SelectParameterWidget(param, onParameterChanged)
         ParameterType.SEED -> SeedParameterWidget(param, onParameterChanged)
+        ParameterType.BOOLEAN -> BooleanParameterWidget(param, onParameterChanged)
+        ParameterType.IMAGE -> ImageParameterWidget(param, onImagePickRequested)
+    }
+}
+
+@Composable
+private fun BooleanParameterWidget(
+    param: ExtractedParameter,
+    onParameterChanged: (String, String, String) -> Unit,
+) {
+    val isChecked = param.currentValue.toBooleanLenient()
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.SpaceBetween,
+    ) {
+        Text(param.paramName, style = MaterialTheme.typography.bodyMedium)
+        Switch(
+            checked = isChecked,
+            onCheckedChange = { newValue ->
+                onParameterChanged(param.nodeId, param.paramName, newValue.toString())
+            },
+        )
+    }
+}
+
+@Composable
+private fun ImageParameterWidget(
+    param: ExtractedParameter,
+    onImagePickRequested: ((String, String) -> Unit)?,
+) {
+    Column(verticalArrangement = Arrangement.spacedBy(Spacing.xs)) {
+        Text(param.paramName, style = MaterialTheme.typography.bodySmall)
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(Spacing.sm),
+        ) {
+            // Image preview placeholder
+            Icon(
+                Icons.Default.Image,
+                contentDescription = null,
+                modifier = Modifier
+                    .size(IMAGE_PREVIEW_SIZE.dp)
+                    .border(
+                        width = 1.dp,
+                        color = MaterialTheme.colorScheme.outline,
+                        shape = RoundedCornerShape(Spacing.md),
+                    )
+                    .padding(Spacing.md),
+                tint = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            Column(verticalArrangement = Arrangement.spacedBy(Spacing.xs)) {
+                Text(
+                    text = param.currentValue.ifBlank {
+                        stringResource(R.string.label_no_image_selected)
+                    },
+                    style = MaterialTheme.typography.bodySmall,
+                    maxLines = 1,
+                )
+                OutlinedButton(
+                    onClick = { onImagePickRequested?.invoke(param.nodeId, param.paramName) },
+                ) {
+                    Text(stringResource(R.string.label_select_from_gallery))
+                }
+            }
+        }
     }
 }
 
 @Composable
 private fun TextParameterWidget(
     param: ExtractedParameter,
-    onParameterChanged: (nodeId: String, paramName: String, newValue: String) -> Unit,
+    onParameterChanged: (String, String, String) -> Unit,
 ) {
     OutlinedTextField(
         value = param.currentValue,
@@ -198,7 +364,7 @@ private fun TextParameterWidget(
 @Composable
 private fun NumberParameterWidget(
     param: ExtractedParameter,
-    onParameterChanged: (nodeId: String, paramName: String, newValue: String) -> Unit,
+    onParameterChanged: (String, String, String) -> Unit,
 ) {
     val min = param.min
     val max = param.max
@@ -214,7 +380,7 @@ private fun NumberSliderWidget(
     param: ExtractedParameter,
     min: Double,
     max: Double,
-    onParameterChanged: (nodeId: String, paramName: String, newValue: String) -> Unit,
+    onParameterChanged: (String, String, String) -> Unit,
 ) {
     val currentFloat = param.currentValue.toFloatOrNull() ?: min.toFloat()
     Column {
@@ -242,7 +408,7 @@ private fun NumberSliderWidget(
 @Composable
 private fun NumberFieldWidget(
     param: ExtractedParameter,
-    onParameterChanged: (nodeId: String, paramName: String, newValue: String) -> Unit,
+    onParameterChanged: (String, String, String) -> Unit,
 ) {
     OutlinedTextField(
         value = param.currentValue,
@@ -257,7 +423,7 @@ private fun NumberFieldWidget(
 @Composable
 private fun SelectParameterWidget(
     param: ExtractedParameter,
-    onParameterChanged: (nodeId: String, paramName: String, newValue: String) -> Unit,
+    onParameterChanged: (String, String, String) -> Unit,
 ) {
     var expanded by remember { mutableStateOf(false) }
     Column {
@@ -289,7 +455,7 @@ private fun SelectParameterWidget(
 @Composable
 private fun SeedParameterWidget(
     param: ExtractedParameter,
-    onParameterChanged: (nodeId: String, paramName: String, newValue: String) -> Unit,
+    onParameterChanged: (String, String, String) -> Unit,
 ) {
     Row(
         verticalAlignment = Alignment.CenterVertically,
@@ -315,6 +481,13 @@ private fun SeedParameterWidget(
     }
 }
 
+/**
+ * Parses a boolean value leniently from common ComfyUI representations.
+ */
+private fun String.toBooleanLenient(): Boolean {
+    return equals("true", ignoreCase = true) || this == "1"
+}
+
 private fun formatNumber(value: String): String {
     val doubleVal = value.toDoubleOrNull() ?: return value
     return if (doubleVal == doubleVal.toLong().toDouble()) {
@@ -329,8 +502,5 @@ private fun calculateSteps(min: Double, max: Double, step: Double?): Int {
     val range = max - min
     if (range <= 0) return 0
     val numSteps = (range / step).toInt()
-    // Limit to avoid performance issues with very fine-grained sliders
     return numSteps.coerceAtMost(MAX_SLIDER_STEPS) - 1
 }
-
-private const val MAX_SLIDER_STEPS = 1000

--- a/androidApp/src/main/res/values/strings.xml
+++ b/androidApp/src/main/res/values/strings.xml
@@ -93,6 +93,10 @@
     <string name="cd_edit_parameters">Edit parameters</string>
     <string name="cd_randomize_seed">Randomize seed</string>
     <string name="cd_refresh_parameters">Refresh parameters</string>
+    <string name="cd_select_image">Select image</string>
+    <string name="cd_toggle_parameter">Toggle %1$s</string>
+    <string name="cd_expand_section">Expand section</string>
+    <string name="cd_collapse_section">Collapse section</string>
     <string name="cd_open_details">Open details</string>
     <string name="cd_enable_plugin">Enable %1$s</string>
     <string name="cd_plugin_active">Active</string>
@@ -288,6 +292,10 @@
     <string name="label_importing">Importing…</string>
     <string name="label_required">Required</string>
     <string name="label_optional">Optional</string>
+    <string name="label_advanced_parameters">Advanced Parameters</string>
+    <string name="label_select_from_gallery">Gallery</string>
+    <string name="label_recent_generations">Recent</string>
+    <string name="label_no_image_selected">No image selected</string>
     <string name="label_enabled">Enabled</string>
     <string name="label_name">Name</string>
     <string name="label_description">Description</string>

--- a/core/core-domain/src/commonMain/kotlin/com/riox432/civitdeck/domain/model/WorkflowTemplate.kt
+++ b/core/core-domain/src/commonMain/kotlin/com/riox432/civitdeck/domain/model/WorkflowTemplate.kt
@@ -47,4 +47,7 @@ enum class TemplateVariableType {
     NUMBER,
     SELECT,
     SLIDER,
+    IMAGE,
+    BOOLEAN,
+    SEED,
 }

--- a/desktopApp/src/jvmMain/kotlin/com/riox432/civitdeck/ui/comfyui/template/DesktopTemplateParameterScreen.kt
+++ b/desktopApp/src/jvmMain/kotlin/com/riox432/civitdeck/ui/comfyui/template/DesktopTemplateParameterScreen.kt
@@ -10,8 +10,10 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Casino
 import androidx.compose.material3.Button
 import androidx.compose.material3.Card
 import androidx.compose.material3.DropdownMenu
@@ -22,6 +24,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Slider
 import androidx.compose.material3.Surface
+import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
@@ -32,12 +35,14 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.input.KeyboardType
 import com.riox432.civitdeck.domain.model.TemplateVariable
 import com.riox432.civitdeck.domain.model.TemplateVariableType
 import com.riox432.civitdeck.domain.model.WorkflowTemplate
 import com.riox432.civitdeck.ui.theme.Elevation
 import com.riox432.civitdeck.ui.theme.Spacing
 import kotlin.math.roundToInt
+import kotlin.random.Random
 
 @Composable
 fun DesktopTemplateParameterScreen(
@@ -139,7 +144,11 @@ private fun ParameterInput(
                 TemplateVariableType.SLIDER -> SliderInput(variable, value, onValueChange)
                 TemplateVariableType.SELECT -> SelectInput(variable, value, onValueChange)
                 TemplateVariableType.NUMBER -> NumberInput(variable, value, onValueChange)
-                TemplateVariableType.TEXT -> TextInput(variable, value, onValueChange)
+                TemplateVariableType.BOOLEAN -> BooleanInput(variable, value, onValueChange)
+                TemplateVariableType.SEED -> SeedInput(variable, value, onValueChange)
+                TemplateVariableType.TEXT, TemplateVariableType.IMAGE -> {
+                    TextInput(variable, value, onValueChange)
+                }
             }
         }
     }
@@ -242,6 +251,55 @@ private fun TextInput(
             if (variable.required) Text("Required") else Text("Optional")
         },
     )
+}
+
+@Composable
+private fun BooleanInput(
+    variable: TemplateVariable,
+    value: String,
+    onValueChange: (String) -> Unit,
+) {
+    val isChecked = value.equals("true", ignoreCase = true) || value == "1"
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.SpaceBetween,
+    ) {
+        Text(
+            variable.label.ifBlank { variable.name },
+            style = MaterialTheme.typography.bodyMedium,
+        )
+        Switch(
+            checked = isChecked,
+            onCheckedChange = { onValueChange(it.toString()) },
+        )
+    }
+}
+
+@Composable
+private fun SeedInput(
+    variable: TemplateVariable,
+    value: String,
+    onValueChange: (String) -> Unit,
+) {
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(Spacing.sm),
+    ) {
+        OutlinedTextField(
+            value = value,
+            onValueChange = onValueChange,
+            modifier = Modifier.weight(1f),
+            singleLine = true,
+            keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+        )
+        IconButton(onClick = {
+            val randomSeed = Random.nextLong(0, Long.MAX_VALUE)
+            onValueChange(randomSeed.toString())
+        }) {
+            Icon(Icons.Default.Casino, contentDescription = "Randomize seed")
+        }
+    }
 }
 
 private fun formatSliderValue(value: Float, step: Float): String {

--- a/desktopApp/src/jvmMain/kotlin/com/riox432/civitdeck/ui/settings/DesktopComfyUIWorkflowSection.kt
+++ b/desktopApp/src/jvmMain/kotlin/com/riox432/civitdeck/ui/settings/DesktopComfyUIWorkflowSection.kt
@@ -16,6 +16,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Slider
+import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
@@ -181,10 +182,11 @@ private fun DesktopParamWidget(
     onChanged: (String, String, String) -> Unit,
 ) {
     when (param.paramType) {
-        ParameterType.TEXT -> ParamTextInput(param, onChanged)
+        ParameterType.TEXT, ParameterType.IMAGE -> ParamTextInput(param, onChanged)
         ParameterType.NUMBER -> ParamNumberInput(param, onChanged)
         ParameterType.SELECT -> DesktopParamDropdown(param, onChanged)
         ParameterType.SEED -> ParamSeedInput(param, onChanged)
+        ParameterType.BOOLEAN -> ParamBooleanInput(param, onChanged)
     }
 }
 
@@ -304,5 +306,27 @@ private fun DesktopParamDropdown(
                 )
             }
         }
+    }
+}
+
+@Composable
+private fun ParamBooleanInput(
+    param: ExtractedParameter,
+    onChanged: (String, String, String) -> Unit,
+) {
+    val isChecked = param.currentValue.equals("true", ignoreCase = true) ||
+        param.currentValue == "1"
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.SpaceBetween,
+    ) {
+        Text(param.paramName, style = MaterialTheme.typography.bodyMedium)
+        Switch(
+            checked = isChecked,
+            onCheckedChange = { newValue ->
+                onChanged(param.nodeId, param.paramName, newValue.toString())
+            },
+        )
     }
 }

--- a/feature/feature-comfyui/src/commonMain/kotlin/com/riox432/civitdeck/feature/comfyui/domain/model/ExtractedParameter.kt
+++ b/feature/feature-comfyui/src/commonMain/kotlin/com/riox432/civitdeck/feature/comfyui/domain/model/ExtractedParameter.kt
@@ -37,4 +37,10 @@ enum class ParameterType {
 
     /** Seed value with randomize button. */
     SEED,
+
+    /** Image upload input (gallery picker or recent generations). */
+    IMAGE,
+
+    /** Boolean toggle switch. */
+    BOOLEAN,
 }

--- a/feature/feature-comfyui/src/commonMain/kotlin/com/riox432/civitdeck/feature/comfyui/domain/usecase/ExtractWorkflowParametersUseCase.kt
+++ b/feature/feature-comfyui/src/commonMain/kotlin/com/riox432/civitdeck/feature/comfyui/domain/usecase/ExtractWorkflowParametersUseCase.kt
@@ -206,6 +206,14 @@ class ExtractWorkflowParametersUseCase(
         // Seed fields are always SEED type
         if (paramName == "seed" || paramName == "noise_seed") return ParameterType.SEED
 
+        // Image upload fields
+        if (paramName == "image" || paramName in KNOWN_IMAGE_PARAMS) return ParameterType.IMAGE
+
+        // Boolean fields (schema type or known names)
+        if (schema?.isBoolean == true || paramName in KNOWN_BOOLEAN_PARAMS) {
+            return ParameterType.BOOLEAN
+        }
+
         // If schema has options, it's a SELECT
         if (schema != null && schema.options.isNotEmpty()) return ParameterType.SELECT
 
@@ -225,6 +233,7 @@ class ExtractWorkflowParametersUseCase(
         val max: Double? = null,
         val step: Double? = null,
         val options: List<String> = emptyList(),
+        val isBoolean: Boolean = false,
     )
 
     /**
@@ -260,11 +269,14 @@ class ExtractWorkflowParametersUseCase(
 
         // If first element is a string type descriptor, check for constraints in second element
         if (first is JsonPrimitive) {
+            val typeStr = first.content
+            val isBoolean = typeStr.equals("BOOLEAN", ignoreCase = true)
             val constraints = if (paramDef.size > 1) paramDef[1] as? JsonObject else null
             return SchemaInfo(
                 min = constraints?.get("min")?.jsonPrimitive?.doubleOrNull,
                 max = constraints?.get("max")?.jsonPrimitive?.doubleOrNull,
                 step = constraints?.get("step")?.jsonPrimitive?.doubleOrNull,
+                isBoolean = isBoolean,
             )
         }
 
@@ -305,6 +317,15 @@ class ExtractWorkflowParametersUseCase(
         private val KNOWN_NUMERIC_PARAMS = setOf(
             "steps", "cfg", "denoise", "strength_model", "strength_clip",
             "width", "height", "batch_size", "start_at_step", "end_at_step",
+        )
+
+        private val KNOWN_IMAGE_PARAMS = setOf(
+            "image", "input_image", "source_image", "mask",
+        )
+
+        private val KNOWN_BOOLEAN_PARAMS = setOf(
+            "add_noise", "return_with_leftover_noise", "tiling",
+            "disable_noise", "force_inpaint",
         )
     }
 }

--- a/feature/feature-comfyui/src/commonMain/kotlin/com/riox432/civitdeck/feature/comfyui/domain/usecase/InjectWorkflowParametersUseCase.kt
+++ b/feature/feature-comfyui/src/commonMain/kotlin/com/riox432/civitdeck/feature/comfyui/domain/usecase/InjectWorkflowParametersUseCase.kt
@@ -96,7 +96,13 @@ class InjectWorkflowParametersUseCase {
                     JsonPrimitive(doubleVal)
                 }
             }
-            ParameterType.TEXT, ParameterType.SELECT -> JsonPrimitive(value)
+            ParameterType.BOOLEAN -> {
+                val boolVal = value.equals("true", ignoreCase = true) || value == "1"
+                JsonPrimitive(boolVal)
+            }
+            ParameterType.IMAGE, ParameterType.TEXT, ParameterType.SELECT -> {
+                JsonPrimitive(value)
+            }
         }
     }
 

--- a/iosApp/iosApp/Features/ComfyUI/TemplateParameterView.swift
+++ b/iosApp/iosApp/Features/ComfyUI/TemplateParameterView.swift
@@ -76,6 +76,10 @@ struct TemplateParameterView: View {
                 selectInput(variable: variable)
             case .number:
                 numberInput(variable: variable)
+            case .boolean_:
+                booleanInput(variable: variable)
+            case .seed:
+                seedInput(variable: variable)
             default:
                 textInput(variable: variable)
             }
@@ -165,6 +169,43 @@ struct TemplateParameterView: View {
         )
         .lineLimit(isPrompt ? 3...6 : 1...1)
         .textFieldStyle(.roundedBorder)
+    }
+
+    private func booleanInput(variable: TemplateVariable) -> some View {
+        let isOn = (values[variable.name] ?? variable.defaultValue).lowercased() == "true"
+            || (values[variable.name] ?? variable.defaultValue) == "1"
+        return Toggle(
+            variable.label.isEmpty ? variable.name : variable.label,
+            isOn: Binding(
+                get: { isOn },
+                set: { newValue in
+                    values[variable.name] = "\(newValue)"
+                }
+            )
+        )
+        .font(.civitBodyMedium)
+    }
+
+    private func seedInput(variable: TemplateVariable) -> some View {
+        HStack(spacing: Spacing.sm) {
+            TextField(
+                variable.required ? "Required" : "Optional",
+                text: Binding(
+                    get: { values[variable.name] ?? "" },
+                    set: { values[variable.name] = $0 }
+                )
+            )
+            .keyboardType(.numberPad)
+            .textFieldStyle(.roundedBorder)
+            Button {
+                let randomSeed = Int64.random(in: 0..<Int64.max)
+                values[variable.name] = "\(randomSeed)"
+            } label: {
+                Image(systemName: "dice")
+                    .accessibilityLabel("Randomize seed")
+            }
+            .buttonStyle(.bordered)
+        }
     }
 
     private func formatSliderValue(_ value: Double, step: Double) -> String {

--- a/iosApp/iosApp/Features/ComfyUI/WorkflowParameterView.swift
+++ b/iosApp/iosApp/Features/ComfyUI/WorkflowParameterView.swift
@@ -1,20 +1,26 @@
 import SwiftUI
 import Shared
+import PhotosUI
 
 private let sliderLabelWidth: CGFloat = 130
 
-/// Renders extracted workflow parameters as a SwiftUI Form grouped by node.
+/// Renders extracted workflow parameters as a SwiftUI Form grouped by APP mode groups or nodes.
 struct WorkflowParameterView: View {
     let parameters: [Feature_comfyuiExtractedParameter]
     let onParameterChanged: (String, String, String) -> Void
     let onRefresh: () -> Void
+    var onImagePickRequested: ((String, String) -> Void)?
     @Environment(\.dismiss) private var dismiss
+    @State private var showAdvanced = false
 
     var body: some View {
         NavigationStack {
             List {
-                ForEach(groupedParameters, id: \.nodeId) { group in
-                    nodeSection(group)
+                ForEach(groupedSections, id: \.title) { section in
+                    sectionView(section)
+                }
+                if !advancedParameters.isEmpty {
+                    advancedSection
                 }
             }
             .navigationTitle("Workflow Parameters")
@@ -35,15 +41,47 @@ struct WorkflowParameterView: View {
         }
     }
 
-    private var groupedParameters: [NodeGroup] {
-        var groups: [String: NodeGroup] = [:]
+    // MARK: - Grouped sections
+
+    private var groupedSections: [ParameterSection] {
+        let hasGroups = parameters.contains { $0.group != nil }
+        if hasGroups {
+            return buildAppModeGroups()
+        }
+        return buildNodeGroups()
+    }
+
+    private var advancedParameters: [Feature_comfyuiExtractedParameter] {
+        let hasGroups = parameters.contains { $0.group != nil }
+        guard hasGroups else { return [] }
+        return parameters.filter { $0.group == nil }
+    }
+
+    private func buildAppModeGroups() -> [ParameterSection] {
+        var groups: [String: [Feature_comfyuiExtractedParameter]] = [:]
+        var order: [String] = []
+        for param in parameters where param.group != nil {
+            let group = param.group!
+            if groups[group] == nil {
+                order.append(group)
+                groups[group] = []
+            }
+            groups[group]?.append(param)
+        }
+        return order.compactMap { key in
+            guard let params = groups[key] else { return nil }
+            let sorted = params.sorted { $0.order < $1.order }
+            return ParameterSection(title: key, parameters: sorted)
+        }
+    }
+
+    private func buildNodeGroups() -> [ParameterSection] {
+        var groups: [String: ParameterSection] = [:]
         var order: [String] = []
         for param in parameters {
             if groups[param.nodeId] == nil {
-                groups[param.nodeId] = NodeGroup(
-                    nodeId: param.nodeId,
-                    nodeTitle: param.nodeTitle,
-                    classType: param.nodeClassType,
+                groups[param.nodeId] = ParameterSection(
+                    title: param.nodeTitle,
                     parameters: []
                 )
                 order.append(param.nodeId)
@@ -53,20 +91,38 @@ struct WorkflowParameterView: View {
         return order.compactMap { groups[$0] }
     }
 
+    // MARK: - Section views
+
     @ViewBuilder
-    private func nodeSection(_ group: NodeGroup) -> some View {
+    private func sectionView(_ section: ParameterSection) -> some View {
         Section {
-            ForEach(group.parameters, id: \.paramKey) { param in
+            ForEach(section.parameters, id: \.paramKey) { param in
                 parameterWidget(param)
             }
         } header: {
-            VStack(alignment: .leading, spacing: Spacing.xs) {
-                Text(group.nodeTitle).font(.civitLabelMedium)
-                Text(group.classType).font(.civitBodySmall)
-                    .foregroundColor(.civitOnSurfaceVariant)
-            }
+            Text(section.title).font(.civitLabelMedium)
         }
     }
+
+    @ViewBuilder
+    private var advancedSection: some View {
+        Section {
+            DisclosureGroup(
+                isExpanded: $showAdvanced,
+                content: {
+                    ForEach(advancedParameters, id: \.paramKey) { param in
+                        parameterWidget(param)
+                    }
+                },
+                label: {
+                    Text("Advanced Parameters")
+                        .font(.civitBodyMedium)
+                }
+            )
+        }
+    }
+
+    // MARK: - Parameter widgets
 
     @ViewBuilder
     private func parameterWidget(_ param: Feature_comfyuiExtractedParameter) -> some View {
@@ -79,8 +135,50 @@ struct WorkflowParameterView: View {
             selectWidget(param)
         case .seed:
             seedWidget(param)
+        case .boolean_:
+            booleanWidget(param)
+        case .image:
+            imageWidget(param)
         default:
             textWidget(param)
+        }
+    }
+
+    private func booleanWidget(_ param: Feature_comfyuiExtractedParameter) -> some View {
+        let isOn = param.currentValue.lowercased() == "true" || param.currentValue == "1"
+        return Toggle(param.paramName, isOn: Binding(
+            get: { isOn },
+            set: { newValue in
+                // Update immediately to prevent visual revert
+                onParameterChanged(param.nodeId, param.paramName, "\(newValue)")
+            }
+        ))
+        .font(.civitBodyMedium)
+    }
+
+    private func imageWidget(_ param: Feature_comfyuiExtractedParameter) -> some View {
+        VStack(alignment: .leading, spacing: Spacing.xs) {
+            Text(param.paramName).font(.civitBodySmall)
+            HStack(spacing: Spacing.sm) {
+                Image(systemName: "photo")
+                    .font(.title2)
+                    .frame(width: 48, height: 48)
+                    .foregroundColor(.civitOnSurfaceVariant)
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 12)
+                            .stroke(Color.civitOutline, lineWidth: 1)
+                    )
+                VStack(alignment: .leading, spacing: Spacing.xs) {
+                    Text(param.currentValue.isEmpty ? "No image selected" : param.currentValue)
+                        .font(.civitBodySmall)
+                        .lineLimit(1)
+                    Button("Gallery") {
+                        onImagePickRequested?(param.nodeId, param.paramName)
+                    }
+                    .buttonStyle(.bordered)
+                    .controlSize(.small)
+                }
+            }
         }
     }
 
@@ -168,6 +266,8 @@ struct WorkflowParameterView: View {
         }
     }
 
+    // MARK: - Helpers
+
     private func bindingFor(_ param: Feature_comfyuiExtractedParameter) -> Binding<String> {
         Binding(
             get: { param.currentValue },
@@ -186,16 +286,14 @@ struct WorkflowParameterView: View {
     }
 }
 
-private class NodeGroup {
-    let nodeId: String
-    let nodeTitle: String
-    let classType: String
+// MARK: - Supporting types
+
+private class ParameterSection {
+    let title: String
     var parameters: [Feature_comfyuiExtractedParameter]
 
-    init(nodeId: String, nodeTitle: String, classType: String, parameters: [Feature_comfyuiExtractedParameter]) {
-        self.nodeId = nodeId
-        self.nodeTitle = nodeTitle
-        self.classType = classType
+    init(title: String, parameters: [Feature_comfyuiExtractedParameter]) {
+        self.title = title
         self.parameters = parameters
     }
 }


### PR DESCRIPTION
## Summary
- Add `IMAGE` and `BOOLEAN` to `ParameterType` and `TemplateVariableType` enums across the KMP domain layer
- Implement grouped parameter sections using `ExtractedParameter.group` from APP mode metadata (#891): parameters with groups render as named sections, ungrouped parameters fall into a collapsible "Advanced Parameters" section
- Add `BooleanParameterWidget` (Switch/Toggle) on Android, iOS, and Desktop
- Add `ImageParameterWidget` with placeholder + gallery button on Android and iOS; falls back to text input on Desktop
- Add `SeedInput` with randomize button to template parameter screens (Android + Desktop)
- Update `ExtractWorkflowParametersUseCase` to detect BOOLEAN (schema type + known params) and IMAGE (known input names) types
- Update `InjectWorkflowParametersUseCase` to serialize BOOLEAN as JSON boolean and IMAGE as string

## Platforms
- **Android**: `WorkflowParameterSheet.kt`, `TemplateParameterScreen.kt`
- **iOS**: `WorkflowParameterView.swift`, `TemplateParameterView.swift`
- **Desktop**: `DesktopTemplateParameterScreen.kt`, `DesktopComfyUIWorkflowSection.kt`

## Build Verification
- Android detekt: PASSED
- Android assembleDebug: PASSED
- iOS Simulator build: PASSED (pre-existing errors in unrelated files only)
- Desktop compileKotlinJvm: PASSED

## Test plan
- [ ] Verify BOOLEAN parameters render as Switch/Toggle on all platforms
- [ ] Verify IMAGE parameters show image placeholder with Gallery button on mobile
- [ ] Verify APP mode workflows group parameters by `group` field
- [ ] Verify ungrouped parameters appear in collapsible "Advanced Parameters" section
- [ ] Verify SEED template input shows randomize button
- [ ] Verify legacy (non-APP mode) workflows still group by node as before

Closes #892