### PR TITLE
Android: in-app self-update via PackageInstaller

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,11 +41,18 @@ jobs:
           cp androidApp/build/outputs/apk/release/androidApp-release.apk \
             "CivitDeck-${VERSION}-android.apk"
 
+      - name: Generate SHA-256 checksum
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          sha256sum "CivitDeck-${VERSION}-android.apk" > "CivitDeck-${VERSION}-android.apk.sha256"
+
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
           name: android-apk
-          path: CivitDeck-*-android.apk
+          path: |
+            CivitDeck-*-android.apk
+            CivitDeck-*-android.apk.sha256
 
   # Build macOS DMG
   build-macos:

--- a/androidApp/src/main/AndroidManifest.xml
+++ b/androidApp/src/main/AndroidManifest.xml
@@ -8,6 +8,7 @@
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_SPECIAL_USE" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <uses-permission android:name="android.permission.CAMERA" />
+    <uses-permission android:name="android.permission.REQUEST_INSTALL_PACKAGES" />
 
     <uses-feature android:name="android.hardware.camera" android:required="false" />
     <uses-permission

--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/navigation/CivitDeckNavGraph.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/navigation/CivitDeckNavGraph.kt
@@ -316,7 +316,6 @@ private fun CivitDeckNavDisplay(
                 val updateVm: UpdateViewModel = koinViewModel()
                 val gestureTutorialVm: com.riox432.civitdeck.feature.gallery.presentation.GestureTutorialViewModel =
                     koinViewModel()
-                val context = androidx.compose.ui.platform.LocalContext.current
                 SettingsScreen(
                     authViewModel = authVm,
                     storageViewModel = storageVm,
@@ -332,13 +331,6 @@ private fun CivitDeckNavDisplay(
                     onNavigateToDownloadQueue = { backStack.add(DownloadQueueRoute) },
                     onNavigateToLicenses = { backStack.add(LicensesRoute) },
                     onReplayGestureTutorial = gestureTutorialVm::resetTutorial,
-                    onOpenUrl = { url ->
-                        val intent = android.content.Intent(
-                            android.content.Intent.ACTION_VIEW,
-                            android.net.Uri.parse(url),
-                        )
-                        context.startActivity(intent)
-                    },
                     scrollToTopTrigger = settingsScrollTrigger,
                 )
             }

--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/settings/SettingsScreen.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/settings/SettingsScreen.kt
@@ -32,6 +32,9 @@ import com.riox432.civitdeck.feature.settings.presentation.StorageSettingsViewMo
 import com.riox432.civitdeck.ui.components.EmptyStateMessage
 import com.riox432.civitdeck.ui.theme.Spacing
 import com.riox432.civitdeck.ui.update.UpdateBanner
+import com.riox432.civitdeck.ui.update.UpdateInstallController
+import com.riox432.civitdeck.ui.update.UpdateInstallHost
+import com.riox432.civitdeck.ui.update.rememberUpdateInstallController
 
 @Suppress("LongParameterList")
 @Composable
@@ -50,13 +53,13 @@ fun SettingsScreen(
     onNavigateToDownloadQueue: () -> Unit = {},
     onNavigateToLicenses: () -> Unit = {},
     onReplayGestureTutorial: () -> Unit = {},
-    onOpenUrl: (String) -> Unit = {},
     scrollToTopTrigger: Int = 0,
 ) {
     val authState by authViewModel.uiState.collectAsStateWithLifecycle()
     val storageState by storageViewModel.uiState.collectAsStateWithLifecycle()
     val appBehaviorState by appBehaviorViewModel.uiState.collectAsStateWithLifecycle()
     val updateState by updateViewModel.uiState.collectAsStateWithLifecycle()
+    val installController = rememberUpdateInstallController()
     val listState = rememberLazyListState()
     var lastHandledTrigger by rememberSaveable { mutableIntStateOf(scrollToTopTrigger) }
     LaunchedEffect(scrollToTopTrigger) {
@@ -90,7 +93,7 @@ fun SettingsScreen(
                 item { SectionHeader(stringResource(R.string.settings_section_analytics)) }
                 item { SubScreenRow(stringResource(R.string.settings_usage_stats), onNavigateToAnalytics) }
             }
-            settingsUpdateItems(updateState, updateViewModel, onOpenUrl)
+            settingsUpdateItems(updateState, updateViewModel, installController)
             settingsAboutItems(
                 appBehaviorState.powerUserMode,
                 updateState,
@@ -106,6 +109,7 @@ fun SettingsScreen(
                 modifier = Modifier.fillMaxSize(),
             )
         }
+        UpdateInstallHost(installController)
     }
 }
 
@@ -129,14 +133,14 @@ internal fun LazyListScope.settingsAccountItems(
 private fun LazyListScope.settingsUpdateItems(
     updateState: UpdateUiState,
     updateViewModel: UpdateViewModel,
-    onOpenUrl: (String) -> Unit,
+    installController: UpdateInstallController,
 ) {
     val updateResult = updateState.updateResult
     if (updateState.showBanner && updateResult != null) {
         item {
             UpdateBanner(
                 updateResult = updateResult,
-                onDownload = { onOpenUrl(updateResult.htmlUrl) },
+                onDownload = { installController.start(updateResult.downloadUrl) },
                 onDismiss = updateViewModel::dismissBanner,
             )
         }

--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/update/ApkInstaller.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/update/ApkInstaller.kt
@@ -1,0 +1,150 @@
+package com.riox432.civitdeck.ui.update
+
+import android.app.PendingIntent
+import android.content.Context
+import android.content.Intent
+import android.content.pm.PackageInstaller
+import android.content.pm.PackageManager
+import android.content.pm.Signature
+import android.content.pm.SigningInfo
+import java.io.File
+import java.net.HttpURLConnection
+import java.net.URL
+import java.security.MessageDigest
+
+/**
+ * Low-level Android APK download + integrity verification + install via [PackageInstaller].
+ *
+ * Lives in the app layer (not in common/domain) because the install flow is inherently
+ * Activity/Context-bound and asynchronous — see [UpdateInstallState]. Uses only the application
+ * context; the Activity-bound steps are surfaced as effects and handled by the host Composable.
+ */
+class ApkInstaller(private val context: Context) {
+
+    fun canRequestInstalls(): Boolean =
+        context.packageManager.canRequestPackageInstalls()
+
+    /**
+     * Downloads the APK to app-private cache, reporting progress via [onProgress]. Performs blocking
+     * IO — callers must invoke it off the main thread.
+     */
+    fun download(url: String, onProgress: (bytesRead: Long, total: Long) -> Unit): File {
+        val dir = File(context.cacheDir, UPDATE_DIR).apply { mkdirs() }
+        val target = File(dir, APK_NAME)
+        if (target.exists()) target.delete()
+
+        val connection = (URL(url).openConnection() as HttpURLConnection).apply {
+            connectTimeout = CONNECT_TIMEOUT_MS
+            readTimeout = READ_TIMEOUT_MS
+            instanceFollowRedirects = true
+        }
+        try {
+            val total = connection.contentLengthLong
+            connection.inputStream.use { input ->
+                target.outputStream().use { out -> copyWithProgress(input, out, total, onProgress) }
+            }
+        } finally {
+            connection.disconnect()
+        }
+        return target
+    }
+
+    private fun copyWithProgress(
+        input: java.io.InputStream,
+        out: java.io.OutputStream,
+        total: Long,
+        onProgress: (bytesRead: Long, total: Long) -> Unit,
+    ) {
+        val buffer = ByteArray(DOWNLOAD_CHUNK)
+        var read = 0L
+        while (true) {
+            val count = input.read(buffer)
+            if (count < 0) break
+            out.write(buffer, 0, count)
+            read += count
+            onProgress(read, total)
+        }
+    }
+
+    /**
+     * Verifies the downloaded APK is a genuine, matching build of this app: package name must match
+     * and the signing certificate set must be identical to the running app. This is the primary
+     * integrity gate — it defends against a swapped APK even if release metadata were tampered with.
+     */
+    @Suppress("DEPRECATION")
+    fun verify(apk: File): Boolean {
+        val pm = context.packageManager
+        val flags = PackageManager.GET_SIGNING_CERTIFICATES
+        val downloaded = pm.getPackageArchiveInfo(apk.absolutePath, flags) ?: return false
+        if (downloaded.packageName != context.packageName) return false
+
+        val installed = pm.getPackageInfo(context.packageName, flags)
+        // Reject downgrades / equal builds — only a strictly newer APK is installable here.
+        if (downloaded.longVersionCode <= installed.longVersionCode) return false
+        return signersMatch(downloaded.signingInfo, installed.signingInfo)
+    }
+
+    /**
+     * Accepts the downloaded APK when its current signer set equals the installed one, or — for
+     * single-signer apps — when the downloaded signing lineage includes the currently installed
+     * signer (supports APK Signature Scheme key rotation).
+     */
+    private fun signersMatch(downloaded: SigningInfo?, installed: SigningInfo?): Boolean {
+        if (downloaded == null || installed == null) return false
+        val downloadedCurrent = downloaded.apkContentsSigners.toCertSet()
+        val installedCurrent = installed.apkContentsSigners.toCertSet()
+        if (downloadedCurrent.isEmpty() || installedCurrent.isEmpty()) return false
+        if (downloadedCurrent == installedCurrent) return true
+
+        if (downloaded.hasMultipleSigners() || installed.hasMultipleSigners()) return false
+        val lineage = downloaded.signingCertificateHistory?.toCertSet().orEmpty()
+        return lineage.isNotEmpty() && installedCurrent.all { it in lineage }
+    }
+
+    /**
+     * Streams the APK into a [PackageInstaller] session and commits it. The result (and any required
+     * user confirmation) is delivered to the broadcast receiver listening for [statusAction].
+     */
+    fun commit(apk: File, statusAction: String) {
+        val installer = context.packageManager.packageInstaller
+        val params = PackageInstaller.SessionParams(
+            PackageInstaller.SessionParams.MODE_FULL_INSTALL,
+        )
+        val sessionId = installer.createSession(params)
+        installer.openSession(sessionId).use { session ->
+            session.openWrite(APK_NAME, 0, apk.length()).use { out ->
+                apk.inputStream().use { input -> input.copyTo(out) }
+                session.fsync(out)
+            }
+            session.commit(buildStatusSender(sessionId, statusAction).intentSender)
+        }
+    }
+
+    fun cleanup() {
+        File(context.cacheDir, UPDATE_DIR).deleteRecursively()
+    }
+
+    private fun buildStatusSender(sessionId: Int, statusAction: String): PendingIntent {
+        val intent = Intent(statusAction).setPackage(context.packageName)
+        return PendingIntent.getBroadcast(
+            context,
+            sessionId,
+            intent,
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_MUTABLE,
+        )
+    }
+
+    private fun Array<Signature>.toCertSet(): Set<String> {
+        val digest = MessageDigest.getInstance("SHA-256")
+        return map { digest.digest(it.toByteArray()).joinToString("") { b -> "%02x".format(b) } }
+            .toSet()
+    }
+
+    companion object {
+        private const val UPDATE_DIR = "app_update"
+        private const val APK_NAME = "update.apk"
+        private const val DOWNLOAD_CHUNK = 64 * 1024
+        private const val CONNECT_TIMEOUT_MS = 30_000
+        private const val READ_TIMEOUT_MS = 30_000
+    }
+}

--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/update/UpdateInstallController.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/update/UpdateInstallController.kt
@@ -1,0 +1,179 @@
+package com.riox432.civitdeck.ui.update
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.content.IntentFilter
+import android.content.pm.PackageInstaller
+import androidx.core.content.ContextCompat
+import androidx.core.content.IntentCompat
+import com.riox432.civitdeck.util.Logger
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.receiveAsFlow
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runInterruptible
+import kotlinx.coroutines.withContext
+import java.io.File
+import kotlin.coroutines.cancellation.CancellationException
+
+/**
+ * Drives the Android in-app self-update state machine: download -> verify -> (permission) -> install.
+ *
+ * Holds only the application context; all Activity-bound steps are surfaced through [effects] and
+ * executed by the host Composable. The PackageInstaller commit result is delivered asynchronously
+ * through a runtime [BroadcastReceiver] and folded back into [state].
+ */
+class UpdateInstallController(
+    context: Context,
+    private val scope: CoroutineScope,
+) {
+    private val appContext = context.applicationContext
+    private val installer = ApkInstaller(appContext)
+    private val statusAction = "${appContext.packageName}.APK_INSTALL_STATUS"
+
+    private val _state = MutableStateFlow<UpdateInstallState>(UpdateInstallState.Idle)
+    val state: StateFlow<UpdateInstallState> = _state.asStateFlow()
+
+    private val _effects = Channel<UpdateInstallEffect>(Channel.BUFFERED)
+    val effects = _effects.receiveAsFlow()
+
+    private var pendingApk: File? = null
+    private var receiverRegistered = false
+
+    private val receiver = object : BroadcastReceiver() {
+        override fun onReceive(context: Context?, intent: Intent?) {
+            if (intent?.action != statusAction) return
+            handleStatus(intent)
+        }
+    }
+
+    /** Starts a fresh install attempt. No-ops while one is already in progress. */
+    fun start(downloadUrl: String) {
+        if (_state.value.isInProgress()) return
+        scope.launch {
+            try {
+                val apk = downloadAndVerify(downloadUrl) ?: return@launch
+                pendingApk = apk
+                proceedToInstall()
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                fail(InstallFailure.DOWNLOAD_FAILED, e)
+            }
+        }
+    }
+
+    /** Called by the host after the user returns from the unknown-app-sources settings screen. */
+    fun onUnknownSourcesResult() {
+        val apk = pendingApk ?: return
+        if (installer.canRequestInstalls()) {
+            scope.launch { commit(apk) }
+        } else {
+            _state.value = UpdateInstallState.Cancelled
+            reset()
+        }
+    }
+
+    fun dismiss() {
+        _state.value = UpdateInstallState.Idle
+        reset()
+    }
+
+    fun dispose() = reset()
+
+    private suspend fun downloadAndVerify(url: String): File? {
+        _state.value = UpdateInstallState.Downloading(0, 0)
+        val apk = runInterruptible(Dispatchers.IO) {
+            installer.download(url) { read, total ->
+                _state.value = UpdateInstallState.Downloading(read, total)
+            }
+        }
+        _state.value = UpdateInstallState.Verifying
+        val valid = runInterruptible(Dispatchers.IO) { installer.verify(apk) }
+        if (!valid) {
+            fail(InstallFailure.INTEGRITY_CHECK_FAILED)
+            return null
+        }
+        return apk
+    }
+
+    private suspend fun proceedToInstall() {
+        val apk = pendingApk ?: return
+        if (installer.canRequestInstalls()) {
+            commit(apk)
+        } else {
+            _state.value = UpdateInstallState.NeedsUnknownAppsPermission
+            _effects.send(UpdateInstallEffect.OpenUnknownAppsSettings)
+        }
+    }
+
+    private suspend fun commit(apk: File) {
+        registerReceiver()
+        _state.value = UpdateInstallState.Installing
+        withContext(Dispatchers.IO) { installer.commit(apk, statusAction) }
+    }
+
+    private fun handleStatus(intent: Intent) {
+        when (intent.getIntExtra(PackageInstaller.EXTRA_STATUS, Int.MIN_VALUE)) {
+            PackageInstaller.STATUS_PENDING_USER_ACTION -> {
+                val confirm = IntentCompat.getParcelableExtra(intent, Intent.EXTRA_INTENT, Intent::class.java)
+                val delivered = confirm != null &&
+                    _effects.trySend(UpdateInstallEffect.LaunchInstallConfirmation(confirm)).isSuccess
+                if (!delivered) fail(InstallFailure.UNKNOWN)
+            }
+            PackageInstaller.STATUS_SUCCESS -> {
+                _state.value = UpdateInstallState.Success
+                reset()
+            }
+            PackageInstaller.STATUS_FAILURE_ABORTED -> {
+                _state.value = UpdateInstallState.Cancelled
+                reset()
+            }
+            else -> fail(InstallFailure.INSTALL_REJECTED)
+        }
+    }
+
+    private fun fail(reason: InstallFailure, error: Exception? = null) {
+        if (error != null) Logger.w(TAG, "Install failed: ${error.message}")
+        _state.value = UpdateInstallState.Failed(reason)
+        reset()
+    }
+
+    private fun registerReceiver() {
+        if (receiverRegistered) return
+        ContextCompat.registerReceiver(
+            appContext,
+            receiver,
+            IntentFilter(statusAction),
+            ContextCompat.RECEIVER_NOT_EXPORTED,
+        )
+        receiverRegistered = true
+    }
+
+    private fun reset() {
+        if (receiverRegistered) {
+            runCatching { appContext.unregisterReceiver(receiver) }
+            receiverRegistered = false
+        }
+        pendingApk = null
+        installer.cleanup()
+    }
+
+    private fun UpdateInstallState.isInProgress(): Boolean = when (this) {
+        is UpdateInstallState.Downloading,
+        UpdateInstallState.Verifying,
+        UpdateInstallState.NeedsUnknownAppsPermission,
+        UpdateInstallState.Installing,
+        -> true
+        else -> false
+    }
+
+    private companion object {
+        const val TAG = "UpdateInstallController"
+    }
+}

--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/update/UpdateInstallHost.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/update/UpdateInstallHost.kt
@@ -1,0 +1,121 @@
+package com.riox432.civitdeck.ui.update
+
+import android.content.Context
+import android.content.Intent
+import android.net.Uri
+import android.provider.Settings
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts.StartActivityForResult
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.LinearProgressIndicator
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.window.DialogProperties
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.riox432.civitdeck.R
+
+/** Remembers a [UpdateInstallController] scoped to the current composition. */
+@Composable
+fun rememberUpdateInstallController(): UpdateInstallController {
+    val context = LocalContext.current
+    val scope = androidx.compose.runtime.rememberCoroutineScope()
+    val controller = remember { UpdateInstallController(context, scope) }
+    DisposableEffect(Unit) { onDispose { controller.dispose() } }
+    return controller
+}
+
+/**
+ * Owns the Activity-bound mechanics of the install flow: launches the unknown-app-sources settings
+ * screen (re-checking permission on return) and the system install confirmation, then renders the
+ * install progress/error dialog. The controller itself never touches an Activity.
+ */
+@Composable
+fun UpdateInstallHost(controller: UpdateInstallController) {
+    val context = LocalContext.current
+    val state by controller.state.collectAsStateWithLifecycle()
+
+    val settingsLauncher = rememberLauncherForActivityResult(StartActivityForResult()) {
+        controller.onUnknownSourcesResult()
+    }
+
+    LaunchedEffect(controller) {
+        controller.effects.collect { effect ->
+            when (effect) {
+                UpdateInstallEffect.OpenUnknownAppsSettings ->
+                    settingsLauncher.launch(unknownSourcesIntent(context))
+                is UpdateInstallEffect.LaunchInstallConfirmation ->
+                    context.startActivity(effect.intent)
+            }
+        }
+    }
+
+    UpdateInstallDialog(state = state, onDismiss = controller::dismiss)
+}
+
+@Composable
+private fun UpdateInstallDialog(state: UpdateInstallState, onDismiss: () -> Unit) {
+    val message = state.messageRes() ?: return
+    val dismissible = state.isDismissible()
+    AlertDialog(
+        onDismissRequest = { if (dismissible) onDismiss() },
+        properties = DialogProperties(
+            dismissOnBackPress = dismissible,
+            dismissOnClickOutside = dismissible,
+        ),
+        title = { Text(stringResource(R.string.update_install_title)) },
+        text = {
+            when (state) {
+                is UpdateInstallState.Downloading -> DownloadProgress(state)
+                else -> Text(stringResource(message))
+            }
+        },
+        confirmButton = {
+            if (dismissible) {
+                TextButton(onClick = onDismiss) { Text(stringResource(R.string.update_dismiss)) }
+            }
+        },
+    )
+}
+
+@Composable
+private fun DownloadProgress(state: UpdateInstallState.Downloading) {
+    if (state.totalBytes > 0) {
+        LinearProgressIndicator(progress = { state.bytesRead.toFloat() / state.totalBytes })
+    } else {
+        LinearProgressIndicator()
+    }
+}
+
+private fun unknownSourcesIntent(context: Context): Intent =
+    Intent(
+        Settings.ACTION_MANAGE_UNKNOWN_APP_SOURCES,
+        Uri.parse("package:${context.packageName}"),
+    )
+
+private fun UpdateInstallState.messageRes(): Int? = when (this) {
+    is UpdateInstallState.Downloading -> R.string.update_downloading
+    UpdateInstallState.Verifying -> R.string.update_verifying
+    UpdateInstallState.NeedsUnknownAppsPermission -> R.string.update_permission_needed
+    UpdateInstallState.Installing -> R.string.update_installing
+    is UpdateInstallState.Failed -> reason.messageRes()
+    UpdateInstallState.Idle,
+    UpdateInstallState.Success,
+    UpdateInstallState.Cancelled,
+    -> null
+}
+
+private fun InstallFailure.messageRes(): Int = when (this) {
+    InstallFailure.DOWNLOAD_FAILED -> R.string.update_failed_download
+    InstallFailure.INTEGRITY_CHECK_FAILED -> R.string.update_failed_integrity
+    InstallFailure.INSTALL_REJECTED -> R.string.update_failed_rejected
+    InstallFailure.UNKNOWN -> R.string.update_failed_unknown
+}
+
+private fun UpdateInstallState.isDismissible(): Boolean = this is UpdateInstallState.Failed

--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/update/UpdateInstallState.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/update/UpdateInstallState.kt
@@ -1,0 +1,42 @@
+package com.riox432.civitdeck.ui.update
+
+import android.content.Intent
+
+/**
+ * Persistent UI state for the Android in-app self-update flow.
+ *
+ * Installation crosses Activity/process boundaries (unknown-sources settings, the system install
+ * confirmation, and the [android.content.pm.PackageInstaller] result broadcast), so it is modelled
+ * as a state machine rather than a single suspend call. One-shot, Activity-bound actions are
+ * delivered separately via [UpdateInstallEffect].
+ */
+sealed interface UpdateInstallState {
+    data object Idle : UpdateInstallState
+    data class Downloading(val bytesRead: Long, val totalBytes: Long) : UpdateInstallState
+    data object Verifying : UpdateInstallState
+    data object NeedsUnknownAppsPermission : UpdateInstallState
+    data object Installing : UpdateInstallState
+    data object Success : UpdateInstallState
+    data class Failed(val reason: InstallFailure) : UpdateInstallState
+    data object Cancelled : UpdateInstallState
+}
+
+/** Reasons an install attempt can fail, mapped to a user-facing message at the UI layer. */
+enum class InstallFailure {
+    DOWNLOAD_FAILED,
+    INTEGRITY_CHECK_FAILED,
+    INSTALL_REJECTED,
+    UNKNOWN,
+}
+
+/**
+ * One-shot, Activity-bound side effects. The host Composable owns the launchers/Activity context and
+ * executes these; the controller never holds an Activity reference.
+ */
+sealed interface UpdateInstallEffect {
+    /** Route the user to the per-source "install unknown apps" settings screen. */
+    data object OpenUnknownAppsSettings : UpdateInstallEffect
+
+    /** Launch the system install confirmation dialog returned by PackageInstaller. */
+    data class LaunchInstallConfirmation(val intent: Intent) : UpdateInstallEffect
+}

--- a/androidApp/src/main/res/values/strings.xml
+++ b/androidApp/src/main/res/values/strings.xml
@@ -338,6 +338,17 @@
     <string name="update_dismiss">Dismiss</string>
     <string name="update_download">Download</string>
 
+    <!-- In-app update install -->
+    <string name="update_install_title">Updating CivitDeck</string>
+    <string name="update_downloading">Downloading update…</string>
+    <string name="update_verifying">Verifying update…</string>
+    <string name="update_permission_needed">Allow CivitDeck to install apps to continue.</string>
+    <string name="update_installing">Installing…</string>
+    <string name="update_failed_download">Download failed. Check your connection and try again.</string>
+    <string name="update_failed_integrity">The downloaded update could not be verified and was discarded.</string>
+    <string name="update_failed_rejected">Installation was blocked or could not be completed.</string>
+    <string name="update_failed_unknown">Something went wrong during the update.</string>
+
     <!-- ComfyUI -->
     <string name="comfyui_title">ComfyUI</string>
     <string name="comfyui_open_txt2img">Open txt2img Generator</string>


### PR DESCRIPTION
Closes #967

## Summary
Replaces the dead-end Android update flow (which only opened the GitHub release **web page**, forcing the browser to be the install source) with a proper **in-app self-update** using the platform-native `PackageInstaller` Session API. The repository already computed the direct `.apk` URL (`UpdateResult.downloadUrl`) but the UI never used it — now the "Download" button downloads, verifies, and installs the APK with CivitDeck itself as the install source.

Scope is **Android only**; Desktop/iOS are unchanged. No `commonMain` / shared-VM changes.

## Approach (researched + Codex-reviewed)
Per the design review, the Activity-bound install flow is kept out of `core-domain` (no `expect/actual` `AppInstaller`) — the shared `UpdateViewModel` stays discovery-only. New Android-local pieces in `androidApp/.../ui/update/`:

- **`ApkInstaller`** — downloads the APK to app-private cache (`HttpURLConnection`, no new dependency), integrity-verifies it, and commits a `PackageInstaller.Session` (`MODE_FULL_INSTALL`).
- **`UpdateInstallController`** — state machine (`Idle/Downloading/Verifying/NeedsUnknownAppsPermission/Installing/Success/Failed/Cancelled`) + one-shot effects; folds the `PackageInstaller` `IntentSender` broadcast (runtime receiver, `RECEIVER_NOT_EXPORTED`) back into state. No Activity reference.
- **`UpdateInstallHost`** — owns the Activity-bound mechanics: launches `ACTION_MANAGE_UNKNOWN_APP_SOURCES` (re-checks permission on return) and the system install confirmation; renders the progress/error dialog.

Manifest: adds `REQUEST_INSTALL_PACKAGES` (Play policy is inapplicable — GitHub-only distribution). `release.yml` now publishes a `*.apk.sha256` checksum asset.

## Integrity / security
- Verifies the downloaded APK's **package name** matches and its **signing certificate set matches** the running app (defends against a swapped APK even if release metadata were tampered with).
- Accepts APK Signature Scheme **key rotation** (single-signer lineage) to avoid false negatives.
- Rejects **downgrades / equal builds** (`longVersionCode` check).

## Codex review applied
- Block back/outside dismissal of the dialog mid-install (was unregistering the receiver and dropping the terminal `STATUS_*`).
- Re-throw `CancellationException` (no longer mis-reported as a download failure); download runs under `runInterruptible(Dispatchers.IO)` so it's cancellation-cooperative.
- Handle `trySend` failure for the confirmation effect.
- Added version-code downgrade check + key-rotation lineage acceptance.

## Verification
- `./gradlew :androidApp:assembleDebug` — green
- `./gradlew detekt` (root, all modules) — green
- No shared/feature/core/iOS/Desktop modules touched, so their CI jobs are unaffected.

## Notes / follow-ups
- The published `*.apk.sha256` asset is not yet consumed at install time — the signing-cert check is the stronger primary gate; wiring optional checksum verification through `UpdateResult` is a possible follow-up.
- Silent self-update is intentionally not attempted (not reliable for a normal sideloaded app); each install shows the system confirmation, as expected for GitHub-Releases distribution.
