### PR TITLE
#938 Log failures in ML model loaders instead of silent null

### DIFF
--- a/core/core-domain/src/androidMain/kotlin/com/riox432/civitdeck/domain/ml/ImageEmbeddingModelImpl.kt
+++ b/core/core-domain/src/androidMain/kotlin/com/riox432/civitdeck/domain/ml/ImageEmbeddingModelImpl.kt
@@ -6,6 +6,7 @@ import ai.onnxruntime.OrtSession
 import android.content.Context
 import android.graphics.Bitmap
 import android.graphics.BitmapFactory
+import com.riox432.civitdeck.util.Logger
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import java.nio.ByteBuffer
@@ -43,14 +44,16 @@ class ImageEmbeddingModelImpl(
      * ONNX Runtime session, lazily loaded from the app bundle. Returns `null`
      * when the asset file is missing or unreadable.
      */
-    @Suppress("TooGenericExceptionCaught", "SwallowedException")
+    @Suppress("TooGenericExceptionCaught")
     private val session: OrtSession? by lazy {
         try {
             val bytes = context.assets.open(ASSET_PATH).use { it.readBytes() }
             ortEnv.createSession(bytes)
-        } catch (_: java.io.IOException) {
+        } catch (e: java.io.IOException) {
+            Logger.w(TAG, "SigLIP-2 vision asset '$ASSET_PATH' missing or unreadable: ${e.message}")
             null
-        } catch (_: Exception) {
+        } catch (e: Exception) {
+            Logger.e(TAG, "Failed to create SigLIP-2 vision ONNX session from '$ASSET_PATH'", e)
             null
         }
     }
@@ -82,6 +85,7 @@ class ImageEmbeddingModelImpl(
     }
 
     private companion object {
+        private const val TAG = "ImageEmbeddingModel"
         private const val ASSET_PATH = "ml/siglip2_vision_q4f16.onnx"
         private const val IMAGE_SIZE = 224
         private const val BATCH_SIZE = 1

--- a/core/core-domain/src/androidMain/kotlin/com/riox432/civitdeck/domain/ml/SigLipTokenizer.kt
+++ b/core/core-domain/src/androidMain/kotlin/com/riox432/civitdeck/domain/ml/SigLipTokenizer.kt
@@ -1,6 +1,7 @@
 package com.riox432.civitdeck.domain.ml
 
 import android.content.Context
+import com.riox432.civitdeck.util.Logger
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonArray
@@ -121,6 +122,8 @@ internal class SigLipTokenizer private constructor(
     }
 
     companion object {
+        private const val TAG = "SigLipTokenizer"
+
         /** SentencePiece uses U+2581 (LOWER ONE EIGHTH BLOCK) as whitespace marker. */
         private const val WHITESPACE_PREFIX = "▁"
 
@@ -137,16 +140,18 @@ internal class SigLipTokenizer private constructor(
          *
          * @return the tokenizer, or null if the vocab file is missing.
          */
-        @Suppress("TooGenericExceptionCaught", "SwallowedException")
+        @Suppress("TooGenericExceptionCaught")
         fun load(context: Context): SigLipTokenizer? {
             return try {
                 val jsonStr = context.assets.open(VOCAB_ASSET_PATH).use {
                     it.bufferedReader().readText()
                 }
                 parseVocab(jsonStr)
-            } catch (_: java.io.IOException) {
+            } catch (e: java.io.IOException) {
+                Logger.w(TAG, "Vocab asset '$VOCAB_ASSET_PATH' missing or unreadable: ${e.message}")
                 null
-            } catch (_: Exception) {
+            } catch (e: Exception) {
+                Logger.e(TAG, "Failed to parse vocab from '$VOCAB_ASSET_PATH'", e)
                 null
             }
         }

--- a/core/core-domain/src/androidMain/kotlin/com/riox432/civitdeck/domain/ml/TextEmbeddingModelImpl.kt
+++ b/core/core-domain/src/androidMain/kotlin/com/riox432/civitdeck/domain/ml/TextEmbeddingModelImpl.kt
@@ -4,6 +4,7 @@ import ai.onnxruntime.OnnxTensor
 import ai.onnxruntime.OrtEnvironment
 import ai.onnxruntime.OrtSession
 import android.content.Context
+import com.riox432.civitdeck.util.Logger
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import java.nio.LongBuffer
@@ -31,14 +32,16 @@ class TextEmbeddingModelImpl(
 
     private val ortEnv: OrtEnvironment by lazy { OrtEnvironment.getEnvironment() }
 
-    @Suppress("TooGenericExceptionCaught", "SwallowedException")
+    @Suppress("TooGenericExceptionCaught")
     private val session: OrtSession? by lazy {
         try {
             val bytes = context.assets.open(MODEL_ASSET_PATH).use { it.readBytes() }
             ortEnv.createSession(bytes)
-        } catch (_: java.io.IOException) {
+        } catch (e: java.io.IOException) {
+            Logger.w(TAG, "SigLIP-2 text asset '$MODEL_ASSET_PATH' missing or unreadable: ${e.message}")
             null
-        } catch (_: Exception) {
+        } catch (e: Exception) {
+            Logger.e(TAG, "Failed to create SigLIP-2 text ONNX session from '$MODEL_ASSET_PATH'", e)
             null
         }
     }
@@ -116,6 +119,7 @@ class TextEmbeddingModelImpl(
     }
 
     private companion object {
+        private const val TAG = "TextEmbeddingModel"
         private const val MODEL_ASSET_PATH = "ml/siglip2_text_int8.onnx"
         private const val EMBEDDING_MODEL_ID = "siglip2-base-p16-224"
         private const val BATCH_SIZE = 1


### PR DESCRIPTION
## Description
ML model loaders in `core-domain` androidMain caught exceptions and returned `null` silently (`catch (_: ...) { null }`), leaving callers with no failure context when SigLIP-2 inference was unavailable.

Minimal high-value fix (no public API change): log context + the caught exception before returning `null`, using the project's existing `Logger` facility (matching the `BackgroundMonitorStarterImpl` pattern):
- `Logger.w(TAG, ...)` for the expected "asset missing/unreadable" `IOException` case (logs `e.message`).
- `Logger.e(TAG, ..., e)` for unexpected load/parse failures (logs the full throwable).

Added a `TAG` constant to each file. Removed the now-unneeded `SwallowedException` detekt suppression (exceptions are no longer swallowed); kept `TooGenericExceptionCaught` for the broad fallback catch. The loaders run in `by lazy` / static `load()` (not coroutine bodies), so `CancellationException` rethrow is not applicable here.

Files:
- `ImageEmbeddingModelImpl.kt`
- `TextEmbeddingModelImpl.kt`
- `SigLipTokenizer.kt`

No behavior change beyond logging.

## Related Issue
Closes #938

## Automated Tests
- [x] `./gradlew detekt` (twice) — clean
- [x] `./gradlew :core:core-domain:compileDebugKotlinAndroid` — success

## Checklist
- [x] CLAUDE.md rules followed
- [x] Error handling complete (logs in English per coding conventions)
- [x] No `!!` or force unwrap
- [x] No `GlobalScope`
