### PR TITLE
#947 Implement iOS haptic feedback

### DIFF
--- a/core/core-ui/src/iosMain/kotlin/com/riox432/civitdeck/ui/components/HapticFeedback.ios.kt
+++ b/core/core-ui/src/iosMain/kotlin/com/riox432/civitdeck/ui/components/HapticFeedback.ios.kt
@@ -1,10 +1,54 @@
 package com.riox432.civitdeck.ui.components
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import com.riox432.civitdeck.domain.model.HapticFeedbackType
+import platform.UIKit.UIImpactFeedbackGenerator
+import platform.UIKit.UIImpactFeedbackStyle.UIImpactFeedbackStyleMedium
+import platform.UIKit.UINotificationFeedbackGenerator
+import platform.UIKit.UINotificationFeedbackType.UINotificationFeedbackTypeError
+import platform.UIKit.UINotificationFeedbackType.UINotificationFeedbackTypeSuccess
+import platform.UIKit.UINotificationFeedbackType.UINotificationFeedbackTypeWarning
+import platform.UIKit.UISelectionFeedbackGenerator
 
+/**
+ * iOS haptic feedback via UIKit feedback generators.
+ *
+ * SwiftUI screens trigger haptics natively, but the shared Compose UI (used when a screen is
+ * rendered through Compose Multiplatform on iOS) routes through this actual. Feedback generators
+ * must be invoked on the main thread; the returned lambda is only called from Compose event
+ * handlers, which run on the main thread, so no explicit dispatch is required.
+ */
 @Composable
 actual fun rememberHapticFeedback(): (HapticFeedbackType) -> Unit {
-    // No-op on iOS — haptic feedback is handled natively in SwiftUI views
-    return { _ -> }
+    val impactGenerator = remember { UIImpactFeedbackGenerator(style = UIImpactFeedbackStyleMedium) }
+    val selectionGenerator = remember { UISelectionFeedbackGenerator() }
+    val notificationGenerator = remember { UINotificationFeedbackGenerator() }
+    return remember {
+        {
+                type: HapticFeedbackType ->
+            when (type) {
+                HapticFeedbackType.Impact -> {
+                    impactGenerator.prepare()
+                    impactGenerator.impactOccurred()
+                }
+                HapticFeedbackType.Selection -> {
+                    selectionGenerator.prepare()
+                    selectionGenerator.selectionChanged()
+                }
+                HapticFeedbackType.Success -> {
+                    notificationGenerator.prepare()
+                    notificationGenerator.notificationOccurred(UINotificationFeedbackTypeSuccess)
+                }
+                HapticFeedbackType.Warning -> {
+                    notificationGenerator.prepare()
+                    notificationGenerator.notificationOccurred(UINotificationFeedbackTypeWarning)
+                }
+                HapticFeedbackType.Error -> {
+                    notificationGenerator.prepare()
+                    notificationGenerator.notificationOccurred(UINotificationFeedbackTypeError)
+                }
+            }
+        }
+    }
 }


### PR DESCRIPTION
## Description
`HapticFeedback.ios.kt` was a no-op stub, so the shared Compose `rememberHapticFeedback` API produced no tactile feedback on iOS. This implements a real iOS actual using UIKit feedback generators, mapping each `HapticFeedbackType` to the appropriate generator:

- `Impact` → `UIImpactFeedbackGenerator(.medium)` → `impactOccurred()`
- `Selection` → `UISelectionFeedbackGenerator` → `selectionChanged()`
- `Success` / `Warning` / `Error` → `UINotificationFeedbackGenerator` → `notificationOccurred(...)`

Generators are `remember`ed per composition and `prepare()`d before each trigger to reduce latency. The returned lambda is only invoked from Compose event handlers (main thread), satisfying UIKit's main-thread requirement; no explicit dispatch is needed (mirrors the Android actual's model).

Note: today the shared Compose haptic API is only exercised by Android Compose screens (iOS screens are SwiftUI with native haptics). This change makes the shared API correct on iOS regardless of current usage, removing the tech-debt stub and future-proofing any Compose Multiplatform iOS rendering.

## Related Issue
Closes #947

## Manual Test Checklist
- [x] iOS Kotlin/Native target compiles (`:core:core-ui:compileKotlinIosSimulatorArm64`)
- [ ] Physical iOS device — haptic felt (simulator does not emit haptics)

## Automated Tests
- N/A — platform UIKit binding, no testable logic beyond the type→generator mapping

## Checklist
- [x] CLAUDE.md rules followed
- [x] No `!!` or force unwrap
- [x] No `GlobalScope`
- [x] `./gradlew detekt` passes (root, all modules)
- [x] iOS K/N compile passes
