### PR TITLE
#940 Centralize default ComfyUI host/port constants

### DIFF
--- a/core/core-domain/src/commonMain/kotlin/com/riox432/civitdeck/domain/model/ComfyUiConnectionDefaults.kt
+++ b/core/core-domain/src/commonMain/kotlin/com/riox432/civitdeck/domain/model/ComfyUiConnectionDefaults.kt
@@ -1,0 +1,19 @@
+package com.riox432.civitdeck.domain.model
+
+/**
+ * Centralized default connection values shared across local-generation server
+ * settings screens (ComfyUI / SD WebUI) and the network layer.
+ *
+ * Keeping these in one place avoids the host/port literals drifting between the
+ * Desktop/Android settings UIs and the WebSocket connection code.
+ */
+object ComfyUiConnectionDefaults {
+    /** Default host used when adding a new local server connection. */
+    const val DEFAULT_HOST = "127.0.0.1"
+
+    /** Fallback WebSocket (ws://) port when none is present in the base URL. */
+    const val DEFAULT_WS_PORT = 80
+
+    /** Fallback secure WebSocket (wss://) port when none is present in the base URL. */
+    const val DEFAULT_WSS_PORT = 443
+}

--- a/core/core-network/src/commonMain/kotlin/com/riox432/civitdeck/data/api/comfyui/ComfyUIWebSocketApi.kt
+++ b/core/core-network/src/commonMain/kotlin/com/riox432/civitdeck/data/api/comfyui/ComfyUIWebSocketApi.kt
@@ -1,6 +1,7 @@
 package com.riox432.civitdeck.data.api.comfyui
 
 import com.riox432.civitdeck.data.api.RetryConfig
+import com.riox432.civitdeck.domain.model.ComfyUiConnectionDefaults
 import com.riox432.civitdeck.util.Logger
 import io.ktor.client.HttpClient
 import io.ktor.client.network.sockets.ConnectTimeoutException
@@ -21,8 +22,6 @@ import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.decodeFromJsonElement
 
 private const val BINARY_HEADER_SIZE = 8
-private const val DEFAULT_WS_PORT = 80
-private const val DEFAULT_WSS_PORT = 443
 
 /**
  * Manages a ComfyUI WebSocket connection and emits typed [ComfyUIWebSocketMessage] events.
@@ -113,7 +112,11 @@ class ComfyUIWebSocketApi(
         val hostPart = stripped.substringBefore("/").substringBefore(":")
         val portPart = stripped.substringBefore("/").substringAfter(":", "")
         val port = portPart.toIntOrNull()
-            ?: if (wsScheme == "wss") DEFAULT_WSS_PORT else DEFAULT_WS_PORT
+            ?: if (wsScheme == "wss") {
+                ComfyUiConnectionDefaults.DEFAULT_WSS_PORT
+            } else {
+                ComfyUiConnectionDefaults.DEFAULT_WS_PORT
+            }
         return hostPart to port
     }
 

--- a/desktopApp/src/jvmMain/kotlin/com/riox432/civitdeck/ui/settings/DesktopComfyUIConnectionSection.kt
+++ b/desktopApp/src/jvmMain/kotlin/com/riox432/civitdeck/ui/settings/DesktopComfyUIConnectionSection.kt
@@ -24,6 +24,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import com.riox432.civitdeck.domain.model.ComfyUIConnection
 import com.riox432.civitdeck.domain.model.ComfyUIConnectionStatus
+import com.riox432.civitdeck.domain.model.ComfyUiConnectionDefaults
 import com.riox432.civitdeck.domain.model.ConnectionSecurityLevel
 import com.riox432.civitdeck.domain.model.SystemStats
 import com.riox432.civitdeck.feature.comfyui.presentation.ComfyUISettingsViewModel
@@ -72,7 +73,7 @@ fun ComfyUISettingsSection(viewModel: ComfyUISettingsViewModel) {
 @Composable
 private fun AddConnectionFormSection(viewModel: ComfyUISettingsViewModel) {
     var nameInput by remember { mutableStateOf("") }
-    var hostInput by remember { mutableStateOf("127.0.0.1") }
+    var hostInput by remember { mutableStateOf(ComfyUiConnectionDefaults.DEFAULT_HOST) }
     var portInput by remember { mutableStateOf(ComfyUIConnection.DEFAULT_COMFYUI_PORT.toString()) }
     var useHttpsInput by remember { mutableStateOf(false) }
     var ntfyServerUrlInput by remember { mutableStateOf("") }
@@ -94,7 +95,7 @@ private fun AddConnectionFormSection(viewModel: ComfyUISettingsViewModel) {
         onSave = { name, host, port, https, ntfyUrl, ntfyTopic ->
             viewModel.onSaveConnection(name, host, port, https, false, ntfyUrl, ntfyTopic)
             nameInput = ""
-            hostInput = "127.0.0.1"
+            hostInput = ComfyUiConnectionDefaults.DEFAULT_HOST
             portInput = ComfyUIConnection.DEFAULT_COMFYUI_PORT.toString()
             useHttpsInput = false
             ntfyServerUrlInput = ""

--- a/desktopApp/src/jvmMain/kotlin/com/riox432/civitdeck/ui/settings/DesktopSDWebUISection.kt
+++ b/desktopApp/src/jvmMain/kotlin/com/riox432/civitdeck/ui/settings/DesktopSDWebUISection.kt
@@ -22,6 +22,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import com.riox432.civitdeck.domain.model.ComfyUiConnectionDefaults
 import com.riox432.civitdeck.domain.model.SDWebUIConnection
 import com.riox432.civitdeck.domain.model.SDWebUIConnectionStatus
 import com.riox432.civitdeck.feature.comfyui.presentation.SDWebUIGenerationViewModel
@@ -33,7 +34,7 @@ import com.riox432.civitdeck.ui.theme.Spacing
 fun SDWebUISettingsSection(viewModel: SDWebUISettingsViewModel) {
     val state by viewModel.uiState.collectAsState()
     var nameInput by remember { mutableStateOf("") }
-    var hostInput by remember { mutableStateOf("127.0.0.1") }
+    var hostInput by remember { mutableStateOf(ComfyUiConnectionDefaults.DEFAULT_HOST) }
     var portInput by remember { mutableStateOf(SDWebUIConnection.DEFAULT_SDWEBUI_PORT.toString()) }
 
     SettingsCard(title = "SD WebUI Server") {
@@ -121,7 +122,7 @@ fun SDWebUISettingsSection(viewModel: SDWebUISettingsViewModel) {
                 val port = portInput.toIntOrNull() ?: return@Button
                 viewModel.onSaveConnection(nameInput, hostInput, port)
                 nameInput = ""
-                hostInput = "127.0.0.1"
+                hostInput = ComfyUiConnectionDefaults.DEFAULT_HOST
                 portInput = SDWebUIConnection.DEFAULT_SDWEBUI_PORT.toString()
             },
             enabled = nameInput.isNotBlank() && hostInput.isNotBlank(),


### PR DESCRIPTION
## Description
Tech debt cleanup. The default ComfyUI/SD WebUI host `127.0.0.1` and the WebSocket fallback ports (`80`/`443`) were duplicated across multiple connection/settings sites:
- `desktopApp/.../ui/settings/DesktopComfyUIConnectionSection.kt` (host literal x2)
- `desktopApp/.../ui/settings/DesktopSDWebUISection.kt` (host literal x2)
- `core-network/.../comfyui/ComfyUIWebSocketApi.kt` (`DEFAULT_WS_PORT` / `DEFAULT_WSS_PORT` file-private constants)

Introduced a single `ComfyUiConnectionDefaults` object in `core-domain` commonMain holding `DEFAULT_HOST`, `DEFAULT_WS_PORT`, `DEFAULT_WSS_PORT`, and replaced all the duplicated literals with references to it.

`core-domain` was chosen because it is reachable from both the network layer (core-network depends on core-domain) and the Desktop UI (via `shared` `api(core-domain)`), and the existing per-connection port defaults (`ComfyUIConnection.DEFAULT_COMFYUI_PORT`, `SDWebUIConnection.DEFAULT_SDWEBUI_PORT`) already live there — so this is consistent with the established convention. No new cross-module dependency was introduced.

Test fixtures using `hostname = "127.0.0.1"` were intentionally left as literals (they are arrange values, not the production default).

## Related Issue
Closes #940

## Automated Tests
- `./gradlew detekt` (twice) — clean
- `:core:core-network:compileKotlinMetadata`, `:desktopApp:compileKotlinJvm`, `:shared:testDebugUnitTest`, `:feature:feature-comfyui:jvmTest` — all pass

## Checklist
- [x] CLAUDE.md rules followed
- [x] No hardcoded magic constants (now named)
- [x] No `!!` or force unwrap
- [x] No `GlobalScope`
