### PR TITLE
#941 Surface swallowed LAN scan errors to UI state

### DIFF
--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/comfyui/ComfyUISettingsScreen.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/comfyui/ComfyUISettingsScreen.kt
@@ -516,11 +516,20 @@ private fun ScanLanSection(
                     DiscoveredServerRow(server, onSelect)
                 }
             } else if (!state.isScanning) {
-                Text(
-                    stringResource(R.string.comfyui_lan_scan_hint),
-                    style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                )
+                val scanError = state.scanError
+                if (scanError != null) {
+                    Text(
+                        stringResource(R.string.comfyui_scan_failed, scanError),
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.error,
+                    )
+                } else {
+                    Text(
+                        stringResource(R.string.comfyui_lan_scan_hint),
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
             }
         }
     }

--- a/androidApp/src/main/res/values/strings.xml
+++ b/androidApp/src/main/res/values/strings.xml
@@ -341,6 +341,7 @@
     <string name="comfyui_scan_lan">Scan LAN</string>
     <string name="comfyui_lan_discovery">LAN Discovery</string>
     <string name="comfyui_lan_scan_hint">Scan your local network for ComfyUI servers</string>
+    <string name="comfyui_scan_failed">Scan failed: %1$s</string>
     <string name="comfyui_use_https">Use HTTPS</string>
     <string name="comfyui_accept_self_signed">Accept self-signed certificates</string>
     <string name="comfyui_hostname_label">Hostname / IP</string>

--- a/desktopApp/src/jvmMain/kotlin/com/riox432/civitdeck/ui/settings/DesktopComfyUIConnectionSection.kt
+++ b/desktopApp/src/jvmMain/kotlin/com/riox432/civitdeck/ui/settings/DesktopComfyUIConnectionSection.kt
@@ -51,6 +51,7 @@ fun ComfyUISettingsSection(viewModel: ComfyUISettingsViewModel) {
         LanScanSection(
             isScanning = state.isScanning,
             discoveredServers = state.discoveredServers,
+            scanError = state.scanError,
             onScanLan = viewModel::onScanLan,
             onSelectServer = viewModel::onSelectDiscoveredServer,
         )
@@ -132,6 +133,7 @@ private fun SecurityLevelIndicator(
 private fun LanScanSection(
     isScanning: Boolean,
     discoveredServers: List<com.riox432.civitdeck.domain.model.DiscoveredServer>,
+    scanError: String?,
     onScanLan: () -> Unit,
     onSelectServer: (com.riox432.civitdeck.domain.model.DiscoveredServer) -> Unit,
 ) {
@@ -148,6 +150,13 @@ private fun LanScanSection(
         discoveredServers.forEach { server ->
             DiscoveredServerRow(server = server, onSelect = { onSelectServer(server) })
         }
+    } else if (!isScanning && scanError != null) {
+        Spacer(modifier = Modifier.height(Spacing.xs))
+        Text(
+            text = "Scan failed: $scanError",
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.error,
+        )
     }
 }
 

--- a/feature/feature-comfyui/src/commonMain/kotlin/com/riox432/civitdeck/feature/comfyui/presentation/ComfyUISettingsViewModel.kt
+++ b/feature/feature-comfyui/src/commonMain/kotlin/com/riox432/civitdeck/feature/comfyui/presentation/ComfyUISettingsViewModel.kt
@@ -39,6 +39,7 @@ data class ComfyUISettingsUiState(
     val showAddDialog: Boolean = false,
     val editingConnection: ComfyUIConnection? = null,
     val isScanning: Boolean = false,
+    val scanError: String? = null,
     val discoveredServers: List<DiscoveredServer> = emptyList(),
     val systemStats: SystemStats? = null,
     val optimizationSuggestions: List<OptimizationSuggestion> = emptyList(),
@@ -150,10 +151,15 @@ class ComfyUISettingsViewModel(
 
     fun onScanLan() {
         scanJob?.cancel()
-        _mutableState.update { it.copy(isScanning = true, discoveredServers = emptyList()) }
+        _mutableState.update { it.copy(isScanning = true, scanError = null, discoveredServers = emptyList()) }
         scanJob = viewModelScope.launch {
             scanForServers()
-                .catch { _mutableState.update { it.copy(isScanning = false) } }
+                .catch { e ->
+                    // Surface scan failures so the user is not left with a silent empty result.
+                    _mutableState.update {
+                        it.copy(isScanning = false, scanError = e.message ?: e.toString())
+                    }
+                }
                 .collect { servers ->
                     _mutableState.update { it.copy(discoveredServers = servers) }
                 }

--- a/feature/feature-comfyui/src/jvmTest/kotlin/com/riox432/civitdeck/feature/comfyui/presentation/ComfyUISettingsViewModelTest.kt
+++ b/feature/feature-comfyui/src/jvmTest/kotlin/com/riox432/civitdeck/feature/comfyui/presentation/ComfyUISettingsViewModelTest.kt
@@ -95,8 +95,12 @@ class ComfyUISettingsViewModelTest {
 
     private class FakeServerDiscoveryRepo(
         private val servers: List<DiscoveredServer> = emptyList(),
+        private val failWith: Throwable? = null,
     ) : ServerDiscoveryRepository {
-        override fun scanForServers(): Flow<List<DiscoveredServer>> = flow { emit(servers) }
+        override fun scanForServers(): Flow<List<DiscoveredServer>> = flow {
+            failWith?.let { throw it }
+            emit(servers)
+        }
     }
 
     private fun mockApi(): ComfyUIApi {
@@ -221,6 +225,26 @@ class ComfyUISettingsViewModelTest {
 
         assertEquals(servers, vm.uiState.value.discoveredServers)
         assertFalse(vm.uiState.value.isScanning)
+        assertNull(vm.uiState.value.scanError)
+        collectJob.cancel()
+    }
+
+    @Test
+    fun scan_lan_failure_surfaces_error_to_ui_state() = runTest {
+        val repo = FakeConnectionRepo()
+        val vm = createViewModel(
+            repo,
+            discoveryRepo = FakeServerDiscoveryRepo(failWith = IllegalStateException("network down")),
+        )
+        val collectJob = backgroundScope.launch { vm.uiState.collect {} }
+        advanceUntilIdle()
+
+        vm.onScanLan()
+        advanceUntilIdle()
+
+        assertFalse(vm.uiState.value.isScanning)
+        assertEquals("network down", vm.uiState.value.scanError)
+        assertTrue(vm.uiState.value.discoveredServers.isEmpty())
         collectJob.cancel()
     }
 }

--- a/iosApp/iosApp/Features/ComfyUI/ComfyUISettingsView.swift
+++ b/iosApp/iosApp/Features/ComfyUI/ComfyUISettingsView.swift
@@ -262,6 +262,11 @@ struct ComfyUISettingsView: View {
                     Button("Scan LAN", action: viewModel.onScanLan)
                 }
             }
+            if let scanError = viewModel.scanError, !viewModel.isScanning {
+                Text("Scan failed: \(scanError)")
+                    .font(.civitBodySmall)
+                    .foregroundColor(.civitError)
+            }
             ForEach(viewModel.discoveredServers, id: \.ip) { server in
                 Button {
                     viewModel.onSelectDiscoveredServer(server: server)

--- a/iosApp/iosApp/Features/ComfyUI/ComfyUISettingsViewModel.swift
+++ b/iosApp/iosApp/Features/ComfyUI/ComfyUISettingsViewModel.swift
@@ -14,6 +14,7 @@ final class ComfyUISettingsViewModelOwner: ObservableObject {
     @Published var showAddSheet = false
     @Published var editingConnection: ComfyUIConnection?
     @Published var isScanning = false
+    @Published var scanError: String?
     @Published var discoveredServers: [DiscoveredServer] = []
     @Published var systemStats: Core_domainSystemStats?
     @Published var optimizationSuggestions: [OptimizationSuggestion] = []
@@ -39,6 +40,7 @@ final class ComfyUISettingsViewModelOwner: ObservableObject {
             showAddSheet = state.showAddDialog
             editingConnection = state.editingConnection
             isScanning = state.isScanning
+            scanError = state.scanError
             discoveredServers = state.discoveredServers as? [DiscoveredServer] ?? []
             systemStats = state.systemStats
             optimizationSuggestions = state.optimizationSuggestions as? [OptimizationSuggestion] ?? []


### PR DESCRIPTION
## Description
- The LAN scan `flow.catch` in `ComfyUISettingsViewModel` previously only cleared `isScanning`, silently dropping errors and leaving the user with an empty result and no feedback.
- Added a `scanError` field to `ComfyUISettingsUiState` and route scan failures into it.
- Surface the error in the UI across Android, Desktop, and iOS (shown in error color when a scan fails).
- Added a unit test asserting the error reaches `uiState`.

Scope kept bounded to the cited concrete defect; legitimate fire-and-forget background swallows were left intact.

## Related Issues
Closes #941