### PR TITLE
#946 Use design tokens for spacing and elevation

### DIFF
--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/collections/CollectionDetailScreen.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/collections/CollectionDetailScreen.kt
@@ -59,6 +59,7 @@ import com.riox432.civitdeck.ui.components.CivitAsyncImage
 import com.riox432.civitdeck.ui.components.EmptyStateMessage
 import com.riox432.civitdeck.ui.components.ModelStatsRow
 import com.riox432.civitdeck.ui.theme.CornerRadius
+import com.riox432.civitdeck.ui.theme.Elevation
 import com.riox432.civitdeck.ui.theme.IconSize
 import com.riox432.civitdeck.ui.theme.Spacing
 
@@ -388,7 +389,7 @@ private fun ModelCard(
     Card(
         modifier = modifier.fillMaxWidth(),
         shape = RoundedCornerShape(CornerRadius.card),
-        elevation = CardDefaults.cardElevation(defaultElevation = 2.dp),
+        elevation = CardDefaults.cardElevation(defaultElevation = Elevation.sm),
         colors = CardDefaults.cardColors(
             containerColor = MaterialTheme.colorScheme.surface,
         ),

--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/collections/CollectionsScreen.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/collections/CollectionsScreen.kt
@@ -49,7 +49,6 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextOverflow
-import androidx.compose.ui.unit.dp
 import com.riox432.civitdeck.R
 import com.riox432.civitdeck.domain.model.ModelCollection
 import com.riox432.civitdeck.feature.prompts.presentation.SavedPromptsViewModel
@@ -57,6 +56,7 @@ import com.riox432.civitdeck.ui.components.CivitAsyncImage
 import com.riox432.civitdeck.ui.components.EmptyStateMessage
 import com.riox432.civitdeck.ui.prompts.SavedPromptsScreen
 import com.riox432.civitdeck.ui.theme.CornerRadius
+import com.riox432.civitdeck.ui.theme.Elevation
 import com.riox432.civitdeck.ui.theme.Spacing
 import com.riox432.civitdeck.ui.theme.ThumbnailSize
 
@@ -209,7 +209,7 @@ private fun CollectionCard(
             .fillMaxWidth()
             .clickable(onClickLabel = stringResource(R.string.cd_open_collection), onClick = onClick),
         shape = RoundedCornerShape(CornerRadius.card),
-        elevation = CardDefaults.cardElevation(defaultElevation = 2.dp),
+        elevation = CardDefaults.cardElevation(defaultElevation = Elevation.sm),
     ) {
         CollectionCardContent(
             collection = collection,

--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/dataset/DatasetListScreen.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/dataset/DatasetListScreen.kt
@@ -46,13 +46,13 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.text.style.TextOverflow
-import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.riox432.civitdeck.R
 import com.riox432.civitdeck.domain.model.DatasetCollection
 import com.riox432.civitdeck.feature.collections.presentation.DatasetListViewModel
 import com.riox432.civitdeck.ui.components.EmptyStateMessage
 import com.riox432.civitdeck.ui.theme.CornerRadius
+import com.riox432.civitdeck.ui.theme.Elevation
 import com.riox432.civitdeck.ui.theme.Spacing
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -155,7 +155,7 @@ private fun DatasetCard(
             .fillMaxWidth()
             .clickable(onClickLabel = "Open dataset", onClick = onClick),
         shape = RoundedCornerShape(CornerRadius.card),
-        elevation = CardDefaults.cardElevation(defaultElevation = 2.dp),
+        elevation = CardDefaults.cardElevation(defaultElevation = Elevation.sm),
     ) {
         DatasetCardContent(
             dataset = dataset,

--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/discovery/CardStack.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/discovery/CardStack.kt
@@ -38,6 +38,7 @@ import com.riox432.civitdeck.domain.model.Model
 import com.riox432.civitdeck.domain.model.thumbnailUrl
 import com.riox432.civitdeck.ui.components.ImageErrorPlaceholder
 import com.riox432.civitdeck.ui.theme.CornerRadius
+import com.riox432.civitdeck.ui.theme.Elevation
 import com.riox432.civitdeck.ui.theme.Spacing
 import com.riox432.civitdeck.ui.theme.shimmer
 import kotlin.math.roundToInt
@@ -163,7 +164,7 @@ private fun DiscoveryCard(model: Model) {
 
     Card(
         shape = RoundedCornerShape(CornerRadius.card),
-        elevation = CardDefaults.cardElevation(defaultElevation = 4.dp),
+        elevation = CardDefaults.cardElevation(defaultElevation = Elevation.md),
         colors = CardDefaults.cardColors(
             containerColor = MaterialTheme.colorScheme.surface,
         ),

--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/feed/FeedScreen.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/feed/FeedScreen.kt
@@ -50,6 +50,7 @@ import com.riox432.civitdeck.ui.components.EmptyStateMessage
 import com.riox432.civitdeck.ui.components.ErrorStateView
 import com.riox432.civitdeck.ui.components.LoadingStateOverlay
 import com.riox432.civitdeck.ui.theme.CornerRadius
+import com.riox432.civitdeck.ui.theme.Elevation
 import com.riox432.civitdeck.ui.theme.Spacing
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -185,7 +186,7 @@ private fun FeedGridCard(
             .fillMaxWidth()
             .clickable(onClick = onModelClick, onClickLabel = "View model details"),
         shape = RoundedCornerShape(CornerRadius.card),
-        elevation = CardDefaults.cardElevation(defaultElevation = 1.dp),
+        elevation = CardDefaults.cardElevation(defaultElevation = Elevation.xs),
     ) {
         Column {
             if (item.thumbnailUrl != null) {

--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/search/RecommendationRow.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/search/RecommendationRow.kt
@@ -30,6 +30,7 @@ import com.riox432.civitdeck.R
 import com.riox432.civitdeck.domain.model.RecommendationSection
 import com.riox432.civitdeck.ui.adaptive.isExpandedWidth
 import com.riox432.civitdeck.ui.components.ModelCard
+import com.riox432.civitdeck.ui.theme.Elevation
 import com.riox432.civitdeck.ui.theme.Spacing
 
 @Composable
@@ -82,7 +83,7 @@ internal fun ComparisonBottomBar(
         exit = slideOutVertically(targetOffsetY = { it }) + fadeOut(),
     ) {
         Surface(
-            tonalElevation = 3.dp,
+            tonalElevation = Elevation.sm,
             modifier = Modifier.fillMaxWidth(),
         ) {
             Row(

--- a/core/core-ui/src/commonMain/kotlin/com/riox432/civitdeck/ui/components/ModelCardLayout.kt
+++ b/core/core-ui/src/commonMain/kotlin/com/riox432/civitdeck/ui/components/ModelCardLayout.kt
@@ -28,12 +28,12 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.text.style.TextOverflow
-import androidx.compose.ui.unit.dp
 import com.riox432.civitdeck.domain.model.Model
 import com.riox432.civitdeck.domain.model.ModelSource
 import com.riox432.civitdeck.domain.model.thumbnailUrl
 import com.riox432.civitdeck.ui.theme.CivitDeckColors
 import com.riox432.civitdeck.ui.theme.CornerRadius
+import com.riox432.civitdeck.ui.theme.Elevation
 import com.riox432.civitdeck.ui.theme.IconSize
 import com.riox432.civitdeck.ui.theme.Spacing
 
@@ -82,7 +82,7 @@ fun ModelCardLayout(
             )
         }
     val shape = RoundedCornerShape(CornerRadius.card)
-    val elevation = CardDefaults.cardElevation(defaultElevation = 2.dp)
+    val elevation = CardDefaults.cardElevation(defaultElevation = Elevation.sm)
     val colors = CardDefaults.cardColors(
         containerColor = MaterialTheme.colorScheme.surface,
     )

--- a/core/core-ui/src/commonMain/kotlin/com/riox432/civitdeck/ui/components/ModelStatsRow.kt
+++ b/core/core-ui/src/commonMain/kotlin/com/riox432/civitdeck/ui/components/ModelStatsRow.kt
@@ -16,7 +16,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
-import androidx.compose.ui.unit.dp
 import com.riox432.civitdeck.domain.util.FormatUtils
 import com.riox432.civitdeck.ui.theme.IconSize
 import com.riox432.civitdeck.ui.theme.Spacing
@@ -89,7 +88,7 @@ private fun StatItem(
 ) {
     Row(
         modifier = modifier,
-        horizontalArrangement = Arrangement.spacedBy(2.dp),
+        horizontalArrangement = Arrangement.spacedBy(Spacing.xxs),
         verticalAlignment = Alignment.CenterVertically,
     ) {
         Icon(

--- a/desktopApp/src/jvmMain/kotlin/com/riox432/civitdeck/ui/dataset/DesktopDatasetListScreen.kt
+++ b/desktopApp/src/jvmMain/kotlin/com/riox432/civitdeck/ui/dataset/DesktopDatasetListScreen.kt
@@ -44,7 +44,6 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.text.style.TextOverflow
-import androidx.compose.ui.unit.dp
 import com.riox432.civitdeck.domain.model.DatasetCollection
 import com.riox432.civitdeck.feature.collections.presentation.DatasetListViewModel
 import com.riox432.civitdeck.ui.desktopFocusRing
@@ -181,7 +180,7 @@ private fun DesktopDatasetCard(
             .desktopFocusRing()
             .clickable(onClickLabel = "Open dataset", onClick = onClick),
         shape = RoundedCornerShape(CornerRadius.card),
-        elevation = CardDefaults.cardElevation(defaultElevation = 2.dp),
+        elevation = CardDefaults.cardElevation(defaultElevation = Elevation.sm),
     ) {
         Row(
             modifier = Modifier.fillMaxWidth().padding(Spacing.md),

--- a/desktopApp/src/jvmMain/kotlin/com/riox432/civitdeck/ui/detail/ImageMetadataPanel.kt
+++ b/desktopApp/src/jvmMain/kotlin/com/riox432/civitdeck/ui/detail/ImageMetadataPanel.kt
@@ -25,10 +25,10 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.style.TextOverflow
-import androidx.compose.ui.unit.dp
 import com.riox432.civitdeck.domain.model.ImageGenerationMeta
 import com.riox432.civitdeck.domain.model.ModelImage
 import com.riox432.civitdeck.ui.theme.CornerRadius
+import com.riox432.civitdeck.ui.theme.Elevation
 import com.riox432.civitdeck.ui.theme.Spacing
 
 @Composable
@@ -38,7 +38,7 @@ internal fun ImageMetadataPanel(
     onOpenFullscreen: () -> Unit,
 ) {
     Surface(
-        tonalElevation = 2.dp,
+        tonalElevation = Elevation.sm,
         shape = RoundedCornerShape(topStart = CornerRadius.card, topEnd = CornerRadius.card),
         modifier = Modifier.fillMaxWidth(),
     ) {


### PR DESCRIPTION
## Description
Replace hardcoded spacing/elevation literals with existing design tokens to comply with the 8pt grid and centralize elevation values (#946).

**Token substitutions (visually identical — same dp value):**
- `core-ui/ModelStatsRow.kt` — stat item gap `2.dp` -> `Spacing.xxs` (2dp)
- `core-ui/ModelCardLayout.kt` — card `defaultElevation 2.dp` -> `Elevation.sm`
- `androidApp/CardStack.kt` — `defaultElevation 4.dp` -> `Elevation.md`
- `androidApp/FeedScreen.kt` — `defaultElevation 1.dp` -> `Elevation.xs`
- `androidApp/CollectionsScreen.kt`, `CollectionDetailScreen.kt`, `DatasetListScreen.kt` — `defaultElevation 2.dp` -> `Elevation.sm`
- `desktopApp/DesktopDatasetListScreen.kt` — `defaultElevation 2.dp` -> `Elevation.sm`
- `desktopApp/ImageMetadataPanel.kt` — `tonalElevation 2.dp` -> `Elevation.sm`

**Minor visual change (off-grid -> nearest token):**
- `androidApp/RecommendationRow.kt` — compare-bar `tonalElevation 3.dp` -> `Elevation.sm` (2dp). 3dp violated the grid and had no matching token; snapped to the nearest existing token. Tonal-elevation tint difference between 2dp/3dp is negligible.

**Intentionally skipped (legitimate decorative dimensions, not spacing/grid violations):**
- `Shape.kt:39` `IconSize.statIcon = 10.dp` — already a named decorative icon-size token.
- `Shape.kt:50` `DotSize.pagination = 6.dp` — already a named decorative dot-diameter token.
- `FeedScreen.kt` `UNREAD_DOT_SIZE = 6.dp` — decorative dot diameter, already a named constant.

No new tokens were added — the theme (`Spacing`, `Elevation` in `core-ui/.../ui/theme/Shape.kt`) already covered every needed value.

## Related Issue
Closes #946

## Screenshots / Video
No meaningful visual change. All substitutions are token-equivalent except RecommendationRow's compare-bar tonal elevation (3dp -> 2dp), a sub-perceptible tint difference.

## Automated Tests
- `./gradlew detekt` x2 — clean
- `./gradlew :androidApp:assembleDebug` — success
- `./gradlew :desktopApp:compileKotlinJvm` — success
- Roborazzi is not wired up in this repo; no golden images exist to update. No test references the changed components.

## Checklist
- [x] CLAUDE.md rules followed
- [x] No hardcoded strings (all externalized)
- [x] No `!!` or force unwrap
- [x] No `GlobalScope`
- [x] Error handling complete
