### PR TITLE
#939 Add content descriptions to actionable icons

### DIFF
--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/detail/ModelDetailScreen.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/detail/ModelDetailScreen.kt
@@ -341,7 +341,10 @@ private fun DetailOverflowMenu(
     var expanded by remember { mutableStateOf(false) }
     Box {
         IconButton(onClick = { expanded = true }) {
-            Icon(Icons.Default.MoreVert, contentDescription = "More options")
+            Icon(
+                Icons.Default.MoreVert,
+                contentDescription = stringResource(R.string.cd_more_options),
+            )
         }
         DropdownMenu(expanded = expanded, onDismissRequest = { expanded = false }) {
             if (onFindSimilar != null) {

--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/downloadqueue/DownloadQueueScreen.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/downloadqueue/DownloadQueueScreen.kt
@@ -67,7 +67,10 @@ fun DownloadQueueScreen(
                 title = { Text(stringResource(R.string.download_queue_title)) },
                 navigationIcon = {
                     IconButton(onClick = onBack) {
-                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = null)
+                        Icon(
+                            Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = stringResource(R.string.cd_navigate_back),
+                        )
                     }
                 },
             )
@@ -360,7 +363,7 @@ private fun FailedDownloadItem(
         IconButton(onClick = { onDelete(download.id) }) {
             Icon(
                 Icons.Default.Delete,
-                contentDescription = null,
+                contentDescription = stringResource(R.string.cd_delete),
                 tint = MaterialTheme.colorScheme.error,
             )
         }
@@ -403,7 +406,7 @@ private fun CompletedDownloadItem(
         IconButton(onClick = { onDelete(download.id) }) {
             Icon(
                 Icons.Default.Delete,
-                contentDescription = null,
+                contentDescription = stringResource(R.string.cd_delete),
                 tint = MaterialTheme.colorScheme.error,
             )
         }

--- a/androidApp/src/main/res/values/strings.xml
+++ b/androidApp/src/main/res/values/strings.xml
@@ -102,6 +102,7 @@
     <string name="cd_plugin_active">Active</string>
     <string name="cd_plugin_inactive">Inactive</string>
     <string name="cd_plugin_error">Error</string>
+    <string name="cd_more_options">More options</string>
     <string name="settings_replay_gesture_tutorial">Replay Gesture Tutorial</string>
 
     <!-- Download Queue -->


### PR DESCRIPTION
## Description
Accessibility fix for issue #939. Audited all ~14 cited `contentDescription = null` icon/image spots and added localized content descriptions ONLY to actionable/standalone icons where a screen-reader user would otherwise get no cue. Genuinely decorative icons paired with a visible text label were intentionally left `null` (correct accessibility practice).

### Icons given a content description (actionable, androidApp)
- `DownloadQueueScreen.kt` — top-bar back button (`cd_navigate_back`)
- `DownloadQueueScreen.kt` — Delete icon-button in failed-download row (`cd_delete`)
- `DownloadQueueScreen.kt` — Delete icon-button in completed-download row (`cd_delete`)
- `ModelDetailScreen.kt` — overflow "more options" icon-button: was a hardcoded English string, now localized via new `cd_more_options`

### Intentionally left `null` (decorative, paired with visible text — correct)
- `TextSearchScreen.kt:105` — search field `leadingIcon` (field has a placeholder label)
- `ComfyHubDetailScreen.kt:217/322` — stat icon next to value; Star icon inside a labeled button
- `ComfyHubBrowserScreen.kt:195/211` — download/rating stat icons next to count/rating text
- `WorkflowParameterSheet.kt:320` — image-preview placeholder icon next to "No image selected"
- `ModelDetailScreen.kt:350/359/367` — `DropdownMenuItem` leading icons (each item already has a text label)
- `CreateHubScreen.kt:104/121` — leading icon + trailing chevron in a clickable row with title/subtitle text
- `core-ui ModelStatsRow.kt:97` — stat icon next to label text
- `core-ui EmptyStateMessage.kt:41` — large empty-state illustration icon with title/subtitle below
- `DesktopDownloadQueueScreen.kt:152` — empty-state illustration icon with text (desktop actionable icons already had descriptions)

### Notes
- L10n: new/reused string keys use the existing `cd_` content-description convention in `androidApp/src/main/res/values/strings.xml` (base `values/` only — repo has no other Android locale).
- core-ui and desktop required no code changes (their cited icons are correctly decorative or already described).

## Related Issue
Closes #939

## Checklist
- [x] CLAUDE.md rules followed
- [x] No hardcoded strings (all externalized)
- [x] No `!!` or force unwrap
- [x] New strings added to resources
- [x] `./gradlew detekt` passes (twice, clean)
- [x] `./gradlew :androidApp:assembleDebug` and `:desktopApp:compileKotlinJvm` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
