### PR TITLE
#932 Externalize hardcoded user-facing strings

### DIFF
--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/comfyhub/ComfyHubDetailScreen.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/comfyhub/ComfyHubDetailScreen.kt
@@ -63,7 +63,9 @@ fun ComfyHubDetailScreen(
     Scaffold(
         topBar = {
             TopAppBar(
-                title = { Text(state.workflow?.name ?: "Workflow Detail") },
+                title = {
+                    Text(state.workflow?.name ?: stringResource(R.string.comfyhub_detail_fallback_title))
+                },
                 navigationIcon = {
                     IconButton(onClick = onBack) {
                         Icon(
@@ -229,7 +231,7 @@ private fun StatItem(icon: androidx.compose.ui.graphics.vector.ImageVector, valu
 @Composable
 private fun DescriptionSection(description: String) {
     Column {
-        Text("Description", style = MaterialTheme.typography.titleMedium)
+        Text(stringResource(R.string.comfyhub_description_title), style = MaterialTheme.typography.titleMedium)
         Text(
             text = description,
             style = MaterialTheme.typography.bodyMedium,

--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/comfyui/CivitaiLinkSettingsScreen.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/comfyui/CivitaiLinkSettingsScreen.kt
@@ -171,7 +171,7 @@ private fun ConfigCard(
                 modifier = Modifier.fillMaxWidth(),
             )
             Text(
-                text = "Get your link key from civitai.com \u2192 Account Settings \u2192 Civitai Link",
+                text = stringResource(R.string.civitai_link_key_hint),
                 style = MaterialTheme.typography.bodySmall,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
             )
@@ -180,7 +180,15 @@ private fun ConfigCard(
                 enabled = state.linkKey.isNotBlank() && !state.isSaving,
                 modifier = Modifier.fillMaxWidth(),
             ) {
-                Text(if (state.isSaving) "Connecting..." else "Save & Connect")
+                Text(
+                    stringResource(
+                        if (state.isSaving) {
+                            R.string.civitai_link_connecting
+                        } else {
+                            R.string.civitai_link_save_and_connect
+                        },
+                    ),
+                )
             }
         }
     }

--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/comfyui/ComfyUIResultSection.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/comfyui/ComfyUIResultSection.kt
@@ -59,7 +59,11 @@ internal fun GenerateButton(
             if (isGenerating) {
                 CircularProgressIndicator(modifier = Modifier.padding(end = Spacing.sm))
             }
-            Text(if (isGenerating) "Generating..." else "Generate")
+            Text(
+                stringResource(
+                    if (isGenerating) R.string.label_generating else R.string.action_generate,
+                ),
+            )
         }
         if (isGenerating) {
             Button(

--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/dataset/ExportDatasetSheet.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/dataset/ExportDatasetSheet.kt
@@ -89,16 +89,22 @@ private fun ExportSheetContent(
         modifier = Modifier.padding(start = Spacing.lg, end = Spacing.lg, bottom = Spacing.lg),
         verticalArrangement = Arrangement.spacedBy(Spacing.md),
     ) {
-        Text(text = "Export Dataset", style = MaterialTheme.typography.titleMedium)
+        Text(
+            text = stringResource(R.string.dataset_export_title),
+            style = MaterialTheme.typography.titleMedium,
+        )
         ExportFormatSelector(
             formats = availableFormats,
             selectedFormatId = selectedFormatId,
             onFormatSelected = onFormatSelected,
         )
-        Text(text = "$imageCount trainable images will be exported", style = MaterialTheme.typography.bodyMedium)
+        Text(
+            text = stringResource(R.string.dataset_export_trainable_count, imageCount),
+            style = MaterialTheme.typography.bodyMedium,
+        )
         if (nonTrainableCount > 0) {
             Text(
-                text = "$nonTrainableCount images excluded (non-trainable or flagged)",
+                text = stringResource(R.string.dataset_export_excluded_count, nonTrainableCount),
                 style = MaterialTheme.typography.bodySmall,
                 color = MaterialTheme.colorScheme.error,
             )
@@ -124,13 +130,17 @@ private fun ExportFormatSelector(
 ) {
     if (formats.size <= 1) {
         val format = formats.firstOrNull()
+        val formatName = format?.name ?: stringResource(R.string.dataset_export_format_default)
         Text(
-            text = "Format: ${format?.name ?: "ZIP (kohya-ss compatible)"}",
+            text = stringResource(R.string.dataset_export_format_single, formatName),
             style = MaterialTheme.typography.bodyMedium,
             color = MaterialTheme.colorScheme.onSurfaceVariant,
         )
     } else {
-        Text(text = "Format", style = MaterialTheme.typography.labelMedium)
+        Text(
+            text = stringResource(R.string.dataset_export_format_label),
+            style = MaterialTheme.typography.labelMedium,
+        )
         Row(horizontalArrangement = Arrangement.spacedBy(Spacing.sm)) {
             formats.forEach { format ->
                 FilterChip(

--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/dataset/ResolutionFilterSheet.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/dataset/ResolutionFilterSheet.kt
@@ -18,6 +18,8 @@ import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import com.riox432.civitdeck.R
 import com.riox432.civitdeck.ui.theme.Spacing
 import kotlin.math.roundToInt
 
@@ -65,14 +67,14 @@ private fun ResolutionFilterContent(
             .padding(horizontal = Spacing.lg, vertical = Spacing.md),
         verticalArrangement = Arrangement.spacedBy(Spacing.md),
     ) {
-        Text(text = "Resolution Filter")
+        Text(text = stringResource(R.string.dataset_resolution_filter_title))
         ResolutionSlider(
-            label = "Min Width: ${widthSlider.roundToInt()}px",
+            label = stringResource(R.string.dataset_resolution_min_width, widthSlider.roundToInt()),
             value = widthSlider,
             onValueChange = onWidthChange,
         )
         ResolutionSlider(
-            label = "Min Height: ${heightSlider.roundToInt()}px",
+            label = stringResource(R.string.dataset_resolution_min_height, heightSlider.roundToInt()),
             value = heightSlider,
             onValueChange = onHeightChange,
         )
@@ -113,13 +115,13 @@ private fun ResolutionFilterActions(
             onClick = onClear,
             modifier = Modifier.weight(1f),
         ) {
-            Text(text = "Clear")
+            Text(text = stringResource(R.string.action_clear))
         }
         Button(
             onClick = onApply,
             modifier = Modifier.weight(1f),
         ) {
-            Text(text = "Apply")
+            Text(text = stringResource(R.string.action_apply))
         }
     }
 }

--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/gallery/MetadataBottomSheet.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/gallery/MetadataBottomSheet.kt
@@ -205,5 +205,5 @@ private fun shareText(context: Context, text: String, title: String) {
 private fun copyToClipboard(context: Context, label: String, text: String) {
     val clipboard = context.getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
     clipboard.setPrimaryClip(ClipData.newPlainText(label, text))
-    Toast.makeText(context, "Copied to clipboard", Toast.LENGTH_SHORT).show()
+    Toast.makeText(context, context.getString(R.string.gallery_copied_to_clipboard), Toast.LENGTH_SHORT).show()
 }

--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/plugin/PluginDetailScreen.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/plugin/PluginDetailScreen.kt
@@ -58,7 +58,7 @@ fun PluginDetailScreen(
     Scaffold(
         topBar = {
             TopAppBar(
-                title = { Text(plugin?.name ?: "Plugin") },
+                title = { Text(plugin?.name ?: stringResource(R.string.plugin_detail_fallback_title)) },
                 navigationIcon = {
                     IconButton(onClick = onBack) {
                         Icon(
@@ -113,7 +113,7 @@ private fun DetailContent(
 @Composable
 private fun ManifestSection(plugin: InstalledPlugin) {
     Column(verticalArrangement = Arrangement.spacedBy(Spacing.xs)) {
-        Text("Plugin Info", style = MaterialTheme.typography.titleMedium)
+        Text(stringResource(R.string.plugin_info_title), style = MaterialTheme.typography.titleMedium)
         ManifestRow("Name", plugin.name)
         ManifestRow("Version", plugin.version)
         ManifestRow("Author", plugin.author)
@@ -165,7 +165,7 @@ private fun EnableToggleRow(
 @Composable
 private fun CapabilitiesSection(capabilities: List<String>) {
     Column(verticalArrangement = Arrangement.spacedBy(Spacing.xs)) {
-        Text("Capabilities", style = MaterialTheme.typography.titleMedium)
+        Text(stringResource(R.string.plugin_capabilities_title), style = MaterialTheme.typography.titleMedium)
         if (capabilities.isEmpty()) {
             Text(
                 "No capabilities declared",

--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/search/FilterSheetSection.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/search/FilterSheetSection.kt
@@ -271,7 +271,7 @@ private fun FilterSheetHeader(
         horizontalArrangement = Arrangement.SpaceBetween,
         verticalAlignment = Alignment.CenterVertically,
     ) {
-        Text(text = "Filters", style = MaterialTheme.typography.titleMedium)
+        Text(text = stringResource(R.string.search_filters_title), style = MaterialTheme.typography.titleMedium)
         Row(verticalAlignment = Alignment.CenterVertically) {
             IconButton(onClick = onShowSavedFilters) {
                 Icon(Icons.Default.Bookmarks, contentDescription = stringResource(R.string.cd_saved_filters))
@@ -395,7 +395,7 @@ private fun FreshOnlyToggleRow(
         horizontalArrangement = Arrangement.SpaceBetween,
         verticalAlignment = Alignment.CenterVertically,
     ) {
-        Text(text = "Fresh Only", style = MaterialTheme.typography.titleSmall)
+        Text(text = stringResource(R.string.search_fresh_only), style = MaterialTheme.typography.titleSmall)
         Switch(checked = isFreshFindEnabled, onCheckedChange = { onFreshFindToggled() })
     }
 }
@@ -413,9 +413,12 @@ private fun QualityFilterToggleRow(
         verticalAlignment = Alignment.CenterVertically,
     ) {
         Column {
-            Text(text = "Quality Filter", style = MaterialTheme.typography.titleSmall)
             Text(
-                text = "Hide low-quality results",
+                text = stringResource(R.string.search_quality_filter_title),
+                style = MaterialTheme.typography.titleSmall
+            )
+            Text(
+                text = stringResource(R.string.search_quality_filter_subtitle),
                 style = MaterialTheme.typography.bodySmall,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
             )

--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/tutorial/GestureTutorialScreen.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/tutorial/GestureTutorialScreen.kt
@@ -137,6 +137,10 @@ private fun NavigationButtons(
         onClick = if (isLastPage) onDismiss else onNext,
         modifier = Modifier.fillMaxWidth(0.6f),
     ) {
-        Text(if (isLastPage) "Get Started" else "Next")
+        Text(
+            stringResource(
+                if (isLastPage) R.string.tutorial_get_started else R.string.tutorial_next,
+            ),
+        )
     }
 }

--- a/androidApp/src/main/res/values/strings.xml
+++ b/androidApp/src/main/res/values/strings.xml
@@ -315,6 +315,8 @@
 
     <!-- Tutorial -->
     <string name="tutorial_skip">Skip</string>
+    <string name="tutorial_get_started">Get Started</string>
+    <string name="tutorial_next">Next</string>
 
     <!-- Text search -->
     <string name="text_search_title">AI Search</string>
@@ -328,6 +330,8 @@
     <string name="comfyhub_saving_template">Saving…</string>
     <string name="comfyhub_template_saved">Workflow saved as template!</string>
     <string name="comfyhub_save_template_failed">Save failed: %1$s</string>
+    <string name="comfyhub_detail_fallback_title">Workflow Detail</string>
+    <string name="comfyhub_description_title">Description</string>
     <string name="template_app_mode_badge">APP</string>
 
     <!-- Update banner -->
@@ -441,6 +445,9 @@
     <string name="civitai_link_title">Civitai Link</string>
     <string name="civitai_link_key_label">Link Key</string>
     <string name="civitai_link_key_placeholder">Paste your Civitai Link key here</string>
+    <string name="civitai_link_key_hint">Get your link key from civitai.com → Account Settings → Civitai Link</string>
+    <string name="civitai_link_save_and_connect">Save &amp; Connect</string>
+    <string name="civitai_link_connecting">Connecting…</string>
 
     <!-- Workflow templates -->
     <string name="template_editor_create">Create Template</string>
@@ -486,6 +493,15 @@
     <string name="dataset_export_anyway">Export Anyway</string>
     <string name="dataset_license_warning">License Warning</string>
     <string name="dataset_license_warning_message">%1$d images are non-trainable or have license restrictions. They will be excluded from the export.</string>
+    <string name="dataset_resolution_filter_title">Resolution Filter</string>
+    <string name="dataset_resolution_min_width">Min Width: %1$dpx</string>
+    <string name="dataset_resolution_min_height">Min Height: %1$dpx</string>
+    <string name="dataset_export_title">Export Dataset</string>
+    <string name="dataset_export_trainable_count">%1$d trainable images will be exported</string>
+    <string name="dataset_export_excluded_count">%1$d images excluded (non-trainable or flagged)</string>
+    <string name="dataset_export_format_label">Format</string>
+    <string name="dataset_export_format_single">Format: %1$s</string>
+    <string name="dataset_export_format_default">ZIP (kohya-ss compatible)</string>
 
     <!-- Gallery -->
     <string name="gallery_title">Images</string>
@@ -493,6 +509,7 @@
     <string name="gallery_save_prompt">Save Prompt</string>
     <string name="gallery_comfyui_workflow">ComfyUI Workflow</string>
     <string name="gallery_a1111_params">A1111 Params</string>
+    <string name="gallery_copied_to_clipboard">Copied to clipboard</string>
 
     <!-- Discovery -->
     <string name="discovery_title">Discover</string>
@@ -506,6 +523,9 @@
     <string name="plugin_uninstall_confirm_message">Are you sure? This will remove the plugin and its data.</string>
     <string name="plugin_uninstall_action">Uninstall</string>
     <string name="plugin_list_title">Plugins</string>
+    <string name="plugin_detail_fallback_title">Plugin</string>
+    <string name="plugin_info_title">Plugin Info</string>
+    <string name="plugin_capabilities_title">Capabilities</string>
 
     <!-- QR Code -->
     <string name="qr_scanner_title">Scan QR Code</string>
@@ -518,6 +538,10 @@
     <string name="search_compare">Compare</string>
     <string name="search_hide_model">Hide model</string>
     <string name="search_placeholder">Search models…</string>
+    <string name="search_filters_title">Filters</string>
+    <string name="search_fresh_only">Fresh Only</string>
+    <string name="search_quality_filter_title">Quality Filter</string>
+    <string name="search_quality_filter_subtitle">Hide low-quality results</string>
 
     <!-- Detail -->
     <string name="detail_find_similar">Find similar</string>


### PR DESCRIPTION
## Description
Externalizes hardcoded user-visible strings flagged by `/audit` (issue #932) into Android string resources, per the project l10n conventions (no raw text in Compose, all user-visible strings in `strings.xml`).

### Android keys added (`androidApp/src/main/res/values/strings.xml`)
- Tutorial: `tutorial_get_started`, `tutorial_next`
- ComfyHub: `comfyhub_detail_fallback_title`, `comfyhub_description_title`
- Civitai Link: `civitai_link_key_hint`, `civitai_link_save_and_connect`, `civitai_link_connecting`
- Dataset: `dataset_resolution_filter_title`, `dataset_resolution_min_width`/`_min_height` (positional `%1$d`), `dataset_export_title`, `dataset_export_trainable_count`, `dataset_export_excluded_count`, `dataset_export_format_label`/`_format_single`/`_format_default`
- Gallery: `gallery_copied_to_clipboard`
- Plugin: `plugin_detail_fallback_title`, `plugin_info_title`, `plugin_capabilities_title`
- Search: `search_filters_title`, `search_fresh_only`, `search_quality_filter_title`/`_subtitle`

Reused existing keys where available: `action_clear`, `action_apply`, `action_generate`, `label_generating`.

### Sites fixed (all cited locations)
GestureTutorialScreen, ComfyHubDetailScreen (title + Description), ComfyUIResultSection, CivitaiLinkSettingsScreen (hint + button), ResolutionFilterSheet (title/slider labels/buttons), ExportDatasetSheet (title/counts/format), MetadataBottomSheet (clipboard Toast via `context.getString`), PluginDetailScreen (title/Plugin Info/Capabilities), FilterSheetSection (Filters/Fresh Only/Quality Filter + subtitle).

Parameterized strings use positional `%1$s`/`%1$d`. Toast in a non-composable uses `context.getString`. No non-base locales exist in `androidApp` (no `values-ja/` etc.), so base English values only.

### iOS — out of scope (documented)
The iOS app currently has **no localization infrastructure** — no `.xcstrings` String Catalog, no `Localizable.strings`, and zero `NSLocalizedString` / `String(localized:)` usage anywhere. Per the issue scope, standing up a full iOS L10n system (catalog + project wiring) is a separate, larger task. The two iOS sites (`NsfwBlurView.swift`, `SettingsScreen.swift`) are left as a follow-up so they can be migrated together with the rest of the app's iOS strings under a dedicated L10n setup issue.

## Related Issue
Addresses #932 (Android portion only — iOS has no L10n infrastructure; that setup is tracked separately and #932 stays open)

## Automated Tests
- `./gradlew detekt` passes (run twice; second pass clean)
- `./gradlew :androidApp:assembleDebug` succeeds — confirms all new `R.string` keys resolve

## Checklist
- [x] CLAUDE.md rules followed
- [x] No hardcoded strings at the cited Android sites (all externalized)
- [x] New strings added to resources

🤖 Generated with [Claude Code](https://claude.com/claude-code)