### PR TITLE
#935 Migrate KMP modules to com.android.kotlin.multiplatform.library

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,21 +65,26 @@ jobs:
         uses: gradle/actions/setup-gradle@v4
 
       - name: Test, Lint & Build
-        # Feature/core ViewModel tests run via testDebugUnitTest (Android target);
-        # comfyui runs via jvmTest because its use-case tests need android.util.Log
-        # unmocked and ComfyUISettingsViewModelTest needs the parameterless JVM
-        # GenerationNotificationService actual (the Android actual requires a Context).
+        # Feature/core ViewModel tests run via testAndroidHostTest (the Android host
+        # unit-test task under com.android.kotlin.multiplatform.library — replaces the
+        # old testDebugUnitTest, which no longer exists since the new KMP library plugin
+        # has a single-variant model); comfyui runs via jvmTest because its use-case
+        # tests need android.util.Log unmocked and ComfyUISettingsViewModelTest needs the
+        # parameterless JVM GenerationNotificationService actual (the Android actual
+        # requires a Context). core-database's only tests live in jvmTest (Fp16Test), so
+        # it runs via :jvmTest — its androidHostTest source set is empty (the previous
+        # :core:core-database:testDebugUnitTest line was a no-op for the same reason).
         run: >-
           ./gradlew
-          :shared:testDebugUnitTest
-          :core:core-database:testDebugUnitTest
-          :core:core-data:testDebugUnitTest
-          :feature:feature-search:testDebugUnitTest
-          :feature:feature-detail:testDebugUnitTest
-          :feature:feature-gallery:testDebugUnitTest
-          :feature:feature-prompts:testDebugUnitTest
-          :feature:feature-creator:testDebugUnitTest
-          :feature:feature-externalserver:testDebugUnitTest
+          :shared:testAndroidHostTest
+          :core:core-database:jvmTest
+          :core:core-data:testAndroidHostTest
+          :feature:feature-search:testAndroidHostTest
+          :feature:feature-detail:testAndroidHostTest
+          :feature:feature-gallery:testAndroidHostTest
+          :feature:feature-prompts:testAndroidHostTest
+          :feature:feature-creator:testAndroidHostTest
+          :feature:feature-externalserver:testAndroidHostTest
           :feature:feature-comfyui:jvmTest
           detekt
           :androidApp:assembleDebug

--- a/build-logic/convention/src/main/kotlin/CivitDeckKmpLibraryPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/CivitDeckKmpLibraryPlugin.kt
@@ -1,5 +1,4 @@
-import com.android.build.api.dsl.LibraryExtension
-import org.gradle.api.JavaVersion
+import com.android.build.api.dsl.KotlinMultiplatformAndroidLibraryTarget
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.kotlin.dsl.configure
@@ -10,32 +9,31 @@ class CivitDeckKmpLibraryPlugin : Plugin<Project> {
     override fun apply(target: Project) {
         with(target) {
             with(pluginManager) {
-                // kotlin.multiplatform + com.android.library combo works via android.newDsl=false
-                // Migrate to com.android.kotlin.multiplatform.library when removing compat flags
                 apply("org.jetbrains.kotlin.multiplatform")
-                apply("com.android.library")
-            }
-
-            extensions.configure<LibraryExtension> {
-                compileSdk = 36
-                defaultConfig {
-                    minSdk = 29
-                }
-                compileOptions {
-                    sourceCompatibility = JavaVersion.VERSION_17
-                    targetCompatibility = JavaVersion.VERSION_17
-                }
+                apply("com.android.kotlin.multiplatform.library")
             }
 
             extensions.configure<KotlinMultiplatformExtension> {
                 jvm()
-                androidTarget {
-                    compilerOptions {
-                        jvmTarget.set(JvmTarget.JVM_17)
-                    }
-                }
                 iosArm64()
                 iosSimulatorArm64()
+
+                // The new com.android.kotlin.multiplatform.library plugin replaces
+                // androidTarget() + the top-level android {} block. The Android target
+                // is configured here; each module sets its own namespace.
+                targets.withType(KotlinMultiplatformAndroidLibraryTarget::class.java)
+                    .configureEach {
+                        compileSdk = 36
+                        minSdk = 29
+                        compilerOptions {
+                            jvmTarget.set(JvmTarget.JVM_17)
+                        }
+                        // Host (JVM) unit tests are opt-in under the new plugin.
+                        // commonTest runs on the androidHostTest compilation.
+                        withHostTest {
+                            isIncludeAndroidResources = true
+                        }
+                    }
             }
         }
     }

--- a/core/core-data/build.gradle.kts
+++ b/core/core-data/build.gradle.kts
@@ -27,8 +27,8 @@ kotlin {
             implementation(libs.kotlin.test)
         }
     }
-}
 
-android {
-    namespace = "com.riox432.civitdeck.core.data"
+    android {
+        namespace = "com.riox432.civitdeck.core.data"
+    }
 }

--- a/core/core-database/build.gradle.kts
+++ b/core/core-database/build.gradle.kts
@@ -24,10 +24,10 @@ kotlin {
             implementation(libs.kotlin.test)
         }
     }
-}
 
-android {
-    namespace = "com.riox432.civitdeck.core.database"
+    android {
+        namespace = "com.riox432.civitdeck.core.database"
+    }
 }
 
 dependencies {

--- a/core/core-domain/build.gradle.kts
+++ b/core/core-domain/build.gradle.kts
@@ -23,8 +23,8 @@ kotlin {
             implementation(libs.turbine)
         }
     }
-}
 
-android {
-    namespace = "com.riox432.civitdeck.core.domain"
+    android {
+        namespace = "com.riox432.civitdeck.core.domain"
+    }
 }

--- a/core/core-network/build.gradle.kts
+++ b/core/core-network/build.gradle.kts
@@ -33,8 +33,8 @@ kotlin {
             implementation(libs.kotlinx.coroutines.test)
         }
     }
-}
 
-android {
-    namespace = "com.riox432.civitdeck.core.network"
+    android {
+        namespace = "com.riox432.civitdeck.core.network"
+    }
 }

--- a/core/core-plugin/build.gradle.kts
+++ b/core/core-plugin/build.gradle.kts
@@ -18,8 +18,8 @@ kotlin {
             implementation(libs.turbine)
         }
     }
-}
 
-android {
-    namespace = "com.riox432.civitdeck.core.plugin"
+    android {
+        namespace = "com.riox432.civitdeck.core.plugin"
+    }
 }

--- a/core/core-testing/build.gradle.kts
+++ b/core/core-testing/build.gradle.kts
@@ -14,8 +14,8 @@ kotlin {
             implementation(libs.kotlinx.coroutines.test)
         }
     }
-}
 
-android {
-    namespace = "com.riox432.civitdeck.core.testing"
+    android {
+        namespace = "com.riox432.civitdeck.core.testing"
+    }
 }

--- a/core/core-ui/build.gradle.kts
+++ b/core/core-ui/build.gradle.kts
@@ -24,12 +24,8 @@ kotlin {
             implementation(libs.coil.network.okhttp)
         }
     }
-}
 
-android {
-    namespace = "com.riox432.civitdeck.core.ui"
-
-    buildFeatures {
-        compose = true
+    android {
+        namespace = "com.riox432.civitdeck.core.ui"
     }
 }

--- a/feature/feature-collections/build.gradle.kts
+++ b/feature/feature-collections/build.gradle.kts
@@ -15,8 +15,8 @@ kotlin {
             implementation(libs.turbine)
         }
     }
-}
 
-android {
-    namespace = "com.riox432.civitdeck.feature.collections"
+    android {
+        namespace = "com.riox432.civitdeck.feature.collections"
+    }
 }

--- a/feature/feature-comfyui/build.gradle.kts
+++ b/feature/feature-comfyui/build.gradle.kts
@@ -30,8 +30,8 @@ kotlin {
             implementation(libs.ktor.client.mock)
         }
     }
-}
 
-android {
-    namespace = "com.riox432.civitdeck.feature.comfyui"
+    android {
+        namespace = "com.riox432.civitdeck.feature.comfyui"
+    }
 }

--- a/feature/feature-creator/build.gradle.kts
+++ b/feature/feature-creator/build.gradle.kts
@@ -14,8 +14,8 @@ kotlin {
             implementation(libs.turbine)
         }
     }
-}
 
-android {
-    namespace = "com.riox432.civitdeck.feature.creator"
+    android {
+        namespace = "com.riox432.civitdeck.feature.creator"
+    }
 }

--- a/feature/feature-detail/build.gradle.kts
+++ b/feature/feature-detail/build.gradle.kts
@@ -14,8 +14,8 @@ kotlin {
             implementation(libs.turbine)
         }
     }
-}
 
-android {
-    namespace = "com.riox432.civitdeck.feature.detail"
+    android {
+        namespace = "com.riox432.civitdeck.feature.detail"
+    }
 }

--- a/feature/feature-externalserver/build.gradle.kts
+++ b/feature/feature-externalserver/build.gradle.kts
@@ -19,8 +19,8 @@ kotlin {
             implementation(libs.turbine)
         }
     }
-}
 
-android {
-    namespace = "com.riox432.civitdeck.feature.externalserver"
+    android {
+        namespace = "com.riox432.civitdeck.feature.externalserver"
+    }
 }

--- a/feature/feature-gallery/build.gradle.kts
+++ b/feature/feature-gallery/build.gradle.kts
@@ -15,8 +15,8 @@ kotlin {
             implementation(libs.turbine)
         }
     }
-}
 
-android {
-    namespace = "com.riox432.civitdeck.feature.gallery"
+    android {
+        namespace = "com.riox432.civitdeck.feature.gallery"
+    }
 }

--- a/feature/feature-prompts/build.gradle.kts
+++ b/feature/feature-prompts/build.gradle.kts
@@ -14,8 +14,8 @@ kotlin {
             implementation(libs.turbine)
         }
     }
-}
 
-android {
-    namespace = "com.riox432.civitdeck.feature.prompts"
+    android {
+        namespace = "com.riox432.civitdeck.feature.prompts"
+    }
 }

--- a/feature/feature-search/build.gradle.kts
+++ b/feature/feature-search/build.gradle.kts
@@ -15,8 +15,8 @@ kotlin {
             implementation(libs.turbine)
         }
     }
-}
 
-android {
-    namespace = "com.riox432.civitdeck.feature.search"
+    android {
+        namespace = "com.riox432.civitdeck.feature.search"
+    }
 }

--- a/feature/feature-settings/build.gradle.kts
+++ b/feature/feature-settings/build.gradle.kts
@@ -14,8 +14,8 @@ kotlin {
             implementation(libs.turbine)
         }
     }
-}
 
-android {
-    namespace = "com.riox432.civitdeck.feature.settings"
+    android {
+        namespace = "com.riox432.civitdeck.feature.settings"
+    }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,8 +7,13 @@ kotlin.code.style=official
 android.useAndroidX=true
 android.nonTransitiveRClass=true
 
-# AGP 9 backward-compatibility flags (remove when detekt 2.0 stable + full KMP plugin migration)
-# Keeps kotlin-android plugin required (detekt 1.23 needs KotlinSourceSetContainer)
+# AGP 9 backward-compatibility flags.
+# KMP library/feature modules migrated to com.android.kotlin.multiplatform.library in #935,
+# so they no longer depend on these flags. They remain ONLY for :androidApp, which still
+# applies org.jetbrains.kotlin.android (com.android.application has no new-KMP equivalent):
+#   - builtInKotlin=false keeps the standalone kotlin-android plugin available (detekt 1.23
+#     needs its KotlinSourceSetContainer).
+#   - newDsl=false is required because org.jetbrains.kotlin.android is incompatible with AGP 9's
+#     new DSL (android.newDsl=true). Removable only once :androidApp moves to built-in Kotlin.
 android.builtInKotlin=false
-# Keeps old DSL types (BaseAppModuleExtension etc.) and variant API so third-party plugins still work
 android.newDsl=false

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -117,6 +117,7 @@ turbine = { module = "app.cash.turbine:turbine", version = "1.2.0" }
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }
 android-library = { id = "com.android.library", version.ref = "agp" }
+android-kotlin-multiplatform-library = { id = "com.android.kotlin.multiplatform.library", version.ref = "agp" }
 kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 kotlin-multiplatform = { id = "org.jetbrains.kotlin.multiplatform", version.ref = "kotlin" }
 kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }

--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -49,14 +49,14 @@ kotlin {
             implementation(libs.turbine)
         }
     }
+
+    android {
+        namespace = "com.riox432.civitdeck.shared"
+    }
 }
 
 skie {
     features {
         enableSwiftUIObservingPreview = true
     }
-}
-
-android {
-    namespace = "com.riox432.civitdeck.shared"
 }


### PR DESCRIPTION
## Description

Migrates all KMP library/feature modules from the deprecated `com.android.library` (used with `org.jetbrains.kotlin.multiplatform` + the `android.newDsl=false` compat flag) to the new **`com.android.kotlin.multiplatform.library`** plugin. The old combination is removed in AGP 10; AGP is already 9.1.1.

### What changed
- **`CivitDeckKmpLibraryPlugin`**: now applies `com.android.kotlin.multiplatform.library` instead of `com.android.library`. The Android config (compileSdk=36, minSdk=29, jvmTarget=17, host-test opt-in) moves into `kotlin { ... }` via `targets.withType(KotlinMultiplatformAndroidLibraryTarget).configureEach { ... }`. `androidTarget()` is gone (the new plugin provides the `android` target). Host (JVM) unit tests are opt-in under the new plugin, enabled via `withHostTest { isIncludeAndroidResources = true }` so `commonTest` keeps running.
- **Every KMP module build.gradle.kts** (`shared`, all `core:*`, all `feature:*`): the top-level `android { namespace = ... }` block moved inside `kotlin { android { namespace = ... } }`. `core-ui` dropped `buildFeatures { compose = true }` — Compose now comes solely from the `org.jetbrains.compose` + Compose-compiler plugins (verified `:androidApp:assembleDebug` compiles core-ui Compose code).
- **`libs.versions.toml`**: added `android-kotlin-multiplatform-library` plugin alias (version.ref = agp).
- **`gradle.properties`**: documented that the remaining `android.newDsl=false` / `android.builtInKotlin=false` flags now exist ONLY for `:androidApp` (see note below). `:androidApp` was intentionally NOT touched — the new KMP plugin has no `com.android.application` replacement.

### New Gradle task name
The new KMP library plugin has a single-variant model, so `:module:testDebugUnitTest` **no longer exists**. The Android host unit-test task is now **`:module:testAndroidHostTest`**.

### ci.yml changes
Replaced every `:module:testDebugUnitTest` with `:module:testAndroidHostTest`, except:
- `:core:core-database` → **`:jvmTest`**. Its only tests (`Fp16Test`) live in `jvmTest`, not `commonTest`; its `androidHostTest` source set is empty. (The previous `:core:core-database:testDebugUnitTest` line was a silent no-op for the same reason — this fixes that.)
- `:feature:feature-comfyui` → unchanged (`:jvmTest`, as before).

### Compat flag note
The issue asked to remove `android.newDsl=false`. It **cannot be fully removed yet**: `:androidApp` still applies `org.jetbrains.kotlin.android` (kept via `android.builtInKotlin=false` because detekt 1.23 needs `KotlinSourceSetContainer`), and that plugin is **incompatible with AGP 9's `android.newDsl=true`** (verified: build fails with `ApplicationExtensionImpl cannot be cast to BaseExtension`). The KMP modules themselves no longer depend on the flag. Removing it requires migrating `:androidApp` to built-in Kotlin — out of scope for this issue and explicitly excluded. The flags are now documented as androidApp-only.

## Verification (local, AGP 9.1.1)
- `./gradlew detekt` — clean (run twice).
- `./gradlew :androidApp:assembleDebug` — BUILD SUCCESSFUL (whole graph, incl. core-ui Compose, Room/KSP in core-database).
- `./gradlew :desktopApp:compileKotlinJvm` — SUCCESSFUL (jvm targets intact).
- Host tests EXECUTE (not NO-SOURCE) — verified test counts: shared=90, core-data=3, feature-search=21, feature-detail=6, feature-gallery=9, feature-prompts=2, feature-creator=6, feature-externalserver=10, feature-comfyui `jvmTest`=49, core-database `jvmTest`=4 (Room/KSP generation confirmed).

## Reviewer note
Please **confirm CI actually RUNS (does not skip) the `testAndroidHostTest` tasks** — verify the Android job shows non-zero test counts for each module, not NO-SOURCE. This repo has no required status checks, so a green/red mismatch is possible.

## Related Issue
Closes #935

## Automated Tests
- [x] Existing unit tests still execute under the new host-test task (verified counts above)
