### PR TITLE
#948 Return typed failure for missing API key in ReviewRepositoryImpl

### DIFF
--- a/core/core-network/src/commonMain/kotlin/com/riox432/civitdeck/data/api/repository/ReviewRepositoryImpl.kt
+++ b/core/core-network/src/commonMain/kotlin/com/riox432/civitdeck/data/api/repository/ReviewRepositoryImpl.kt
@@ -2,6 +2,7 @@ package com.riox432.civitdeck.data.api.repository
 
 import com.riox432.civitdeck.data.api.ApiKeyProvider
 import com.riox432.civitdeck.data.api.CivitAiApi
+import com.riox432.civitdeck.domain.model.DomainException
 import com.riox432.civitdeck.domain.model.RatingTotals
 import com.riox432.civitdeck.domain.model.ResourceReview
 import com.riox432.civitdeck.domain.repository.ReviewPage
@@ -61,9 +62,8 @@ class ReviewRepositoryImpl(
         recommended: Boolean,
         details: String?,
     ) {
-        val apiKey = checkNotNull(apiKeyProvider.apiKey) {
-            "API key required to submit reviews"
-        }
+        val apiKey = apiKeyProvider.apiKey
+            ?: throw DomainException.AuthException("API key required to submit reviews")
         api.createReview(apiKey, modelId, modelVersionId, rating, recommended, details)
     }
 }


### PR DESCRIPTION
## Description
`ReviewRepositoryImpl.submitReview` used `checkNotNull(apiKeyProvider.apiKey)`, which throws a generic `IllegalStateException` if the API key is null at runtime. This replaces it with the existing typed domain failure so the missing-key case is signaled as an auth error rather than a generic crash-style exception.

- Throw `DomainException.AuthException("API key required to submit reviews")` when `apiKeyProvider.apiKey` is null
- Follows the existing error convention: the repository throws and the caller (`DetailReviewDelegate.submitReview`) already handles it via `suspendRunCatching { ... }.onFailure { ... }`
- No interface change (`ReviewRepository.submitReview` signature unchanged) — no caller updates required

## Related Issue
Closes #948

## Automated Tests
- [ ] Unit tests added/updated — N/A (single null-guard branch; existing caller-side `suspendRunCatching` handling unchanged; faking the final `CivitAiApi` would require a MockEngine test dep — out of scope for this minimal fix)

## Checklist
- [x] CLAUDE.md rules followed
- [x] No `!!` or force unwrap
- [x] No `GlobalScope`
- [x] Error handling complete

## Verification
- `./gradlew :core:core-network:detekt` (x2) — clean
- `./gradlew :core:core-network:compileKotlinMetadata` — BUILD SUCCESSFUL