### PR TITLE
Fix API reload on back navigation to search screen

### DIFF
--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/search/SearchBarSection.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/search/SearchBarSection.kt
@@ -156,7 +156,6 @@ private fun SearchBarWithFilterButton(
                 showHistory = false
             },
             onFocusChanged = { focused ->
-                if (!focused) onSearch()
                 showHistory = focused && query.isEmpty() && searchHistory.isNotEmpty()
             },
             onClear = {

--- a/feature/feature-search/src/commonMain/kotlin/com/riox432/civitdeck/feature/search/presentation/ModelSearchViewModel.kt
+++ b/feature/feature-search/src/commonMain/kotlin/com/riox432/civitdeck/feature/search/presentation/ModelSearchViewModel.kt
@@ -364,14 +364,16 @@ class ModelSearchViewModel(
 
     private fun observeNsfwFilter() {
         viewModelScope.launch {
+            var initialized = false
             observeNsfwFilterUseCase().collect { level ->
                 val prev = _uiState.value.nsfwFilterLevel
                 _uiState.update { it.copy(nsfwFilterLevel = level) }
-                if (prev != level) {
-                    _filterState.update { it.copy(nsfwFilterLevel = level) }
+                _filterState.update { it.copy(nsfwFilterLevel = level) }
+                if (initialized && prev != level) {
                     loadRecommendations()
                     refresh()
                 }
+                initialized = true
             }
         }
     }


### PR DESCRIPTION
## Summary
- Remove `onSearch()` call from SearchTextField's `onFocusChanged` — Nav3 decomposing the composable triggered focus loss, causing a full API reload on every back navigation
- Skip first emission in `observeNsfwFilter` to prevent double-reload when stored NSFW level differs from the hardcoded default

Follow-up to #909 which addressed stagger animation replay. This fixes the actual root cause: real API reloads triggered by focus events and NSFW observer.

## Test plan
- [ ] Navigate from Discover tab → model detail → back: grid should NOT reload
- [ ] Shared Element Transition should animate smoothly on back navigation
- [ ] Search by typing query + pressing search still works
- [ ] Search by typing query + tapping outside still submits (via keyboard dismiss, not focus loss)
- [ ] Changing NSFW filter in settings still triggers a reload

Closes #908