### PR TITLE
Migrate Phase A platform services to interface + Koin DI

### DIFF
--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/comfyui/MaskEditorScreen.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/comfyui/MaskEditorScreen.kt
@@ -39,7 +39,6 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.riox432.civitdeck.R
-import com.riox432.civitdeck.feature.comfyui.data.encoder.MaskPngEncoder
 import com.riox432.civitdeck.feature.comfyui.domain.model.MaskEditorState
 import com.riox432.civitdeck.feature.comfyui.domain.model.PathSegment
 import com.riox432.civitdeck.feature.comfyui.presentation.MaskEditorViewModel
@@ -59,7 +58,6 @@ fun MaskEditorScreen(
     onMaskReady: (String) -> Unit,
 ) {
     val state by viewModel.uiState.collectAsStateWithLifecycle()
-    val encoder = MaskPngEncoder()
 
     MaskUploadEffect(state, onMaskReady)
 
@@ -68,12 +66,7 @@ fun MaskEditorScreen(
             MaskEditorTopBar(
                 onBack = onBack,
                 onDone = {
-                    val bytes = encoder.encode(
-                        segments = state.pathSegments,
-                        width = imageWidth,
-                        height = imageHeight,
-                        inverted = state.isInverted,
-                    )
+                    val bytes = viewModel.encodeMask(imageWidth, imageHeight)
                     viewModel.onUploadMask(bytes)
                 },
                 isUploading = state.isUploading,

--- a/core/core-database/src/androidMain/kotlin/com/riox432/civitdeck/data/scanner/FileScannerImpl.kt
+++ b/core/core-database/src/androidMain/kotlin/com/riox432/civitdeck/data/scanner/FileScannerImpl.kt
@@ -2,15 +2,16 @@ package com.riox432.civitdeck.data.scanner
 
 import com.riox432.civitdeck.util.Logger
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.IO
 import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.withContext
 import java.io.File
 import java.security.MessageDigest
 import kotlin.coroutines.coroutineContext
 
-actual class FileScanner actual constructor() {
+class FileScannerImpl : FileScanner {
 
-    actual suspend fun scanDirectory(
+    override suspend fun scanDirectory(
         path: String,
         onProgress: (current: Int, total: Int) -> Unit,
     ): List<ScannedFile> = withContext(Dispatchers.IO) {

--- a/core/core-database/src/androidMain/kotlin/com/riox432/civitdeck/di/DatabasePlatformModule.android.kt
+++ b/core/core-database/src/androidMain/kotlin/com/riox432/civitdeck/di/DatabasePlatformModule.android.kt
@@ -1,0 +1,10 @@
+package com.riox432.civitdeck.di
+
+import com.riox432.civitdeck.data.scanner.FileScanner
+import com.riox432.civitdeck.data.scanner.FileScannerImpl
+import org.koin.core.module.Module
+import org.koin.dsl.module
+
+actual val databasePlatformModule: Module = module {
+    factory<FileScanner> { FileScannerImpl() }
+}

--- a/core/core-database/src/commonMain/kotlin/com/riox432/civitdeck/data/scanner/FileScanner.kt
+++ b/core/core-database/src/commonMain/kotlin/com/riox432/civitdeck/data/scanner/FileScanner.kt
@@ -7,7 +7,7 @@ data class ScannedFile(
     val sizeBytes: Long,
 )
 
-expect class FileScanner() {
+interface FileScanner {
     suspend fun scanDirectory(
         path: String,
         onProgress: (current: Int, total: Int) -> Unit,

--- a/core/core-database/src/commonMain/kotlin/com/riox432/civitdeck/di/DatabaseModule.kt
+++ b/core/core-database/src/commonMain/kotlin/com/riox432/civitdeck/di/DatabaseModule.kt
@@ -22,7 +22,6 @@ import com.riox432.civitdeck.data.local.repository.ModelUpdateNotificationReposi
 import com.riox432.civitdeck.data.local.repository.ModelVersionCheckpointRepositoryImpl
 import com.riox432.civitdeck.data.local.repository.PluginRepositoryImpl
 import com.riox432.civitdeck.data.local.repository.ShareHashtagRepositoryImpl
-import com.riox432.civitdeck.data.scanner.FileScanner
 import com.riox432.civitdeck.domain.repository.AnalyticsRepository
 import com.riox432.civitdeck.domain.repository.BackupRepository
 import com.riox432.civitdeck.domain.repository.BrowsingHistoryRepository
@@ -73,8 +72,7 @@ val databaseModule = module {
     // Data Sources
     single { LocalCacheDataSource(get()) }
 
-    // File Scanner
-    factory { FileScanner() }
+    // FileScanner is registered in databasePlatformModule (interface + platform impl)
 
     // Repositories (DB-only)
     single<CacheRepository> { CacheRepositoryImpl(get()) }

--- a/core/core-database/src/commonMain/kotlin/com/riox432/civitdeck/di/DatabasePlatformModule.kt
+++ b/core/core-database/src/commonMain/kotlin/com/riox432/civitdeck/di/DatabasePlatformModule.kt
@@ -1,0 +1,10 @@
+package com.riox432.civitdeck.di
+
+import org.koin.core.module.Module
+
+/**
+ * Platform-specific Koin bindings for core-database services that have an
+ * `interface` in commonMain and a platform `actual` implementation class
+ * (e.g. [com.riox432.civitdeck.data.scanner.FileScanner]).
+ */
+expect val databasePlatformModule: Module

--- a/core/core-database/src/iosMain/kotlin/com/riox432/civitdeck/data/scanner/FileScannerImpl.kt
+++ b/core/core-database/src/iosMain/kotlin/com/riox432/civitdeck/data/scanner/FileScannerImpl.kt
@@ -16,9 +16,9 @@ import platform.Foundation.NSURL
 import kotlin.coroutines.coroutineContext
 
 @OptIn(ExperimentalForeignApi::class)
-actual class FileScanner actual constructor() {
+class FileScannerImpl : FileScanner {
 
-    actual suspend fun scanDirectory(
+    override suspend fun scanDirectory(
         path: String,
         onProgress: (current: Int, total: Int) -> Unit,
     ): List<ScannedFile> = withContext(Dispatchers.IO) {

--- a/core/core-database/src/iosMain/kotlin/com/riox432/civitdeck/di/DatabasePlatformModule.ios.kt
+++ b/core/core-database/src/iosMain/kotlin/com/riox432/civitdeck/di/DatabasePlatformModule.ios.kt
@@ -1,0 +1,10 @@
+package com.riox432.civitdeck.di
+
+import com.riox432.civitdeck.data.scanner.FileScanner
+import com.riox432.civitdeck.data.scanner.FileScannerImpl
+import org.koin.core.module.Module
+import org.koin.dsl.module
+
+actual val databasePlatformModule: Module = module {
+    factory<FileScanner> { FileScannerImpl() }
+}

--- a/core/core-database/src/jvmMain/kotlin/com/riox432/civitdeck/data/scanner/FileScannerImpl.kt
+++ b/core/core-database/src/jvmMain/kotlin/com/riox432/civitdeck/data/scanner/FileScannerImpl.kt
@@ -2,16 +2,15 @@ package com.riox432.civitdeck.data.scanner
 
 import com.riox432.civitdeck.util.Logger
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.IO
 import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.withContext
 import java.io.File
 import java.security.MessageDigest
 import kotlin.coroutines.coroutineContext
 
-actual class FileScanner actual constructor() {
+class FileScannerImpl : FileScanner {
 
-    actual suspend fun scanDirectory(
+    override suspend fun scanDirectory(
         path: String,
         onProgress: (current: Int, total: Int) -> Unit,
     ): List<ScannedFile> = withContext(Dispatchers.IO) {

--- a/core/core-database/src/jvmMain/kotlin/com/riox432/civitdeck/di/DatabasePlatformModule.jvm.kt
+++ b/core/core-database/src/jvmMain/kotlin/com/riox432/civitdeck/di/DatabasePlatformModule.jvm.kt
@@ -1,0 +1,10 @@
+package com.riox432.civitdeck.di
+
+import com.riox432.civitdeck.data.scanner.FileScanner
+import com.riox432.civitdeck.data.scanner.FileScannerImpl
+import org.koin.core.module.Module
+import org.koin.dsl.module
+
+actual val databasePlatformModule: Module = module {
+    factory<FileScanner> { FileScannerImpl() }
+}

--- a/desktopApp/src/jvmMain/kotlin/com/riox432/civitdeck/ui/comfyui/mask/DesktopMaskEditorScreen.kt
+++ b/desktopApp/src/jvmMain/kotlin/com/riox432/civitdeck/ui/comfyui/mask/DesktopMaskEditorScreen.kt
@@ -51,7 +51,6 @@ import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.input.pointer.PointerIcon
 import androidx.compose.ui.input.pointer.pointerHoverIcon
 import androidx.compose.ui.input.pointer.pointerInput
-import com.riox432.civitdeck.feature.comfyui.data.encoder.MaskPngEncoder
 import com.riox432.civitdeck.feature.comfyui.domain.model.MaskEditorState
 import com.riox432.civitdeck.feature.comfyui.domain.model.PathSegment
 import com.riox432.civitdeck.feature.comfyui.presentation.MaskEditorViewModel
@@ -71,7 +70,6 @@ fun DesktopMaskEditorScreen(
     onMaskReady: (String) -> Unit,
 ) {
     val state by viewModel.uiState.collectAsState()
-    val encoder = MaskPngEncoder()
 
     val filename = state.uploadedMaskFilename
     LaunchedEffect(filename) {
@@ -83,12 +81,7 @@ fun DesktopMaskEditorScreen(
             DesktopMaskTopBar(
                 onBack = onBack,
                 onDone = {
-                    val bytes = encoder.encode(
-                        segments = state.pathSegments,
-                        width = imageWidth,
-                        height = imageHeight,
-                        inverted = state.isInverted,
-                    )
+                    val bytes = viewModel.encodeMask(imageWidth, imageHeight)
                     viewModel.onUploadMask(bytes)
                 },
                 isUploading = state.isUploading,

--- a/feature/feature-comfyui/src/androidMain/kotlin/com/riox432/civitdeck/data/image/ImageSaverImpl.kt
+++ b/feature/feature-comfyui/src/androidMain/kotlin/com/riox432/civitdeck/data/image/ImageSaverImpl.kt
@@ -8,15 +8,14 @@ import android.provider.MediaStore
 import com.riox432.civitdeck.util.Logger
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
-import org.koin.core.component.KoinComponent
-import org.koin.core.component.inject
 
 private const val TAG = "ImageSaver"
 
-actual class ImageSaver actual constructor() : KoinComponent {
-    private val context: Context by inject()
+class ImageSaverImpl(
+    private val context: Context,
+) : ImageSaver {
 
-    actual suspend fun saveToGallery(imageBytes: ByteArray, filename: String): Boolean =
+    override suspend fun saveToGallery(imageBytes: ByteArray, filename: String): Boolean =
         withContext(Dispatchers.IO) {
             try {
                 val values = ContentValues().apply {

--- a/feature/feature-comfyui/src/androidMain/kotlin/com/riox432/civitdeck/feature/comfyui/data/encoder/MaskPngEncoderImpl.kt
+++ b/feature/feature-comfyui/src/androidMain/kotlin/com/riox432/civitdeck/feature/comfyui/data/encoder/MaskPngEncoderImpl.kt
@@ -8,9 +8,9 @@ import android.graphics.Path
 import com.riox432.civitdeck.feature.comfyui.domain.model.PathSegment
 import java.io.ByteArrayOutputStream
 
-actual class MaskPngEncoder actual constructor() {
+class MaskPngEncoderImpl : MaskPngEncoder {
 
-    actual fun encode(
+    override fun encode(
         segments: List<PathSegment>,
         width: Int,
         height: Int,

--- a/feature/feature-comfyui/src/androidMain/kotlin/com/riox432/civitdeck/feature/comfyui/data/repository/LocalIpProviderImpl.kt
+++ b/feature/feature-comfyui/src/androidMain/kotlin/com/riox432/civitdeck/feature/comfyui/data/repository/LocalIpProviderImpl.kt
@@ -2,8 +2,8 @@ package com.riox432.civitdeck.feature.comfyui.data.repository
 
 import java.net.NetworkInterface
 
-actual class LocalIpProvider actual constructor() {
-    actual fun getLocalSubnet(): String? {
+class LocalIpProviderImpl : LocalIpProvider {
+    override fun getLocalSubnet(): String? {
         return try {
             NetworkInterface.getNetworkInterfaces()?.toList()
                 ?.flatMap { it.inetAddresses.toList() }

--- a/feature/feature-comfyui/src/androidMain/kotlin/com/riox432/civitdeck/feature/comfyui/di/ComfyUIPlatformModule.android.kt
+++ b/feature/feature-comfyui/src/androidMain/kotlin/com/riox432/civitdeck/feature/comfyui/di/ComfyUIPlatformModule.android.kt
@@ -1,0 +1,16 @@
+package com.riox432.civitdeck.feature.comfyui.di
+
+import com.riox432.civitdeck.data.image.ImageSaver
+import com.riox432.civitdeck.data.image.ImageSaverImpl
+import com.riox432.civitdeck.feature.comfyui.data.encoder.MaskPngEncoder
+import com.riox432.civitdeck.feature.comfyui.data.encoder.MaskPngEncoderImpl
+import com.riox432.civitdeck.feature.comfyui.data.repository.LocalIpProvider
+import com.riox432.civitdeck.feature.comfyui.data.repository.LocalIpProviderImpl
+import org.koin.core.module.Module
+import org.koin.dsl.module
+
+actual val comfyuiPlatformModule: Module = module {
+    single<LocalIpProvider> { LocalIpProviderImpl() }
+    factory<ImageSaver> { ImageSaverImpl(get()) }
+    single<MaskPngEncoder> { MaskPngEncoderImpl() }
+}

--- a/feature/feature-comfyui/src/commonMain/kotlin/com/riox432/civitdeck/data/image/ImageSaver.kt
+++ b/feature/feature-comfyui/src/commonMain/kotlin/com/riox432/civitdeck/data/image/ImageSaver.kt
@@ -5,7 +5,7 @@ package com.riox432.civitdeck.data.image
  * Android: uses MediaStore (Pictures/CivitDeck).
  * iOS: uses PHPhotoLibrary.
  */
-expect class ImageSaver() {
+interface ImageSaver {
     /**
      * Saves the given [imageBytes] (JPEG/PNG raw bytes) to the device photo gallery.
      * @param imageBytes raw image data

--- a/feature/feature-comfyui/src/commonMain/kotlin/com/riox432/civitdeck/feature/comfyui/data/encoder/MaskPngEncoder.kt
+++ b/feature/feature-comfyui/src/commonMain/kotlin/com/riox432/civitdeck/feature/comfyui/data/encoder/MaskPngEncoder.kt
@@ -8,7 +8,7 @@ package com.riox432.civitdeck.feature.comfyui.data.encoder
  *
  * When [inverted] is true, the colors are swapped.
  */
-expect class MaskPngEncoder() {
+interface MaskPngEncoder {
     /**
      * Renders the given path segments into a PNG mask image.
      *

--- a/feature/feature-comfyui/src/commonMain/kotlin/com/riox432/civitdeck/feature/comfyui/data/repository/ServerDiscoveryRepositoryImpl.kt
+++ b/feature/feature-comfyui/src/commonMain/kotlin/com/riox432/civitdeck/feature/comfyui/data/repository/ServerDiscoveryRepositoryImpl.kt
@@ -76,6 +76,6 @@ class ServerDiscoveryRepositoryImpl(
  * Platform-specific provider for the local device IP subnet.
  * Returns the first 3 octets (e.g. "192.168.1") or null.
  */
-expect class LocalIpProvider() {
+interface LocalIpProvider {
     fun getLocalSubnet(): String?
 }

--- a/feature/feature-comfyui/src/commonMain/kotlin/com/riox432/civitdeck/feature/comfyui/di/ComfyUIModule.kt
+++ b/feature/feature-comfyui/src/commonMain/kotlin/com/riox432/civitdeck/feature/comfyui/di/ComfyUIModule.kt
@@ -14,7 +14,6 @@ import com.riox432.civitdeck.domain.repository.SDWebUIGenerationRepository
 import com.riox432.civitdeck.domain.repository.ServerDiscoveryRepository
 import com.riox432.civitdeck.domain.util.SystemStatsProvider
 import com.riox432.civitdeck.feature.comfyui.data.NtfySubscriptionService
-import com.riox432.civitdeck.feature.comfyui.data.encoder.MaskPngEncoder
 import com.riox432.civitdeck.feature.comfyui.data.repository.CivitaiLinkRepositoryImpl
 import com.riox432.civitdeck.feature.comfyui.data.repository.ComfyHubRepositoryImpl
 import com.riox432.civitdeck.feature.comfyui.data.repository.ComfyUIConnectionRepositoryImpl
@@ -22,7 +21,6 @@ import com.riox432.civitdeck.feature.comfyui.data.repository.ComfyUIConnectionTe
 import com.riox432.civitdeck.feature.comfyui.data.repository.ComfyUIGenerationRepositoryImpl
 import com.riox432.civitdeck.feature.comfyui.data.repository.ComfyUIHistoryRepositoryImpl
 import com.riox432.civitdeck.feature.comfyui.data.repository.ComfyUIQueueRepositoryImpl
-import com.riox432.civitdeck.feature.comfyui.data.repository.LocalIpProvider
 import com.riox432.civitdeck.feature.comfyui.data.repository.SDWebUIRepositoryImpl
 import com.riox432.civitdeck.feature.comfyui.data.repository.ServerDiscoveryRepositoryImpl
 import com.riox432.civitdeck.feature.comfyui.data.repository.lanScanSupported
@@ -110,7 +108,7 @@ val comfyuiModule = module {
             json = get(),
         )
     }
-    single { LocalIpProvider() }
+    // LocalIpProvider is registered in comfyuiPlatformModule (interface + platform impl)
     single<ServerDiscoveryRepository> {
         ServerDiscoveryRepositoryImpl(get(named("comfyui")), get(), get())
     }
@@ -147,7 +145,7 @@ val comfyuiModule = module {
     factory { CancelComfyUIJobUseCase(get()) }
     factory { InterruptComfyUIGenerationUseCase(get()) }
     factory { UploadMaskUseCase(get()) }
-    single { MaskPngEncoder() }
+    // MaskPngEncoder is registered in comfyuiPlatformModule (interface + platform impl)
     factory { FindMatchingLocalModelUseCase(get()) }
     factory { PopulateGenerationFromModelUseCase() }
     factory { SaveGeneratedImageUseCase(get(named("comfyui")), get()) }
@@ -229,5 +227,5 @@ val comfyuiModule = module {
     viewModel { SDWebUIGenerationViewModel(get(), get(), get(), get(), get()) }
     viewModel { CivitaiLinkSettingsViewModel(get(), get(), get(), get(), get(), get(), get()) }
     viewModel { CivitaiLinkSendViewModel(get(), get()) }
-    viewModel { MaskEditorViewModel(get()) }
+    viewModel { MaskEditorViewModel(get(), get()) }
 }

--- a/feature/feature-comfyui/src/commonMain/kotlin/com/riox432/civitdeck/feature/comfyui/di/ComfyUIPlatformModule.kt
+++ b/feature/feature-comfyui/src/commonMain/kotlin/com/riox432/civitdeck/feature/comfyui/di/ComfyUIPlatformModule.kt
@@ -1,0 +1,10 @@
+package com.riox432.civitdeck.feature.comfyui.di
+
+import org.koin.core.module.Module
+
+/**
+ * Platform-specific Koin bindings for feature-comfyui services that have an
+ * `interface` in commonMain and a platform `actual` implementation class
+ * (LocalIpProvider, ImageSaver, MaskPngEncoder).
+ */
+expect val comfyuiPlatformModule: Module

--- a/feature/feature-comfyui/src/commonMain/kotlin/com/riox432/civitdeck/feature/comfyui/presentation/MaskEditorViewModel.kt
+++ b/feature/feature-comfyui/src/commonMain/kotlin/com/riox432/civitdeck/feature/comfyui/presentation/MaskEditorViewModel.kt
@@ -2,6 +2,7 @@ package com.riox432.civitdeck.feature.comfyui.presentation
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.riox432.civitdeck.feature.comfyui.data.encoder.MaskPngEncoder
 import com.riox432.civitdeck.feature.comfyui.domain.model.MaskEditorState
 import com.riox432.civitdeck.feature.comfyui.domain.model.PathSegment
 import com.riox432.civitdeck.feature.comfyui.domain.usecase.UploadMaskUseCase
@@ -18,10 +19,23 @@ import kotlinx.coroutines.launch
  */
 class MaskEditorViewModel(
     private val uploadMask: UploadMaskUseCase,
+    private val maskPngEncoder: MaskPngEncoder,
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow(MaskEditorState())
     val uiState: StateFlow<MaskEditorState> = _uiState
+
+    /**
+     * Encodes the current mask path segments into PNG bytes using the
+     * platform-specific [MaskPngEncoder].
+     */
+    fun encodeMask(width: Int, height: Int): ByteArray =
+        maskPngEncoder.encode(
+            segments = _uiState.value.pathSegments,
+            width = width,
+            height = height,
+            inverted = _uiState.value.isInverted,
+        )
 
     fun setSourceImageUrl(url: String) {
         _uiState.update { it.copy(sourceImageUrl = url) }

--- a/feature/feature-comfyui/src/iosMain/kotlin/com/riox432/civitdeck/data/image/ImageSaverImpl.kt
+++ b/feature/feature-comfyui/src/iosMain/kotlin/com/riox432/civitdeck/data/image/ImageSaverImpl.kt
@@ -14,10 +14,10 @@ import platform.UIKit.UIImageWriteToSavedPhotosAlbum
 
 private const val TAG = "ImageSaver"
 
-actual class ImageSaver actual constructor() {
+class ImageSaverImpl : ImageSaver {
 
     @OptIn(ExperimentalForeignApi::class)
-    actual suspend fun saveToGallery(imageBytes: ByteArray, filename: String): Boolean =
+    override suspend fun saveToGallery(imageBytes: ByteArray, filename: String): Boolean =
         withContext(Dispatchers.IO) {
             try {
                 val nsData = imageBytes.toNSData()

--- a/feature/feature-comfyui/src/iosMain/kotlin/com/riox432/civitdeck/feature/comfyui/data/encoder/MaskPngEncoderImpl.kt
+++ b/feature/feature-comfyui/src/iosMain/kotlin/com/riox432/civitdeck/feature/comfyui/data/encoder/MaskPngEncoderImpl.kt
@@ -27,10 +27,10 @@ import platform.posix.memcpy
 // CGLineCap values: butt=0, round=1, square=2
 // CGLineJoin values: miter=0, round=1, bevel=2
 
-actual class MaskPngEncoder actual constructor() {
+class MaskPngEncoderImpl : MaskPngEncoder {
 
     @OptIn(ExperimentalForeignApi::class)
-    actual fun encode(
+    override fun encode(
         segments: List<PathSegment>,
         width: Int,
         height: Int,

--- a/feature/feature-comfyui/src/iosMain/kotlin/com/riox432/civitdeck/feature/comfyui/data/repository/LocalIpProviderImpl.kt
+++ b/feature/feature-comfyui/src/iosMain/kotlin/com/riox432/civitdeck/feature/comfyui/data/repository/LocalIpProviderImpl.kt
@@ -1,13 +1,13 @@
 package com.riox432.civitdeck.feature.comfyui.data.repository
 
-actual class LocalIpProvider actual constructor() {
+class LocalIpProviderImpl : LocalIpProvider {
     /**
      * On iOS, getting the local IP requires low-level C interop with getifaddrs.
      * For simplicity, we return a common default subnet. Users can also enter
      * a specific subnet range in settings if auto-detection fails.
      * A full implementation would use NWPathMonitor or getifaddrs via cinterop.
      */
-    actual fun getLocalSubnet(): String? {
+    override fun getLocalSubnet(): String? {
         // Return a common home network subnet as fallback.
         // Full implementation would use NWPathMonitor to detect the actual interface address.
         return "192.168.1"

--- a/feature/feature-comfyui/src/iosMain/kotlin/com/riox432/civitdeck/feature/comfyui/di/ComfyUIPlatformModule.ios.kt
+++ b/feature/feature-comfyui/src/iosMain/kotlin/com/riox432/civitdeck/feature/comfyui/di/ComfyUIPlatformModule.ios.kt
@@ -1,0 +1,16 @@
+package com.riox432.civitdeck.feature.comfyui.di
+
+import com.riox432.civitdeck.data.image.ImageSaver
+import com.riox432.civitdeck.data.image.ImageSaverImpl
+import com.riox432.civitdeck.feature.comfyui.data.encoder.MaskPngEncoder
+import com.riox432.civitdeck.feature.comfyui.data.encoder.MaskPngEncoderImpl
+import com.riox432.civitdeck.feature.comfyui.data.repository.LocalIpProvider
+import com.riox432.civitdeck.feature.comfyui.data.repository.LocalIpProviderImpl
+import org.koin.core.module.Module
+import org.koin.dsl.module
+
+actual val comfyuiPlatformModule: Module = module {
+    single<LocalIpProvider> { LocalIpProviderImpl() }
+    factory<ImageSaver> { ImageSaverImpl() }
+    single<MaskPngEncoder> { MaskPngEncoderImpl() }
+}

--- a/feature/feature-comfyui/src/jvmMain/kotlin/com/riox432/civitdeck/data/image/ImageSaverImpl.kt
+++ b/feature/feature-comfyui/src/jvmMain/kotlin/com/riox432/civitdeck/data/image/ImageSaverImpl.kt
@@ -7,9 +7,9 @@ import java.io.File
 
 private const val TAG = "ImageSaver"
 
-actual class ImageSaver actual constructor() {
+class ImageSaverImpl : ImageSaver {
 
-    actual suspend fun saveToGallery(imageBytes: ByteArray, filename: String): Boolean =
+    override suspend fun saveToGallery(imageBytes: ByteArray, filename: String): Boolean =
         withContext(Dispatchers.IO) {
             try {
                 val picturesDir = File(System.getProperty("user.home"), "Pictures/CivitDeck")

--- a/feature/feature-comfyui/src/jvmMain/kotlin/com/riox432/civitdeck/feature/comfyui/data/encoder/MaskPngEncoderImpl.kt
+++ b/feature/feature-comfyui/src/jvmMain/kotlin/com/riox432/civitdeck/feature/comfyui/data/encoder/MaskPngEncoderImpl.kt
@@ -9,9 +9,9 @@ import java.awt.image.BufferedImage
 import java.io.ByteArrayOutputStream
 import javax.imageio.ImageIO
 
-actual class MaskPngEncoder actual constructor() {
+class MaskPngEncoderImpl : MaskPngEncoder {
 
-    actual fun encode(
+    override fun encode(
         segments: List<PathSegment>,
         width: Int,
         height: Int,

--- a/feature/feature-comfyui/src/jvmMain/kotlin/com/riox432/civitdeck/feature/comfyui/data/repository/LocalIpProviderImpl.kt
+++ b/feature/feature-comfyui/src/jvmMain/kotlin/com/riox432/civitdeck/feature/comfyui/data/repository/LocalIpProviderImpl.kt
@@ -2,8 +2,8 @@ package com.riox432.civitdeck.feature.comfyui.data.repository
 
 import java.net.NetworkInterface
 
-actual class LocalIpProvider actual constructor() {
-    actual fun getLocalSubnet(): String? {
+class LocalIpProviderImpl : LocalIpProvider {
+    override fun getLocalSubnet(): String? {
         return try {
             NetworkInterface.getNetworkInterfaces()?.toList()
                 ?.flatMap { it.inetAddresses.toList() }

--- a/feature/feature-comfyui/src/jvmMain/kotlin/com/riox432/civitdeck/feature/comfyui/di/ComfyUIPlatformModule.jvm.kt
+++ b/feature/feature-comfyui/src/jvmMain/kotlin/com/riox432/civitdeck/feature/comfyui/di/ComfyUIPlatformModule.jvm.kt
@@ -1,0 +1,16 @@
+package com.riox432.civitdeck.feature.comfyui.di
+
+import com.riox432.civitdeck.data.image.ImageSaver
+import com.riox432.civitdeck.data.image.ImageSaverImpl
+import com.riox432.civitdeck.feature.comfyui.data.encoder.MaskPngEncoder
+import com.riox432.civitdeck.feature.comfyui.data.encoder.MaskPngEncoderImpl
+import com.riox432.civitdeck.feature.comfyui.data.repository.LocalIpProvider
+import com.riox432.civitdeck.feature.comfyui.data.repository.LocalIpProviderImpl
+import org.koin.core.module.Module
+import org.koin.dsl.module
+
+actual val comfyuiPlatformModule: Module = module {
+    single<LocalIpProvider> { LocalIpProviderImpl() }
+    factory<ImageSaver> { ImageSaverImpl() }
+    single<MaskPngEncoder> { MaskPngEncoderImpl() }
+}

--- a/shared/src/commonMain/kotlin/com/riox432/civitdeck/di/DataModule.kt
+++ b/shared/src/commonMain/kotlin/com/riox432/civitdeck/di/DataModule.kt
@@ -2,15 +2,13 @@ package com.riox432.civitdeck.di
 
 import com.riox432.civitdeck.data.export.ExportRepositoryImpl
 import com.riox432.civitdeck.data.export.KohyaZipExportPlugin
-import com.riox432.civitdeck.data.image.ImageSaver
 import com.riox432.civitdeck.domain.repository.ExportRepository
 import com.riox432.civitdeck.feature.collections.domain.usecase.ExportWithPluginUseCase
 import com.riox432.civitdeck.feature.collections.domain.usecase.GetAvailableExportFormatsUseCase
 import org.koin.dsl.module
 
 val dataModule = module {
-    // Image Saver (platform-specific via expect/actual)
-    factory { ImageSaver() }
+    // ImageSaver is registered in comfyuiPlatformModule (interface + platform impl)
 
     // Export
     single<ExportRepository> { ExportRepositoryImpl(get(), get()) }

--- a/shared/src/commonMain/kotlin/com/riox432/civitdeck/di/Koin.kt
+++ b/shared/src/commonMain/kotlin/com/riox432/civitdeck/di/Koin.kt
@@ -7,6 +7,7 @@ import com.riox432.civitdeck.domain.util.ApplicationScope
 import com.riox432.civitdeck.domain.util.CivitAiFrontDoor
 import com.riox432.civitdeck.feature.collections.di.collectionsModule
 import com.riox432.civitdeck.feature.comfyui.di.comfyuiModule
+import com.riox432.civitdeck.feature.comfyui.di.comfyuiPlatformModule
 import com.riox432.civitdeck.feature.creator.di.creatorModule
 import com.riox432.civitdeck.feature.detail.di.detailModule
 import com.riox432.civitdeck.feature.externalserver.di.externalServerModule
@@ -24,9 +25,11 @@ val sharedModules: List<Module>
     get() = listOf(
         platformModule,
         networkModule,
+        databasePlatformModule,
         databaseModule,
         coreDataModule,
         dataModule,
+        comfyuiPlatformModule,
         domainModule,
         settingsModule,
         settingsViewModelModule,


### PR DESCRIPTION
Closes #917

## Summary

Phase A of the Service-Locator removal. Converts four no-arg `expect class Foo()` platform services into a commonMain `interface` + platform `actual` implementation class + Koin DI, so consumers receive them via constructor injection instead of reaching into the container.

## Conversions (4)

| Service | Module | Notes |
|---|---|---|
| `FileScanner` | `:core:core-database` | `interface` + `FileScannerImpl` (android/ios/jvm). No deps. |
| `LocalIpProvider` | `:feature:feature-comfyui` | `interface` + `LocalIpProviderImpl`. No deps. |
| `ImageSaver` | `:feature:feature-comfyui` | `interface` + `ImageSaverImpl`. **Android impl now takes `Context` via constructor** (removed `KoinComponent` + `by inject()` Service-Locator leak). |
| `MaskPngEncoder` | `:feature:feature-comfyui` | `interface` + `MaskPngEncoderImpl`. Now injected into `MaskEditorViewModel` via a `encodeMask(width, height)` passthrough; the two Compose screens (Android `MaskEditorScreen`, Desktop `DesktopMaskEditorScreen`) call `viewModel.encodeMask(...)` instead of constructing `MaskPngEncoder()` directly. |

## DI wiring

- New `expect val databasePlatformModule` (core-database) and `expect val comfyuiPlatformModule` (feature-comfyui) with android/ios/jvm `actual`s registering the `Impl` classes against their interfaces.
- Both added to `sharedModules` in `Koin.kt` (loaded before the modules that resolve them).
- Removed the old common registrations: `factory { FileScanner() }` (databaseModule), `single { LocalIpProvider() }` + `single { MaskPngEncoder() }` (comfyuiModule), `factory { ImageSaver() }` (shared dataModule).

## Acceptance

- All four are `interface` + Koin DI; **no `KoinPlatform.getKoin().get()` / `KoinComponent` / `by inject()` remains** in their impls (verified).
- Consumers (`LocalModelFileRepositoryImpl`, `ServerDiscoveryRepositoryImpl`, `SaveGeneratedImageUseCase`, `MaskEditorViewModel`) receive the interfaces via constructor injection.
- Behavior preserved — platform logic moved verbatim into the `Impl` classes.

## Verification

- `./gradlew detekt` (all modules) — pass (run twice, stable)
- Android CI test list (`:shared`, `:core:core-database`, `:core:core-data`, feature-* `testDebugUnitTest`, `:feature:feature-comfyui:jvmTest`) — pass
- `:androidApp:assembleDebug` — pass
- `:desktopApp:compileKotlinJvm` — pass
- iOS Kotlin: `:shared`, `:core:core-database`, `:feature:feature-comfyui` `compileKotlinIosSimulatorArm64` — pass
- iOS app: full `xcodebuild` (iOS Simulator, arm64) — `** BUILD SUCCEEDED **`
- SwiftLint: N/A (no Swift files touched)

## Phase B (deferred follow-up)

Out of scope per issue. Remaining `expect class()` services with higher platform divergence: ML embedding models (`ImageEmbeddingModel`, `TextEmbeddingModel`), notification/foreground-service (`GenerationNotificationService`, `BackgroundMonitorStarter`, `AppLifecycleTracker`), and `DatasetZipWriter`. To be migrated in a separate effort once their platform differences are addressed.