### PR TITLE
Fix onCleared end-view tracking via injected ApplicationScope

### DIFF
--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/CivitDeckApplication.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/CivitDeckApplication.kt
@@ -22,13 +22,11 @@ import com.riox432.civitdeck.domain.repository.AppVersionProvider
 import com.riox432.civitdeck.domain.usecase.CleanupBrowsingHistoryUseCase
 import com.riox432.civitdeck.domain.usecase.ObserveNotificationsEnabledUseCase
 import com.riox432.civitdeck.domain.usecase.ObservePollingIntervalUseCase
+import com.riox432.civitdeck.domain.util.ApplicationScope
 import com.riox432.civitdeck.feature.detail.presentation.ModelDetailViewModel
 import com.riox432.civitdeck.notification.ModelUpdateScheduler
 import com.riox432.civitdeck.ui.dataset.DuplicateReviewViewModel
 import com.riox432.civitdeck.widget.WidgetRefreshWorker
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.launch
@@ -41,7 +39,7 @@ import java.util.concurrent.TimeUnit
 
 class CivitDeckApplication : Application(), SingletonImageLoader.Factory, KoinComponent {
 
-    private val applicationScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+    private val applicationScope: ApplicationScope by inject()
     private val observeNotificationsEnabled: ObserveNotificationsEnabledUseCase by inject()
     private val observePollingInterval: ObservePollingIntervalUseCase by inject()
     private val cleanupBrowsingHistory: CleanupBrowsingHistoryUseCase by inject()
@@ -114,7 +112,7 @@ class CivitDeckApplication : Application(), SingletonImageLoader.Factory, KoinCo
 val androidModule = module {
     single<AppVersionProvider> { AndroidAppVersionProvider() }
     viewModel { params ->
-        ModelDetailViewModel(params.get(), get(), get(), get(), get(), get(), get())
+        ModelDetailViewModel(params.get(), get(), get(), get(), get(), get(), get(), get())
     }
     viewModel { params -> DuplicateReviewViewModel(params.get(), get(), get()) }
     // DownloadQueueViewModel now registered in shared Phase3ViewModelModule

--- a/androidApp/src/test/kotlin/com/riox432/civitdeck/ui/detail/ModelDetailViewModelTest.kt
+++ b/androidApp/src/test/kotlin/com/riox432/civitdeck/ui/detail/ModelDetailViewModelTest.kt
@@ -53,6 +53,7 @@ import com.riox432.civitdeck.domain.usecase.SaveModelNoteUseCase
 import com.riox432.civitdeck.domain.usecase.SubmitReviewUseCase
 import com.riox432.civitdeck.domain.usecase.ToggleFavoriteUseCase
 import com.riox432.civitdeck.domain.usecase.TrackModelViewUseCase
+import com.riox432.civitdeck.domain.util.ApplicationScope
 import com.riox432.civitdeck.domain.util.SystemStatsProvider
 import com.riox432.civitdeck.feature.detail.presentation.CollectionUseCases
 import com.riox432.civitdeck.feature.detail.presentation.DownloadUseCases
@@ -60,6 +61,7 @@ import com.riox432.civitdeck.feature.detail.presentation.ModelDetailViewModel
 import com.riox432.civitdeck.feature.detail.presentation.ModelUseCases
 import com.riox432.civitdeck.feature.detail.presentation.NotesTagsUseCases
 import com.riox432.civitdeck.feature.detail.presentation.ReviewUseCases
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
@@ -73,6 +75,7 @@ import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
@@ -159,6 +162,8 @@ class ModelDetailViewModelTest {
 
     private class FakeBrowsingRepo : BrowsingHistoryRepository {
         var trackCalled = false
+        var endViewModelId: Long? = null
+        var endViewDurationMs: Long? = null
         override suspend fun trackView(
             modelId: Long,
             modelName: String,
@@ -179,7 +184,10 @@ class ModelDetailViewModelTest {
         override suspend fun getWeightedTypes(limit: Int) = error("not used")
         override suspend fun getWeightedTags(limit: Int) = error("not used")
         override suspend fun getWeightedCreators(limit: Int) = error("not used")
-        override suspend fun updateViewDuration(modelId: Long, durationMs: Long) = Unit
+        override suspend fun updateViewDuration(modelId: Long, durationMs: Long) {
+            endViewModelId = modelId
+            endViewDurationMs = durationMs
+        }
         override suspend fun trackInteraction(
             modelId: Long,
             interactionType: com.riox432.civitdeck.domain.model.InteractionType,
@@ -317,10 +325,11 @@ class ModelDetailViewModelTest {
     private fun createViewModel(
         model: Model = testModel(),
         isFavorite: Boolean = false,
+        browsingRepo: FakeBrowsingRepo = FakeBrowsingRepo(),
+        appScope: ApplicationScope = ApplicationScope(CoroutineScope(testDispatcher)),
     ): Triple<ModelDetailViewModel, FakeModelRepo, FakeFavoriteRepo> {
         val modelRepo = FakeModelRepo(model)
         val favRepo = FakeFavoriteRepo(MutableStateFlow(isFavorite))
-        val browsingRepo = FakeBrowsingRepo()
         val prefsRepo = FakePrefsRepo()
         val collectionRepo = FakeCollectionRepo()
         val noteRepo = FakeNoteRepo()
@@ -376,6 +385,7 @@ class ModelDetailViewModelTest {
             downloadUseCases = downloadUseCases,
             reviewUseCases = reviewUseCases,
             systemStatsProvider = SystemStatsProvider { null },
+            appScope = appScope,
         )
         return Triple(vm, modelRepo, favRepo)
     }
@@ -401,6 +411,17 @@ class ModelDetailViewModelTest {
         val (vm, _, favRepo) = createViewModel()
         vm.onFavoriteToggle()
         assertTrue(favRepo.toggleCalled)
+    }
+
+    @Test
+    fun on_cleared_tracks_end_view_via_application_scope() {
+        val browsingRepo = FakeBrowsingRepo()
+        val (vm, _, _) = createViewModel(browsingRepo = browsingRepo)
+        // loadModel() sets viewStartTimeMs on init; clearing triggers onCleared -> trackEndView.
+        vm.clear()
+        assertEquals(1L, browsingRepo.endViewModelId)
+        assertNotNull(browsingRepo.endViewDurationMs)
+        assertTrue(requireNotNull(browsingRepo.endViewDurationMs) >= 0L)
     }
 
     @Test

--- a/core/core-domain/src/androidMain/kotlin/com/riox432/civitdeck/domain/util/ApplicationScope.android.kt
+++ b/core/core-domain/src/androidMain/kotlin/com/riox432/civitdeck/domain/util/ApplicationScope.android.kt
@@ -1,0 +1,6 @@
+package com.riox432.civitdeck.domain.util
+
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+
+actual val ioDispatcher: CoroutineDispatcher = Dispatchers.IO

--- a/core/core-domain/src/commonMain/kotlin/com/riox432/civitdeck/di/DomainModule.kt
+++ b/core/core-domain/src/commonMain/kotlin/com/riox432/civitdeck/di/DomainModule.kt
@@ -1,8 +1,10 @@
 package com.riox432.civitdeck.di
 
+import com.riox432.civitdeck.domain.util.ApplicationScope
 import org.koin.dsl.module
 
 val domainModule = module {
+    single { ApplicationScope() }
     includes(
         detailDomainModule,
         favoritesDomainModule,

--- a/core/core-domain/src/commonMain/kotlin/com/riox432/civitdeck/domain/util/ApplicationScope.kt
+++ b/core/core-domain/src/commonMain/kotlin/com/riox432/civitdeck/domain/util/ApplicationScope.kt
@@ -1,0 +1,30 @@
+package com.riox432.civitdeck.domain.util
+
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.SupervisorJob
+
+/**
+ * Platform IO dispatcher for offloading blocking work (DB / network writes).
+ *
+ * `Dispatchers.IO` is not visible from `commonMain`, so it is provided per
+ * platform via `expect`/`actual`.
+ */
+expect val ioDispatcher: CoroutineDispatcher
+
+/**
+ * Application-lifetime [CoroutineScope] for fire-and-forget work that must
+ * outlive the component that started it (e.g. a ViewModel's `onCleared`).
+ *
+ * Uses a [SupervisorJob] so a failure in one job does not cancel others, and
+ * [ioDispatcher] because these tasks are typically DB or network writes.
+ *
+ * Registered as a Koin `single` so all platforms share one instance instead of
+ * creating ad-hoc scopes in their entry points.
+ *
+ * Intended only for app-lifetime side effects — do NOT use it for regular
+ * ViewModel work that should be cancelled when the screen closes.
+ */
+class ApplicationScope(
+    private val delegate: CoroutineScope = CoroutineScope(SupervisorJob() + ioDispatcher),
+) : CoroutineScope by delegate

--- a/core/core-domain/src/iosMain/kotlin/com/riox432/civitdeck/domain/util/ApplicationScope.ios.kt
+++ b/core/core-domain/src/iosMain/kotlin/com/riox432/civitdeck/domain/util/ApplicationScope.ios.kt
@@ -1,0 +1,9 @@
+package com.riox432.civitdeck.domain.util
+
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+
+// Kotlin/Native does not expose `Dispatchers.IO`; `Default` is the appropriate
+// background dispatcher. Room KMP manages its own write threading, so the short
+// DB write does not require a dedicated IO pool here.
+actual val ioDispatcher: CoroutineDispatcher = Dispatchers.Default

--- a/core/core-domain/src/jvmMain/kotlin/com/riox432/civitdeck/domain/util/ApplicationScope.jvm.kt
+++ b/core/core-domain/src/jvmMain/kotlin/com/riox432/civitdeck/domain/util/ApplicationScope.jvm.kt
@@ -1,0 +1,6 @@
+package com.riox432.civitdeck.domain.util
+
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+
+actual val ioDispatcher: CoroutineDispatcher = Dispatchers.IO

--- a/desktopApp/src/jvmMain/kotlin/com/riox432/civitdeck/Main.kt
+++ b/desktopApp/src/jvmMain/kotlin/com/riox432/civitdeck/Main.kt
@@ -27,9 +27,7 @@ import com.riox432.civitdeck.di.registerExportPlugins
 import com.riox432.civitdeck.di.registerThemePlugins
 import com.riox432.civitdeck.di.registerWorkflowPlugins
 import com.riox432.civitdeck.domain.usecase.CleanupBrowsingHistoryUseCase
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.SupervisorJob
+import com.riox432.civitdeck.domain.util.ApplicationScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import okio.Path.Companion.toPath
@@ -42,7 +40,7 @@ fun main() {
         modules(desktopModule)
     }
     setupCoilImageLoader()
-    val applicationScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+    val applicationScope: ApplicationScope = KoinPlatform.getKoin().get()
     applicationScope.launch {
         registerWorkflowPlugins()
         registerExportPlugins()

--- a/desktopApp/src/jvmMain/kotlin/com/riox432/civitdeck/di/DesktopModule.kt
+++ b/desktopApp/src/jvmMain/kotlin/com/riox432/civitdeck/di/DesktopModule.kt
@@ -12,7 +12,7 @@ val desktopModule = module {
     single<AppVersionProvider> { DesktopAppVersionProvider() }
     viewModel { DesktopUpdateViewModel(get(), get(), get()) }
     viewModel { params ->
-        ModelDetailViewModel(params.get(), get(), get(), get(), get(), get(), get())
+        ModelDetailViewModel(params.get(), get(), get(), get(), get(), get(), get(), get())
     }
     viewModel {
         DesktopDiscoveryViewModel(get(), get())

--- a/feature/feature-detail/src/commonMain/kotlin/com/riox432/civitdeck/feature/detail/di/DetailModule.kt
+++ b/feature/feature-detail/src/commonMain/kotlin/com/riox432/civitdeck/feature/detail/di/DetailModule.kt
@@ -44,6 +44,6 @@ val detailModule = module {
     factory { DownloadUseCases(observeModelDownloads = get(), enqueueDownload = get(), cancelDownload = get()) }
     factory { ReviewUseCases(getModelReviews = get(), getRatingTotals = get(), submitReview = get()) }
     viewModel { params ->
-        ModelDetailViewModel(params.get(), get(), get(), get(), get(), get(), get())
+        ModelDetailViewModel(params.get(), get(), get(), get(), get(), get(), get(), get())
     }
 }

--- a/feature/feature-detail/src/commonMain/kotlin/com/riox432/civitdeck/feature/detail/presentation/ModelDetailViewModel.kt
+++ b/feature/feature-detail/src/commonMain/kotlin/com/riox432/civitdeck/feature/detail/presentation/ModelDetailViewModel.kt
@@ -15,6 +15,7 @@ import com.riox432.civitdeck.domain.model.RatingTotals
 import com.riox432.civitdeck.domain.model.ResourceReview
 import com.riox432.civitdeck.domain.model.ReviewSortOrder
 import com.riox432.civitdeck.domain.model.SystemStats
+import com.riox432.civitdeck.domain.util.ApplicationScope
 import com.riox432.civitdeck.domain.util.SystemStatsProvider
 import com.riox432.civitdeck.domain.util.UiLoadingState
 import com.riox432.civitdeck.domain.util.VramCompatibility
@@ -23,7 +24,6 @@ import com.riox432.civitdeck.domain.util.currentTimeMillis
 import com.riox432.civitdeck.domain.util.launchSafe
 import com.riox432.civitdeck.domain.util.suspendRunCatching
 import com.riox432.civitdeck.util.Logger
-import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharedFlow
@@ -33,7 +33,6 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeoutOrNull
 
 data class ModelDetailUiState(
@@ -66,6 +65,7 @@ class ModelDetailViewModel(
     private val downloadUseCases: DownloadUseCases,
     private val reviewUseCases: ReviewUseCases,
     private val systemStatsProvider: SystemStatsProvider,
+    private val appScope: ApplicationScope,
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow(ModelDetailUiState())
@@ -365,15 +365,11 @@ class ModelDetailViewModel(
         if (viewStartTimeMs <= 0L) return
         val durationMs = currentTimeMillis() - viewStartTimeMs
         viewStartTimeMs = 0L
-        viewModelScope.launch {
-            withContext(NonCancellable) {
-                try {
-                    withTimeoutOrNull(END_VIEW_TIMEOUT) {
-                        modelUseCases.trackModelView.endView(modelId, durationMs)
-                    }
-                } catch (e: Exception) {
-                    Logger.w(TAG, "End view tracking failed: ${e.message}")
-                }
+        // Use the application-lifetime scope: viewModelScope is already cancelled
+        // by the time onCleared() runs, so a launch into it would be dropped.
+        appScope.launchSafe(TAG, "End view tracking") {
+            withTimeoutOrNull(END_VIEW_TIMEOUT) {
+                modelUseCases.trackModelView.endView(modelId, durationMs)
             }
         }
     }


### PR DESCRIPTION
## Description
Fixes a silent data-loss bug in detail-screen end-view duration tracking.

`ModelDetailViewModel.onCleared()` called `trackEndView()`, which launched the DB write on `viewModelScope`. By the time `onCleared()` runs the scope is already cancelled, so the launched coroutine was dropped (`NonCancellable` only protects work *after* it starts, not a launch into a dead scope). The end-view duration was never written.

### Changes
- New `ApplicationScope` (core-domain `commonMain`): a thin `CoroutineScope`-by-delegation wrapper over `SupervisorJob() + ioDispatcher`, registered as a Koin `single` in `domainModule` so all platforms share one app-lifetime scope.
- `ioDispatcher` provided via `expect`/`actual`: Android/JVM use `Dispatchers.IO`; iOS/Native uses `Dispatchers.Default` (`Dispatchers.IO` is not accessible from `commonMain`, and Kotlin/Native does not expose it — Room KMP manages its own write threading).
- `ModelDetailViewModel` now injects `ApplicationScope`; `trackEndView()` uses `appScope.launchSafe(...) { withTimeoutOrNull(END_VIEW_TIMEOUT) { endView(...) } }`. `NonCancellable`/`withContext` removed — the app scope outlives the VM and is never cancelled at `onCleared`. `launchSafe` already re-throws `CancellationException` and logs failures.
- The `viewStartTimeMs <= 0L` guard and `END_VIEW_TIMEOUT` named constant are preserved.
- Replaced the ad-hoc `CoroutineScope(SupervisorJob()+Dispatchers.IO)` instances in `CivitDeckApplication.kt` (Android) and `Main.kt` (Desktop) with the injected `ApplicationScope`.
- Updated all four VM construction sites (Koin `detailModule`, `androidModule`, `desktopModule`) for the new constructor arg.

### Design verification (Codex)
Cross-reviewed with Codex MCP: confirmed the semantic wrapper type is preferable to a Koin named qualifier on a raw `CoroutineScope`; confirmed dropping `NonCancellable` is correct since the app scope is never cancelled; confirmed keeping `withTimeoutOrNull`; confirmed re-throwing `CancellationException` (handled here by reusing the existing `launchSafe` helper). Registering an app-lifetime `SupervisorJob` scope as a Koin `single` is appropriate.

## Related Issue
Closes #912

## Automated Tests
- [x] Unit test added: `on_cleared_tracks_end_view_via_application_scope` injects a `TestScope`-backed `ApplicationScope`, calls `clear()`, and asserts `endView` was invoked with the correct model id and a non-negative duration.

## Checklist
- [x] CLAUDE.md rules followed
- [x] No `!!` or force unwrap
- [x] No `GlobalScope`
- [x] Error handling complete (`launchSafe` + `withTimeoutOrNull`)

## CI / Build status
- detekt (`:androidApp:detekt`, twice): PASS
- `:androidApp:assembleDebug`: PASS
- `:desktopApp:compileKotlinJvm`: PASS
- iOS shared framework `:shared:linkDebugFrameworkIosSimulatorArm64`: PASS (Kotlin/Native side compiles cleanly)

## Notes (pre-existing breakage, out of scope)
- The `androidApp` unit-test source set does **not** compile on the merge base (`SavedPromptsViewModelTest`, `ImageGalleryViewModelTest` reference moved/renamed symbols). CI does not run `:androidApp:testDebugUnitTest`, and these failures pre-date this PR. The new test is correct and will run once that source set is repaired.
- `:shared:testDebugUnitTest` and a full iOS Xcode build (`SharedTypeAliases.swift` / theme use-case type mismatches) are also pre-existing-broken on the merge base, independent of this change (verified by building clean HEAD with cleared DerivedData). The iOS Xcode CI job is path-filtered to `iosApp/**`, which this PR does not touch.
