### PR TITLE
Set up iOS localization infrastructure and externalize hardcoded strings

### DIFF
--- a/iosApp/iosApp.xcodeproj/project.pbxproj
+++ b/iosApp/iosApp.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		058557BB273AAA24004C7B11 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 058557BA273AAA24004C7B11 /* Assets.xcassets */; };
 		058557D9273AAEEB004C7B11 /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 058557D8273AAEEB004C7B11 /* Preview Assets.xcassets */; };
+		058557E1273AAEEB004C7B11 /* Localizable.xcstrings in Resources */ = {isa = PBXBuildFile; fileRef = 058557E0273AAEEB004C7B11 /* Localizable.xcstrings */; };
 		2152FB042600AC8F00CF470E /* iOSApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2152FB032600AC8F00CF470E /* iOSApp.swift */; };
 		CDML01012800001000CD001 /* SigLIP2Embedder.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDML01002800001000CD001 /* SigLIP2Embedder.swift */; };
 		CD0001012D000001000CD001 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD0001002D000001000CD001 /* ContentView.swift */; };
@@ -189,6 +190,7 @@
 /* Begin PBXFileReference section */
 		058557BA273AAA24004C7B11 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		058557D8273AAEEB004C7B11 /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
+		058557E0273AAEEB004C7B11 /* Localizable.xcstrings */ = {isa = PBXFileReference; lastKnownFileType = text.json.xcstrings; path = Localizable.xcstrings; sourceTree = "<group>"; };
 		2152FB032600AC8F00CF470E /* iOSApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = iOSApp.swift; sourceTree = "<group>"; };
 		CDML01002800001000CD001 /* SigLIP2Embedder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SigLIP2Embedder.swift; sourceTree = "<group>"; };
 		7555FF7B242A565900829871 /* CivitDeck.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = CivitDeck.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -421,6 +423,7 @@
 			isa = PBXGroup;
 			children = (
 				058557BA273AAA24004C7B11 /* Assets.xcassets */,
+				058557E0273AAEEB004C7B11 /* Localizable.xcstrings */,
 				7555FF8C242A565B00829871 /* Info.plist */,
 				2152FB032600AC8F00CF470E /* iOSApp.swift */,
 				CD0001002D000001000CD001 /* ContentView.swift */,
@@ -955,6 +958,7 @@
 			files = (
 				058557D9273AAEEB004C7B11 /* Preview Assets.xcassets in Resources */,
 				058557BB273AAA24004C7B11 /* Assets.xcassets in Resources */,
+				058557E1273AAEEB004C7B11 /* Localizable.xcstrings in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/iosApp/iosApp/DesignSystem/NsfwBlurView.swift
+++ b/iosApp/iosApp/DesignSystem/NsfwBlurView.swift
@@ -18,14 +18,14 @@ struct NsfwBlurView<Content: View>: View {
                 Color.clear
                     .contentShape(Rectangle())
                     .accessibilityAddTraits(.isButton)
-                    .accessibilityLabel("Show content")
+                    .accessibilityLabel(Text("nsfw_show_content_accessibility"))
                     .onTapGesture {
                         withAnimation(MotionAnimation.standard) {
                             isRevealed = true
                         }
                     }
                     .overlay {
-                        Text("Tap to reveal")
+                        Text("nsfw_tap_to_reveal")
                             .font(.civitLabelMedium)
                             .foregroundColor(.civitOnSurface.opacity(0.7))
                     }

--- a/iosApp/iosApp/Features/Settings/SettingsScreen.swift
+++ b/iosApp/iosApp/Features/Settings/SettingsScreen.swift
@@ -37,14 +37,14 @@ struct SettingsScreen: View {
                 aboutSection
                 if !appBehaviorState.powerUserMode {
                     Section {
-                        Text("Enable Power User Mode in Advanced & Integrations for more features")
+                        Text("settings_power_user_hint")
                             .font(.civitBodySmall)
                             .foregroundColor(.civitOnSurfaceVariant)
                             .lineLimit(3)
                     }
                 }
             }
-            .navigationTitle("Settings")
+            .navigationTitle("settings_title")
             .navigationBarTitleDisplayMode(.inline)
         }
     }
@@ -52,7 +52,7 @@ struct SettingsScreen: View {
     private var offlineBanner: some View {
         HStack {
             Spacer()
-            Text("You are offline — showing cached data")
+            Text("settings_offline_banner")
                 .font(.civitBodySmall)
                 .foregroundColor(.civitOnErrorContainer)
             Spacer()
@@ -61,7 +61,7 @@ struct SettingsScreen: View {
     }
 
     private func accountSection(authState: AuthSettingsUiState) -> some View {
-        Section("Account") {
+        Section("settings_section_account") {
             if let username = authState.connectedUsername, authState.apiKey != nil {
                 ConnectedAccountRow(username: username, onClear: vmStore.auth.onClearApiKey)
             } else {
@@ -77,15 +77,15 @@ struct SettingsScreen: View {
     private var appearanceSection: some View {
         Section {
             NavigationLink(destination: AppearanceSettingsView(viewModel: vmStore.display)) {
-                Text("Appearance")
+                Text("settings_appearance")
             }
         }
     }
 
     private var notificationsSection: some View {
-        Section("Notifications") {
+        Section("settings_section_notifications") {
             NavigationLink(destination: NotificationCenterView()) {
-                Label("Model Updates", systemImage: "bell")
+                Label("settings_model_updates", systemImage: "bell")
             }
         }
     }
@@ -97,15 +97,15 @@ struct SettingsScreen: View {
                 displayViewModel: vmStore.display,
                 appBehaviorViewModel: vmStore.appBehavior
             )) {
-                Text("Content & Behavior")
+                Text("settings_content_behavior")
             }
         }
     }
 
     private var historySection: some View {
-        Section("History") {
+        Section("settings_section_history") {
             NavigationLink(destination: BrowsingHistoryView()) {
-                Label("Browsing History", systemImage: "clock.arrow.circlepath")
+                Label("settings_browsing_history", systemImage: "clock.arrow.circlepath")
             }
         }
     }
@@ -113,7 +113,7 @@ struct SettingsScreen: View {
     private var dataStorageSection: some View {
         Section {
             NavigationLink(destination: StorageSettingsView(viewModel: vmStore.storage)) {
-                Text("Data & Storage")
+                Text("settings_data_storage")
             }
         }
     }
@@ -124,42 +124,42 @@ struct SettingsScreen: View {
                 viewModel: vmStore.appBehavior,
                 displayViewModel: vmStore.display
             )) {
-                Text("Advanced & Integrations")
+                Text("settings_advanced_integrations")
             }
         }
     }
 
     private var analyticsSection: some View {
-        Section("Analytics") {
+        Section("settings_section_analytics") {
             NavigationLink(destination: AnalyticsView()) {
-                Label("Usage Stats", systemImage: "chart.bar.xaxis")
+                Label("settings_usage_stats", systemImage: "chart.bar.xaxis")
             }
         }
     }
 
     private var datasetsSection: some View {
-        Section("Training") {
+        Section("settings_section_training") {
             NavigationLink(destination: DatasetListView()) {
-                Label("Datasets", systemImage: "photo.on.rectangle.angled")
+                Label("settings_datasets", systemImage: "photo.on.rectangle.angled")
             }
         }
     }
 
     private var aboutSection: some View {
-        Section("About") {
+        Section("settings_section_about") {
             HStack {
-                Text("App Version")
+                Text("settings_app_version")
                 Spacer()
                 Text(Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "1.0.0")
                     .foregroundColor(.civitOnSurfaceVariant)
             }
-            NavigationLink("Open Source Licenses") {
+            NavigationLink("settings_open_source_licenses") {
                 LicensesView()
             }
             Button {
                 vmStore.replayGestureTutorial()
             } label: {
-                Text("Replay Gesture Tutorial")
+                Text("settings_replay_gesture_tutorial")
                     .foregroundColor(.civitOnSurface)
             }
         }
@@ -174,21 +174,21 @@ private struct ConnectedAccountRow: View {
     var body: some View {
         HStack {
             VStack(alignment: .leading, spacing: Spacing.xs) {
-                Text("Connected as")
+                Text("settings_connected_as")
                     .font(.civitBodySmall)
                     .foregroundColor(.civitOnSurfaceVariant)
                 Text(username)
                     .font(.civitBodyMedium)
             }
             Spacer()
-            Button("Disconnect") { showConfirmation = true }
+            Button("settings_disconnect") { showConfirmation = true }
                 .foregroundColor(.civitError)
         }
-        .alert("Disconnect", isPresented: $showConfirmation) {
-            Button("Cancel", role: .cancel) {}
-            Button("Remove", role: .destructive) { onClear() }
+        .alert("settings_disconnect", isPresented: $showConfirmation) {
+            Button("action_cancel", role: .cancel) {}
+            Button("action_remove", role: .destructive) { onClear() }
         } message: {
-            Text("Remove your CivitAI API key?")
+            Text("settings_disconnect_confirm_message")
         }
     }
 }
@@ -202,12 +202,12 @@ private struct ApiKeyInputRow: View {
     var body: some View {
         VStack(alignment: .leading, spacing: Spacing.sm) {
             HStack {
-                SecureField("Paste API key", text: $keyInput)
+                SecureField("settings_api_key_placeholder", text: $keyInput)
                     .textContentType(.password)
                 if isValidating {
                     ProgressView()
                 } else {
-                    Button("Verify") {
+                    Button("settings_api_key_verify") {
                         onValidateAndSave(keyInput)
                         keyInput = ""
                     }
@@ -219,7 +219,7 @@ private struct ApiKeyInputRow: View {
                     .font(.civitBodySmall)
                     .foregroundColor(.civitError)
             }
-            Text("Get your key at civitai.com/user/account")
+            Text("settings_api_key_help")
                 .font(.civitBodySmall)
                 .foregroundColor(.civitOnSurfaceVariant)
         }

--- a/iosApp/iosApp/Localizable.xcstrings
+++ b/iosApp/iosApp/Localizable.xcstrings
@@ -1,0 +1,336 @@
+{
+  "sourceLanguage" : "en",
+  "strings" : {
+    "nsfw_tap_to_reveal" : {
+      "comment" : "Label shown over blurred NSFW content prompting the user to tap to reveal it",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tap to reveal"
+          }
+        }
+      }
+    },
+    "nsfw_show_content_accessibility" : {
+      "comment" : "Accessibility label for the tappable area that reveals blurred content",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Show content"
+          }
+        }
+      }
+    },
+    "settings_title" : {
+      "comment" : "Navigation title for the Settings screen",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Settings"
+          }
+        }
+      }
+    },
+    "settings_power_user_hint" : {
+      "comment" : "Hint shown when Power User Mode is disabled",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Enable Power User Mode in Advanced & Integrations for more features"
+          }
+        }
+      }
+    },
+    "settings_offline_banner" : {
+      "comment" : "Banner shown when the device is offline and cached data is displayed",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "You are offline — showing cached data"
+          }
+        }
+      }
+    },
+    "settings_section_account" : {
+      "comment" : "Settings section header for account",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Account"
+          }
+        }
+      }
+    },
+    "settings_appearance" : {
+      "comment" : "Settings row title for appearance",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Appearance"
+          }
+        }
+      }
+    },
+    "settings_section_notifications" : {
+      "comment" : "Settings section header for notifications",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Notifications"
+          }
+        }
+      }
+    },
+    "settings_model_updates" : {
+      "comment" : "Settings row title for model update notifications",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Model Updates"
+          }
+        }
+      }
+    },
+    "settings_content_behavior" : {
+      "comment" : "Settings row title for content and behavior",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Content & Behavior"
+          }
+        }
+      }
+    },
+    "settings_section_history" : {
+      "comment" : "Settings section header for history",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "History"
+          }
+        }
+      }
+    },
+    "settings_browsing_history" : {
+      "comment" : "Settings row title for browsing history",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Browsing History"
+          }
+        }
+      }
+    },
+    "settings_data_storage" : {
+      "comment" : "Settings row title for data and storage",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Data & Storage"
+          }
+        }
+      }
+    },
+    "settings_advanced_integrations" : {
+      "comment" : "Settings row title for advanced and integrations",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Advanced & Integrations"
+          }
+        }
+      }
+    },
+    "settings_section_analytics" : {
+      "comment" : "Settings section header for analytics",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Analytics"
+          }
+        }
+      }
+    },
+    "settings_usage_stats" : {
+      "comment" : "Settings row title for usage statistics",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Usage Stats"
+          }
+        }
+      }
+    },
+    "settings_section_training" : {
+      "comment" : "Settings section header for training",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Training"
+          }
+        }
+      }
+    },
+    "settings_datasets" : {
+      "comment" : "Settings row title for datasets",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Datasets"
+          }
+        }
+      }
+    },
+    "settings_section_about" : {
+      "comment" : "Settings section header for about",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "About"
+          }
+        }
+      }
+    },
+    "settings_app_version" : {
+      "comment" : "Settings row label for the app version",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "App Version"
+          }
+        }
+      }
+    },
+    "settings_open_source_licenses" : {
+      "comment" : "Settings row title for open source licenses",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Open Source Licenses"
+          }
+        }
+      }
+    },
+    "settings_replay_gesture_tutorial" : {
+      "comment" : "Settings button to replay the gesture tutorial",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Replay Gesture Tutorial"
+          }
+        }
+      }
+    },
+    "settings_connected_as" : {
+      "comment" : "Label above the connected account username",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Connected as"
+          }
+        }
+      }
+    },
+    "settings_disconnect" : {
+      "comment" : "Button to disconnect the connected account",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Disconnect"
+          }
+        }
+      }
+    },
+    "settings_disconnect_confirm_message" : {
+      "comment" : "Confirmation message asking whether to remove the saved API key",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Remove your CivitAI API key?"
+          }
+        }
+      }
+    },
+    "action_cancel" : {
+      "comment" : "Generic cancel button",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cancel"
+          }
+        }
+      }
+    },
+    "action_remove" : {
+      "comment" : "Generic remove button",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Remove"
+          }
+        }
+      }
+    },
+    "settings_api_key_placeholder" : {
+      "comment" : "Placeholder for the API key input field",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Paste API key"
+          }
+        }
+      }
+    },
+    "settings_api_key_verify" : {
+      "comment" : "Button to validate and save the API key",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Verify"
+          }
+        }
+      }
+    },
+    "settings_api_key_help" : {
+      "comment" : "Helper text guiding the user to where they can get their API key",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Get your key at civitai.com/user/account"
+          }
+        }
+      }
+    }
+  },
+  "version" : "1.0"
+}


### PR DESCRIPTION
Closes #932

## Summary
The iOS app had **no localization infrastructure** (no String Catalog / `Localizable.strings` / `NSLocalizedString`), which is why the iOS portion of #932 was left open after the Android portion shipped in #961. This PR sets up the modern iOS L10n infra and externalizes the hardcoded user-facing strings called out in the issue, plus the rest of the strings on the same screens.

## L10n approach
- **`Localizable.xcstrings` (Xcode String Catalog)**, `sourceLanguage: "en"`. This is the modern format for iOS 16+ and is fully supported by `xcodebuild` (Xcode 15+; CI uses Xcode 26).
- Keys are `snake_case` and descriptive per `.claude/rules/l10n-conventions.md`; base language is English.
- SwiftUI references resolve via `LocalizedStringKey` for `Text(...)` / `Section(...)` / `Label(...)` / `Button(...)` / `NavigationLink(...)` / `navigationTitle(...)` / `SecureField(...)` string literals, and via `Text(key)` for `accessibilityLabel(...)`.
- Verified the design with **Codex MCP** before implementing: confirmed `.xcstrings` over legacy `.strings`, xcodebuild CLI support, snake_case key resolution through `LocalizedStringKey`, and the exact pbxproj wiring (file goes in **Resources**, not Sources).

## pbxproj wiring
`Localizable.xcstrings` added with all 4 required entries: `PBXBuildFile`, `PBXFileReference` (`lastKnownFileType = text.json.xcstrings`), group `children`, and `PBXResourcesBuildPhase`. Confirmed the catalog compiles into `CivitDeck.app/en.lproj/Localizable.strings` at build time.

## Strings externalized (30 keys)
**`NsfwBlurView.swift`**
- `:28` "Tap to reveal" → `nsfw_tap_to_reveal`
- `:21` "Show content" (accessibility) → `nsfw_show_content_accessibility`

**`SettingsScreen.swift`** (issue-listed lines + full screen sweep)
- `:40` power-user hint → `settings_power_user_hint`
- `:47` "Settings" (nav title) → `settings_title`
- `:55` offline banner → `settings_offline_banner`
- `:64`/`:80`/`:100`/`:116`/`:127` section/row titles → `settings_section_account`, `settings_appearance`, `settings_content_behavior`, `settings_data_storage`, `settings_advanced_integrations`
- `:86`/`:88` notifications → `settings_section_notifications`, `settings_model_updates`
- `:106`/`:108` history → `settings_section_history`, `settings_browsing_history`
- `:133`/`:135` analytics → `settings_section_analytics`, `settings_usage_stats`
- `:141`/`:143` training → `settings_section_training`, `settings_datasets`
- `:149`/`:151`/`:156`/`:162` about → `settings_section_about`, `settings_app_version`, `settings_open_source_licenses`, `settings_replay_gesture_tutorial`
- ConnectedAccountRow: `settings_connected_as`, `settings_disconnect`, `settings_disconnect_confirm_message`, `action_cancel`, `action_remove`
- ApiKeyInputRow: `settings_api_key_placeholder`, `settings_api_key_verify`, `settings_api_key_help`

## Verification
- `swiftlint --strict`: **pass** (exit 0)
- Local iOS build (`xcodebuild ... ARCHS=arm64 ONLY_ACTIVE_ARCH=NO`): **BUILD SUCCEEDED**
- Confirmed String Catalog bundled into `en.lproj/Localizable.strings`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GthFqjnJ65YWkmujQh47r4