### PR TITLE
#945 Remove force unwrap in DesktopAuthSettingsSection

### DIFF
--- a/desktopApp/src/jvmMain/kotlin/com/riox432/civitdeck/ui/settings/DesktopAuthSettingsSection.kt
+++ b/desktopApp/src/jvmMain/kotlin/com/riox432/civitdeck/ui/settings/DesktopAuthSettingsSection.kt
@@ -26,9 +26,10 @@ internal fun AuthSettingsSection(viewModel: AuthSettingsViewModel) {
     var apiKeyInput by remember { mutableStateOf("") }
 
     SettingsCard(title = "Authentication") {
-        if (state.connectedUsername != null) {
+        val connectedUsername = state.connectedUsername
+        if (connectedUsername != null) {
             ConnectedState(
-                username = state.connectedUsername!!,
+                username = connectedUsername,
                 onRefresh = viewModel::onRefreshUsername,
                 onDisconnect = viewModel::onClearApiKey,
             )


### PR DESCRIPTION
## Description
- Replaced `state.connectedUsername!!` with a local `val connectedUsername` captured before the null check, enabling smart-cast and removing the force unwrap (delegated state properties cannot smart-cast directly).
- No behavior change; pure tech-debt cleanup to satisfy the project no-`!!` rule.

## Related Issue
Closes #945

## Checklist
- [x] CLAUDE.md rules followed
- [x] No `!!` or force unwrap