### PR TITLE
#937 Move Auth/Review/Tag repositories to core-data

### DIFF
--- a/core/core-data/src/commonMain/kotlin/com/riox432/civitdeck/data/repository/AuthRepositoryImpl.kt
+++ b/core/core-data/src/commonMain/kotlin/com/riox432/civitdeck/data/repository/AuthRepositoryImpl.kt
@@ -1,4 +1,4 @@
-package com.riox432.civitdeck.data.api.repository
+package com.riox432.civitdeck.data.repository
 
 import com.riox432.civitdeck.data.api.CivitAiApi
 import com.riox432.civitdeck.domain.repository.AuthRepository

--- a/core/core-data/src/commonMain/kotlin/com/riox432/civitdeck/data/repository/ReviewRepositoryImpl.kt
+++ b/core/core-data/src/commonMain/kotlin/com/riox432/civitdeck/data/repository/ReviewRepositoryImpl.kt
@@ -1,4 +1,4 @@
-package com.riox432.civitdeck.data.api.repository
+package com.riox432.civitdeck.data.repository
 
 import com.riox432.civitdeck.data.api.ApiKeyProvider
 import com.riox432.civitdeck.data.api.CivitAiApi

--- a/core/core-data/src/commonMain/kotlin/com/riox432/civitdeck/data/repository/TagRepositoryImpl.kt
+++ b/core/core-data/src/commonMain/kotlin/com/riox432/civitdeck/data/repository/TagRepositoryImpl.kt
@@ -1,4 +1,4 @@
-package com.riox432.civitdeck.data.api.repository
+package com.riox432.civitdeck.data.repository
 
 import com.riox432.civitdeck.data.api.CivitAiApi
 import com.riox432.civitdeck.data.api.DataParseException

--- a/core/core-data/src/commonMain/kotlin/com/riox432/civitdeck/di/CoreDataModule.kt
+++ b/core/core-data/src/commonMain/kotlin/com/riox432/civitdeck/di/CoreDataModule.kt
@@ -1,14 +1,20 @@
 package com.riox432.civitdeck.di
 
+import com.riox432.civitdeck.data.repository.AuthRepositoryImpl
 import com.riox432.civitdeck.data.repository.CreatorFollowRepositoryImpl
 import com.riox432.civitdeck.data.repository.LocalModelFileRepositoryImpl
 import com.riox432.civitdeck.data.repository.ModelRepositoryImpl
+import com.riox432.civitdeck.data.repository.ReviewRepositoryImpl
+import com.riox432.civitdeck.data.repository.TagRepositoryImpl
 import com.riox432.civitdeck.data.repository.UpdateRepositoryImpl
+import com.riox432.civitdeck.domain.repository.AuthRepository
 import com.riox432.civitdeck.domain.repository.CreatorFollowRepository
 import com.riox432.civitdeck.domain.repository.ModelDirectoryRepository
 import com.riox432.civitdeck.domain.repository.ModelFileHashRepository
 import com.riox432.civitdeck.domain.repository.ModelRepository
 import com.riox432.civitdeck.domain.repository.ModelScanRepository
+import com.riox432.civitdeck.domain.repository.ReviewRepository
+import com.riox432.civitdeck.domain.repository.TagRepository
 import com.riox432.civitdeck.domain.repository.UpdateRepository
 import org.koin.core.module.dsl.bind
 import org.koin.core.module.dsl.singleOf
@@ -31,4 +37,9 @@ val coreDataModule = module {
     }
     single<CreatorFollowRepository> { CreatorFollowRepositoryImpl(get(), get(), get()) }
     single<UpdateRepository> { UpdateRepositoryImpl(get(), get(), get()) }
+
+    // CivitAI network-only repositories (moved from networkModule for organizational consistency)
+    single<AuthRepository> { AuthRepositoryImpl(get()) }
+    single<TagRepository> { TagRepositoryImpl(get()) }
+    single<ReviewRepository> { ReviewRepositoryImpl(get(), get()) }
 }

--- a/core/core-network/src/commonMain/kotlin/com/riox432/civitdeck/di/NetworkModule.kt
+++ b/core/core-network/src/commonMain/kotlin/com/riox432/civitdeck/di/NetworkModule.kt
@@ -16,18 +16,12 @@ import com.riox432.civitdeck.data.api.externalserver.createExternalServerHttpCli
 import com.riox432.civitdeck.data.api.huggingface.HuggingFaceApi
 import com.riox432.civitdeck.data.api.huggingface.HuggingFaceRepositoryImpl
 import com.riox432.civitdeck.data.api.huggingface.createHuggingFaceHttpClient
-import com.riox432.civitdeck.data.api.repository.AuthRepositoryImpl
-import com.riox432.civitdeck.data.api.repository.ReviewRepositoryImpl
-import com.riox432.civitdeck.data.api.repository.TagRepositoryImpl
 import com.riox432.civitdeck.data.api.tensorart.TensorArtApi
 import com.riox432.civitdeck.data.api.tensorart.TensorArtRepositoryImpl
 import com.riox432.civitdeck.data.api.tensorart.createTensorArtHttpClient
 import com.riox432.civitdeck.data.api.webui.SDWebUIApi
 import com.riox432.civitdeck.data.api.webui.createSDWebUIHttpClient
-import com.riox432.civitdeck.domain.repository.AuthRepository
 import com.riox432.civitdeck.domain.repository.HuggingFaceRepository
-import com.riox432.civitdeck.domain.repository.ReviewRepository
-import com.riox432.civitdeck.domain.repository.TagRepository
 import com.riox432.civitdeck.domain.repository.TensorArtRepository
 import com.riox432.civitdeck.domain.repository.ThumbnailDownloader
 import kotlinx.serialization.json.Json
@@ -81,9 +75,4 @@ val networkModule = module {
     single(named("tensorart")) { createTensorArtHttpClient() }
     single { TensorArtApi(get(named("tensorart"))) }
     single<TensorArtRepository> { TensorArtRepositoryImpl(get()) }
-
-    // CivitAI Repositories (network-only)
-    single<AuthRepository> { AuthRepositoryImpl(get()) }
-    single<TagRepository> { TagRepositoryImpl(get()) }
-    single<ReviewRepository> { ReviewRepositoryImpl(get(), get()) }
 }


### PR DESCRIPTION
## Description
Pure organizational refactor (no behavior change). PR #916 moved network/cache repository impls from `:core:core-network` to `:core:core-data`, but `AuthRepositoryImpl`, `ReviewRepositoryImpl`, and `TagRepositoryImpl` were left behind. This moves them for consistency.

Changes:
- `git mv` the 3 impls from `core-network/.../data/api/repository/` to `core-data/.../data/repository/` (history preserved)
- Updated their `package` declaration from `data.api.repository` to `data.repository` (matching the other moved repos)
- Moved their Koin `single<...>` registrations from `networkModule` (core-network) to `coreDataModule` (core-data)

Not a dependency-direction fix: core-network only depends on core-domain; core-data depends on core-network + core-database + core-domain, so the impls' use of `CivitAiApi`/`ApiKeyProvider` still resolves. Both modules are loaded together in `shared/di/Koin.kt`, so `CivitAiApi`/`ApiKeyProvider` (still in networkModule) remain visible to coreDataModule. The domain interfaces stay in core-domain (not moved).

No imports needed changing beyond the package line. No tests existed for these 3 repos in core-network.

## Related Issue
Closes #937

## Automated Tests
- [x] `./gradlew detekt` (twice, clean)
- [x] `./gradlew :androidApp:assembleDebug` (verifies full Koin wiring compiles)
- [x] `./gradlew :shared:testDebugUnitTest :core:core-data:testDebugUnitTest :core:core-network:testDebugUnitTest`

## Checklist
- [x] CLAUDE.md rules followed
- [x] No behavior change (move-only refactor)
