### PR TITLE
#943 Avoid NoSuchElementException from flow.first() on empty flows

### DIFF
--- a/feature/feature-search/src/commonMain/kotlin/com/riox432/civitdeck/feature/search/presentation/ModelSearchViewModel.kt
+++ b/feature/feature-search/src/commonMain/kotlin/com/riox432/civitdeck/feature/search/presentation/ModelSearchViewModel.kt
@@ -45,7 +45,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
-import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
@@ -350,8 +350,10 @@ class ModelSearchViewModel(
         observePeriodUseCase: ObserveDefaultTimePeriodUseCase,
     ) {
         viewModelScope.launch {
-            val sort = observeSortUseCase().first()
-            val period = observePeriodUseCase().first()
+            // firstOrNull avoids NoSuchElementException if the preferences flow emits nothing;
+            // fall back to the same defaults used by ModelSearchUiState/FilterState.
+            val sort = observeSortUseCase().firstOrNull() ?: SortOrder.MostDownloaded
+            val period = observePeriodUseCase().firstOrNull() ?: TimePeriod.AllTime
             _uiState.update { it.copy(selectedSort = sort, selectedPeriod = period) }
             val current = _filterState.value
             if (current.selectedSort != sort || current.selectedPeriod != period) {

--- a/shared/src/commonMain/kotlin/com/riox432/civitdeck/data/export/ExportRepositoryImpl.kt
+++ b/shared/src/commonMain/kotlin/com/riox432/civitdeck/data/export/ExportRepositoryImpl.kt
@@ -9,7 +9,7 @@ import io.ktor.client.HttpClient
 import io.ktor.client.request.get
 import io.ktor.client.statement.bodyAsBytes
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.flow.flow
 
 private const val TAG = "ExportRepositoryImpl"
@@ -24,13 +24,16 @@ class ExportRepositoryImpl(
     override fun exportDataset(datasetId: Long, format: ExportFormat): Flow<ExportProgress> = flow {
         emit(ExportProgress.Preparing)
 
-        val collection = datasetRepo.observeCollections().first().firstOrNull { it.id == datasetId }
+        // flow firstOrNull() avoids NoSuchElementException if the source flow emits nothing;
+        // an empty/absent emission is treated the same as the dataset not being found.
+        val collection = datasetRepo.observeCollections().firstOrNull()
+            ?.firstOrNull { it.id == datasetId }
             ?: run {
                 emit(ExportProgress.Failed("Dataset not found"))
                 return@flow
             }
 
-        val allImages = datasetRepo.observeImages(datasetId).first()
+        val allImages = datasetRepo.observeImages(datasetId).firstOrNull().orEmpty()
         val exportable = allImages.filter { it.trainable && !it.excluded }
         val warningCount = allImages.count { !it.trainable || it.excluded }
 


### PR DESCRIPTION
## Description
`.first()` was called on flows that may emit nothing, risking `NoSuchElementException`.

- `ExportRepositoryImpl.exportDataset`:
  - `observeCollections().first().firstOrNull { ... }` → `observeCollections().firstOrNull()?.firstOrNull { ... }`. An empty/absent emission is now treated the same as the dataset not being found (`ExportProgress.Failed("Dataset not found")`).
  - `observeImages(datasetId).first()` → `observeImages(datasetId).firstOrNull().orEmpty()` (same risk, fixed too). An empty emission falls through to the existing `ExportProgress.Failed("No exportable images")` path.
- `ModelSearchViewModel.loadDefaults`:
  - `observeSortUseCase().first()` / `observePeriodUseCase().first()` → `firstOrNull() ?: SortOrder.MostDownloaded` / `?: TimePeriod.AllTime`. Defaults match `ModelSearchUiState`/`FilterState` and the repository's own `getOrDefault` defaults.

Uses the flow operator `kotlinx.coroutines.flow.firstOrNull` (not the collection operator). The unused `first` import was replaced in both files.

## Related Issue
Closes #943

## Automated Tests
- [x] `./gradlew detekt` (twice, clean)
- [x] `:shared:testDebugUnitTest` and `:feature:feature-search:testDebugUnitTest` pass

## Checklist
- [x] CLAUDE.md rules followed
- [x] No `!!` or force unwrap
- [x] No `GlobalScope`
- [x] Error handling complete
