### PR TITLE
Fix stagger animation replay on back navigation from detail

### DIFF
--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/search/ModelGridSection.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/search/ModelGridSection.kt
@@ -29,7 +29,11 @@ import androidx.compose.material3.pulltorefresh.PullToRefreshDefaults
 import androidx.compose.material3.pulltorefresh.rememberPullToRefreshState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -305,8 +309,21 @@ private fun androidx.compose.foundation.lazy.grid.LazyGridScope.modelItems(
             .firstOrNull()?.images?.firstOrNull()?.thumbnailUrl()
         val isOwned = ownedHashes.isNotEmpty() && model.isOwnedBy(ownedHashes)
 
-        val staggerAnimatable = remember { Animatable(0f) }
-        LaunchStaggerAnimation(index = index, animatable = staggerAnimatable, reducedMotion = reducedMotion)
+        // Track whether this item has already played its entrance animation.
+        // rememberSaveable survives back-navigation recomposition (Navigation 3
+        // decomposes non-top entries), so returning from DetailRoute skips the
+        // stagger replay and avoids a false "API reload" appearance.
+        var hasAnimated by rememberSaveable { mutableStateOf(false) }
+        val staggerAnimatable = remember { Animatable(if (hasAnimated) 1f else 0f) }
+        LaunchStaggerAnimation(
+            index = index,
+            animatable = staggerAnimatable,
+            reducedMotion = reducedMotion,
+            skipAnimation = hasAnimated,
+        )
+        if (!hasAnimated) {
+            hasAnimated = true
+        }
         ModelGridItem(
             model = model,
             isFavorite = model.id in favoriteIds,

--- a/core/core-ui/src/commonMain/kotlin/com/riox432/civitdeck/ui/components/AnimationUtils.kt
+++ b/core/core-ui/src/commonMain/kotlin/com/riox432/civitdeck/ui/components/AnimationUtils.kt
@@ -41,15 +41,19 @@ fun Modifier.staggeredEntrance(
 
 /**
  * Launches the stagger entrance animation for a single item.
+ *
+ * @param skipAnimation When true (e.g. back navigation restores the list), snaps to
+ *   the final state immediately instead of playing the entrance animation.
  */
 @Composable
 fun LaunchStaggerAnimation(
     index: Int,
     animatable: Animatable<Float, AnimationVector1D>,
     reducedMotion: Boolean,
+    skipAnimation: Boolean = false,
 ) {
     LaunchedEffect(Unit) {
-        if (reducedMotion) {
+        if (reducedMotion || skipAnimation) {
             animatable.snapTo(1f)
             return@LaunchedEffect
         }


### PR DESCRIPTION
## Summary
- Add `skipAnimation` parameter to `LaunchStaggerAnimation` so callers can opt out of the entrance animation
- Track per-item `hasAnimated` state via `rememberSaveable` in `modelItems`; on back navigation Navigation 3 recreates `SearchRoute` from scratch, but `rememberSaveable` restores `true`, causing the stagger to snap immediately instead of replaying
- `rememberLazyGridState()` already uses `rememberSaveable` internally and is preserved by `rememberSaveableStateHolderNavEntryDecorator` — no change needed there

## Test plan
- [ ] Navigate Discover tab → tap a model card → back button: grid items should appear instantly (no fade-in replay)
- [ ] Fresh app launch: stagger animation plays normally on first load
- [ ] Reduced motion enabled: items still snap to visible (unchanged behavior)
- [ ] Scroll position is restored after back navigation

Closes #908