### PR TITLE
#934 Handle missing ComfyUI connection gracefully

### DIFF
--- a/core/core-domain/src/commonMain/kotlin/com/riox432/civitdeck/domain/model/DomainException.kt
+++ b/core/core-domain/src/commonMain/kotlin/com/riox432/civitdeck/domain/model/DomainException.kt
@@ -17,4 +17,11 @@ sealed class DomainException(message: String?, cause: Throwable? = null) : Excep
 
     /** Authentication failures: invalid/expired API key. */
     class AuthException(message: String?, cause: Throwable? = null) : DomainException(message, cause)
+
+    /**
+     * Generation-server connection failures: no active/configured server
+     * (e.g. ComfyUI or SD WebUI). Surfaced as a "not connected" UI state
+     * rather than crashing.
+     */
+    class ConnectionException(message: String?, cause: Throwable? = null) : DomainException(message, cause)
 }

--- a/feature/feature-comfyui/src/commonMain/kotlin/com/riox432/civitdeck/feature/comfyui/data/repository/ComfyUIGenerationRepositoryImpl.kt
+++ b/feature/feature-comfyui/src/commonMain/kotlin/com/riox432/civitdeck/feature/comfyui/data/repository/ComfyUIGenerationRepositoryImpl.kt
@@ -7,6 +7,7 @@ import com.riox432.civitdeck.data.api.comfyui.ComfyUIWebSocketMessage
 import com.riox432.civitdeck.data.local.currentTimeMillis
 import com.riox432.civitdeck.data.local.dao.ComfyUIConnectionDao
 import com.riox432.civitdeck.domain.model.ComfyUIGenerationParams
+import com.riox432.civitdeck.domain.model.DomainException
 import com.riox432.civitdeck.domain.model.GenerationProgress
 import com.riox432.civitdeck.domain.model.GenerationResult
 import com.riox432.civitdeck.domain.model.GenerationStatus
@@ -128,7 +129,8 @@ class ComfyUIGenerationRepositoryImpl(
     }
 
     private suspend fun ensureApiConfigured() {
-        val active = dao.getActive() ?: error("No active ComfyUI connection")
+        val active = dao.getActive()
+            ?: throw DomainException.ConnectionException("No active ComfyUI connection")
         val scheme = if (active.useHttps) "https" else "http"
         api.setBaseUrl("$scheme://${active.hostname}:${active.port}")
     }

--- a/feature/feature-comfyui/src/commonMain/kotlin/com/riox432/civitdeck/feature/comfyui/data/repository/ComfyUIHistoryRepositoryImpl.kt
+++ b/feature/feature-comfyui/src/commonMain/kotlin/com/riox432/civitdeck/feature/comfyui/data/repository/ComfyUIHistoryRepositoryImpl.kt
@@ -5,6 +5,7 @@ import com.riox432.civitdeck.data.api.comfyui.HistoryEntry
 import com.riox432.civitdeck.data.local.dao.ComfyUIConnectionDao
 import com.riox432.civitdeck.domain.model.ComfyUIGeneratedImage
 import com.riox432.civitdeck.domain.model.ComfyUIGenerationMeta
+import com.riox432.civitdeck.domain.model.DomainException
 import com.riox432.civitdeck.domain.repository.ComfyUIHistoryRepository
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
@@ -112,7 +113,8 @@ class ComfyUIHistoryRepositoryImpl(
     }
 
     private suspend fun ensureApiConfigured() {
-        val active = dao.getActive() ?: error("No active ComfyUI connection")
+        val active = dao.getActive()
+            ?: throw DomainException.ConnectionException("No active ComfyUI connection")
         val scheme = if (active.useHttps) "https" else "http"
         api.setBaseUrl("$scheme://${active.hostname}:${active.port}")
     }

--- a/feature/feature-comfyui/src/commonMain/kotlin/com/riox432/civitdeck/feature/comfyui/data/repository/ComfyUIQueueRepositoryImpl.kt
+++ b/feature/feature-comfyui/src/commonMain/kotlin/com/riox432/civitdeck/feature/comfyui/data/repository/ComfyUIQueueRepositoryImpl.kt
@@ -2,6 +2,7 @@ package com.riox432.civitdeck.feature.comfyui.data.repository
 
 import com.riox432.civitdeck.data.api.comfyui.ComfyUIApi
 import com.riox432.civitdeck.data.local.dao.ComfyUIConnectionDao
+import com.riox432.civitdeck.domain.model.DomainException
 import com.riox432.civitdeck.domain.model.QueueJob
 import com.riox432.civitdeck.domain.model.QueueJobStatus
 import com.riox432.civitdeck.domain.repository.ComfyUIQueueRepository
@@ -65,7 +66,8 @@ class ComfyUIQueueRepositoryImpl(
     }
 
     private suspend fun ensureApiConfigured() {
-        val active = dao.getActive() ?: error("No active ComfyUI connection")
+        val active = dao.getActive()
+            ?: throw DomainException.ConnectionException("No active ComfyUI connection")
         val scheme = if (active.useHttps) "https" else "http"
         api.setBaseUrl("$scheme://${active.hostname}:${active.port}")
     }

--- a/feature/feature-comfyui/src/commonMain/kotlin/com/riox432/civitdeck/feature/comfyui/data/repository/ComfyUIRepositoryImpl.kt
+++ b/feature/feature-comfyui/src/commonMain/kotlin/com/riox432/civitdeck/feature/comfyui/data/repository/ComfyUIRepositoryImpl.kt
@@ -9,6 +9,7 @@ import com.riox432.civitdeck.data.local.dao.ComfyUIConnectionDao
 import com.riox432.civitdeck.data.local.entity.ComfyUIConnectionEntity
 import com.riox432.civitdeck.domain.model.ComfyUIConnection
 import com.riox432.civitdeck.domain.model.ComfyUIGenerationParams
+import com.riox432.civitdeck.domain.model.DomainException
 import com.riox432.civitdeck.domain.model.GenerationProgress
 import com.riox432.civitdeck.domain.model.GenerationResult
 import com.riox432.civitdeck.domain.model.GenerationStatus
@@ -233,7 +234,8 @@ class ComfyUIRepositoryImpl(
     }
 
     private suspend fun ensureApiConfigured() {
-        val active = dao.getActive() ?: error("No active ComfyUI connection")
+        val active = dao.getActive()
+            ?: throw DomainException.ConnectionException("No active ComfyUI connection")
         api.setBaseUrl(buildBaseUrl(active))
     }
 

--- a/feature/feature-comfyui/src/commonMain/kotlin/com/riox432/civitdeck/feature/comfyui/data/repository/SDWebUIRepositoryImpl.kt
+++ b/feature/feature-comfyui/src/commonMain/kotlin/com/riox432/civitdeck/feature/comfyui/data/repository/SDWebUIRepositoryImpl.kt
@@ -6,6 +6,7 @@ import com.riox432.civitdeck.data.api.webui.SDWebUITxt2ImgRequest
 import com.riox432.civitdeck.data.local.currentTimeMillis
 import com.riox432.civitdeck.data.local.dao.SDWebUIConnectionDao
 import com.riox432.civitdeck.data.local.entity.SDWebUIConnectionEntity
+import com.riox432.civitdeck.domain.model.DomainException
 import com.riox432.civitdeck.domain.model.SDWebUIConnection
 import com.riox432.civitdeck.domain.model.SDWebUIGenerationParams
 import com.riox432.civitdeck.domain.model.SDWebUIGenerationProgress
@@ -157,7 +158,8 @@ class SDWebUIRepositoryImpl(
         }
 
     private suspend fun ensureApiConfigured() {
-        val active = dao.getActive() ?: error("No active SD WebUI connection")
+        val active = dao.getActive()
+            ?: throw DomainException.ConnectionException("No active SD WebUI connection")
         api.setBaseUrl(active.hostname, active.port)
     }
 

--- a/feature/feature-comfyui/src/commonMain/kotlin/com/riox432/civitdeck/feature/comfyui/plugin/ComfyUIWorkflowPlugin.kt
+++ b/feature/feature-comfyui/src/commonMain/kotlin/com/riox432/civitdeck/feature/comfyui/plugin/ComfyUIWorkflowPlugin.kt
@@ -1,6 +1,7 @@
 package com.riox432.civitdeck.feature.comfyui.plugin
 
 import com.riox432.civitdeck.domain.model.ComfyUIConnection
+import com.riox432.civitdeck.domain.model.DomainException
 import com.riox432.civitdeck.domain.repository.ComfyUIConnectionRepository
 import com.riox432.civitdeck.domain.util.suspendRunCatching
 import com.riox432.civitdeck.plugin.WorkflowEnginePlugin
@@ -61,10 +62,11 @@ class ComfyUIWorkflowPlugin(
 
     override suspend fun connect(): Result<Unit> = suspendRunCatching {
         refreshActiveConnection()
-        val connection = cachedConnection ?: error("No active ComfyUI connection")
+        val connection = cachedConnection
+            ?: throw DomainException.ConnectionException("No active ComfyUI connection")
         val success = connectionRepository.testConnection(connection)
         connectionRepository.updateTestResult(connection.id, success)
-        if (!success) error("Connection test failed")
+        if (!success) throw DomainException.ConnectionException("Connection test failed")
         state = PluginState.ACTIVE
     }
 

--- a/feature/feature-comfyui/src/commonTest/kotlin/com/riox432/civitdeck/feature/comfyui/plugin/ComfyUIWorkflowPluginTest.kt
+++ b/feature/feature-comfyui/src/commonTest/kotlin/com/riox432/civitdeck/feature/comfyui/plugin/ComfyUIWorkflowPluginTest.kt
@@ -1,6 +1,7 @@
 package com.riox432.civitdeck.feature.comfyui.plugin
 
 import com.riox432.civitdeck.domain.model.ComfyUIConnection
+import com.riox432.civitdeck.domain.model.DomainException
 import com.riox432.civitdeck.domain.repository.ComfyUIConnectionRepository
 import com.riox432.civitdeck.plugin.capability.WorkflowCapability
 import com.riox432.civitdeck.plugin.model.PluginState
@@ -69,6 +70,9 @@ class ComfyUIWorkflowPluginTest {
         val plugin = createPlugin(connection = null)
         val result = plugin.connect()
         assertTrue(result.isFailure)
+        // Missing connection must surface as a typed, handled failure (not an uncaught crash).
+        assertTrue(result.exceptionOrNull() is DomainException.ConnectionException)
+        assertEquals(PluginState.INSTALLED, plugin.state)
     }
 
     @Test


### PR DESCRIPTION
## Description
ComfyUI / SD WebUI code paths called `error("No active ComfyUI connection")`, throwing an `IllegalStateException` (a generic, unmodeled error) whenever no generation server was configured/active. In paths not guarded by a generic `catch`, this could crash the app.

This adds a typed `DomainException.ConnectionException` to the existing domain exception hierarchy and replaces all six connection-error throw sites with it:

- `plugin/ComfyUIWorkflowPlugin.kt` (both "no active connection" and "connection test failed" — already wrapped in `suspendRunCatching`, now returns a typed `Result.failure`)
- `data/repository/ComfyUIRepositoryImpl.kt`
- `data/repository/ComfyUIGenerationRepositoryImpl.kt`
- `data/repository/SDWebUIRepositoryImpl.kt`
- `data/repository/ComfyUIHistoryRepositoryImpl.kt`
- `data/repository/ComfyUIQueueRepositoryImpl.kt`

`ConnectionException` extends `DomainException` (which extends `Exception`), so it is caught by all existing `suspendRunCatching`, Flow `.catch`, and `catch (Exception)` handlers in the consuming ViewModels — surfacing the missing-connection case as a handled error/UI state instead of an uncaught crash. No consumer relied on catching `IllegalStateException` for a connection error (the single `catch (IllegalStateException)` site handles workflow-JSON validation, which is unchanged).

Mechanism chosen as the least-invasive fix per the existing `DomainException.AuthException` precedent (`?: throw DomainException.AuthException(...)` in `ReviewRepositoryImpl`).

## Related Issue
Closes #934

## Automated Tests
- [x] Unit tests added/updated — `ComfyUIWorkflowPluginTest.connectFailsWhenNoConnection` now asserts the failure is a `DomainException.ConnectionException` and the plugin state stays `INSTALLED`

## Checklist
- [x] CLAUDE.md rules followed
- [x] Error handling complete

## Quality Gate
- `./gradlew detekt` (twice) — clean
- `./gradlew :feature:feature-comfyui:jvmTest` — pass
- `./gradlew :androidApp:assembleDebug` — pass
