### PR TITLE
Add APP mode auto-detection in workflow import and ComfyHub

### DIFF
--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/comfyhub/ComfyHubDetailScreen.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/comfyhub/ComfyHubDetailScreen.kt
@@ -1,5 +1,6 @@
 package com.riox432.civitdeck.ui.comfyhub
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ExperimentalLayoutApi
@@ -10,6 +11,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
@@ -23,6 +25,7 @@ import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
@@ -34,11 +37,13 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.riox432.civitdeck.R
 import com.riox432.civitdeck.domain.model.ComfyHubWorkflow
+import com.riox432.civitdeck.feature.comfyui.presentation.ComfyHubDetailUiState
 import com.riox432.civitdeck.feature.comfyui.presentation.ComfyHubDetailViewModel
 import com.riox432.civitdeck.ui.components.ErrorStateView
 import com.riox432.civitdeck.ui.components.LoadingStateOverlay
@@ -53,6 +58,35 @@ fun ComfyHubDetailScreen(
     val state by viewModel.uiState.collectAsStateWithLifecycle()
     val snackbarHostState = remember { SnackbarHostState() }
 
+    DetailScreenEffects(state, snackbarHostState, viewModel)
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text(state.workflow?.name ?: "Workflow Detail") },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(
+                            Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = stringResource(R.string.cd_navigate_back),
+                        )
+                    }
+                },
+            )
+        },
+        snackbarHost = { SnackbarHost(snackbarHostState) },
+    ) { padding ->
+        DetailContentSwitch(state, viewModel, Modifier.padding(padding))
+    }
+}
+
+@Composable
+private fun DetailScreenEffects(
+    state: ComfyHubDetailUiState,
+    snackbarHostState: SnackbarHostState,
+    viewModel: ComfyHubDetailViewModel,
+) {
+    val context = LocalContext.current
     LaunchedEffect(state.importSuccess, state.importError) {
         if (state.importSuccess) {
             snackbarHostState.showSnackbar("Workflow imported successfully!")
@@ -63,48 +97,53 @@ fun ComfyHubDetailScreen(
             viewModel.dismissImportResult()
         }
     }
-
-    Scaffold(
-        topBar = {
-            TopAppBar(
-                title = {
-                    Text(state.workflow?.name ?: "Workflow Detail")
-                },
-                navigationIcon = {
-                    IconButton(onClick = onBack) {
-                        Icon(
-                            Icons.AutoMirrored.Filled.ArrowBack,
-                            contentDescription = stringResource(R.string.cd_navigate_back)
-                        )
-                    }
-                },
-            )
-        },
-        snackbarHost = { SnackbarHost(snackbarHostState) },
-    ) { padding ->
-        when {
-            state.isLoading -> LoadingStateOverlay()
-            state.error != null -> ErrorStateView(
-                message = requireNotNull(state.error) { "error must not be null" },
-                onRetry = viewModel::retry,
-            )
-            state.workflow != null -> DetailContent(
-                workflow = requireNotNull(state.workflow) { "workflow must not be null" },
-                nodeNames = state.nodeNames,
-                isImporting = state.isImporting,
-                onImport = viewModel::onImport,
-                modifier = Modifier.padding(padding),
-            )
+    LaunchedEffect(state.saveTemplateSuccess, state.saveTemplateError) {
+        if (state.saveTemplateSuccess) {
+            snackbarHostState.showSnackbar(context.getString(R.string.comfyhub_template_saved))
+            viewModel.dismissSaveTemplateResult()
+        }
+        state.saveTemplateError?.let {
+            snackbarHostState.showSnackbar(context.getString(R.string.comfyhub_save_template_failed, it))
+            viewModel.dismissSaveTemplateResult()
         }
     }
 }
 
 @Composable
+private fun DetailContentSwitch(
+    state: ComfyHubDetailUiState,
+    viewModel: ComfyHubDetailViewModel,
+    modifier: Modifier,
+) {
+    when {
+        state.isLoading -> LoadingStateOverlay()
+        state.error != null -> ErrorStateView(
+            message = requireNotNull(state.error) { "error must not be null" },
+            onRetry = viewModel::retry,
+        )
+        state.workflow != null -> DetailContent(
+            workflow = requireNotNull(state.workflow) { "workflow must not be null" },
+            nodeNames = state.nodeNames,
+            isImporting = state.isImporting,
+            hasAppMode = state.hasAppMode,
+            isSavingTemplate = state.isSavingTemplate,
+            onImport = viewModel::onImport,
+            onSaveAsTemplate = viewModel::onSaveAsTemplate,
+            modifier = modifier,
+        )
+    }
+}
+
+@Suppress("LongParameterList")
+@Composable
 private fun DetailContent(
     workflow: ComfyHubWorkflow,
     nodeNames: List<String>,
     isImporting: Boolean,
+    hasAppMode: Boolean,
+    isSavingTemplate: Boolean,
     onImport: () -> Unit,
+    onSaveAsTemplate: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     Column(
@@ -114,7 +153,7 @@ private fun DetailContent(
             .padding(Spacing.md),
         verticalArrangement = Arrangement.spacedBy(Spacing.md),
     ) {
-        WorkflowHeader(workflow)
+        WorkflowHeader(workflow, hasAppMode)
         HorizontalDivider()
         DescriptionSection(workflow.description)
         TagsSection(workflow.tags)
@@ -122,13 +161,26 @@ private fun DetailContent(
         NodeGraphSection(nodeNames)
         HorizontalDivider()
         ImportButton(isImporting, onImport)
+        SaveAsTemplateButton(isSavingTemplate, onSaveAsTemplate)
     }
 }
 
 @Composable
-private fun WorkflowHeader(workflow: ComfyHubWorkflow) {
+private fun WorkflowHeader(workflow: ComfyHubWorkflow, hasAppMode: Boolean = false) {
     Column(verticalArrangement = Arrangement.spacedBy(Spacing.xs)) {
-        Text(workflow.name, style = MaterialTheme.typography.headlineSmall)
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(Spacing.sm),
+        ) {
+            Text(
+                workflow.name,
+                style = MaterialTheme.typography.headlineSmall,
+                modifier = Modifier.weight(1f),
+            )
+            if (hasAppMode) {
+                AppModeBadge()
+            }
+        }
         Text(
             text = "by ${workflow.author}",
             style = MaterialTheme.typography.bodyMedium,
@@ -231,6 +283,47 @@ private fun ImportButton(isImporting: Boolean, onImport: () -> Unit) {
         } else {
             Icon(Icons.Outlined.Download, contentDescription = "Import workflow")
             Text(stringResource(R.string.comfyhub_import_to_comfyui), modifier = Modifier.padding(start = Spacing.sm))
+        }
+    }
+}
+
+@Composable
+private fun AppModeBadge() {
+    Text(
+        text = stringResource(R.string.template_app_mode_badge),
+        style = MaterialTheme.typography.labelSmall,
+        color = MaterialTheme.colorScheme.primary,
+        modifier = Modifier
+            .background(
+                MaterialTheme.colorScheme.primary.copy(alpha = 0.1f),
+                shape = RoundedCornerShape(Spacing.xs),
+            )
+            .padding(horizontal = Spacing.sm, vertical = Spacing.xs),
+    )
+}
+
+@Composable
+private fun SaveAsTemplateButton(isSaving: Boolean, onSave: () -> Unit) {
+    OutlinedButton(
+        onClick = onSave,
+        enabled = !isSaving,
+        modifier = Modifier.fillMaxWidth(),
+    ) {
+        if (isSaving) {
+            CircularProgressIndicator(
+                modifier = Modifier.size(16.dp),
+                strokeWidth = 2.dp,
+            )
+            Text(
+                stringResource(R.string.comfyhub_saving_template),
+                modifier = Modifier.padding(start = Spacing.sm),
+            )
+        } else {
+            Icon(Icons.Outlined.Star, contentDescription = null)
+            Text(
+                stringResource(R.string.comfyhub_save_as_template),
+                modifier = Modifier.padding(start = Spacing.sm),
+            )
         }
     }
 }

--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/comfyui/WorkflowTemplateScreen.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/comfyui/WorkflowTemplateScreen.kt
@@ -2,6 +2,7 @@
 
 package com.riox432.civitdeck.ui.comfyui
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -13,6 +14,7 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListScope
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Add
@@ -50,6 +52,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.riox432.civitdeck.R
 import com.riox432.civitdeck.domain.model.WorkflowTemplate
@@ -432,7 +435,25 @@ private fun TemplateCard(
 @Composable
 private fun TemplateCardInfo(template: WorkflowTemplate, modifier: Modifier) {
     Column(modifier = modifier) {
-        Text(template.name, style = MaterialTheme.typography.titleSmall)
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(Spacing.sm),
+        ) {
+            Text(template.name, style = MaterialTheme.typography.titleSmall)
+            if (template.isAppMode) {
+                Text(
+                    text = stringResource(R.string.template_app_mode_badge),
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.primary,
+                    modifier = Modifier
+                        .background(
+                            MaterialTheme.colorScheme.primary.copy(alpha = 0.1f),
+                            shape = RoundedCornerShape(Spacing.xs),
+                        )
+                        .padding(horizontal = Spacing.xs, vertical = 2.dp),
+                )
+            }
+        }
         if (template.description.isNotBlank()) {
             Text(
                 template.description,

--- a/androidApp/src/main/res/values/strings.xml
+++ b/androidApp/src/main/res/values/strings.xml
@@ -320,6 +320,11 @@
     <string name="comfyhub_workflows_title">ComfyHub Workflows</string>
     <string name="comfyhub_search_placeholder">Search workflows…</string>
     <string name="comfyhub_import_to_comfyui">Import to ComfyUI</string>
+    <string name="comfyhub_save_as_template">Save as Template</string>
+    <string name="comfyhub_saving_template">Saving…</string>
+    <string name="comfyhub_template_saved">Workflow saved as template!</string>
+    <string name="comfyhub_save_template_failed">Save failed: %1$s</string>
+    <string name="template_app_mode_badge">APP</string>
 
     <!-- Update banner -->
     <string name="update_dismiss">Dismiss</string>

--- a/core/core-database/schemas/com.riox432.civitdeck.data.local.CivitDeckDatabase/47.json
+++ b/core/core-database/schemas/com.riox432.civitdeck.data.local.CivitDeckDatabase/47.json
@@ -1,0 +1,2046 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 47,
+    "identityHash": "04b7bcb4a239fd9063e2917f342b29b6",
+    "entities": [
+      {
+        "tableName": "collections",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL, `isDefault` INTEGER NOT NULL, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isDefault",
+            "columnName": "isDefault",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "collection_model_entries",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`collectionId` INTEGER NOT NULL, `modelId` INTEGER NOT NULL, `name` TEXT NOT NULL, `type` TEXT NOT NULL, `nsfw` INTEGER NOT NULL, `thumbnailUrl` TEXT, `creatorName` TEXT, `downloadCount` INTEGER NOT NULL, `favoriteCount` INTEGER NOT NULL, `rating` REAL NOT NULL, `addedAt` INTEGER NOT NULL, PRIMARY KEY(`collectionId`, `modelId`), FOREIGN KEY(`collectionId`) REFERENCES `collections`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "collectionId",
+            "columnName": "collectionId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "modelId",
+            "columnName": "modelId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "nsfw",
+            "columnName": "nsfw",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "thumbnailUrl",
+            "columnName": "thumbnailUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "creatorName",
+            "columnName": "creatorName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "downloadCount",
+            "columnName": "downloadCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "favoriteCount",
+            "columnName": "favoriteCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "rating",
+            "columnName": "rating",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "addedAt",
+            "columnName": "addedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "collectionId",
+            "modelId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_collection_model_entries_modelId",
+            "unique": false,
+            "columnNames": [
+              "modelId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_collection_model_entries_modelId` ON `${TABLE_NAME}` (`modelId`)"
+          },
+          {
+            "name": "index_collection_model_entries_collectionId",
+            "unique": false,
+            "columnNames": [
+              "collectionId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_collection_model_entries_collectionId` ON `${TABLE_NAME}` (`collectionId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "collections",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "collectionId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "cached_api_responses",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`cacheKey` TEXT NOT NULL, `responseJson` TEXT NOT NULL, `cachedAt` INTEGER NOT NULL, `isOfflinePinned` INTEGER NOT NULL, PRIMARY KEY(`cacheKey`))",
+        "fields": [
+          {
+            "fieldPath": "cacheKey",
+            "columnName": "cacheKey",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "responseJson",
+            "columnName": "responseJson",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cachedAt",
+            "columnName": "cachedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isOfflinePinned",
+            "columnName": "isOfflinePinned",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "cacheKey"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_cached_api_responses_cachedAt",
+            "unique": false,
+            "columnNames": [
+              "cachedAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_cached_api_responses_cachedAt` ON `${TABLE_NAME}` (`cachedAt`)"
+          }
+        ]
+      },
+      {
+        "tableName": "user_preferences",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `nsfwFilterLevel` TEXT NOT NULL, `defaultSortOrder` TEXT NOT NULL, `defaultTimePeriod` TEXT NOT NULL, `gridColumns` INTEGER NOT NULL, `apiKey` TEXT, `powerUserMode` INTEGER NOT NULL, `notificationsEnabled` INTEGER NOT NULL, `pollingIntervalMinutes` INTEGER NOT NULL, `nsfwBlurSoft` INTEGER NOT NULL, `nsfwBlurMature` INTEGER NOT NULL, `nsfwBlurExplicit` INTEGER NOT NULL, `offlineCacheEnabled` INTEGER NOT NULL, `cacheSizeLimitMb` INTEGER NOT NULL, `accentColor` TEXT NOT NULL, `amoledDarkMode` INTEGER NOT NULL, `seenTutorialVersion` INTEGER NOT NULL, `civitaiLinkKey` TEXT, `themeMode` TEXT NOT NULL, `customNavShortcuts` TEXT NOT NULL, `feedQualityThreshold` INTEGER NOT NULL, `generationNotificationsEnabled` INTEGER NOT NULL, `autoUpdateCheckEnabled` INTEGER NOT NULL, `lastUpdateCheckTimestamp` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "nsfwFilterLevel",
+            "columnName": "nsfwFilterLevel",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "defaultSortOrder",
+            "columnName": "defaultSortOrder",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "defaultTimePeriod",
+            "columnName": "defaultTimePeriod",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "gridColumns",
+            "columnName": "gridColumns",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "apiKey",
+            "columnName": "apiKey",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "powerUserMode",
+            "columnName": "powerUserMode",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "notificationsEnabled",
+            "columnName": "notificationsEnabled",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "pollingIntervalMinutes",
+            "columnName": "pollingIntervalMinutes",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "nsfwBlurSoft",
+            "columnName": "nsfwBlurSoft",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "nsfwBlurMature",
+            "columnName": "nsfwBlurMature",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "nsfwBlurExplicit",
+            "columnName": "nsfwBlurExplicit",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "offlineCacheEnabled",
+            "columnName": "offlineCacheEnabled",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cacheSizeLimitMb",
+            "columnName": "cacheSizeLimitMb",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "accentColor",
+            "columnName": "accentColor",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "amoledDarkMode",
+            "columnName": "amoledDarkMode",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "seenTutorialVersion",
+            "columnName": "seenTutorialVersion",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "civitaiLinkKey",
+            "columnName": "civitaiLinkKey",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "themeMode",
+            "columnName": "themeMode",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "customNavShortcuts",
+            "columnName": "customNavShortcuts",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "feedQualityThreshold",
+            "columnName": "feedQualityThreshold",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "generationNotificationsEnabled",
+            "columnName": "generationNotificationsEnabled",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "autoUpdateCheckEnabled",
+            "columnName": "autoUpdateCheckEnabled",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastUpdateCheckTimestamp",
+            "columnName": "lastUpdateCheckTimestamp",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "saved_prompts",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `prompt` TEXT NOT NULL, `negativePrompt` TEXT, `sampler` TEXT, `steps` INTEGER, `cfgScale` REAL, `seed` INTEGER, `modelName` TEXT, `size` TEXT, `sourceImageUrl` TEXT, `savedAt` INTEGER NOT NULL, `isTemplate` INTEGER NOT NULL DEFAULT 0, `templateName` TEXT, `autoSaved` INTEGER NOT NULL DEFAULT 0, `templateVariables` TEXT, `templateType` TEXT, `templateMetadata` TEXT, `isAppMode` INTEGER NOT NULL DEFAULT 0, `rawWorkflowJson` TEXT)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "prompt",
+            "columnName": "prompt",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "negativePrompt",
+            "columnName": "negativePrompt",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "sampler",
+            "columnName": "sampler",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "steps",
+            "columnName": "steps",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "cfgScale",
+            "columnName": "cfgScale",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "seed",
+            "columnName": "seed",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "modelName",
+            "columnName": "modelName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "size",
+            "columnName": "size",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "sourceImageUrl",
+            "columnName": "sourceImageUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "savedAt",
+            "columnName": "savedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isTemplate",
+            "columnName": "isTemplate",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "templateName",
+            "columnName": "templateName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "autoSaved",
+            "columnName": "autoSaved",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "templateVariables",
+            "columnName": "templateVariables",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "templateType",
+            "columnName": "templateType",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "templateMetadata",
+            "columnName": "templateMetadata",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "isAppMode",
+            "columnName": "isAppMode",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "rawWorkflowJson",
+            "columnName": "rawWorkflowJson",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "search_history",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `query` TEXT NOT NULL, `searchedAt` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "query",
+            "columnName": "query",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "searchedAt",
+            "columnName": "searchedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "browsing_history",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `modelId` INTEGER NOT NULL, `modelName` TEXT NOT NULL, `modelType` TEXT NOT NULL, `creatorName` TEXT, `thumbnailUrl` TEXT, `tags` TEXT NOT NULL, `viewedAt` INTEGER NOT NULL, `durationMs` INTEGER, `interactionType` TEXT)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "modelId",
+            "columnName": "modelId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "modelName",
+            "columnName": "modelName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "modelType",
+            "columnName": "modelType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "creatorName",
+            "columnName": "creatorName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "thumbnailUrl",
+            "columnName": "thumbnailUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "tags",
+            "columnName": "tags",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "viewedAt",
+            "columnName": "viewedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "durationMs",
+            "columnName": "durationMs",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "interactionType",
+            "columnName": "interactionType",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_browsing_history_modelId",
+            "unique": false,
+            "columnNames": [
+              "modelId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_browsing_history_modelId` ON `${TABLE_NAME}` (`modelId`)"
+          },
+          {
+            "name": "index_browsing_history_viewedAt",
+            "unique": false,
+            "columnNames": [
+              "viewedAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_browsing_history_viewedAt` ON `${TABLE_NAME}` (`viewedAt`)"
+          }
+        ]
+      },
+      {
+        "tableName": "excluded_tags",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`tag` TEXT NOT NULL, `addedAt` INTEGER NOT NULL, PRIMARY KEY(`tag`))",
+        "fields": [
+          {
+            "fieldPath": "tag",
+            "columnName": "tag",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "addedAt",
+            "columnName": "addedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "tag"
+          ]
+        }
+      },
+      {
+        "tableName": "hidden_models",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`modelId` INTEGER NOT NULL, `modelName` TEXT NOT NULL, `hiddenAt` INTEGER NOT NULL, PRIMARY KEY(`modelId`))",
+        "fields": [
+          {
+            "fieldPath": "modelId",
+            "columnName": "modelId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "modelName",
+            "columnName": "modelName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "hiddenAt",
+            "columnName": "hiddenAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "modelId"
+          ]
+        }
+      },
+      {
+        "tableName": "model_directories",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `path` TEXT NOT NULL, `label` TEXT, `lastScannedAt` INTEGER, `isEnabled` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "path",
+            "columnName": "path",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "label",
+            "columnName": "label",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "lastScannedAt",
+            "columnName": "lastScannedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "isEnabled",
+            "columnName": "isEnabled",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "local_model_files",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `directoryId` INTEGER NOT NULL, `filePath` TEXT NOT NULL, `fileName` TEXT NOT NULL, `sha256Hash` TEXT NOT NULL, `sizeBytes` INTEGER NOT NULL, `scannedAt` INTEGER NOT NULL, `matchedModelId` INTEGER, `matchedModelName` TEXT, `matchedVersionId` INTEGER, `matchedVersionName` TEXT, `latestVersionId` INTEGER, `hasUpdate` INTEGER NOT NULL, FOREIGN KEY(`directoryId`) REFERENCES `model_directories`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "directoryId",
+            "columnName": "directoryId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "filePath",
+            "columnName": "filePath",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fileName",
+            "columnName": "fileName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sha256Hash",
+            "columnName": "sha256Hash",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sizeBytes",
+            "columnName": "sizeBytes",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "scannedAt",
+            "columnName": "scannedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "matchedModelId",
+            "columnName": "matchedModelId",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "matchedModelName",
+            "columnName": "matchedModelName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "matchedVersionId",
+            "columnName": "matchedVersionId",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "matchedVersionName",
+            "columnName": "matchedVersionName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "latestVersionId",
+            "columnName": "latestVersionId",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "hasUpdate",
+            "columnName": "hasUpdate",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_local_model_files_directoryId",
+            "unique": false,
+            "columnNames": [
+              "directoryId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_local_model_files_directoryId` ON `${TABLE_NAME}` (`directoryId`)"
+          },
+          {
+            "name": "index_local_model_files_sha256Hash",
+            "unique": false,
+            "columnNames": [
+              "sha256Hash"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_local_model_files_sha256Hash` ON `${TABLE_NAME}` (`sha256Hash`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "model_directories",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "directoryId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "model_version_checkpoints",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`modelId` INTEGER NOT NULL, `lastKnownVersionId` INTEGER NOT NULL, `lastCheckedAt` INTEGER NOT NULL, PRIMARY KEY(`modelId`))",
+        "fields": [
+          {
+            "fieldPath": "modelId",
+            "columnName": "modelId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastKnownVersionId",
+            "columnName": "lastKnownVersionId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastCheckedAt",
+            "columnName": "lastCheckedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "modelId"
+          ]
+        }
+      },
+      {
+        "tableName": "comfyui_connections",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL, `hostname` TEXT NOT NULL, `port` INTEGER NOT NULL, `isActive` INTEGER NOT NULL, `lastTestedAt` INTEGER, `lastTestSuccess` INTEGER, `createdAt` INTEGER NOT NULL, `useHttps` INTEGER NOT NULL, `acceptSelfSigned` INTEGER NOT NULL, `ntfyServerUrl` TEXT, `ntfyTopic` TEXT)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "hostname",
+            "columnName": "hostname",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "port",
+            "columnName": "port",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isActive",
+            "columnName": "isActive",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastTestedAt",
+            "columnName": "lastTestedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "lastTestSuccess",
+            "columnName": "lastTestSuccess",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "useHttps",
+            "columnName": "useHttps",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "acceptSelfSigned",
+            "columnName": "acceptSelfSigned",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ntfyServerUrl",
+            "columnName": "ntfyServerUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "ntfyTopic",
+            "columnName": "ntfyTopic",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "sdwebui_connections",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL, `hostname` TEXT NOT NULL, `port` INTEGER NOT NULL, `isActive` INTEGER NOT NULL, `lastTestedAt` INTEGER, `lastTestSuccess` INTEGER, `createdAt` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "hostname",
+            "columnName": "hostname",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "port",
+            "columnName": "port",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isActive",
+            "columnName": "isActive",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastTestedAt",
+            "columnName": "lastTestedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "lastTestSuccess",
+            "columnName": "lastTestSuccess",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "dataset_collections",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL, `description` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "dataset_images",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `datasetId` INTEGER NOT NULL, `imageUrl` TEXT NOT NULL, `sourceType` TEXT NOT NULL, `trainable` INTEGER NOT NULL, `addedAt` INTEGER NOT NULL, `licenseNote` TEXT, `pHash` TEXT, `excluded` INTEGER NOT NULL, `width` INTEGER, `height` INTEGER, FOREIGN KEY(`datasetId`) REFERENCES `dataset_collections`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "datasetId",
+            "columnName": "datasetId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "imageUrl",
+            "columnName": "imageUrl",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceType",
+            "columnName": "sourceType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "trainable",
+            "columnName": "trainable",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "addedAt",
+            "columnName": "addedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "licenseNote",
+            "columnName": "licenseNote",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "pHash",
+            "columnName": "pHash",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "excluded",
+            "columnName": "excluded",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "width",
+            "columnName": "width",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "height",
+            "columnName": "height",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_dataset_images_datasetId",
+            "unique": false,
+            "columnNames": [
+              "datasetId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_dataset_images_datasetId` ON `${TABLE_NAME}` (`datasetId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "dataset_collections",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "datasetId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "image_tags",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `datasetImageId` INTEGER NOT NULL, `tag` TEXT NOT NULL, FOREIGN KEY(`datasetImageId`) REFERENCES `dataset_images`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "datasetImageId",
+            "columnName": "datasetImageId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "tag",
+            "columnName": "tag",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_image_tags_datasetImageId",
+            "unique": false,
+            "columnNames": [
+              "datasetImageId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_image_tags_datasetImageId` ON `${TABLE_NAME}` (`datasetImageId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "dataset_images",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "datasetImageId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "captions",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`datasetImageId` INTEGER NOT NULL, `text` TEXT NOT NULL, PRIMARY KEY(`datasetImageId`), FOREIGN KEY(`datasetImageId`) REFERENCES `dataset_images`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "datasetImageId",
+            "columnName": "datasetImageId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "text",
+            "columnName": "text",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "datasetImageId"
+          ]
+        },
+        "foreignKeys": [
+          {
+            "table": "dataset_images",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "datasetImageId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "saved_search_filters",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL, `query` TEXT NOT NULL, `selectedType` TEXT, `selectedSort` TEXT NOT NULL, `selectedPeriod` TEXT NOT NULL, `selectedBaseModels` TEXT NOT NULL, `nsfwFilterLevel` TEXT NOT NULL, `isFreshFindEnabled` INTEGER NOT NULL, `excludedTags` TEXT NOT NULL, `includedTags` TEXT NOT NULL, `selectedSources` TEXT NOT NULL, `savedAt` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "query",
+            "columnName": "query",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "selectedType",
+            "columnName": "selectedType",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "selectedSort",
+            "columnName": "selectedSort",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "selectedPeriod",
+            "columnName": "selectedPeriod",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "selectedBaseModels",
+            "columnName": "selectedBaseModels",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "nsfwFilterLevel",
+            "columnName": "nsfwFilterLevel",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isFreshFindEnabled",
+            "columnName": "isFreshFindEnabled",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "excludedTags",
+            "columnName": "excludedTags",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "includedTags",
+            "columnName": "includedTags",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "selectedSources",
+            "columnName": "selectedSources",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "savedAt",
+            "columnName": "savedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "external_server_configs",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL, `baseUrl` TEXT NOT NULL, `apiKey` TEXT NOT NULL, `isActive` INTEGER NOT NULL, `lastTestedAt` INTEGER, `lastTestSuccess` INTEGER, `createdAt` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "baseUrl",
+            "columnName": "baseUrl",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "apiKey",
+            "columnName": "apiKey",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isActive",
+            "columnName": "isActive",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastTestedAt",
+            "columnName": "lastTestedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "lastTestSuccess",
+            "columnName": "lastTestSuccess",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "model_notes",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `modelId` INTEGER NOT NULL, `noteText` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "modelId",
+            "columnName": "modelId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "noteText",
+            "columnName": "noteText",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_model_notes_modelId",
+            "unique": false,
+            "columnNames": [
+              "modelId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_model_notes_modelId` ON `${TABLE_NAME}` (`modelId`)"
+          }
+        ]
+      },
+      {
+        "tableName": "personal_tags",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `modelId` INTEGER NOT NULL, `tag` TEXT NOT NULL, `addedAt` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "modelId",
+            "columnName": "modelId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "tag",
+            "columnName": "tag",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "addedAt",
+            "columnName": "addedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_personal_tags_modelId",
+            "unique": false,
+            "columnNames": [
+              "modelId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_personal_tags_modelId` ON `${TABLE_NAME}` (`modelId`)"
+          },
+          {
+            "name": "index_personal_tags_tag",
+            "unique": false,
+            "columnNames": [
+              "tag"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_personal_tags_tag` ON `${TABLE_NAME}` (`tag`)"
+          }
+        ]
+      },
+      {
+        "tableName": "followed_creators",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`username` TEXT NOT NULL, `displayName` TEXT NOT NULL, `avatarUrl` TEXT, `followedAt` INTEGER NOT NULL, `lastCheckedAt` INTEGER NOT NULL, PRIMARY KEY(`username`))",
+        "fields": [
+          {
+            "fieldPath": "username",
+            "columnName": "username",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayName",
+            "columnName": "displayName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "avatarUrl",
+            "columnName": "avatarUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "followedAt",
+            "columnName": "followedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastCheckedAt",
+            "columnName": "lastCheckedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "username"
+          ]
+        }
+      },
+      {
+        "tableName": "feed_cache",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`modelId` INTEGER NOT NULL, `creatorUsername` TEXT NOT NULL, `title` TEXT NOT NULL, `thumbnailUrl` TEXT, `type` TEXT NOT NULL, `publishedAt` TEXT NOT NULL, `cachedAt` INTEGER NOT NULL, `downloadCount` INTEGER NOT NULL, `favoriteCount` INTEGER NOT NULL, `commentCount` INTEGER NOT NULL, `ratingCount` INTEGER NOT NULL, `rating` REAL NOT NULL, PRIMARY KEY(`modelId`))",
+        "fields": [
+          {
+            "fieldPath": "modelId",
+            "columnName": "modelId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "creatorUsername",
+            "columnName": "creatorUsername",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "thumbnailUrl",
+            "columnName": "thumbnailUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "publishedAt",
+            "columnName": "publishedAt",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cachedAt",
+            "columnName": "cachedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "downloadCount",
+            "columnName": "downloadCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "favoriteCount",
+            "columnName": "favoriteCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "commentCount",
+            "columnName": "commentCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ratingCount",
+            "columnName": "ratingCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "rating",
+            "columnName": "rating",
+            "affinity": "REAL",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "modelId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_feed_cache_creatorUsername",
+            "unique": false,
+            "columnNames": [
+              "creatorUsername"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_feed_cache_creatorUsername` ON `${TABLE_NAME}` (`creatorUsername`)"
+          },
+          {
+            "name": "index_feed_cache_publishedAt",
+            "unique": false,
+            "columnNames": [
+              "publishedAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_feed_cache_publishedAt` ON `${TABLE_NAME}` (`publishedAt`)"
+          }
+        ]
+      },
+      {
+        "tableName": "model_downloads",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `modelId` INTEGER NOT NULL, `modelName` TEXT NOT NULL, `versionId` INTEGER NOT NULL, `versionName` TEXT NOT NULL, `fileId` INTEGER NOT NULL, `fileName` TEXT NOT NULL, `fileUrl` TEXT NOT NULL, `fileSizeBytes` INTEGER NOT NULL, `downloadedBytes` INTEGER NOT NULL, `status` TEXT NOT NULL, `modelType` TEXT NOT NULL, `destinationPath` TEXT, `errorMessage` TEXT, `expectedSha256` TEXT, `hashVerified` INTEGER, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "modelId",
+            "columnName": "modelId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "modelName",
+            "columnName": "modelName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "versionId",
+            "columnName": "versionId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "versionName",
+            "columnName": "versionName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fileId",
+            "columnName": "fileId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fileName",
+            "columnName": "fileName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fileUrl",
+            "columnName": "fileUrl",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fileSizeBytes",
+            "columnName": "fileSizeBytes",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "downloadedBytes",
+            "columnName": "downloadedBytes",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "modelType",
+            "columnName": "modelType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "destinationPath",
+            "columnName": "destinationPath",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "errorMessage",
+            "columnName": "errorMessage",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "expectedSha256",
+            "columnName": "expectedSha256",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "hashVerified",
+            "columnName": "hashVerified",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_model_downloads_modelId",
+            "unique": false,
+            "columnNames": [
+              "modelId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_model_downloads_modelId` ON `${TABLE_NAME}` (`modelId`)"
+          },
+          {
+            "name": "index_model_downloads_status",
+            "unique": false,
+            "columnNames": [
+              "status"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_model_downloads_status` ON `${TABLE_NAME}` (`status`)"
+          },
+          {
+            "name": "index_model_downloads_createdAt",
+            "unique": false,
+            "columnNames": [
+              "createdAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_model_downloads_createdAt` ON `${TABLE_NAME}` (`createdAt`)"
+          }
+        ]
+      },
+      {
+        "tableName": "plugins",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `name` TEXT NOT NULL, `version` TEXT NOT NULL, `author` TEXT NOT NULL, `description` TEXT NOT NULL, `pluginType` TEXT NOT NULL, `capabilities` TEXT NOT NULL, `minAppVersion` TEXT NOT NULL, `state` TEXT NOT NULL, `configJson` TEXT NOT NULL, `installedAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "version",
+            "columnName": "version",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "author",
+            "columnName": "author",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "pluginType",
+            "columnName": "pluginType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "capabilities",
+            "columnName": "capabilities",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "minAppVersion",
+            "columnName": "minAppVersion",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "state",
+            "columnName": "state",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "configJson",
+            "columnName": "configJson",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "installedAt",
+            "columnName": "installedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "share_hashtags",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`tag` TEXT NOT NULL, `isEnabled` INTEGER NOT NULL, `isCustom` INTEGER NOT NULL, `addedAt` INTEGER NOT NULL, PRIMARY KEY(`tag`))",
+        "fields": [
+          {
+            "fieldPath": "tag",
+            "columnName": "tag",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isEnabled",
+            "columnName": "isEnabled",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isCustom",
+            "columnName": "isCustom",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "addedAt",
+            "columnName": "addedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "tag"
+          ]
+        }
+      },
+      {
+        "tableName": "model_update_notifications",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `modelId` INTEGER NOT NULL, `modelName` TEXT NOT NULL, `newVersionName` TEXT NOT NULL, `newVersionId` INTEGER NOT NULL, `source` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, `isRead` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "modelId",
+            "columnName": "modelId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "modelName",
+            "columnName": "modelName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "newVersionName",
+            "columnName": "newVersionName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "newVersionId",
+            "columnName": "newVersionId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "source",
+            "columnName": "source",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isRead",
+            "columnName": "isRead",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_model_update_notifications_createdAt",
+            "unique": false,
+            "columnNames": [
+              "createdAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_model_update_notifications_createdAt` ON `${TABLE_NAME}` (`createdAt`)"
+          },
+          {
+            "name": "index_model_update_notifications_isRead",
+            "unique": false,
+            "columnNames": [
+              "isRead"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_model_update_notifications_isRead` ON `${TABLE_NAME}` (`isRead`)"
+          }
+        ]
+      },
+      {
+        "tableName": "quality_score_cache",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`modelId` INTEGER NOT NULL, `score` INTEGER NOT NULL, `downloadCount` INTEGER NOT NULL, `favoriteCount` INTEGER NOT NULL, `ratingCount` INTEGER NOT NULL, `cachedAt` INTEGER NOT NULL, PRIMARY KEY(`modelId`))",
+        "fields": [
+          {
+            "fieldPath": "modelId",
+            "columnName": "modelId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "score",
+            "columnName": "score",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "downloadCount",
+            "columnName": "downloadCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "favoriteCount",
+            "columnName": "favoriteCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ratingCount",
+            "columnName": "ratingCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cachedAt",
+            "columnName": "cachedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "modelId"
+          ]
+        }
+      },
+      {
+        "tableName": "model_embeddings",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`modelId` INTEGER NOT NULL, `embeddingModel` TEXT NOT NULL, `dim` INTEGER NOT NULL, `embedding` BLOB NOT NULL, `cachedAt` INTEGER NOT NULL, PRIMARY KEY(`modelId`))",
+        "fields": [
+          {
+            "fieldPath": "modelId",
+            "columnName": "modelId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "embeddingModel",
+            "columnName": "embeddingModel",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "dim",
+            "columnName": "dim",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "embedding",
+            "columnName": "embedding",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cachedAt",
+            "columnName": "cachedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "modelId"
+          ]
+        }
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '04b7bcb4a239fd9063e2917f342b29b6')"
+    ]
+  }
+}

--- a/core/core-database/src/commonMain/kotlin/com/riox432/civitdeck/data/local/CivitDeckDatabase.kt
+++ b/core/core-database/src/commonMain/kotlin/com/riox432/civitdeck/data/local/CivitDeckDatabase.kt
@@ -100,6 +100,7 @@ import com.riox432.civitdeck.data.local.migrations.MIGRATION_42_43
 import com.riox432.civitdeck.data.local.migrations.MIGRATION_43_44
 import com.riox432.civitdeck.data.local.migrations.MIGRATION_44_45
 import com.riox432.civitdeck.data.local.migrations.MIGRATION_45_46
+import com.riox432.civitdeck.data.local.migrations.MIGRATION_46_47
 import com.riox432.civitdeck.data.local.migrations.MIGRATION_4_5
 import com.riox432.civitdeck.data.local.migrations.MIGRATION_5_6
 import com.riox432.civitdeck.data.local.migrations.MIGRATION_6_7
@@ -143,7 +144,7 @@ import kotlinx.coroutines.IO
         QualityScoreCacheEntity::class,
         ModelEmbeddingEntity::class,
     ],
-    version = 46,
+    version = 47,
 )
 @ConstructedBy(CivitDeckDatabaseConstructor::class)
 abstract class CivitDeckDatabase : RoomDatabase() {
@@ -226,6 +227,7 @@ fun getRoomDatabase(builder: RoomDatabase.Builder<CivitDeckDatabase>): CivitDeck
             MIGRATION_43_44,
             MIGRATION_44_45,
             MIGRATION_45_46,
+            MIGRATION_46_47,
         )
         .fallbackToDestructiveMigrationOnDowngrade(dropAllTables = true)
         .addCallback(defaultCollectionCallback)

--- a/core/core-database/src/commonMain/kotlin/com/riox432/civitdeck/data/local/entity/SavedPromptEntity.kt
+++ b/core/core-database/src/commonMain/kotlin/com/riox432/civitdeck/data/local/entity/SavedPromptEntity.kt
@@ -23,4 +23,6 @@ data class SavedPromptEntity(
     val templateVariables: String? = null,
     val templateType: String? = null,
     val templateMetadata: String? = null,
+    @ColumnInfo(defaultValue = "0") val isAppMode: Boolean = false,
+    val rawWorkflowJson: String? = null,
 )

--- a/core/core-database/src/commonMain/kotlin/com/riox432/civitdeck/data/local/migrations/Migration46to47.kt
+++ b/core/core-database/src/commonMain/kotlin/com/riox432/civitdeck/data/local/migrations/Migration46to47.kt
@@ -1,0 +1,16 @@
+package com.riox432.civitdeck.data.local.migrations
+
+import androidx.room.migration.Migration
+import androidx.sqlite.SQLiteConnection
+import androidx.sqlite.execSQL
+
+val MIGRATION_46_47 = object : Migration(46, 47) {
+    override fun migrate(connection: SQLiteConnection) {
+        connection.execSQL(
+            "ALTER TABLE saved_prompts ADD COLUMN isAppMode INTEGER NOT NULL DEFAULT 0",
+        )
+        connection.execSQL(
+            "ALTER TABLE saved_prompts ADD COLUMN rawWorkflowJson TEXT DEFAULT NULL",
+        )
+    }
+}

--- a/core/core-domain/src/commonMain/kotlin/com/riox432/civitdeck/domain/model/SavedPrompt.kt
+++ b/core/core-domain/src/commonMain/kotlin/com/riox432/civitdeck/domain/model/SavedPrompt.kt
@@ -18,4 +18,6 @@ data class SavedPrompt(
     val templateVariables: String? = null,
     val templateType: String? = null,
     val templateMetadata: String? = null,
+    val isAppMode: Boolean = false,
+    val rawWorkflowJson: String? = null,
 )

--- a/core/core-domain/src/commonMain/kotlin/com/riox432/civitdeck/domain/model/WorkflowTemplate.kt
+++ b/core/core-domain/src/commonMain/kotlin/com/riox432/civitdeck/domain/model/WorkflowTemplate.kt
@@ -11,6 +11,8 @@ data class WorkflowTemplate(
     val version: Int = 1,
     val author: String = "",
     val createdAt: Long,
+    val isAppMode: Boolean = false,
+    val rawWorkflowJson: String? = null,
 )
 
 enum class WorkflowTemplateType {

--- a/desktopApp/src/jvmMain/kotlin/com/riox432/civitdeck/ui/comfyui/template/DesktopWorkflowTemplateScreen.kt
+++ b/desktopApp/src/jvmMain/kotlin/com/riox432/civitdeck/ui/comfyui/template/DesktopWorkflowTemplateScreen.kt
@@ -2,6 +2,7 @@
 
 package com.riox432.civitdeck.ui.comfyui.template
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -9,6 +10,8 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.ui.unit.dp
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.rememberScrollState
@@ -317,7 +320,25 @@ private fun TemplateCard(
         Column(modifier = Modifier.padding(Spacing.md)) {
             Row(verticalAlignment = Alignment.CenterVertically) {
                 Column(modifier = Modifier.weight(1f)) {
-                    Text(template.name, style = MaterialTheme.typography.titleSmall)
+                    Row(
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.spacedBy(Spacing.sm),
+                    ) {
+                        Text(template.name, style = MaterialTheme.typography.titleSmall)
+                        if (template.isAppMode) {
+                            Text(
+                                text = "APP",
+                                style = MaterialTheme.typography.labelSmall,
+                                color = MaterialTheme.colorScheme.primary,
+                                modifier = Modifier
+                                    .background(
+                                        MaterialTheme.colorScheme.primary.copy(alpha = 0.1f),
+                                        shape = RoundedCornerShape(Spacing.xs),
+                                    )
+                                    .padding(horizontal = Spacing.xs, vertical = 2.dp),
+                            )
+                        }
+                    }
                     if (template.description.isNotBlank()) {
                         Text(
                             template.description,

--- a/feature/feature-comfyui/src/commonMain/kotlin/com/riox432/civitdeck/feature/comfyui/di/ComfyUIModule.kt
+++ b/feature/feature-comfyui/src/commonMain/kotlin/com/riox432/civitdeck/feature/comfyui/di/ComfyUIModule.kt
@@ -147,7 +147,7 @@ val comfyuiModule = module {
     factory { SaveWorkflowTemplateUseCase(get()) }
     factory { DeleteWorkflowTemplateUseCase(get()) }
     factory { ExportWorkflowTemplateUseCase() }
-    factory { ImportWorkflowTemplateUseCase(get()) }
+    factory { ImportWorkflowTemplateUseCase(get(), get(), get()) }
     factory { ApplyWorkflowTemplateUseCase() }
 
     // SD WebUI

--- a/feature/feature-comfyui/src/commonMain/kotlin/com/riox432/civitdeck/feature/comfyui/domain/usecase/ImportWorkflowTemplateUseCase.kt
+++ b/feature/feature-comfyui/src/commonMain/kotlin/com/riox432/civitdeck/feature/comfyui/domain/usecase/ImportWorkflowTemplateUseCase.kt
@@ -1,13 +1,33 @@
 package com.riox432.civitdeck.feature.comfyui.domain.usecase
 
+import com.riox432.civitdeck.domain.model.TemplateVariable
+import com.riox432.civitdeck.domain.model.TemplateVariableType
 import com.riox432.civitdeck.domain.model.WorkflowTemplate
 import com.riox432.civitdeck.domain.model.WorkflowTemplateCategory
 import com.riox432.civitdeck.domain.model.WorkflowTemplateType
 import com.riox432.civitdeck.domain.repository.SavedPromptRepository
 import com.riox432.civitdeck.domain.util.currentTimeMillis
+import com.riox432.civitdeck.feature.comfyui.domain.model.ExtractedParameter
+import com.riox432.civitdeck.feature.comfyui.domain.model.ParameterType
+import com.riox432.civitdeck.util.Logger
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.jsonObject
 
-class ImportWorkflowTemplateUseCase(private val repository: SavedPromptRepository) {
+/**
+ * Imports a workflow template from JSON.
+ *
+ * Supports three import paths:
+ * 1. Raw ComfyUI workflow with APP mode metadata -> auto-creates template from designated inputs
+ * 2. Raw ComfyUI workflow without APP mode -> extracts parameters from PRIORITY_NODES
+ * 3. Legacy ImportDto format -> manual template with explicit variable definitions
+ */
+class ImportWorkflowTemplateUseCase(
+    private val repository: SavedPromptRepository,
+    private val parseAppModeMetadata: ParseAppModeMetadataUseCase,
+    private val extractWorkflowParameters: ExtractWorkflowParametersUseCase,
+) {
     @Serializable
     private data class ImportDto(
         val name: String,
@@ -22,9 +42,127 @@ class ImportWorkflowTemplateUseCase(private val repository: SavedPromptRepositor
     suspend operator fun invoke(jsonString: String) {
         val trimmed = jsonString.trim()
         if (trimmed.isBlank()) error("Template JSON is empty")
+
+        val jsonObj = tryParseJsonObject(trimmed)
+
+        // Path 1: Try APP mode detection
+        if (jsonObj != null) {
+            val appMode = parseAppModeMetadata(trimmed)
+            if (appMode != null) {
+                Logger.d(TAG, "APP mode detected, creating template from metadata")
+                val params = extractWorkflowParameters(trimmed)
+                if (params.isNotEmpty()) {
+                    val template = createTemplateFromExtracted(
+                        jsonObj = jsonObj,
+                        params = params,
+                        rawJson = trimmed,
+                        isAppMode = true,
+                    )
+                    repository.saveTemplate(template.toSavedPrompt())
+                    return
+                }
+            }
+
+            // Path 2: Try raw workflow extraction (PRIORITY_NODES)
+            if (isRawWorkflow(jsonObj)) {
+                val params = extractWorkflowParameters(trimmed)
+                if (params.isNotEmpty()) {
+                    Logger.d(TAG, "Raw workflow detected, extracting parameters")
+                    val template = createTemplateFromExtracted(
+                        jsonObj = jsonObj,
+                        params = params,
+                        rawJson = trimmed,
+                        isAppMode = false,
+                    )
+                    repository.saveTemplate(template.toSavedPrompt())
+                    return
+                }
+            }
+        }
+
+        // Path 3: Fall back to ImportDto format
+        parseImportDto(trimmed)
+    }
+
+    private fun tryParseJsonObject(json: String): JsonObject? {
+        return try {
+            Json.parseToJsonElement(json).jsonObject
+        } catch (@Suppress("TooGenericExceptionCaught") _: Exception) {
+            null
+        }
+    }
+
+    /**
+     * Checks if the JSON object looks like a raw ComfyUI workflow
+     * (has node entries with class_type fields).
+     */
+    private fun isRawWorkflow(obj: JsonObject): Boolean {
+        return obj.any { (_, value) ->
+            (value as? JsonObject)?.containsKey("class_type") == true
+        }
+    }
+
+    @Suppress("LongParameterList")
+    private fun createTemplateFromExtracted(
+        jsonObj: JsonObject,
+        params: List<ExtractedParameter>,
+        rawJson: String,
+        isAppMode: Boolean,
+    ): WorkflowTemplate {
+        val name = resolveWorkflowName(jsonObj) ?: "Imported Workflow"
+        val variables = params.map { it.toTemplateVariable() }
+        val type = inferWorkflowType(params)
+
+        return WorkflowTemplate(
+            id = 0L,
+            name = name,
+            description = if (isAppMode) "Auto-detected from APP mode" else "Auto-extracted from workflow",
+            type = type,
+            category = WorkflowTemplateCategory.GENERAL,
+            variables = variables,
+            isBuiltIn = false,
+            version = 1,
+            createdAt = currentTimeMillis(),
+            isAppMode = isAppMode,
+            rawWorkflowJson = rawJson,
+        )
+    }
+
+    /**
+     * Tries to resolve a human-readable name from the workflow JSON.
+     * Looks for common metadata fields like extra.title or a _meta.title on the first node.
+     */
+    private fun resolveWorkflowName(obj: JsonObject): String? {
+        // Check extra.title
+        val extra = obj["extra"] as? JsonObject
+        val extraTitle = extra?.get("title")?.toString()?.trim('"')
+        if (!extraTitle.isNullOrBlank()) return extraTitle
+
+        return null
+    }
+
+    /**
+     * Infers the workflow type from extracted parameters.
+     */
+    private fun inferWorkflowType(params: List<ExtractedParameter>): WorkflowTemplateType {
+        val classTypes = params.map { it.nodeClassType }.toSet()
+        return when {
+            classTypes.any { it.contains("Inpaint", ignoreCase = true) } ->
+                WorkflowTemplateType.INPAINTING
+            classTypes.any { it.contains("Upscale", ignoreCase = true) } ->
+                WorkflowTemplateType.UPSCALE
+            classTypes.any { it.contains("LoraLoader", ignoreCase = true) } ->
+                WorkflowTemplateType.LORA
+            params.any { it.paramName == "image" || it.paramType == ParameterType.IMAGE } ->
+                WorkflowTemplateType.IMG2IMG
+            else -> WorkflowTemplateType.TXT2IMG
+        }
+    }
+
+    private suspend fun parseImportDto(trimmed: String) {
         val dto = try {
             templateJson.decodeFromString<ImportDto>(trimmed)
-        } catch (e: Exception) {
+        } catch (@Suppress("TooGenericExceptionCaught") e: Exception) {
             error("Invalid template JSON: ${e.message}")
         }
         val type = try {
@@ -51,4 +189,39 @@ class ImportWorkflowTemplateUseCase(private val repository: SavedPromptRepositor
         )
         repository.saveTemplate(template.toSavedPrompt())
     }
+
+    companion object {
+        private const val TAG = "ImportWorkflowTemplate"
+    }
+}
+
+/**
+ * Converts an [ExtractedParameter] to a [TemplateVariable] for storage.
+ */
+internal fun ExtractedParameter.toTemplateVariable(): TemplateVariable {
+    val varType = when (paramType) {
+        ParameterType.TEXT -> TemplateVariableType.TEXT
+        ParameterType.NUMBER -> if (min != null || max != null) {
+            TemplateVariableType.SLIDER
+        } else {
+            TemplateVariableType.NUMBER
+        }
+        ParameterType.SELECT -> TemplateVariableType.SELECT
+        ParameterType.SEED -> TemplateVariableType.SEED
+        ParameterType.IMAGE -> TemplateVariableType.IMAGE
+        ParameterType.BOOLEAN -> TemplateVariableType.BOOLEAN
+    }
+
+    return TemplateVariable(
+        name = "${nodeId}_$paramName",
+        label = "$nodeTitle: $paramName",
+        description = "",
+        type = varType,
+        defaultValue = currentValue,
+        min = min,
+        max = max,
+        step = step,
+        options = options,
+        required = true,
+    )
 }

--- a/feature/feature-comfyui/src/commonMain/kotlin/com/riox432/civitdeck/feature/comfyui/domain/usecase/WorkflowTemplateMapper.kt
+++ b/feature/feature-comfyui/src/commonMain/kotlin/com/riox432/civitdeck/feature/comfyui/domain/usecase/WorkflowTemplateMapper.kt
@@ -46,6 +46,7 @@ internal data class TemplateMetadataDto(
     val category: String = "GENERAL",
     val version: Int = 1,
     val author: String = "",
+    val isAppMode: Boolean = false,
 )
 
 // -- Mappers --
@@ -86,6 +87,7 @@ internal fun WorkflowTemplate.toSavedPrompt(): SavedPrompt {
             category = category.name,
             version = version,
             author = author,
+            isAppMode = isAppMode,
         ),
     )
     return SavedPrompt(
@@ -106,6 +108,8 @@ internal fun WorkflowTemplate.toSavedPrompt(): SavedPrompt {
         templateVariables = variablesJson,
         templateType = type.name,
         templateMetadata = metadataJson,
+        isAppMode = isAppMode,
+        rawWorkflowJson = rawWorkflowJson,
     )
 }
 
@@ -143,5 +147,7 @@ internal fun SavedPrompt.toWorkflowTemplate(): WorkflowTemplate? {
         version = metadata.version,
         author = metadata.author,
         createdAt = savedAt,
+        isAppMode = isAppMode || metadata.isAppMode,
+        rawWorkflowJson = rawWorkflowJson,
     )
 }

--- a/feature/feature-comfyui/src/commonMain/kotlin/com/riox432/civitdeck/feature/comfyui/presentation/ComfyHubDetailViewModel.kt
+++ b/feature/feature-comfyui/src/commonMain/kotlin/com/riox432/civitdeck/feature/comfyui/presentation/ComfyHubDetailViewModel.kt
@@ -6,6 +6,8 @@ import com.riox432.civitdeck.domain.model.ComfyHubWorkflow
 import com.riox432.civitdeck.domain.util.UiLoadingState
 import com.riox432.civitdeck.feature.comfyui.domain.usecase.GetComfyHubWorkflowDetailUseCase
 import com.riox432.civitdeck.feature.comfyui.domain.usecase.ImportComfyHubWorkflowUseCase
+import com.riox432.civitdeck.feature.comfyui.domain.usecase.ImportWorkflowTemplateUseCase
+import com.riox432.civitdeck.feature.comfyui.domain.usecase.ParseAppModeMetadataUseCase
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -24,12 +26,18 @@ data class ComfyHubDetailUiState(
     val importSuccess: Boolean = false,
     val importError: String? = null,
     val nodeNames: List<String> = emptyList(),
+    val hasAppMode: Boolean = false,
+    val isSavingTemplate: Boolean = false,
+    val saveTemplateSuccess: Boolean = false,
+    val saveTemplateError: String? = null,
 ) : UiLoadingState
 
 class ComfyHubDetailViewModel(
     private val workflowId: String,
     private val getWorkflowDetail: GetComfyHubWorkflowDetailUseCase,
     private val importWorkflow: ImportComfyHubWorkflowUseCase,
+    private val parseAppModeMetadata: ParseAppModeMetadataUseCase,
+    private val importWorkflowTemplate: ImportWorkflowTemplateUseCase,
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow(ComfyHubDetailUiState())
@@ -61,8 +69,32 @@ class ComfyHubDetailViewModel(
         }
     }
 
+    fun onSaveAsTemplate() {
+        val workflow = _uiState.value.workflow ?: return
+        viewModelScope.launch {
+            _uiState.update { it.copy(isSavingTemplate = true, saveTemplateError = null) }
+            try {
+                importWorkflowTemplate(workflow.workflowJson)
+                _uiState.update {
+                    it.copy(isSavingTemplate = false, saveTemplateSuccess = true)
+                }
+            } catch (@Suppress("TooGenericExceptionCaught") e: Exception) {
+                _uiState.update {
+                    it.copy(
+                        isSavingTemplate = false,
+                        saveTemplateError = e.message ?: "Save failed",
+                    )
+                }
+            }
+        }
+    }
+
     fun dismissImportResult() {
         _uiState.update { it.copy(importSuccess = false, importError = null) }
+    }
+
+    fun dismissSaveTemplateResult() {
+        _uiState.update { it.copy(saveTemplateSuccess = false, saveTemplateError = null) }
     }
 
     @Suppress("TooGenericExceptionCaught")
@@ -72,8 +104,14 @@ class ComfyHubDetailViewModel(
             try {
                 val workflow = getWorkflowDetail(workflowId)
                 val nodes = parseNodeNames(workflow.workflowJson)
+                val hasAppMode = parseAppModeMetadata(workflow.workflowJson) != null
                 _uiState.update {
-                    it.copy(workflow = workflow, nodeNames = nodes, isLoading = false)
+                    it.copy(
+                        workflow = workflow,
+                        nodeNames = nodes,
+                        hasAppMode = hasAppMode,
+                        isLoading = false,
+                    )
                 }
             } catch (e: Exception) {
                 _uiState.update {

--- a/feature/feature-prompts/src/commonMain/kotlin/com/riox432/civitdeck/feature/prompts/data/repository/SavedPromptRepositoryImpl.kt
+++ b/feature/feature-prompts/src/commonMain/kotlin/com/riox432/civitdeck/feature/prompts/data/repository/SavedPromptRepositoryImpl.kt
@@ -64,6 +64,8 @@ class SavedPromptRepositoryImpl(
         templateVariables = templateVariables,
         templateType = templateType,
         templateMetadata = templateMetadata,
+        isAppMode = isAppMode,
+        rawWorkflowJson = rawWorkflowJson,
     )
 
     private fun ImageGenerationMeta.toEntity(
@@ -101,5 +103,7 @@ class SavedPromptRepositoryImpl(
         templateVariables = templateVariables,
         templateType = templateType,
         templateMetadata = templateMetadata,
+        isAppMode = isAppMode,
+        rawWorkflowJson = rawWorkflowJson,
     )
 }

--- a/iosApp/iosApp/Features/ComfyHub/ComfyHubDetailView.swift
+++ b/iosApp/iosApp/Features/ComfyHub/ComfyHubDetailView.swift
@@ -41,6 +41,20 @@ struct ComfyHubDetailView: View {
                 showImportAlert = true
             }
         }
+        .onChange(of: viewModel.saveTemplateSuccess) { success in
+            if success {
+                alertMessage = "Workflow saved as template!"
+                showImportAlert = true
+                viewModel.dismissSaveTemplateResult()
+            }
+        }
+        .onChange(of: viewModel.saveTemplateError) { error in
+            if let msg = error {
+                alertMessage = "Save failed: \(msg)"
+                showImportAlert = true
+                viewModel.dismissSaveTemplateResult()
+            }
+        }
     }
 
     private func detailContent(_ workflow: ComfyHubWorkflow) -> some View {
@@ -54,6 +68,7 @@ struct ComfyHubDetailView: View {
                 nodeGraphSection
                 Divider()
                 importButton
+                saveAsTemplateButton
             }
             .padding(Spacing.md)
         }
@@ -61,8 +76,19 @@ struct ComfyHubDetailView: View {
 
     private func headerSection(_ workflow: ComfyHubWorkflow) -> some View {
         VStack(alignment: .leading, spacing: Spacing.xs) {
-            Text(workflow.name)
-                .font(.civitHeadlineSmall)
+            HStack(spacing: Spacing.sm) {
+                Text(workflow.name)
+                    .font(.civitHeadlineSmall)
+                if viewModel.hasAppMode {
+                    Text("APP")
+                        .font(.civitLabelSmall)
+                        .foregroundColor(.civitPrimary)
+                        .padding(.horizontal, Spacing.sm)
+                        .padding(.vertical, Spacing.xs)
+                        .background(Color.civitPrimary.opacity(0.1))
+                        .clipShape(RoundedRectangle(cornerRadius: CornerRadius.image))
+                }
+            }
             Text("by \(workflow.author)")
                 .font(.civitBodyMedium)
                 .foregroundColor(.civitOnSurfaceVariant)
@@ -137,6 +163,28 @@ struct ComfyHubDetailView: View {
         }
         .buttonStyle(.borderedProminent)
         .disabled(viewModel.isImporting)
+    }
+
+    private var saveAsTemplateButton: some View {
+        Button {
+            viewModel.onSaveAsTemplate()
+        } label: {
+            HStack {
+                if viewModel.isSavingTemplate {
+                    ProgressView()
+                        .tint(.civitPrimary)
+                    Text("Saving...")
+                } else {
+                    Image(systemName: "star")
+                        .accessibilityHidden(true)
+                    Text("Save as Template")
+                }
+            }
+            .frame(maxWidth: .infinity)
+            .padding(.vertical, Spacing.sm)
+        }
+        .buttonStyle(.bordered)
+        .disabled(viewModel.isSavingTemplate)
     }
 
     private func formatCount(_ count: Int) -> String {

--- a/iosApp/iosApp/Features/ComfyHub/ComfyHubDetailViewModel.swift
+++ b/iosApp/iosApp/Features/ComfyHub/ComfyHubDetailViewModel.swift
@@ -13,6 +13,10 @@ final class ComfyHubDetailViewModelOwner: ObservableObject {
     @Published var importSuccess: Bool = false
     @Published var importError: String?
     @Published var nodeNames: [String] = []
+    @Published var hasAppMode: Bool = false
+    @Published var isSavingTemplate: Bool = false
+    @Published var saveTemplateSuccess: Bool = false
+    @Published var saveTemplateError: String?
 
     init(workflowId: String) {
         vm = KoinHelper.shared.createComfyHubDetailViewModel(workflowId: workflowId)
@@ -30,10 +34,16 @@ final class ComfyHubDetailViewModelOwner: ObservableObject {
             importSuccess = state.importSuccess
             importError = state.importError
             nodeNames = state.nodeNames as? [String] ?? []
+            hasAppMode = state.hasAppMode
+            isSavingTemplate = state.isSavingTemplate
+            saveTemplateSuccess = state.saveTemplateSuccess
+            saveTemplateError = state.saveTemplateError
         }
     }
 
     func retry() { vm.retry() }
     func onImport() { vm.onImport() }
+    func onSaveAsTemplate() { vm.onSaveAsTemplate() }
     func dismissImportResult() { vm.dismissImportResult() }
+    func dismissSaveTemplateResult() { vm.dismissSaveTemplateResult() }
 }

--- a/iosApp/iosApp/Features/ComfyUI/WorkflowTemplateView.swift
+++ b/iosApp/iosApp/Features/ComfyUI/WorkflowTemplateView.swift
@@ -248,8 +248,19 @@ private struct TemplateRow: View {
     var body: some View {
         HStack(alignment: .top) {
             VStack(alignment: .leading, spacing: Spacing.xs) {
-                Text(template.name)
-                    .font(.civitBodyMedium)
+                HStack(spacing: Spacing.sm) {
+                    Text(template.name)
+                        .font(.civitBodyMedium)
+                    if template.isAppMode {
+                        Text("APP")
+                            .font(.civitLabelSmall)
+                            .foregroundColor(.civitPrimary)
+                            .padding(.horizontal, Spacing.xs)
+                            .padding(.vertical, 2)
+                            .background(Color.civitPrimary.opacity(0.1))
+                            .clipShape(RoundedRectangle(cornerRadius: CornerRadius.image))
+                    }
+                }
                 if !template.description_.isEmpty {
                     Text(template.description_)
                         .font(.civitBodySmall)

--- a/shared/src/commonMain/kotlin/com/riox432/civitdeck/di/SharedViewModelModule.kt
+++ b/shared/src/commonMain/kotlin/com/riox432/civitdeck/di/SharedViewModelModule.kt
@@ -8,6 +8,6 @@ import org.koin.dsl.module
 
 val sharedViewModelModule = module {
     viewModel { ComfyHubBrowserViewModel(get()) }
-    viewModel { params -> ComfyHubDetailViewModel(params.get(), get(), get()) }
+    viewModel { params -> ComfyHubDetailViewModel(params.get(), get(), get(), get(), get()) }
     viewModel { ModelFileBrowserViewModel(get(), get(), get(), get(), get(), get()) }
 }


### PR DESCRIPTION
## Summary
- Auto-detect APP mode metadata when importing workflows (file import, ComfyHub, or QR code) and generate mobile-optimized template forms without manual template creation
- Import use case now supports 3 paths: APP mode auto-detect, raw workflow PRIORITY_NODES extraction, and legacy ImportDto format
- Add "Save as Template" button on ComfyHub workflow detail screen (Android, iOS, Desktop)
- Show "APP" badge on workflow template cards/rows that were auto-detected from APP mode
- DB migration 46 -> 47 adds `isAppMode` and `rawWorkflowJson` columns to `saved_prompts` table

## Changes
- **Domain model**: `WorkflowTemplate` and `SavedPrompt` extended with `isAppMode` and `rawWorkflowJson` fields
- **ImportWorkflowTemplateUseCase**: Rewritten to try APP mode detection first, then raw workflow extraction, then legacy format
- **ComfyHubDetailViewModel**: Added `onSaveAsTemplate()`, APP mode detection on load, and save result state
- **Android/iOS/Desktop UI**: APP mode badge on template cards, "Save as Template" button on ComfyHub detail
- **DB**: Migration 46->47 for new columns on `saved_prompts`
- **Koin DI**: Updated registrations for new dependencies

## Test plan
- [ ] Import a raw ComfyUI workflow JSON with `extra.linearData` -> template created with APP badge
- [ ] Import a raw workflow without APP mode -> template created from PRIORITY_NODES extraction
- [ ] Import legacy ImportDto JSON -> still works as before
- [ ] ComfyHub detail: tap "Save as Template" -> snackbar confirms save, template appears in list
- [ ] APP badge visible on template cards (Android, iOS, Desktop)
- [ ] DB migration from v46 -> v47 succeeds (existing data preserved)
- [ ] Verify detekt passes, Android build succeeds, Desktop JVM compiles

Closes #893