### PR TITLE
Raise minSdk to 29 and remove deprecated external-storage fallback

### DIFF
--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/gallery/ImageDownloader.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/gallery/ImageDownloader.kt
@@ -2,7 +2,6 @@ package com.riox432.civitdeck.ui.gallery
 
 import android.content.ContentValues
 import android.content.Context
-import android.os.Build
 import android.os.Environment
 import android.provider.MediaStore
 import android.util.Log
@@ -10,7 +9,6 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import okhttp3.OkHttpClient
 import okhttp3.Request
-import java.io.File
 import java.io.IOException
 
 object ImageDownloader {
@@ -45,11 +43,7 @@ object ImageDownloader {
     }
 
     private fun saveToGallery(context: Context, fileName: String, bytes: ByteArray): Boolean {
-        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
-            saveWithMediaStore(context, fileName, bytes)
-        } else {
-            saveToExternalStorage(fileName, bytes)
-        }
+        return saveWithMediaStore(context, fileName, bytes)
     }
 
     private fun saveWithMediaStore(
@@ -93,28 +87,6 @@ object ImageDownloader {
         } catch (e: SecurityException) {
             Log.w(TAG, "Permission denied writing to MediaStore: $fileName", e)
             resolver.delete(uri, null, null)
-            false
-        }
-    }
-
-    // Legacy fallback for API 24–28 (pre-Q). Uses the deprecated
-    // getExternalStoragePublicDirectory because MediaStore RELATIVE_PATH/IS_PENDING
-    // requires API 29+. Safe to remove once minSdk is raised to 29.
-    @Suppress("DEPRECATION")
-    private fun saveToExternalStorage(fileName: String, bytes: ByteArray): Boolean {
-        return try {
-            val dir = File(
-                Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_PICTURES),
-                "CivitDeck",
-            )
-            dir.mkdirs()
-            File(dir, fileName).writeBytes(bytes)
-            true
-        } catch (e: IOException) {
-            Log.w(TAG, "Failed to save image to external storage: $fileName", e)
-            false
-        } catch (e: SecurityException) {
-            Log.w(TAG, "Permission denied saving to external storage: $fileName", e)
             false
         }
     }

--- a/build-logic/convention/src/main/kotlin/CivitDeckAndroidApplicationPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/CivitDeckAndroidApplicationPlugin.kt
@@ -19,7 +19,7 @@ class CivitDeckAndroidApplicationPlugin : Plugin<Project> {
             extensions.configure<ApplicationExtension> {
                 compileSdk = 36
                 defaultConfig {
-                    minSdk = 24
+                    minSdk = 29
                     targetSdk = 35
                 }
                 compileOptions {

--- a/build-logic/convention/src/main/kotlin/CivitDeckKmpLibraryPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/CivitDeckKmpLibraryPlugin.kt
@@ -19,7 +19,7 @@ class CivitDeckKmpLibraryPlugin : Plugin<Project> {
             extensions.configure<LibraryExtension> {
                 compileSdk = 36
                 defaultConfig {
-                    minSdk = 24
+                    minSdk = 29
                 }
                 compileOptions {
                     sourceCompatibility = JavaVersion.VERSION_17


### PR DESCRIPTION
## Description
- Raise `minSdk` from 24 to **29** (Android 10) in both convention plugins (`CivitDeckAndroidApplicationPlugin`, `CivitDeckKmpLibraryPlugin`).
- Remove the now-dead pre-Q (API 24–28) gallery save path in `ImageDownloader`: drop the `saveToExternalStorage` fallback using the deprecated `Environment.getExternalStoragePublicDirectory` and call `saveWithMediaStore` directly. Clean up the now-unused `Build` / `java.io.File` imports.

### Rationale
- API 29+ covers ~91.1% of devices (Apr 2026 data); dropping API 24–28 costs ~5.5pt globally, and far less for CivitDeck's mobile-ComfyUI power-user audience (GitHub Releases distribution, newer hardware).
- Unblocks removal of the properly-gated deprecation tracked in #818.

### Out of scope
- Other now-obsolete `SDK_INT >= Q` checks (`MainActivity`, `ModelDownloadWorker`) are harmless dead-`else` branches; left untouched to keep this PR focused (CI does not run Android Lint).
- #819 (`startActivityAndCollapse(Intent)`) requires minSdk 34 (Android 14) — too high; stays parked.

### Verification
- `./gradlew detekt` (all modules, twice) — clean
- `./gradlew :androidApp:assembleDebug` — pass
- `./gradlew :shared:testDebugUnitTest` — pass

## Related Issues
Closes #818