### PR TITLE
Split oversized composables and ViewModels (tech debt)

### DIFF
--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/comfyui/ComfyUIAddConnectionDialog.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/comfyui/ComfyUIAddConnectionDialog.kt
@@ -27,7 +27,6 @@ import com.riox432.civitdeck.ui.theme.Spacing
 private const val TOPIC_ID_LENGTH = 8
 
 @Composable
-@Suppress("LongMethod")
 internal fun AddConnectionDialog(
     editing: ComfyUIConnection?,
     onSave: (
@@ -82,24 +81,56 @@ internal fun AddConnectionDialog(
             )
         },
         confirmButton = {
-            TextButton(
-                onClick = {
-                    val port = portText.toIntOrNull() ?: ComfyUIConnection.DEFAULT_COMFYUI_PORT
-                    onSave(
-                        name.ifBlank { hostname },
-                        hostname,
-                        port,
-                        useHttps,
-                        acceptSelfSigned,
-                        ntfyServerUrl.ifBlank { null },
-                        ntfyTopic.ifBlank { null },
-                    )
-                },
-                enabled = hostname.isNotBlank(),
-            ) { Text(stringResource(R.string.action_save)) }
+            AddConnectionConfirmButton(
+                name = name,
+                hostname = hostname,
+                portText = portText,
+                useHttps = useHttps,
+                acceptSelfSigned = acceptSelfSigned,
+                ntfyServerUrl = ntfyServerUrl,
+                ntfyTopic = ntfyTopic,
+                onSave = onSave,
+            )
         },
         dismissButton = { TextButton(onClick = onDismiss) { Text(stringResource(R.string.action_cancel)) } },
     )
+}
+
+@Composable
+@Suppress("LongParameterList")
+private fun AddConnectionConfirmButton(
+    name: String,
+    hostname: String,
+    portText: String,
+    useHttps: Boolean,
+    acceptSelfSigned: Boolean,
+    ntfyServerUrl: String,
+    ntfyTopic: String,
+    onSave: (
+        name: String,
+        hostname: String,
+        port: Int,
+        useHttps: Boolean,
+        acceptSelfSigned: Boolean,
+        ntfyServerUrl: String?,
+        ntfyTopic: String?,
+    ) -> Unit,
+) {
+    TextButton(
+        onClick = {
+            val port = portText.toIntOrNull() ?: ComfyUIConnection.DEFAULT_COMFYUI_PORT
+            onSave(
+                name.ifBlank { hostname },
+                hostname,
+                port,
+                useHttps,
+                acceptSelfSigned,
+                ntfyServerUrl.ifBlank { null },
+                ntfyTopic.ifBlank { null },
+            )
+        },
+        enabled = hostname.isNotBlank(),
+    ) { Text(stringResource(R.string.action_save)) }
 }
 
 @Composable

--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/dataset/DatasetDetailScreen.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/dataset/DatasetDetailScreen.kt
@@ -110,7 +110,7 @@ fun DatasetDetailScreen(
     )
 }
 
-@Suppress("LongParameterList", "LongMethod")
+@Suppress("LongParameterList")
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 private fun DatasetDetailScaffold(
@@ -187,6 +187,32 @@ private fun DatasetDetailScaffold(
         onTrainableToggle = { id, trainable -> viewModel.updateTrainable(id, trainable) },
         onDismissDetail = viewModel::dismissDetail,
     )
+    DatasetExportOverlays(
+        showExportSheet = showExportSheet,
+        exportProgress = exportProgress,
+        allImages = allImages,
+        availableExportFormats = availableExportFormats,
+        selectedExportFormatId = selectedExportFormatId,
+        onDismissExport = onDismissExport,
+        onExportFormatSelected = onExportFormatSelected,
+        onStartExport = onStartExport,
+        onDismissExportResult = onDismissExportResult,
+    )
+}
+
+@Suppress("LongParameterList")
+@Composable
+private fun DatasetExportOverlays(
+    showExportSheet: Boolean,
+    exportProgress: ExportProgress?,
+    allImages: List<DatasetImage>,
+    availableExportFormats: List<PluginExportFormat>,
+    selectedExportFormatId: String?,
+    onDismissExport: () -> Unit,
+    onExportFormatSelected: (String) -> Unit,
+    onStartExport: (String) -> Unit,
+    onDismissExportResult: () -> Unit,
+) {
     if (showExportSheet) {
         val trainableCount = allImages.count { it.trainable && !it.excluded }
         val nonTrainableCount = allImages.size - trainableCount

--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/detail/ModelDetailScreen.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/detail/ModelDetailScreen.kt
@@ -52,7 +52,7 @@ import com.riox432.civitdeck.ui.qrcode.QRCodeSheet
 import com.riox432.civitdeck.ui.share.SocialShareSheet
 
 @Composable
-@Suppress("LongParameterList", "LongMethod")
+@Suppress("LongParameterList")
 fun ModelDetailScreen(
     viewModel: ModelDetailViewModel,
     modelId: Long,
@@ -84,31 +84,17 @@ fun ModelDetailScreen(
     var showSubmitReviewSheet by remember { mutableStateOf(false) }
     var showShareSheet by remember { mutableStateOf(false) }
     val haptic = rememberHapticFeedback()
-    val context = LocalContext.current
 
-    LaunchedEffect(Unit) {
-        viewModel.downloadEnqueuedEvent.collect { downloadId ->
-            DownloadScheduler.enqueue(context, downloadId)
-        }
-    }
+    DownloadEnqueueEffect(viewModel)
 
-    val detailCallbacks = remember(viewModel, onViewImages, onCreatorClick, onTryInComfyUI) {
-        ModelDetailCallbacks(
-            onRetry = viewModel::retry,
-            onVersionSelected = viewModel::onVersionSelected,
-            onViewImages = onViewImages,
-            onCreatorClick = onCreatorClick,
-            onTryInComfyUI = onTryInComfyUI,
-            onSendToPC = { showSendToPCSheet = true },
-            onSaveNote = viewModel::saveNote,
-            onAddTag = viewModel::addTag,
-            onRemoveTag = viewModel::removeTag,
-            onDownloadFile = viewModel::downloadFile,
-            onCancelDownload = viewModel::cancelDownload,
-            onReviewSortChanged = viewModel::onReviewSortChanged,
-            onWriteReview = { showSubmitReviewSheet = true },
-        )
-    }
+    val detailCallbacks = rememberModelDetailCallbacks(
+        viewModel = viewModel,
+        onViewImages = onViewImages,
+        onCreatorClick = onCreatorClick,
+        onTryInComfyUI = onTryInComfyUI,
+        onSendToPC = { showSendToPCSheet = true },
+        onWriteReview = { showSubmitReviewSheet = true },
+    )
 
     ModelDetailScaffold(
         uiState = uiState,
@@ -125,36 +111,130 @@ fun ModelDetailScreen(
         onFindSimilar = onFindSimilar,
     )
 
+    ModelDetailOverlays(
+        uiState = uiState,
+        viewModel = viewModel,
+        modelId = modelId,
+        collections = collections,
+        modelCollectionIds = modelCollectionIds,
+        sheetVisibility = ModelDetailSheetVisibility(
+            showSubmitReviewSheet = showSubmitReviewSheet,
+            showSendToPCSheet = showSendToPCSheet,
+            showCollectionSheet = showCollectionSheet,
+            showQRCodeSheet = showQRCodeSheet,
+            showShareSheet = showShareSheet,
+        ),
+        onDismissSubmitReview = { showSubmitReviewSheet = false },
+        onDismissSendToPC = { showSendToPCSheet = false },
+        onDismissCollection = { showCollectionSheet = false },
+        onDismissQRCode = { showQRCodeSheet = false },
+        onDismissShare = { showShareSheet = false },
+        shareHashtags = shareHashtags,
+        onToggleShareHashtag = onToggleShareHashtag,
+        onAddShareHashtag = onAddShareHashtag,
+        onRemoveShareHashtag = onRemoveShareHashtag,
+    )
+}
+
+private data class ModelDetailSheetVisibility(
+    val showSubmitReviewSheet: Boolean,
+    val showSendToPCSheet: Boolean,
+    val showCollectionSheet: Boolean,
+    val showQRCodeSheet: Boolean,
+    val showShareSheet: Boolean,
+)
+
+@Suppress("LongParameterList")
+@Composable
+private fun ModelDetailOverlays(
+    uiState: ModelDetailUiState,
+    viewModel: ModelDetailViewModel,
+    modelId: Long,
+    collections: List<com.riox432.civitdeck.domain.model.ModelCollection>,
+    modelCollectionIds: List<Long>,
+    sheetVisibility: ModelDetailSheetVisibility,
+    onDismissSubmitReview: () -> Unit,
+    onDismissSendToPC: () -> Unit,
+    onDismissCollection: () -> Unit,
+    onDismissQRCode: () -> Unit,
+    onDismissShare: () -> Unit,
+    shareHashtags: List<ShareHashtag>,
+    onToggleShareHashtag: (String, Boolean) -> Unit,
+    onAddShareHashtag: (String) -> Unit,
+    onRemoveShareHashtag: (String) -> Unit,
+) {
     ReviewSubmitHandler(
         uiState = uiState,
         viewModel = viewModel,
-        showSubmitReviewSheet = showSubmitReviewSheet,
-        onDismissSubmitReview = { showSubmitReviewSheet = false },
+        showSubmitReviewSheet = sheetVisibility.showSubmitReviewSheet,
+        onDismissSubmitReview = onDismissSubmitReview,
     )
 
     ModelDetailSheets(
-        showSendToPCSheet = showSendToPCSheet,
-        onDismissSendToPC = { showSendToPCSheet = false },
+        showSendToPCSheet = sheetVisibility.showSendToPCSheet,
+        onDismissSendToPC = onDismissSendToPC,
         uiState = uiState,
-        showCollectionSheet = showCollectionSheet,
-        onDismissCollection = { showCollectionSheet = false },
+        showCollectionSheet = sheetVisibility.showCollectionSheet,
+        onDismissCollection = onDismissCollection,
         collections = collections,
         modelCollectionIds = modelCollectionIds,
         viewModel = viewModel,
-        showQRCodeSheet = showQRCodeSheet,
-        onDismissQRCode = { showQRCodeSheet = false },
+        showQRCodeSheet = sheetVisibility.showQRCodeSheet,
+        onDismissQRCode = onDismissQRCode,
         modelId = modelId,
     )
 
-    if (showShareSheet) {
+    if (sheetVisibility.showShareSheet) {
         SocialShareSheet(
             hashtags = shareHashtags,
             onToggleHashtag = onToggleShareHashtag,
             onAddHashtag = onAddShareHashtag,
             onRemoveHashtag = onRemoveShareHashtag,
-            onDismiss = { showShareSheet = false },
+            onDismiss = onDismissShare,
         )
     }
+}
+
+@Composable
+private fun DownloadEnqueueEffect(viewModel: ModelDetailViewModel) {
+    val context = LocalContext.current
+    LaunchedEffect(Unit) {
+        viewModel.downloadEnqueuedEvent.collect { downloadId ->
+            DownloadScheduler.enqueue(context, downloadId)
+        }
+    }
+}
+
+@Composable
+private fun rememberModelDetailCallbacks(
+    viewModel: ModelDetailViewModel,
+    onViewImages: (Long) -> Unit,
+    onCreatorClick: (String) -> Unit,
+    onTryInComfyUI: (
+        (
+            sha256: String,
+            modelName: String,
+            meta: com.riox432.civitdeck.domain.model.ImageGenerationMeta?
+        ) -> Unit
+    )?,
+    onSendToPC: () -> Unit,
+    onWriteReview: () -> Unit,
+): ModelDetailCallbacks = remember(viewModel, onViewImages, onCreatorClick, onTryInComfyUI) {
+    ModelDetailCallbacks(
+        onRetry = viewModel::retry,
+        onVersionSelected = viewModel::onVersionSelected,
+        onViewImages = onViewImages,
+        onCreatorClick = onCreatorClick,
+        onTryInComfyUI = onTryInComfyUI,
+        onSendToPC = onSendToPC,
+        onSaveNote = viewModel::saveNote,
+        onAddTag = viewModel::addTag,
+        onRemoveTag = viewModel::removeTag,
+        onDownloadFile = viewModel::downloadFile,
+        onCancelDownload = viewModel::cancelDownload,
+        onReviewSortChanged = viewModel::onReviewSortChanged,
+        onWriteReview = onWriteReview,
+    )
 }
 
 @Suppress("LongParameterList")

--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/navigation/CivitDeckNavGraph.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/navigation/CivitDeckNavGraph.kt
@@ -44,6 +44,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.navigation3.rememberViewModelStoreNavEntryDecorator
+import androidx.navigation3.runtime.EntryProviderScope
 import androidx.navigation3.runtime.entryProvider
 import androidx.navigation3.runtime.rememberSaveableStateHolderNavEntryDecorator
 import androidx.navigation3.ui.NavDisplay
@@ -318,29 +319,15 @@ private fun CivitDeckNavDisplay(
         transitionSpec = { slideTransition(enterOffset = { it / 4 }, exitOffset = { -it / 4 }) },
         popTransitionSpec = { slideTransition(enterOffset = { -it / 4 }, exitOffset = { it / 4 }) },
         entryProvider = entryProvider {
-            entry<SearchRoute> {
-                ModelSearchScreen(
-                    viewModel = searchViewModel,
-                    callbacks = SearchScreenCallbacks(
-                        onModelClick = { modelId, thumbnailUrl, suffix ->
-                            val cmpId = compareModelId
-                            if (cmpId != null) {
-                                backStack.add(CompareRoute(cmpId, modelId))
-                                onCancelCompare()
-                            } else {
-                                backStack.add(DetailRoute(modelId, thumbnailUrl, suffix))
-                            }
-                        },
-                        onCancelCompare = onCancelCompare,
-                        onDiscoverClick = { backStack.add(DiscoveryRoute) },
-                        onCompareModel = onCompareModel,
-                        onScanQRCode = { backStack.add(QRScannerRoute) },
-                        onTextSearch = { backStack.add(TextSearchRoute) },
-                    ),
-                    scrollToTopTrigger = searchScrollTrigger,
-                    compareModelName = compareModelName,
-                )
-            }
+            searchEntry(
+                backStack = backStack,
+                searchViewModel = searchViewModel,
+                searchScrollTrigger = searchScrollTrigger,
+                compareModelId = compareModelId,
+                compareModelName = compareModelName,
+                onCompareModel = onCompareModel,
+                onCancelCompare = onCancelCompare,
+            )
             createHubEntry(backStack)
             collectionsEntry(backStack)
             collectionDetailEntry(backStack, compareModelId, onCancelCompare)
@@ -362,34 +349,76 @@ private fun CivitDeckNavDisplay(
             compareEntry(backStack)
             discoveryEntry(backStack)
             browseImagesEntry(backStack)
-            entry<SettingsRoute> {
-                val authVm: AuthSettingsViewModel = koinViewModel()
-                val storageVm: StorageSettingsViewModel = koinViewModel()
-                val behaviorVm: AppBehaviorSettingsViewModel = koinViewModel()
-                val updateVm: UpdateViewModel = koinViewModel()
-                val gestureTutorialVm: com.riox432.civitdeck.feature.gallery.presentation.GestureTutorialViewModel =
-                    koinViewModel()
-                SettingsScreen(
-                    authViewModel = authVm,
-                    storageViewModel = storageVm,
-                    appBehaviorViewModel = behaviorVm,
-                    updateViewModel = updateVm,
-                    onNavigateToAppearance = { backStack.add(AppearanceSettingsRoute) },
-                    onNavigateToContentFilter = { backStack.add(ContentFilterSettingsRoute) },
-                    onNavigateToStorage = { backStack.add(StorageSettingsRoute) },
-                    onNavigateToAdvanced = { backStack.add(AdvancedSettingsRoute) },
-                    onNavigateToAnalytics = { backStack.add(AnalyticsRoute) },
-                    onNavigateToNotificationCenter = { backStack.add(NotificationCenterRoute) },
-                    onNavigateToBrowsingHistory = { backStack.add(BrowsingHistoryRoute) },
-                    onNavigateToDownloadQueue = { backStack.add(DownloadQueueRoute) },
-                    onNavigateToLicenses = { backStack.add(LicensesRoute) },
-                    onReplayGestureTutorial = gestureTutorialVm::resetTutorial,
-                    scrollToTopTrigger = settingsScrollTrigger,
-                )
-            }
+            settingsEntry(backStack, settingsScrollTrigger)
             settingsSubScreenEntries(backStack)
             comfyUIEntries(backStack)
             externalServerEntries(backStack)
         },
     )
+}
+
+@Suppress("LongParameterList")
+private fun EntryProviderScope<Any>.searchEntry(
+    backStack: MutableList<Any>,
+    searchViewModel: ModelSearchViewModel,
+    searchScrollTrigger: Int,
+    compareModelId: Long?,
+    compareModelName: String?,
+    onCompareModel: (Long, String) -> Unit,
+    onCancelCompare: () -> Unit,
+) {
+    entry<SearchRoute> {
+        ModelSearchScreen(
+            viewModel = searchViewModel,
+            callbacks = SearchScreenCallbacks(
+                onModelClick = { modelId, thumbnailUrl, suffix ->
+                    val cmpId = compareModelId
+                    if (cmpId != null) {
+                        backStack.add(CompareRoute(cmpId, modelId))
+                        onCancelCompare()
+                    } else {
+                        backStack.add(DetailRoute(modelId, thumbnailUrl, suffix))
+                    }
+                },
+                onCancelCompare = onCancelCompare,
+                onDiscoverClick = { backStack.add(DiscoveryRoute) },
+                onCompareModel = onCompareModel,
+                onScanQRCode = { backStack.add(QRScannerRoute) },
+                onTextSearch = { backStack.add(TextSearchRoute) },
+            ),
+            scrollToTopTrigger = searchScrollTrigger,
+            compareModelName = compareModelName,
+        )
+    }
+}
+
+private fun EntryProviderScope<Any>.settingsEntry(
+    backStack: MutableList<Any>,
+    settingsScrollTrigger: Int,
+) {
+    entry<SettingsRoute> {
+        val authVm: AuthSettingsViewModel = koinViewModel()
+        val storageVm: StorageSettingsViewModel = koinViewModel()
+        val behaviorVm: AppBehaviorSettingsViewModel = koinViewModel()
+        val updateVm: UpdateViewModel = koinViewModel()
+        val gestureTutorialVm: com.riox432.civitdeck.feature.gallery.presentation.GestureTutorialViewModel =
+            koinViewModel()
+        SettingsScreen(
+            authViewModel = authVm,
+            storageViewModel = storageVm,
+            appBehaviorViewModel = behaviorVm,
+            updateViewModel = updateVm,
+            onNavigateToAppearance = { backStack.add(AppearanceSettingsRoute) },
+            onNavigateToContentFilter = { backStack.add(ContentFilterSettingsRoute) },
+            onNavigateToStorage = { backStack.add(StorageSettingsRoute) },
+            onNavigateToAdvanced = { backStack.add(AdvancedSettingsRoute) },
+            onNavigateToAnalytics = { backStack.add(AnalyticsRoute) },
+            onNavigateToNotificationCenter = { backStack.add(NotificationCenterRoute) },
+            onNavigateToBrowsingHistory = { backStack.add(BrowsingHistoryRoute) },
+            onNavigateToDownloadQueue = { backStack.add(DownloadQueueRoute) },
+            onNavigateToLicenses = { backStack.add(LicensesRoute) },
+            onReplayGestureTutorial = gestureTutorialVm::resetTutorial,
+            scrollToTopTrigger = settingsScrollTrigger,
+        )
+    }
 }

--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/navigation/CivitDeckNavGraph.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/navigation/CivitDeckNavGraph.kt
@@ -125,7 +125,41 @@ private class TabState(
     }
 }
 
-@Suppress("LongMethod")
+private class NavTabStates(
+    val fixed: Map<String, TabState>,
+    val shortcut: Map<String, TabState>,
+)
+
+@Composable
+private fun rememberNavTabStates(): NavTabStates = remember {
+    NavTabStates(
+        fixed = mapOf(
+            Tab.Discover.name to TabState(mutableStateListOf<Any>(SearchRoute)),
+            Tab.Create.name to TabState(mutableStateListOf<Any>(CreateHubRoute)),
+            Tab.Library.name to TabState(mutableStateListOf<Any>(CollectionsRoute)),
+            Tab.Settings.name to TabState(mutableStateListOf<Any>(SettingsRoute)),
+        ),
+        shortcut = mapOf(
+            NavShortcut.OutputGallery.name to TabState(mutableStateListOf<Any>(ComfyUIHistoryRoute)),
+            NavShortcut.Generate.name to TabState(mutableStateListOf<Any>(ComfyUIGenerationRoute)),
+            NavShortcut.ImageGallery.name to TabState(mutableStateListOf<Any>(BrowseImagesRoute)),
+            NavShortcut.ExternalServerGallery.name to TabState(mutableStateListOf<Any>(ExternalServerGalleryRoute)),
+        ),
+    )
+}
+
+@Composable
+private fun rememberNavLayoutType(): NavigationSuiteType {
+    val adaptiveInfo = currentWindowAdaptiveInfo()
+    return if (
+        adaptiveInfo.windowSizeClass.isWidthAtLeastBreakpoint(WIDTH_DP_EXPANDED_LOWER_BOUND)
+    ) {
+        NavigationSuiteType.NavigationDrawer
+    } else {
+        NavigationSuiteScaffoldDefaults.calculateFromAdaptiveInfo(adaptiveInfo)
+    }
+}
+
 @OptIn(ExperimentalSharedTransitionApi::class)
 @Composable
 internal fun CivitDeckNavGraph(initialTab: Tab = Tab.Discover) {
@@ -137,23 +171,9 @@ internal fun CivitDeckNavGraph(initialTab: Tab = Tab.Discover) {
 
     var selectedTabId by rememberSaveable { mutableStateOf(initialTab.name) }
 
-    val fixedTabStates = remember {
-        mapOf(
-            Tab.Discover.name to TabState(mutableStateListOf<Any>(SearchRoute)),
-            Tab.Create.name to TabState(mutableStateListOf<Any>(CreateHubRoute)),
-            Tab.Library.name to TabState(mutableStateListOf<Any>(CollectionsRoute)),
-            Tab.Settings.name to TabState(mutableStateListOf<Any>(SettingsRoute)),
-        )
-    }
-
-    val shortcutTabStates = remember {
-        mapOf(
-            NavShortcut.OutputGallery.name to TabState(mutableStateListOf<Any>(ComfyUIHistoryRoute)),
-            NavShortcut.Generate.name to TabState(mutableStateListOf<Any>(ComfyUIGenerationRoute)),
-            NavShortcut.ImageGallery.name to TabState(mutableStateListOf<Any>(BrowseImagesRoute)),
-            NavShortcut.ExternalServerGallery.name to TabState(mutableStateListOf<Any>(ExternalServerGalleryRoute)),
-        )
-    }
+    val tabStates = rememberNavTabStates()
+    val fixedTabStates = tabStates.fixed
+    val shortcutTabStates = tabStates.shortcut
 
     val activeShortcuts = if (behaviorState.powerUserMode) displayState.customNavShortcuts else emptyList()
 
@@ -175,61 +195,94 @@ internal fun CivitDeckNavGraph(initialTab: Tab = Tab.Discover) {
     var compareModelId by rememberSaveable { mutableStateOf<Long?>(null) }
     var compareModelName by rememberSaveable { mutableStateOf<String?>(null) }
 
-    val adaptiveInfo = currentWindowAdaptiveInfo()
-    val navLayoutType = if (
-        adaptiveInfo.windowSizeClass.isWidthAtLeastBreakpoint(WIDTH_DP_EXPANDED_LOWER_BOUND)
-    ) {
-        NavigationSuiteType.NavigationDrawer
-    } else {
-        NavigationSuiteScaffoldDefaults.calculateFromAdaptiveInfo(adaptiveInfo)
-    }
-
     NavigationSuiteScaffold(
-        layoutType = navLayoutType,
+        layoutType = rememberNavLayoutType(),
         navigationSuiteItems = {
-            navItems.forEach { navItem ->
-                val info = navItemInfoFor(navItem) ?: return@forEach
-                val selected = info.id == selectedTabId
-                item(
-                    selected = selected,
-                    onClick = {
-                        if (info.id == selectedTabId) {
-                            (fixedTabStates[info.id] ?: shortcutTabStates[info.id])?.onReselected()
-                        } else {
-                            selectedTabId = info.id
-                        }
-                    },
-                    icon = {
-                        Icon(
-                            imageVector = if (selected) info.activeIcon else info.inactiveIcon,
-                            contentDescription = info.label,
-                        )
-                    },
-                    label = { Text(info.label) },
-                )
-            }
+            navSuiteItems(
+                navItems = navItems,
+                selectedTabId = selectedTabId,
+                fixedTabStates = fixedTabStates,
+                shortcutTabStates = shortcutTabStates,
+                onSelectTab = { selectedTabId = it },
+            )
         },
     ) {
-        Scaffold { padding ->
-            SharedTransitionLayout(modifier = Modifier.padding(padding)) {
-                CompositionLocalProvider(LocalSharedTransitionScope provides this) {
-                    CivitDeckNavDisplay(
-                        backStack = activeBackStack,
-                        searchViewModel = searchViewModel,
-                        searchScrollTrigger = fixedTabStates.getValue(Tab.Discover.name).scrollTrigger,
-                        settingsScrollTrigger = fixedTabStates.getValue(Tab.Settings.name).scrollTrigger,
-                        compareModelId = compareModelId,
-                        compareModelName = compareModelName,
-                        onCompareModel = { id, name ->
-                            compareModelId = id
-                            compareModelName = name
-                        },
-                        onCancelCompare = {
-                            compareModelId = null
-                            compareModelName = null
-                        },
-                    )
+        CivitDeckTabContent(
+            activeBackStack = activeBackStack,
+            searchViewModel = searchViewModel,
+            searchScrollTrigger = fixedTabStates.getValue(Tab.Discover.name).scrollTrigger,
+            settingsScrollTrigger = fixedTabStates.getValue(Tab.Settings.name).scrollTrigger,
+            compareModelId = compareModelId,
+            compareModelName = compareModelName,
+            onCompareModel = { id, name ->
+                compareModelId = id
+                compareModelName = name
+            },
+            onCancelCompare = {
+                compareModelId = null
+                compareModelName = null
+            },
+        )
+    }
+}
+
+@Suppress("LongParameterList")
+private fun androidx.compose.material3.adaptive.navigationsuite.NavigationSuiteScope.navSuiteItems(
+    navItems: List<Any>,
+    selectedTabId: String,
+    fixedTabStates: Map<String, TabState>,
+    shortcutTabStates: Map<String, TabState>,
+    onSelectTab: (String) -> Unit,
+) {
+    navItems.forEach { navItem ->
+        val info = navItemInfoFor(navItem) ?: return@forEach
+        val selected = info.id == selectedTabId
+        item(
+            selected = selected,
+            onClick = {
+                if (info.id == selectedTabId) {
+                    (fixedTabStates[info.id] ?: shortcutTabStates[info.id])?.onReselected()
+                } else {
+                    onSelectTab(info.id)
                 }
+            },
+            icon = {
+                Icon(
+                    imageVector = if (selected) info.activeIcon else info.inactiveIcon,
+                    contentDescription = info.label,
+                )
+            },
+            label = { Text(info.label) },
+        )
+    }
+}
+
+@OptIn(ExperimentalSharedTransitionApi::class)
+@Suppress("LongParameterList")
+@Composable
+private fun CivitDeckTabContent(
+    activeBackStack: MutableList<Any>,
+    searchViewModel: ModelSearchViewModel,
+    searchScrollTrigger: Int,
+    settingsScrollTrigger: Int,
+    compareModelId: Long?,
+    compareModelName: String?,
+    onCompareModel: (Long, String) -> Unit,
+    onCancelCompare: () -> Unit,
+) {
+    Scaffold { padding ->
+        SharedTransitionLayout(modifier = Modifier.padding(padding)) {
+            CompositionLocalProvider(LocalSharedTransitionScope provides this) {
+                CivitDeckNavDisplay(
+                    backStack = activeBackStack,
+                    searchViewModel = searchViewModel,
+                    searchScrollTrigger = searchScrollTrigger,
+                    settingsScrollTrigger = settingsScrollTrigger,
+                    compareModelId = compareModelId,
+                    compareModelName = compareModelName,
+                    onCompareModel = onCompareModel,
+                    onCancelCompare = onCancelCompare,
+                )
             }
         }
     }
@@ -243,7 +296,7 @@ private fun slideTransition(enterOffset: (Int) -> Int, exitOffset: (Int) -> Int)
             fadeOut(tween(Duration.normal, easing = Easing.standard)),
     )
 
-@Suppress("LongParameterList", "LongMethod", "UnusedParameter")
+@Suppress("LongParameterList", "UnusedParameter")
 @Composable
 private fun CivitDeckNavDisplay(
     backStack: MutableList<Any>,

--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/search/ModelSearchScreen.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/search/ModelSearchScreen.kt
@@ -115,7 +115,7 @@ fun ModelSearchScreen(
     )
 }
 
-@Suppress("LongParameterList", "LongMethod")
+@Suppress("LongParameterList")
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 private fun SearchScreenBody(
@@ -147,6 +147,67 @@ private fun SearchScreenBody(
         }
     }
 
+    SearchScreenContentBox(
+        padding = padding,
+        layoutDirection = layoutDirection,
+        density = density,
+        headerState = headerState,
+        uiState = uiState,
+        searchHistory = searchHistory,
+        gridState = gridState,
+        viewModel = viewModel,
+        gridColumns = gridColumns,
+        compareModelName = compareModelName,
+        ownedHashes = ownedHashes,
+        favoriteIds = favoriteIds,
+        callbacks = callbacks,
+        onToggleFavorite = onToggleFavorite,
+        isFabVisible = isFabVisible,
+        activeFilterCount = activeFilterCount,
+        onShowFilterSheet = { showFilterSheet = true },
+    )
+
+    SearchScreenSheets(
+        uiState = uiState,
+        viewModel = viewModel,
+        savedFilters = savedFilters,
+        showFilterSheet = showFilterSheet,
+        showSavedFiltersSheet = showSavedFiltersSheet,
+        showSaveDialog = showSaveDialog,
+        saveFilterName = saveFilterName,
+        onSaveFilterNameChange = { saveFilterName = it },
+        onDismissFilterSheet = { showFilterSheet = false },
+        onShowSavedFilters = { showSavedFiltersSheet = true },
+        onShowSaveDialog = { showSaveDialog = true },
+        onDismissSavedFilters = { showSavedFiltersSheet = false },
+        onDismissSaveDialog = {
+            showSaveDialog = false
+            saveFilterName = ""
+        },
+    )
+}
+
+@Suppress("LongParameterList")
+@Composable
+private fun SearchScreenContentBox(
+    padding: androidx.compose.foundation.layout.PaddingValues,
+    layoutDirection: androidx.compose.ui.unit.LayoutDirection,
+    density: androidx.compose.ui.unit.Density,
+    headerState: CollapsibleHeaderState,
+    uiState: com.riox432.civitdeck.feature.search.presentation.ModelSearchUiState,
+    searchHistory: List<String>,
+    gridState: androidx.compose.foundation.lazy.grid.LazyGridState,
+    viewModel: ModelSearchViewModel,
+    gridColumns: Int,
+    compareModelName: String?,
+    ownedHashes: Set<String>,
+    favoriteIds: Set<Long>,
+    callbacks: SearchScreenCallbacks,
+    onToggleFavorite: (com.riox432.civitdeck.domain.model.Model) -> Unit,
+    isFabVisible: Boolean,
+    activeFilterCount: Int,
+    onShowFilterSheet: () -> Unit,
+) {
     Box(
         modifier = Modifier
             .fillMaxSize()
@@ -199,7 +260,7 @@ private fun SearchScreenBody(
         SpeedDialFab(
             visible = isFabVisible,
             activeFilterCount = activeFilterCount,
-            onFilterClick = { showFilterSheet = true },
+            onFilterClick = onShowFilterSheet,
             onDiscoverClick = callbacks.onDiscoverClick,
             onScanQRCode = callbacks.onScanQRCode,
             onTextSearch = if (BuildConfig.FEATURE_SIMILARITY_SEARCH) callbacks.onTextSearch else null,
@@ -214,13 +275,31 @@ private fun SearchScreenBody(
             modifier = Modifier.align(Alignment.BottomCenter),
         )
     }
+}
 
+@Suppress("LongParameterList")
+@Composable
+private fun SearchScreenSheets(
+    uiState: com.riox432.civitdeck.feature.search.presentation.ModelSearchUiState,
+    viewModel: ModelSearchViewModel,
+    savedFilters: List<com.riox432.civitdeck.domain.model.SavedSearchFilter>,
+    showFilterSheet: Boolean,
+    showSavedFiltersSheet: Boolean,
+    showSaveDialog: Boolean,
+    saveFilterName: String,
+    onSaveFilterNameChange: (String) -> Unit,
+    onDismissFilterSheet: () -> Unit,
+    onShowSavedFilters: () -> Unit,
+    onShowSaveDialog: () -> Unit,
+    onDismissSavedFilters: () -> Unit,
+    onDismissSaveDialog: () -> Unit,
+) {
     if (showFilterSheet) {
         FilterBottomSheet(
             uiState = uiState,
-            onDismiss = { showFilterSheet = false },
-            onShowSavedFilters = { showSavedFiltersSheet = true },
-            onSaveFilter = { showSaveDialog = true },
+            onDismiss = onDismissFilterSheet,
+            onShowSavedFilters = onShowSavedFilters,
+            onSaveFilter = onShowSaveDialog,
             onResetFilters = viewModel::resetFilters,
             filterCallbacks = FilterCallbacks(
                 onTypeSelected = viewModel::onTypeSelected,
@@ -242,27 +321,23 @@ private fun SearchScreenBody(
             savedFilters = savedFilters,
             onApply = { filter ->
                 viewModel.applyFilter(filter)
-                showFilterSheet = false
+                onDismissFilterSheet()
             },
             onDelete = viewModel::deleteSavedFilter,
-            onDismiss = { showSavedFiltersSheet = false },
+            onDismiss = onDismissSavedFilters,
         )
     }
     if (showSaveDialog) {
         SaveFilterDialog(
             filterName = saveFilterName,
-            onFilterNameChange = { saveFilterName = it },
+            onFilterNameChange = onSaveFilterNameChange,
             onConfirm = {
                 if (saveFilterName.isNotBlank()) {
                     viewModel.saveCurrentFilter(saveFilterName.trim())
                 }
-                showSaveDialog = false
-                saveFilterName = ""
+                onDismissSaveDialog()
             },
-            onDismiss = {
-                showSaveDialog = false
-                saveFilterName = ""
-            },
+            onDismiss = onDismissSaveDialog,
         )
     }
 }

--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/search/ModelSearchScreen.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/search/ModelSearchScreen.kt
@@ -10,6 +10,7 @@ import androidx.compose.animation.slideInVertically
 import androidx.compose.animation.slideOutVertically
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxScope
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.WindowInsets
@@ -246,35 +247,61 @@ private fun SearchScreenContentBox(
             isComparing = compareModelName != null,
         )
 
-        CollapsibleHeader(
+        SearchScreenForeground(
             headerState = headerState,
-            query = uiState.query,
+            uiState = uiState,
             searchHistory = searchHistory,
-            onQueryChange = viewModel::onQueryChange,
-            onSearch = viewModel::onSearch,
-            onHistoryItemClick = viewModel::onHistoryItemClick,
-            onDeleteHistoryItem = viewModel::removeSearchHistoryItem,
-            onClearHistory = viewModel::clearSearchHistory,
-        )
-
-        SpeedDialFab(
-            visible = isFabVisible,
+            viewModel = viewModel,
+            callbacks = callbacks,
+            isFabVisible = isFabVisible,
             activeFilterCount = activeFilterCount,
-            onFilterClick = onShowFilterSheet,
-            onDiscoverClick = callbacks.onDiscoverClick,
-            onScanQRCode = callbacks.onScanQRCode,
-            onTextSearch = if (BuildConfig.FEATURE_SIMILARITY_SEARCH) callbacks.onTextSearch else null,
-            modifier = Modifier
-                .align(Alignment.BottomEnd)
-                .padding(Spacing.lg),
-        )
-
-        ComparisonBottomBar(
             compareModelName = compareModelName,
-            onCancel = callbacks.onCancelCompare,
-            modifier = Modifier.align(Alignment.BottomCenter),
+            onShowFilterSheet = onShowFilterSheet,
         )
     }
+}
+
+@Suppress("LongParameterList")
+@Composable
+private fun BoxScope.SearchScreenForeground(
+    headerState: CollapsibleHeaderState,
+    uiState: com.riox432.civitdeck.feature.search.presentation.ModelSearchUiState,
+    searchHistory: List<String>,
+    viewModel: ModelSearchViewModel,
+    callbacks: SearchScreenCallbacks,
+    isFabVisible: Boolean,
+    activeFilterCount: Int,
+    compareModelName: String?,
+    onShowFilterSheet: () -> Unit,
+) {
+    CollapsibleHeader(
+        headerState = headerState,
+        query = uiState.query,
+        searchHistory = searchHistory,
+        onQueryChange = viewModel::onQueryChange,
+        onSearch = viewModel::onSearch,
+        onHistoryItemClick = viewModel::onHistoryItemClick,
+        onDeleteHistoryItem = viewModel::removeSearchHistoryItem,
+        onClearHistory = viewModel::clearSearchHistory,
+    )
+
+    SpeedDialFab(
+        visible = isFabVisible,
+        activeFilterCount = activeFilterCount,
+        onFilterClick = onShowFilterSheet,
+        onDiscoverClick = callbacks.onDiscoverClick,
+        onScanQRCode = callbacks.onScanQRCode,
+        onTextSearch = if (BuildConfig.FEATURE_SIMILARITY_SEARCH) callbacks.onTextSearch else null,
+        modifier = Modifier
+            .align(Alignment.BottomEnd)
+            .padding(Spacing.lg),
+    )
+
+    ComparisonBottomBar(
+        compareModelName = compareModelName,
+        onCancel = callbacks.onCancelCompare,
+        modifier = Modifier.align(Alignment.BottomCenter),
+    )
 }
 
 @Suppress("LongParameterList")

--- a/core/core-database/src/commonMain/kotlin/com/riox432/civitdeck/data/local/migrations/Migrations1to10.kt
+++ b/core/core-database/src/commonMain/kotlin/com/riox432/civitdeck/data/local/migrations/Migrations1to10.kt
@@ -99,7 +99,6 @@ val MIGRATION_5_6 = object : Migration(5, 6) {
     }
 }
 
-@Suppress("LongMethod")
 val MIGRATION_6_7 = object : Migration(6, 7) {
     override fun migrate(connection: SQLiteConnection) {
         // Create collections table
@@ -163,7 +162,6 @@ val MIGRATION_7_8 = object : Migration(7, 8) {
     }
 }
 
-@Suppress("LongMethod")
 val MIGRATION_8_9 = object : Migration(8, 9) {
     override fun migrate(connection: SQLiteConnection) {
         connection.execSQL(

--- a/core/core-database/src/commonMain/kotlin/com/riox432/civitdeck/data/local/migrations/SeedData.kt
+++ b/core/core-database/src/commonMain/kotlin/com/riox432/civitdeck/data/local/migrations/SeedData.kt
@@ -22,7 +22,6 @@ internal val defaultCollectionCallback = object : RoomDatabase.Callback() {
     }
 }
 
-@Suppress("LongMethod")
 private fun seedBuiltInTemplates(connection: SQLiteConnection) {
     // INSERT OR IGNORE guarantees idempotency: rows with the same negative IDs are silently
     // skipped if they already exist, so this function is safe to call on every app open.

--- a/core/core-domain/src/commonMain/kotlin/com/riox432/civitdeck/domain/usecase/CheckModelUpdatesUseCase.kt
+++ b/core/core-domain/src/commonMain/kotlin/com/riox432/civitdeck/domain/usecase/CheckModelUpdatesUseCase.kt
@@ -59,7 +59,6 @@ class CheckModelUpdatesUseCase(
         )
     }
 
-    @Suppress("LongMethod")
     private suspend fun checkModels(
         modelIds: Set<Long>,
         source: UpdateSource,

--- a/desktopApp/src/jvmMain/kotlin/com/riox432/civitdeck/DesktopApp.kt
+++ b/desktopApp/src/jvmMain/kotlin/com/riox432/civitdeck/DesktopApp.kt
@@ -58,7 +58,6 @@ enum class DesktopTab(
     Settings("Settings", Icons.Default.Settings),
 }
 
-@Suppress("LongMethod")
 @Composable
 fun DesktopApp(
     onScreenChanged: (String) -> Unit = {},
@@ -77,69 +76,94 @@ fun DesktopApp(
         accentColor = displayState.accentColor,
         amoledDarkMode = displayState.amoledDarkMode,
     ) {
-        var selectedTab by remember { mutableStateOf(DesktopTab.Discover) }
-        val backstack = remember {
-            androidx.compose.runtime.mutableStateListOf<DesktopRoute>()
-        }
+        DesktopAppScaffold(onScreenChanged = onScreenChanged)
+    }
+}
 
-        LaunchedEffect(selectedTab) {
-            onScreenChanged(selectedTab.label)
-        }
-        val searchFocusRequester = remember { FocusRequester() }
-        val isMac = remember {
-            System.getProperty("os.name").lowercase().contains("mac")
-        }
-        val focusManager = LocalFocusManager.current
+@Composable
+private fun DesktopAppScaffold(
+    onScreenChanged: (String) -> Unit,
+) {
+    var selectedTab by remember { mutableStateOf(DesktopTab.Discover) }
+    val backstack = remember {
+        androidx.compose.runtime.mutableStateListOf<DesktopRoute>()
+    }
 
-        Surface(
-            color = MaterialTheme.colorScheme.background,
-            modifier = Modifier.onPreviewKeyEvent { event ->
-                if (event.type != KeyEventType.KeyDown) return@onPreviewKeyEvent false
+    LaunchedEffect(selectedTab) {
+        onScreenChanged(selectedTab.label)
+    }
+    val searchFocusRequester = remember { FocusRequester() }
+    val isMac = remember {
+        System.getProperty("os.name").lowercase().contains("mac")
+    }
+    val focusManager = LocalFocusManager.current
 
-                // Tab / Shift+Tab -> move focus between interactive elements
-                if (event.key == Key.Tab) {
-                    if (event.isShiftPressed) {
-                        focusManager.moveFocus(FocusDirection.Previous)
-                    } else {
-                        focusManager.moveFocus(FocusDirection.Next)
-                    }
-                    return@onPreviewKeyEvent true
-                }
-
-                val hasModifier = if (isMac) event.isMetaPressed else event.isCtrlPressed
-                handleKeyboardShortcut(
-                    key = event.key,
-                    hasModifier = hasModifier,
-                    onTabSelected = {
-                        selectedTab = it
-                        backstack.clear()
-                    },
-                    onBack = { backstack.removeLastOrNull() },
-                    onFocusSearch = {
-                        selectedTab = DesktopTab.Discover
-                        backstack.clear()
-                        searchFocusRequester.requestFocus()
-                    },
-                )
-            },
-        ) {
-            Row(modifier = Modifier.fillMaxSize()) {
-                DesktopNavigationRail(
-                    selectedTab = selectedTab,
-                    onTabSelected = {
-                        selectedTab = it
-                        backstack.clear()
-                    },
-                )
-                DesktopContent(
-                    selectedTab = selectedTab,
-                    backstack = backstack,
-                    searchFocusRequester = searchFocusRequester,
-                    modifier = Modifier.weight(1f).fillMaxHeight(),
-                )
-            }
+    Surface(
+        color = MaterialTheme.colorScheme.background,
+        modifier = Modifier.onPreviewKeyEvent { event ->
+            handleAppKeyEvent(
+                event = event,
+                isMac = isMac,
+                focusManager = focusManager,
+                onTabSelected = {
+                    selectedTab = it
+                    backstack.clear()
+                },
+                onBack = { backstack.removeLastOrNull() },
+                onFocusSearch = {
+                    selectedTab = DesktopTab.Discover
+                    backstack.clear()
+                    searchFocusRequester.requestFocus()
+                },
+            )
+        },
+    ) {
+        Row(modifier = Modifier.fillMaxSize()) {
+            DesktopNavigationRail(
+                selectedTab = selectedTab,
+                onTabSelected = {
+                    selectedTab = it
+                    backstack.clear()
+                },
+            )
+            DesktopContent(
+                selectedTab = selectedTab,
+                backstack = backstack,
+                searchFocusRequester = searchFocusRequester,
+                modifier = Modifier.weight(1f).fillMaxHeight(),
+            )
         }
     }
+}
+
+private fun handleAppKeyEvent(
+    event: androidx.compose.ui.input.key.KeyEvent,
+    isMac: Boolean,
+    focusManager: androidx.compose.ui.focus.FocusManager,
+    onTabSelected: (DesktopTab) -> Unit,
+    onBack: () -> Unit,
+    onFocusSearch: () -> Unit,
+): Boolean {
+    if (event.type != KeyEventType.KeyDown) return false
+
+    // Tab / Shift+Tab -> move focus between interactive elements
+    if (event.key == Key.Tab) {
+        if (event.isShiftPressed) {
+            focusManager.moveFocus(FocusDirection.Previous)
+        } else {
+            focusManager.moveFocus(FocusDirection.Next)
+        }
+        return true
+    }
+
+    val hasModifier = if (isMac) event.isMetaPressed else event.isCtrlPressed
+    return handleKeyboardShortcut(
+        key = event.key,
+        hasModifier = hasModifier,
+        onTabSelected = onTabSelected,
+        onBack = onBack,
+        onFocusSearch = onFocusSearch,
+    )
 }
 
 private fun handleKeyboardShortcut(

--- a/desktopApp/src/jvmMain/kotlin/com/riox432/civitdeck/Main.kt
+++ b/desktopApp/src/jvmMain/kotlin/com/riox432/civitdeck/Main.kt
@@ -1,5 +1,6 @@
 package com.riox432.civitdeck
 
+import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -34,37 +35,16 @@ import okio.Path.Companion.toPath
 import org.koin.mp.KoinPlatform
 import java.util.prefs.Preferences
 
-@Suppress("LongMethod")
 fun main() {
     initKoin {
         modules(desktopModule)
     }
     setupCoilImageLoader()
-    val applicationScope: ApplicationScope = KoinPlatform.getKoin().get()
-    applicationScope.launch {
-        registerWorkflowPlugins()
-        registerExportPlugins()
-        registerThemePlugins()
-    }
-    applicationScope.launch {
-        val cleanup: CleanupBrowsingHistoryUseCase = KoinPlatform.getKoin().get()
-        cleanup(System.currentTimeMillis())
-    }
+    startBackgroundTasks()
 
     application {
         val windowPrefs = remember { WindowPreferences.load() }
-        val windowState by remember {
-            mutableStateOf(
-                WindowState(
-                    size = DpSize(windowPrefs.width.dp, windowPrefs.height.dp),
-                    position = if (windowPrefs.x >= 0 && windowPrefs.y >= 0) {
-                        WindowPosition(windowPrefs.x.dp, windowPrefs.y.dp)
-                    } else {
-                        WindowPosition.PlatformDefault
-                    },
-                ),
-            )
-        }
+        val windowState by remember { mutableStateOf(createWindowState(windowPrefs)) }
 
         var currentScreen by remember { mutableStateOf("Discover") }
         val windowTitle = "CivitDeck — $currentScreen"
@@ -77,36 +57,10 @@ fun main() {
             title = windowTitle,
             state = windowState,
         ) {
-            MenuBar {
-                Menu("Edit") {
-                    Item("Cut", shortcut = KeyShortcut(Key.X, meta = true), onClick = {})
-                    Item("Copy", shortcut = KeyShortcut(Key.C, meta = true), onClick = {})
-                    Item("Paste", shortcut = KeyShortcut(Key.V, meta = true), onClick = {})
-                    Item("Select All", shortcut = KeyShortcut(Key.A, meta = true), onClick = {})
-                }
-                Menu("View") {
-                    Item(
-                        "Refresh",
-                        shortcut = KeyShortcut(Key.R, meta = true),
-                        onClick = { currentScreen = "Discover" },
-                    )
-                    Item(
-                        "Toggle Sidebar",
-                        shortcut = KeyShortcut(Key.Backslash, meta = true),
-                        onClick = {},
-                    )
-                }
-                Menu("Window") {
-                    Item(
-                        "Minimize",
-                        shortcut = KeyShortcut(Key.M, meta = true),
-                        onClick = { windowState.isMinimized = true },
-                    )
-                }
-                Menu("Help") {
-                    Item("About", onClick = {})
-                }
-            }
+            AppMenuBar(
+                onRefresh = { currentScreen = "Discover" },
+                onMinimize = { windowState.isMinimized = true },
+            )
             window.minimumSize = java.awt.Dimension(MIN_WINDOW_WIDTH, MIN_WINDOW_HEIGHT)
 
             DisposableEffect(Unit) {
@@ -122,6 +76,65 @@ fun main() {
             }
 
             DesktopApp(onScreenChanged = { currentScreen = it })
+        }
+    }
+}
+
+private fun startBackgroundTasks() {
+    val applicationScope: ApplicationScope = KoinPlatform.getKoin().get()
+    applicationScope.launch {
+        registerWorkflowPlugins()
+        registerExportPlugins()
+        registerThemePlugins()
+    }
+    applicationScope.launch {
+        val cleanup: CleanupBrowsingHistoryUseCase = KoinPlatform.getKoin().get()
+        cleanup(System.currentTimeMillis())
+    }
+}
+
+private fun createWindowState(windowPrefs: WindowPreferences): WindowState = WindowState(
+    size = DpSize(windowPrefs.width.dp, windowPrefs.height.dp),
+    position = if (windowPrefs.x >= 0 && windowPrefs.y >= 0) {
+        WindowPosition(windowPrefs.x.dp, windowPrefs.y.dp)
+    } else {
+        WindowPosition.PlatformDefault
+    },
+)
+
+@Composable
+private fun androidx.compose.ui.window.FrameWindowScope.AppMenuBar(
+    onRefresh: () -> Unit,
+    onMinimize: () -> Unit,
+) {
+    MenuBar {
+        Menu("Edit") {
+            Item("Cut", shortcut = KeyShortcut(Key.X, meta = true), onClick = {})
+            Item("Copy", shortcut = KeyShortcut(Key.C, meta = true), onClick = {})
+            Item("Paste", shortcut = KeyShortcut(Key.V, meta = true), onClick = {})
+            Item("Select All", shortcut = KeyShortcut(Key.A, meta = true), onClick = {})
+        }
+        Menu("View") {
+            Item(
+                "Refresh",
+                shortcut = KeyShortcut(Key.R, meta = true),
+                onClick = onRefresh,
+            )
+            Item(
+                "Toggle Sidebar",
+                shortcut = KeyShortcut(Key.Backslash, meta = true),
+                onClick = {},
+            )
+        }
+        Menu("Window") {
+            Item(
+                "Minimize",
+                shortcut = KeyShortcut(Key.M, meta = true),
+                onClick = onMinimize,
+            )
+        }
+        Menu("Help") {
+            Item("About", onClick = {})
         }
     }
 }

--- a/desktopApp/src/jvmMain/kotlin/com/riox432/civitdeck/ui/DiscoverTabContent.kt
+++ b/desktopApp/src/jvmMain/kotlin/com/riox432/civitdeck/ui/DiscoverTabContent.kt
@@ -153,27 +153,13 @@ private fun DiscoverBaseContent(
 }
 
 @Composable
-@Suppress("CyclomaticComplexMethod", "LongMethod")
+@Suppress("CyclomaticComplexMethod")
 private fun DiscoverOverlayContent(
     backstack: SnapshotStateList<DesktopRoute>,
     currentRoute: DesktopRoute?,
 ) {
     when (currentRoute) {
-        is DesktopRoute.ModelDetail -> {
-            val detailVm: ModelDetailViewModel = koinViewModel(
-                key = "detail_${currentRoute.modelId}",
-            ) { parametersOf(currentRoute.modelId) }
-            DesktopDetailScreen(
-                viewModel = detailVm,
-                onBack = { backstack.removeLastOrNull() },
-                onImageClick = { urls, index ->
-                    backstack.add(DesktopRoute.ImageViewer(urls, index))
-                },
-                onCreatorClick = { username ->
-                    backstack.add(DesktopRoute.CreatorProfile(username))
-                },
-            )
-        }
+        is DesktopRoute.ModelDetail -> DiscoverModelDetailOverlay(backstack, currentRoute)
         is DesktopRoute.ImageViewer -> {
             DesktopImageViewer(
                 imageUrls = currentRoute.imageUrls,
@@ -202,19 +188,45 @@ private fun DiscoverOverlayContent(
                 },
             )
         }
-        is DesktopRoute.ModelCompare -> {
-            val leftVm: ModelDetailViewModel = koinViewModel(
-                key = "compare_left_${currentRoute.leftModelId}",
-            ) { parametersOf(currentRoute.leftModelId) }
-            val rightVm: ModelDetailViewModel = koinViewModel(
-                key = "compare_right_${currentRoute.rightModelId}",
-            ) { parametersOf(currentRoute.rightModelId) }
-            DesktopCompareScreen(
-                leftViewModel = leftVm,
-                rightViewModel = rightVm,
-                onBack = { backstack.removeLastOrNull() },
-            )
-        }
+        is DesktopRoute.ModelCompare -> DiscoverModelCompareOverlay(backstack, currentRoute)
         else -> { /* Base content is shown */ }
     }
+}
+
+@Composable
+private fun DiscoverModelDetailOverlay(
+    backstack: SnapshotStateList<DesktopRoute>,
+    route: DesktopRoute.ModelDetail,
+) {
+    val detailVm: ModelDetailViewModel = koinViewModel(
+        key = "detail_${route.modelId}",
+    ) { parametersOf(route.modelId) }
+    DesktopDetailScreen(
+        viewModel = detailVm,
+        onBack = { backstack.removeLastOrNull() },
+        onImageClick = { urls, index ->
+            backstack.add(DesktopRoute.ImageViewer(urls, index))
+        },
+        onCreatorClick = { username ->
+            backstack.add(DesktopRoute.CreatorProfile(username))
+        },
+    )
+}
+
+@Composable
+private fun DiscoverModelCompareOverlay(
+    backstack: SnapshotStateList<DesktopRoute>,
+    route: DesktopRoute.ModelCompare,
+) {
+    val leftVm: ModelDetailViewModel = koinViewModel(
+        key = "compare_left_${route.leftModelId}",
+    ) { parametersOf(route.leftModelId) }
+    val rightVm: ModelDetailViewModel = koinViewModel(
+        key = "compare_right_${route.rightModelId}",
+    ) { parametersOf(route.rightModelId) }
+    DesktopCompareScreen(
+        leftViewModel = leftVm,
+        rightViewModel = rightVm,
+        onBack = { backstack.removeLastOrNull() },
+    )
 }

--- a/desktopApp/src/jvmMain/kotlin/com/riox432/civitdeck/ui/LibraryTabContent.kt
+++ b/desktopApp/src/jvmMain/kotlin/com/riox432/civitdeck/ui/LibraryTabContent.kt
@@ -136,25 +136,13 @@ private fun LibraryBaseContent(
 }
 
 @Composable
-@Suppress("CyclomaticComplexMethod", "LongMethod")
+@Suppress("CyclomaticComplexMethod")
 private fun LibraryOverlayContent(
     backstack: SnapshotStateList<DesktopRoute>,
     currentRoute: DesktopRoute?,
 ) {
     when (currentRoute) {
-        is DesktopRoute.CollectionDetail -> {
-            val detailVm: CollectionDetailViewModel = koinViewModel(
-                key = "collection_${currentRoute.collectionId}",
-            ) { parametersOf(currentRoute.collectionId) }
-            DesktopCollectionDetailScreen(
-                viewModel = detailVm,
-                collectionName = currentRoute.collectionName,
-                onBack = { backstack.removeLastOrNull() },
-                onModelClick = { modelId ->
-                    backstack.add(DesktopRoute.ModelDetail(modelId))
-                },
-            )
-        }
+        is DesktopRoute.CollectionDetail -> LibraryCollectionDetailOverlay(backstack, currentRoute)
         is DesktopRoute.DatasetDetail -> {
             val vm: DatasetDetailViewModel = koinViewModel(
                 key = "dataset_detail_${currentRoute.datasetId}",
@@ -165,21 +153,7 @@ private fun LibraryOverlayContent(
                 onBack = { backstack.removeLastOrNull() },
             )
         }
-        is DesktopRoute.ModelDetail -> {
-            val modelVm: ModelDetailViewModel = koinViewModel(
-                key = "detail_${currentRoute.modelId}",
-            ) { parametersOf(currentRoute.modelId) }
-            DesktopDetailScreen(
-                viewModel = modelVm,
-                onBack = { backstack.removeLastOrNull() },
-                onImageClick = { urls, index ->
-                    backstack.add(DesktopRoute.ImageViewer(urls, index))
-                },
-                onCreatorClick = { username ->
-                    backstack.add(DesktopRoute.CreatorProfile(username))
-                },
-            )
-        }
+        is DesktopRoute.ModelDetail -> LibraryModelDetailOverlay(backstack, currentRoute)
         is DesktopRoute.CreatorProfile -> {
             val creatorVm: CreatorProfileViewModel = koinViewModel(
                 key = "creator_${currentRoute.username}",
@@ -201,4 +175,42 @@ private fun LibraryOverlayContent(
         }
         else -> { /* Base section is shown */ }
     }
+}
+
+@Composable
+private fun LibraryCollectionDetailOverlay(
+    backstack: SnapshotStateList<DesktopRoute>,
+    route: DesktopRoute.CollectionDetail,
+) {
+    val detailVm: CollectionDetailViewModel = koinViewModel(
+        key = "collection_${route.collectionId}",
+    ) { parametersOf(route.collectionId) }
+    DesktopCollectionDetailScreen(
+        viewModel = detailVm,
+        collectionName = route.collectionName,
+        onBack = { backstack.removeLastOrNull() },
+        onModelClick = { modelId ->
+            backstack.add(DesktopRoute.ModelDetail(modelId))
+        },
+    )
+}
+
+@Composable
+private fun LibraryModelDetailOverlay(
+    backstack: SnapshotStateList<DesktopRoute>,
+    route: DesktopRoute.ModelDetail,
+) {
+    val modelVm: ModelDetailViewModel = koinViewModel(
+        key = "detail_${route.modelId}",
+    ) { parametersOf(route.modelId) }
+    DesktopDetailScreen(
+        viewModel = modelVm,
+        onBack = { backstack.removeLastOrNull() },
+        onImageClick = { urls, index ->
+            backstack.add(DesktopRoute.ImageViewer(urls, index))
+        },
+        onCreatorClick = { username ->
+            backstack.add(DesktopRoute.CreatorProfile(username))
+        },
+    )
 }

--- a/desktopApp/src/jvmMain/kotlin/com/riox432/civitdeck/ui/SettingsTabContent.kt
+++ b/desktopApp/src/jvmMain/kotlin/com/riox432/civitdeck/ui/SettingsTabContent.kt
@@ -97,7 +97,7 @@ private fun SettingsMainContent(
 }
 
 @Composable
-@Suppress("CyclomaticComplexMethod", "LongMethod")
+@Suppress("CyclomaticComplexMethod")
 private fun SettingsOverlayContent(
     backstack: SnapshotStateList<DesktopRoute>,
     currentRoute: DesktopRoute?,

--- a/desktopApp/src/jvmMain/kotlin/com/riox432/civitdeck/ui/SettingsTabContent.kt
+++ b/desktopApp/src/jvmMain/kotlin/com/riox432/civitdeck/ui/SettingsTabContent.kt
@@ -135,26 +135,8 @@ private fun SettingsOverlayContent(
                 onBack = { backstack.removeLastOrNull() },
             )
         }
-        is DesktopRoute.NotificationCenter -> {
-            val vm: NotificationCenterViewModel = koinViewModel()
-            DesktopNotificationCenterScreen(
-                viewModel = vm,
-                onBack = { backstack.removeLastOrNull() },
-                onModelClick = { modelId ->
-                    backstack.add(DesktopRoute.ModelDetail(modelId))
-                },
-            )
-        }
-        is DesktopRoute.BrowsingHistory -> {
-            val vm: BrowsingHistoryViewModel = koinViewModel()
-            DesktopBrowsingHistoryScreen(
-                viewModel = vm,
-                onBack = { backstack.removeLastOrNull() },
-                onModelClick = { modelId ->
-                    backstack.add(DesktopRoute.ModelDetail(modelId))
-                },
-            )
-        }
+        is DesktopRoute.NotificationCenter -> SettingsNotificationCenterOverlay(backstack)
+        is DesktopRoute.BrowsingHistory -> SettingsBrowsingHistoryOverlay(backstack)
         is DesktopRoute.DownloadQueue -> {
             val vm: DownloadQueueViewModel = koinViewModel()
             DesktopDownloadQueueScreen(
@@ -164,4 +146,32 @@ private fun SettingsOverlayContent(
         }
         else -> { /* Settings main screen is shown */ }
     }
+}
+
+@Composable
+private fun SettingsNotificationCenterOverlay(
+    backstack: SnapshotStateList<DesktopRoute>,
+) {
+    val vm: NotificationCenterViewModel = koinViewModel()
+    DesktopNotificationCenterScreen(
+        viewModel = vm,
+        onBack = { backstack.removeLastOrNull() },
+        onModelClick = { modelId ->
+            backstack.add(DesktopRoute.ModelDetail(modelId))
+        },
+    )
+}
+
+@Composable
+private fun SettingsBrowsingHistoryOverlay(
+    backstack: SnapshotStateList<DesktopRoute>,
+) {
+    val vm: BrowsingHistoryViewModel = koinViewModel()
+    DesktopBrowsingHistoryScreen(
+        viewModel = vm,
+        onBack = { backstack.removeLastOrNull() },
+        onModelClick = { modelId ->
+            backstack.add(DesktopRoute.ModelDetail(modelId))
+        },
+    )
 }

--- a/desktopApp/src/jvmMain/kotlin/com/riox432/civitdeck/ui/backup/DesktopBackupScreen.kt
+++ b/desktopApp/src/jvmMain/kotlin/com/riox432/civitdeck/ui/backup/DesktopBackupScreen.kt
@@ -120,7 +120,6 @@ private fun BackupToolbar(onBack: () -> Unit) {
     }
 }
 
-@Suppress("LongMethod")
 @Composable
 private fun BackupBody(
     state: BackupUiState,
@@ -147,62 +146,82 @@ private fun BackupBody(
             }
         }
         items(BackupCategory.entries.toList(), key = { it.name }) { category ->
-            Row(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(horizontal = Spacing.lg, vertical = Spacing.sm)
-                    .desktopFocusRing()
-                    .clickable(onClickLabel = "Toggle") { viewModel.onToggleCategory(category) },
-                verticalAlignment = Alignment.CenterVertically,
-            ) {
-                Checkbox(
-                    checked = category in state.selectedCategories,
-                    onCheckedChange = { viewModel.onToggleCategory(category) },
-                )
-                Text(
-                    text = category.displayName,
-                    style = MaterialTheme.typography.bodyLarge,
-                    modifier = Modifier.padding(start = Spacing.sm),
-                )
-            }
+            BackupCategoryRow(
+                category = category,
+                checked = category in state.selectedCategories,
+                onToggle = { viewModel.onToggleCategory(category) },
+            )
         }
         item { HorizontalDivider() }
         item { Spacer(Modifier.height(Spacing.md)) }
         item {
-            Column(
-                modifier = Modifier.fillMaxWidth().padding(horizontal = Spacing.lg),
-                verticalArrangement = Arrangement.spacedBy(Spacing.sm),
-            ) {
-                Button(
-                    onClick = viewModel::onExport,
-                    modifier = Modifier.fillMaxWidth(),
-                    enabled = state.selectedCategories.isNotEmpty() && !state.isExporting,
-                ) {
-                    if (state.isExporting) {
-                        CircularProgressIndicator(
-                            modifier = Modifier.padding(end = Spacing.sm),
-                            color = MaterialTheme.colorScheme.onPrimary,
-                        )
-                    }
-                    Text("Export Backup")
-                }
-                OutlinedButton(
-                    onClick = { loadBackupFromFile(viewModel) },
-                    modifier = Modifier.fillMaxWidth(),
-                    enabled = !state.isImporting,
-                ) {
-                    if (state.isImporting) {
-                        CircularProgressIndicator(modifier = Modifier.padding(end = Spacing.sm))
-                    }
-                    Text("Import from File")
-                }
-                Spacer(Modifier.height(Spacing.lg))
-            }
+            BackupActionButtons(state = state, viewModel = viewModel)
         }
     }
 }
 
-@Suppress("LongMethod")
+@Composable
+private fun BackupCategoryRow(
+    category: BackupCategory,
+    checked: Boolean,
+    onToggle: () -> Unit,
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = Spacing.lg, vertical = Spacing.sm)
+            .desktopFocusRing()
+            .clickable(onClickLabel = "Toggle") { onToggle() },
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Checkbox(
+            checked = checked,
+            onCheckedChange = { onToggle() },
+        )
+        Text(
+            text = category.displayName,
+            style = MaterialTheme.typography.bodyLarge,
+            modifier = Modifier.padding(start = Spacing.sm),
+        )
+    }
+}
+
+@Composable
+private fun BackupActionButtons(
+    state: BackupUiState,
+    viewModel: BackupViewModel,
+) {
+    Column(
+        modifier = Modifier.fillMaxWidth().padding(horizontal = Spacing.lg),
+        verticalArrangement = Arrangement.spacedBy(Spacing.sm),
+    ) {
+        Button(
+            onClick = viewModel::onExport,
+            modifier = Modifier.fillMaxWidth(),
+            enabled = state.selectedCategories.isNotEmpty() && !state.isExporting,
+        ) {
+            if (state.isExporting) {
+                CircularProgressIndicator(
+                    modifier = Modifier.padding(end = Spacing.sm),
+                    color = MaterialTheme.colorScheme.onPrimary,
+                )
+            }
+            Text("Export Backup")
+        }
+        OutlinedButton(
+            onClick = { loadBackupFromFile(viewModel) },
+            modifier = Modifier.fillMaxWidth(),
+            enabled = !state.isImporting,
+        ) {
+            if (state.isImporting) {
+                CircularProgressIndicator(modifier = Modifier.padding(end = Spacing.sm))
+            }
+            Text("Import from File")
+        }
+        Spacer(Modifier.height(Spacing.lg))
+    }
+}
+
 @Composable
 private fun ImportConfirmationDialog(
     state: BackupUiState,
@@ -221,43 +240,16 @@ private fun ImportConfirmationDialog(
                     style = MaterialTheme.typography.bodyMedium,
                 )
                 Spacer(Modifier.height(Spacing.md))
-                Text("Restore Strategy:", style = MaterialTheme.typography.titleSmall)
-                RestoreStrategy.entries.forEach { strategy ->
-                    key(strategy.name) {
-                        Row(
-                            verticalAlignment = Alignment.CenterVertically,
-                            modifier = Modifier
-                                .fillMaxWidth()
-                                .padding(vertical = Spacing.xs)
-                                .clickable { onStrategyChanged(strategy) },
-                        ) {
-                            RadioButton(
-                                selected = state.restoreStrategy == strategy,
-                                onClick = { onStrategyChanged(strategy) },
-                            )
-                            Text(strategy.displayName, style = MaterialTheme.typography.bodyMedium)
-                        }
-                    }
-                }
+                RestoreStrategyList(
+                    selectedStrategy = state.restoreStrategy,
+                    onStrategyChanged = onStrategyChanged,
+                )
                 Spacer(Modifier.height(Spacing.sm))
-                Text("Categories to restore:", style = MaterialTheme.typography.titleSmall)
-                state.importCategories.forEach { category ->
-                    key(category.name) {
-                        Row(
-                            verticalAlignment = Alignment.CenterVertically,
-                            modifier = Modifier
-                                .fillMaxWidth()
-                                .padding(vertical = Spacing.xs)
-                                .clickable { onToggleCategory(category) },
-                        ) {
-                            Checkbox(
-                                checked = category in state.selectedCategories,
-                                onCheckedChange = { onToggleCategory(category) },
-                            )
-                            Text(category.displayName, style = MaterialTheme.typography.bodySmall)
-                        }
-                    }
-                }
+                RestoreCategoryList(
+                    importCategories = state.importCategories,
+                    selectedCategories = state.selectedCategories,
+                    onToggleCategory = onToggleCategory,
+                )
             }
         },
         confirmButton = {
@@ -270,6 +262,57 @@ private fun ImportConfirmationDialog(
             TextButton(onClick = onDismiss) { Text("Cancel") }
         },
     )
+}
+
+@Composable
+private fun RestoreStrategyList(
+    selectedStrategy: RestoreStrategy,
+    onStrategyChanged: (RestoreStrategy) -> Unit,
+) {
+    Text("Restore Strategy:", style = MaterialTheme.typography.titleSmall)
+    RestoreStrategy.entries.forEach { strategy ->
+        key(strategy.name) {
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(vertical = Spacing.xs)
+                    .clickable { onStrategyChanged(strategy) },
+            ) {
+                RadioButton(
+                    selected = selectedStrategy == strategy,
+                    onClick = { onStrategyChanged(strategy) },
+                )
+                Text(strategy.displayName, style = MaterialTheme.typography.bodyMedium)
+            }
+        }
+    }
+}
+
+@Composable
+private fun RestoreCategoryList(
+    importCategories: Set<BackupCategory>,
+    selectedCategories: Set<BackupCategory>,
+    onToggleCategory: (BackupCategory) -> Unit,
+) {
+    Text("Categories to restore:", style = MaterialTheme.typography.titleSmall)
+    importCategories.forEach { category ->
+        key(category.name) {
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(vertical = Spacing.xs)
+                    .clickable { onToggleCategory(category) },
+            ) {
+                Checkbox(
+                    checked = category in selectedCategories,
+                    onCheckedChange = { onToggleCategory(category) },
+                )
+                Text(category.displayName, style = MaterialTheme.typography.bodySmall)
+            }
+        }
+    }
 }
 
 private fun saveBackupToFile(json: String) {

--- a/desktopApp/src/jvmMain/kotlin/com/riox432/civitdeck/ui/comfyui/template/DesktopWorkflowTemplateEditorScreen.kt
+++ b/desktopApp/src/jvmMain/kotlin/com/riox432/civitdeck/ui/comfyui/template/DesktopWorkflowTemplateEditorScreen.kt
@@ -120,7 +120,7 @@ private fun EditorToolbar(
 }
 
 @Composable
-@Suppress("LongParameterList", "LongMethod")
+@Suppress("LongParameterList")
 private fun EditorContent(
     name: String,
     description: String,
@@ -139,45 +139,23 @@ private fun EditorContent(
         verticalArrangement = Arrangement.spacedBy(Spacing.md),
     ) {
         item {
-            OutlinedTextField(
-                value = name,
-                onValueChange = onNameChange,
-                label = { Text("Template Name") },
-                modifier = Modifier.fillMaxWidth(),
-                singleLine = true,
+            TemplateBasicFields(
+                name = name,
+                description = description,
+                type = type,
+                category = category,
+                onNameChange = onNameChange,
+                onDescriptionChange = onDescriptionChange,
+                onTypeChange = onTypeChange,
+                onCategoryChange = onCategoryChange,
             )
         }
         item {
-            OutlinedTextField(
-                value = description,
-                onValueChange = onDescriptionChange,
-                label = { Text("Description") },
-                modifier = Modifier.fillMaxWidth(),
-                minLines = 2,
-                maxLines = 4,
+            VariablesHeader(
+                onAddVariable = {
+                    onVariablesChange(variables + newVariable(variables.size))
+                },
             )
-        }
-        item {
-            Row(horizontalArrangement = Arrangement.spacedBy(Spacing.md)) {
-                TypeSelector(type = type, onTypeChange = onTypeChange)
-                CategorySelector(category = category, onCategoryChange = onCategoryChange)
-            }
-        }
-        item {
-            Row(verticalAlignment = Alignment.CenterVertically) {
-                Text(
-                    "Variables",
-                    style = MaterialTheme.typography.titleSmall,
-                    modifier = Modifier.weight(1f),
-                )
-                IconButton(
-                    onClick = {
-                        onVariablesChange(variables + newVariable(variables.size))
-                    },
-                ) {
-                    Icon(Icons.Default.Add, "Add variable")
-                }
-            }
         }
         itemsIndexed(variables, key = { _, v -> v.name }) { index, variable ->
             VariableEditor(
@@ -193,6 +171,54 @@ private fun EditorContent(
                     )
                 },
             )
+        }
+    }
+}
+
+@Composable
+private fun TemplateBasicFields(
+    name: String,
+    description: String,
+    type: WorkflowTemplateType,
+    category: WorkflowTemplateCategory,
+    onNameChange: (String) -> Unit,
+    onDescriptionChange: (String) -> Unit,
+    onTypeChange: (WorkflowTemplateType) -> Unit,
+    onCategoryChange: (WorkflowTemplateCategory) -> Unit,
+) {
+    Column(verticalArrangement = Arrangement.spacedBy(Spacing.md)) {
+        OutlinedTextField(
+            value = name,
+            onValueChange = onNameChange,
+            label = { Text("Template Name") },
+            modifier = Modifier.fillMaxWidth(),
+            singleLine = true,
+        )
+        OutlinedTextField(
+            value = description,
+            onValueChange = onDescriptionChange,
+            label = { Text("Description") },
+            modifier = Modifier.fillMaxWidth(),
+            minLines = 2,
+            maxLines = 4,
+        )
+        Row(horizontalArrangement = Arrangement.spacedBy(Spacing.md)) {
+            TypeSelector(type = type, onTypeChange = onTypeChange)
+            CategorySelector(category = category, onCategoryChange = onCategoryChange)
+        }
+    }
+}
+
+@Composable
+private fun VariablesHeader(onAddVariable: () -> Unit) {
+    Row(verticalAlignment = Alignment.CenterVertically) {
+        Text(
+            "Variables",
+            style = MaterialTheme.typography.titleSmall,
+            modifier = Modifier.weight(1f),
+        )
+        IconButton(onClick = onAddVariable) {
+            Icon(Icons.Default.Add, "Add variable")
         }
     }
 }

--- a/desktopApp/src/jvmMain/kotlin/com/riox432/civitdeck/ui/comfyui/template/DesktopWorkflowTemplateScreen.kt
+++ b/desktopApp/src/jvmMain/kotlin/com/riox432/civitdeck/ui/comfyui/template/DesktopWorkflowTemplateScreen.kt
@@ -56,7 +56,6 @@ import com.riox432.civitdeck.feature.comfyui.presentation.WorkflowTemplateViewMo
 import com.riox432.civitdeck.ui.theme.Elevation
 import com.riox432.civitdeck.ui.theme.Spacing
 
-@Suppress("LongMethod")
 @Composable
 fun DesktopWorkflowTemplateScreen(
     viewModel: WorkflowTemplateViewModel,
@@ -120,21 +119,42 @@ fun DesktopWorkflowTemplateScreen(
         }
     }
 
+    TemplateScreenDialogs(
+        showImportDialog = showImportDialog,
+        importText = importText,
+        exportedJson = state.exportedJson,
+        onImportTextChange = { importText = it },
+        onImportConfirm = {
+            viewModel.onImportTemplate(importText)
+            importText = ""
+            showImportDialog = false
+        },
+        onImportDismiss = { showImportDialog = false },
+        onExportDismiss = viewModel::onDismissExport,
+    )
+}
+
+@Composable
+private fun TemplateScreenDialogs(
+    showImportDialog: Boolean,
+    importText: String,
+    exportedJson: String?,
+    onImportTextChange: (String) -> Unit,
+    onImportConfirm: () -> Unit,
+    onImportDismiss: () -> Unit,
+    onExportDismiss: () -> Unit,
+) {
     if (showImportDialog) {
         ImportDialog(
             text = importText,
-            onTextChange = { importText = it },
-            onConfirm = {
-                viewModel.onImportTemplate(importText)
-                importText = ""
-                showImportDialog = false
-            },
-            onDismiss = { showImportDialog = false },
+            onTextChange = onImportTextChange,
+            onConfirm = onImportConfirm,
+            onDismiss = onImportDismiss,
         )
     }
 
-    state.exportedJson?.let { json ->
-        ExportDialog(json = json, onDismiss = viewModel::onDismissExport)
+    exportedJson?.let { json ->
+        ExportDialog(json = json, onDismiss = onExportDismiss)
     }
 }
 

--- a/desktopApp/src/jvmMain/kotlin/com/riox432/civitdeck/ui/comfyui/template/DesktopWorkflowTemplateScreen.kt
+++ b/desktopApp/src/jvmMain/kotlin/com/riox432/civitdeck/ui/comfyui/template/DesktopWorkflowTemplateScreen.kt
@@ -70,53 +70,19 @@ fun DesktopWorkflowTemplateScreen(
     var showImportDialog by remember { mutableStateOf(false) }
     var importText by remember { mutableStateOf("") }
 
-    LaunchedEffect(state.error) {
-        state.error?.let {
-            snackbarHostState.showSnackbar(it)
-            viewModel.dismissError()
-        }
-    }
-    LaunchedEffect(state.importError) {
-        state.importError?.let {
-            snackbarHostState.showSnackbar("Import failed: $it")
-            viewModel.onDismissImportError()
-        }
-    }
+    TemplateSnackbarEffects(state, snackbarHostState, viewModel)
 
     Surface(modifier = modifier.fillMaxSize()) {
-        Scaffold(
-            snackbarHost = { SnackbarHost(snackbarHostState) },
-            floatingActionButton = {
-                if (onSelectTemplate == null) {
-                    FloatingActionButton(onClick = onCreateTemplate) {
-                        Icon(Icons.Default.Add, "Create template")
-                    }
-                }
-            },
-        ) { padding ->
-            Column(modifier = Modifier.padding(padding).fillMaxSize()) {
-                TemplateToolbar(
-                    onBack = onBack,
-                    onImportClick = { showImportDialog = true },
-                    isPicker = onSelectTemplate != null,
-                )
-                TemplateSearchAndFilters(
-                    searchQuery = state.searchQuery,
-                    selectedCategory = state.selectedCategory,
-                    selectedType = state.selectedType,
-                    onSearchQueryChanged = viewModel::onSearchQueryChanged,
-                    onCategorySelected = viewModel::onCategorySelected,
-                    onTypeSelected = viewModel::onTypeSelected,
-                )
-                TemplateList(
-                    state = state,
-                    onSelectTemplate = onSelectTemplate,
-                    onEditTemplate = onEditTemplate,
-                    onExport = viewModel::onExportTemplate,
-                    onDelete = viewModel::onDeleteTemplate,
-                )
-            }
-        }
+        TemplateScaffold(
+            state = state,
+            snackbarHostState = snackbarHostState,
+            viewModel = viewModel,
+            onBack = onBack,
+            onCreateTemplate = onCreateTemplate,
+            onEditTemplate = onEditTemplate,
+            onSelectTemplate = onSelectTemplate,
+            onImportClick = { showImportDialog = true },
+        )
     }
 
     TemplateScreenDialogs(
@@ -132,6 +98,73 @@ fun DesktopWorkflowTemplateScreen(
         onImportDismiss = { showImportDialog = false },
         onExportDismiss = viewModel::onDismissExport,
     )
+}
+
+@Composable
+private fun TemplateSnackbarEffects(
+    state: WorkflowTemplateUiState,
+    snackbarHostState: SnackbarHostState,
+    viewModel: WorkflowTemplateViewModel,
+) {
+    LaunchedEffect(state.error) {
+        state.error?.let {
+            snackbarHostState.showSnackbar(it)
+            viewModel.dismissError()
+        }
+    }
+    LaunchedEffect(state.importError) {
+        state.importError?.let {
+            snackbarHostState.showSnackbar("Import failed: $it")
+            viewModel.onDismissImportError()
+        }
+    }
+}
+
+@Composable
+@Suppress("LongParameterList")
+private fun TemplateScaffold(
+    state: WorkflowTemplateUiState,
+    snackbarHostState: SnackbarHostState,
+    viewModel: WorkflowTemplateViewModel,
+    onBack: () -> Unit,
+    onCreateTemplate: () -> Unit,
+    onEditTemplate: (WorkflowTemplate) -> Unit,
+    onSelectTemplate: ((WorkflowTemplate) -> Unit)?,
+    onImportClick: () -> Unit,
+) {
+    Scaffold(
+        snackbarHost = { SnackbarHost(snackbarHostState) },
+        floatingActionButton = {
+            if (onSelectTemplate == null) {
+                FloatingActionButton(onClick = onCreateTemplate) {
+                    Icon(Icons.Default.Add, "Create template")
+                }
+            }
+        },
+    ) { padding ->
+        Column(modifier = Modifier.padding(padding).fillMaxSize()) {
+            TemplateToolbar(
+                onBack = onBack,
+                onImportClick = onImportClick,
+                isPicker = onSelectTemplate != null,
+            )
+            TemplateSearchAndFilters(
+                searchQuery = state.searchQuery,
+                selectedCategory = state.selectedCategory,
+                selectedType = state.selectedType,
+                onSearchQueryChanged = viewModel::onSearchQueryChanged,
+                onCategorySelected = viewModel::onCategorySelected,
+                onTypeSelected = viewModel::onTypeSelected,
+            )
+            TemplateList(
+                state = state,
+                onSelectTemplate = onSelectTemplate,
+                onEditTemplate = onEditTemplate,
+                onExport = viewModel::onExportTemplate,
+                onDelete = viewModel::onDeleteTemplate,
+            )
+        }
+    }
 }
 
 @Composable

--- a/desktopApp/src/jvmMain/kotlin/com/riox432/civitdeck/ui/dataset/DesktopDatasetDetailScreen.kt
+++ b/desktopApp/src/jvmMain/kotlin/com/riox432/civitdeck/ui/dataset/DesktopDatasetDetailScreen.kt
@@ -71,7 +71,6 @@ private const val DEFAULT_GRID_COLUMNS = 4
 private const val IMAGE_ASPECT_RATIO = 1f
 private const val DATASET_IMAGE_SIZE = 300
 
-@Suppress("LongMethod")
 @Composable
 fun DesktopDatasetDetailScreen(
     datasetName: String,
@@ -127,25 +126,46 @@ fun DesktopDatasetDetailScreen(
         }
     }
 
+    DatasetDetailDialogs(
+        showExportDialog = showExportDialog,
+        availableExportFormats = availableExportFormats,
+        captionEditState = captionEditState,
+        onExport = { formatId ->
+            viewModel.startExport(formatId)
+            showExportDialog = false
+        },
+        onExportDismiss = { showExportDialog = false },
+        onCaptionSave = { imageId, text ->
+            viewModel.editCaption(imageId, text)
+            captionEditState = null
+        },
+        onCaptionDismiss = { captionEditState = null },
+    )
+}
+
+@Composable
+private fun DatasetDetailDialogs(
+    showExportDialog: Boolean,
+    availableExportFormats: List<com.riox432.civitdeck.plugin.PluginExportFormat>,
+    captionEditState: Pair<Long, String>?,
+    onExport: (String) -> Unit,
+    onExportDismiss: () -> Unit,
+    onCaptionSave: (Long, String) -> Unit,
+    onCaptionDismiss: () -> Unit,
+) {
     if (showExportDialog) {
         DesktopExportDialog(
             formats = availableExportFormats,
-            onExport = { formatId ->
-                viewModel.startExport(formatId)
-                showExportDialog = false
-            },
-            onDismiss = { showExportDialog = false },
+            onExport = onExport,
+            onDismiss = onExportDismiss,
         )
     }
 
     captionEditState?.let { (imageId, initialCaption) ->
         CaptionEditDialog(
             initialCaption = initialCaption,
-            onSave = { text ->
-                viewModel.editCaption(imageId, text)
-                captionEditState = null
-            },
-            onDismiss = { captionEditState = null },
+            onSave = { text -> onCaptionSave(imageId, text) },
+            onDismiss = onCaptionDismiss,
         )
     }
 }
@@ -289,7 +309,6 @@ private fun DatasetImageGridContent(
     }
 }
 
-@Suppress("LongMethod")
 @OptIn(ExperimentalFoundationApi::class)
 @Composable
 private fun DesktopDatasetImageItem(
@@ -320,49 +339,58 @@ private fun DesktopDatasetImageItem(
                 .clip(RoundedCornerShape(CornerRadius.image)),
         )
         if (isSelectionMode) {
-            Box(
-                modifier = Modifier
-                    .padding(Spacing.sm)
-                    .size(24.dp)
-                    .clip(CircleShape)
-                    .background(
-                        if (isSelected) {
-                            MaterialTheme.colorScheme.primary
-                        } else {
-                            MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.7f)
-                        },
-                    ),
-                contentAlignment = Alignment.Center,
-            ) {
-                if (isSelected) {
-                    Icon(
-                        Icons.Default.CheckCircle,
-                        contentDescription = "Selected",
-                        tint = MaterialTheme.colorScheme.onPrimary,
-                        modifier = Modifier.size(20.dp),
-                    )
-                }
-            }
+            SelectionIndicator(isSelected = isSelected)
         } else {
             SourceBadge(
                 sourceType = image.sourceType,
                 modifier = Modifier.align(Alignment.BottomEnd).padding(Spacing.xs),
             )
             if (image.excluded) {
-                Text(
-                    text = "Flagged",
-                    style = MaterialTheme.typography.labelSmall,
-                    color = MaterialTheme.colorScheme.onError,
-                    modifier = Modifier
-                        .align(Alignment.TopStart)
-                        .padding(Spacing.xs)
-                        .clip(RoundedCornerShape(CornerRadius.chip))
-                        .background(MaterialTheme.colorScheme.error.copy(alpha = 0.85f))
-                        .padding(horizontal = Spacing.xs, vertical = 2.dp),
-                )
+                FlaggedBadge(modifier = Modifier.align(Alignment.TopStart))
             }
         }
     }
+}
+
+@Composable
+private fun SelectionIndicator(isSelected: Boolean) {
+    Box(
+        modifier = Modifier
+            .padding(Spacing.sm)
+            .size(24.dp)
+            .clip(CircleShape)
+            .background(
+                if (isSelected) {
+                    MaterialTheme.colorScheme.primary
+                } else {
+                    MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.7f)
+                },
+            ),
+        contentAlignment = Alignment.Center,
+    ) {
+        if (isSelected) {
+            Icon(
+                Icons.Default.CheckCircle,
+                contentDescription = "Selected",
+                tint = MaterialTheme.colorScheme.onPrimary,
+                modifier = Modifier.size(20.dp),
+            )
+        }
+    }
+}
+
+@Composable
+private fun FlaggedBadge(modifier: Modifier = Modifier) {
+    Text(
+        text = "Flagged",
+        style = MaterialTheme.typography.labelSmall,
+        color = MaterialTheme.colorScheme.onError,
+        modifier = modifier
+            .padding(Spacing.xs)
+            .clip(RoundedCornerShape(CornerRadius.chip))
+            .background(MaterialTheme.colorScheme.error.copy(alpha = 0.85f))
+            .padding(horizontal = Spacing.xs, vertical = 2.dp),
+    )
 }
 
 @Composable

--- a/desktopApp/src/jvmMain/kotlin/com/riox432/civitdeck/ui/dataset/DesktopDatasetDetailScreen.kt
+++ b/desktopApp/src/jvmMain/kotlin/com/riox432/civitdeck/ui/dataset/DesktopDatasetDetailScreen.kt
@@ -87,43 +87,17 @@ fun DesktopDatasetDetailScreen(
     var captionEditState by remember { mutableStateOf<Pair<Long, String>?>(null) }
 
     Surface(modifier = modifier.fillMaxSize()) {
-        Column {
-            DatasetDetailToolbar(
-                datasetName = datasetName,
-                isSelectionMode = isSelectionMode,
-                selectedCount = selectedImageIds.size,
-                onBack = onBack,
-                onClearSelection = viewModel::clearSelection,
-                onSelectAll = viewModel::selectAll,
-                onExport = { showExportDialog = true },
-            )
-            SourceFilterRow(
-                selectedSource = selectedSource,
-                onSourceSelected = viewModel::setSourceFilter,
-            )
-            if (isSelectionMode && selectedImageIds.isNotEmpty()) {
-                SelectionActionBar(
-                    selectedCount = selectedImageIds.size,
-                    onRemove = viewModel::removeSelected,
-                )
-            }
-            DatasetImageGridContent(
-                images = filteredImages,
-                isSelectionMode = isSelectionMode,
-                selectedImageIds = selectedImageIds,
-                onImageClick = { image ->
-                    if (isSelectionMode) {
-                        viewModel.toggleSelection(image.id)
-                    } else {
-                        captionEditState = image.id to (image.caption?.text.orEmpty())
-                    }
-                },
-                onImageLongClick = { imageId ->
-                    if (!isSelectionMode) viewModel.enterSelectionMode(imageId)
-                },
-                modifier = Modifier.weight(1f),
-            )
-        }
+        DatasetDetailContent(
+            datasetName = datasetName,
+            filteredImages = filteredImages,
+            selectedImageIds = selectedImageIds,
+            isSelectionMode = isSelectionMode,
+            selectedSource = selectedSource,
+            viewModel = viewModel,
+            onBack = onBack,
+            onExportClick = { showExportDialog = true },
+            onEditCaption = { id, caption -> captionEditState = id to caption },
+        )
     }
 
     DatasetDetailDialogs(
@@ -141,6 +115,58 @@ fun DesktopDatasetDetailScreen(
         },
         onCaptionDismiss = { captionEditState = null },
     )
+}
+
+@Composable
+@Suppress("LongParameterList")
+private fun DatasetDetailContent(
+    datasetName: String,
+    filteredImages: List<DatasetImage>,
+    selectedImageIds: Set<Long>,
+    isSelectionMode: Boolean,
+    selectedSource: ImageSource?,
+    viewModel: DatasetDetailViewModel,
+    onBack: () -> Unit,
+    onExportClick: () -> Unit,
+    onEditCaption: (Long, String) -> Unit,
+) {
+    Column {
+        DatasetDetailToolbar(
+            datasetName = datasetName,
+            isSelectionMode = isSelectionMode,
+            selectedCount = selectedImageIds.size,
+            onBack = onBack,
+            onClearSelection = viewModel::clearSelection,
+            onSelectAll = viewModel::selectAll,
+            onExport = onExportClick,
+        )
+        SourceFilterRow(
+            selectedSource = selectedSource,
+            onSourceSelected = viewModel::setSourceFilter,
+        )
+        if (isSelectionMode && selectedImageIds.isNotEmpty()) {
+            SelectionActionBar(
+                selectedCount = selectedImageIds.size,
+                onRemove = viewModel::removeSelected,
+            )
+        }
+        DatasetImageGridContent(
+            images = filteredImages,
+            isSelectionMode = isSelectionMode,
+            selectedImageIds = selectedImageIds,
+            onImageClick = { image ->
+                if (isSelectionMode) {
+                    viewModel.toggleSelection(image.id)
+                } else {
+                    onEditCaption(image.id, image.caption?.text.orEmpty())
+                }
+            },
+            onImageLongClick = { imageId ->
+                if (!isSelectionMode) viewModel.enterSelectionMode(imageId)
+            },
+            modifier = Modifier.weight(1f),
+        )
+    }
 }
 
 @Composable

--- a/desktopApp/src/jvmMain/kotlin/com/riox432/civitdeck/ui/dataset/DesktopDatasetListScreen.kt
+++ b/desktopApp/src/jvmMain/kotlin/com/riox432/civitdeck/ui/dataset/DesktopDatasetListScreen.kt
@@ -163,7 +163,6 @@ private fun DatasetListBody(
     }
 }
 
-@Suppress("LongMethod")
 @Composable
 private fun DesktopDatasetCard(
     dataset: DatasetCollection,
@@ -186,64 +185,15 @@ private fun DesktopDatasetCard(
             modifier = Modifier.fillMaxWidth().padding(Spacing.md),
             verticalAlignment = Alignment.CenterVertically,
         ) {
-            BadgedBox(
-                badge = {
-                    if (dataset.imageCount > 0) {
-                        Badge { Text(dataset.imageCount.toString()) }
-                    }
-                },
-            ) {
-                Icon(
-                    imageVector = Icons.Default.Dataset,
-                    contentDescription = "Dataset",
-                    tint = MaterialTheme.colorScheme.primary,
-                )
-            }
+            DatasetCardIcon(imageCount = dataset.imageCount)
             Spacer(modifier = Modifier.width(Spacing.md))
-            Column(modifier = Modifier.weight(1f)) {
-                Text(
-                    text = dataset.name,
-                    style = MaterialTheme.typography.titleMedium,
-                    maxLines = 1,
-                    overflow = TextOverflow.Ellipsis,
-                )
-                Text(
-                    text = "${dataset.imageCount} images",
-                    style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                )
-            }
-            Box {
-                Text(
-                    text = "...",
-                    style = MaterialTheme.typography.titleLarge,
-                    modifier = Modifier.clickable(
-                        role = Role.Button,
-                        onClickLabel = "Open menu",
-                    ) { showMenu = true },
-                )
-                DropdownMenu(
-                    expanded = showMenu,
-                    onDismissRequest = { showMenu = false },
-                ) {
-                    DropdownMenuItem(
-                        text = { Text("Rename") },
-                        leadingIcon = { Icon(Icons.Default.Edit, contentDescription = "Rename") },
-                        onClick = {
-                            showMenu = false
-                            showRenameDialog = true
-                        },
-                    )
-                    DropdownMenuItem(
-                        text = { Text("Delete") },
-                        leadingIcon = { Icon(Icons.Default.Delete, contentDescription = "Delete") },
-                        onClick = {
-                            showMenu = false
-                            onDelete()
-                        },
-                    )
-                }
-            }
+            DatasetCardInfo(dataset = dataset, modifier = Modifier.weight(1f))
+            DatasetCardMenu(
+                expanded = showMenu,
+                onExpandedChange = { showMenu = it },
+                onRename = { showRenameDialog = true },
+                onDelete = onDelete,
+            )
         }
     }
 
@@ -258,6 +208,83 @@ private fun DesktopDatasetCard(
                 showRenameDialog = false
             },
         )
+    }
+}
+
+@Composable
+private fun DatasetCardIcon(imageCount: Int) {
+    BadgedBox(
+        badge = {
+            if (imageCount > 0) {
+                Badge { Text(imageCount.toString()) }
+            }
+        },
+    ) {
+        Icon(
+            imageVector = Icons.Default.Dataset,
+            contentDescription = "Dataset",
+            tint = MaterialTheme.colorScheme.primary,
+        )
+    }
+}
+
+@Composable
+private fun DatasetCardInfo(
+    dataset: DatasetCollection,
+    modifier: Modifier = Modifier,
+) {
+    Column(modifier = modifier) {
+        Text(
+            text = dataset.name,
+            style = MaterialTheme.typography.titleMedium,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
+        )
+        Text(
+            text = "${dataset.imageCount} images",
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+    }
+}
+
+@Composable
+private fun DatasetCardMenu(
+    expanded: Boolean,
+    onExpandedChange: (Boolean) -> Unit,
+    onRename: () -> Unit,
+    onDelete: () -> Unit,
+) {
+    Box {
+        Text(
+            text = "...",
+            style = MaterialTheme.typography.titleLarge,
+            modifier = Modifier.clickable(
+                role = Role.Button,
+                onClickLabel = "Open menu",
+            ) { onExpandedChange(true) },
+        )
+        DropdownMenu(
+            expanded = expanded,
+            onDismissRequest = { onExpandedChange(false) },
+        ) {
+            DropdownMenuItem(
+                text = { Text("Rename") },
+                leadingIcon = { Icon(Icons.Default.Edit, contentDescription = "Rename") },
+                onClick = {
+                    onExpandedChange(false)
+                    onRename()
+                },
+            )
+            DropdownMenuItem(
+                text = { Text("Delete") },
+                leadingIcon = { Icon(Icons.Default.Delete, contentDescription = "Delete") },
+                onClick = {
+                    onExpandedChange(false)
+                    onDelete()
+                },
+            )
+        }
     }
 }
 

--- a/desktopApp/src/jvmMain/kotlin/com/riox432/civitdeck/ui/discovery/DesktopDiscoveryScreen.kt
+++ b/desktopApp/src/jvmMain/kotlin/com/riox432/civitdeck/ui/discovery/DesktopDiscoveryScreen.kt
@@ -34,7 +34,6 @@ import com.riox432.civitdeck.ui.theme.Elevation
 import com.riox432.civitdeck.ui.theme.Spacing
 import org.koin.compose.viewmodel.koinViewModel
 
-@Suppress("LongMethod")
 @Composable
 fun DesktopDiscoveryScreen(
     viewModel: DesktopDiscoveryViewModel,
@@ -79,47 +78,60 @@ fun DesktopDiscoveryScreen(
                 }
             }
             else -> {
-                val columns = displayState.gridColumns
-                val nsfwFilterLevel = contentFilterState.nsfwFilterLevel
-                val nsfwBlurSettings = contentFilterState.nsfwBlurSettings
+                DiscoveryGrid(
+                    sections = uiState.sections,
+                    columns = displayState.gridColumns,
+                    nsfwFilterLevel = contentFilterState.nsfwFilterLevel,
+                    nsfwBlurSettings = contentFilterState.nsfwBlurSettings,
+                    onModelClick = onModelClick,
+                )
+            }
+        }
+    }
+}
 
-                LazyVerticalGrid(
-                    columns = if (columns > 0) {
-                        GridCells.Fixed(columns)
-                    } else {
-                        GridCells.Adaptive(minSize = CARD_MIN_WIDTH)
-                    },
-                    contentPadding = PaddingValues(Spacing.md),
-                    horizontalArrangement = Arrangement.spacedBy(Spacing.sm),
-                    verticalArrangement = Arrangement.spacedBy(Spacing.sm),
-                    modifier = Modifier.fillMaxSize(),
-                ) {
-                    uiState.sections.forEach { section ->
-                        item(span = { GridItemSpan(maxLineSpan) }) {
-                            SectionHeader(
-                                title = section.title,
-                                subtitle = section.reason,
-                            )
-                        }
+@Composable
+private fun DiscoveryGrid(
+    sections: List<com.riox432.civitdeck.domain.model.RecommendationSection>,
+    columns: Int,
+    nsfwFilterLevel: NsfwFilterLevel,
+    nsfwBlurSettings: com.riox432.civitdeck.domain.model.NsfwBlurSettings,
+    onModelClick: (Long) -> Unit,
+) {
+    LazyVerticalGrid(
+        columns = if (columns > 0) {
+            GridCells.Fixed(columns)
+        } else {
+            GridCells.Adaptive(minSize = CARD_MIN_WIDTH)
+        },
+        contentPadding = PaddingValues(Spacing.md),
+        horizontalArrangement = Arrangement.spacedBy(Spacing.sm),
+        verticalArrangement = Arrangement.spacedBy(Spacing.sm),
+        modifier = Modifier.fillMaxSize(),
+    ) {
+        sections.forEach { section ->
+            item(span = { GridItemSpan(maxLineSpan) }) {
+                SectionHeader(
+                    title = section.title,
+                    subtitle = section.reason,
+                )
+            }
 
-                        val models = if (nsfwFilterLevel == NsfwFilterLevel.All) {
-                            section.models.filter { !it.nsfw }
-                        } else {
-                            section.models
-                        }
+            val models = if (nsfwFilterLevel == NsfwFilterLevel.All) {
+                section.models.filter { !it.nsfw }
+            } else {
+                section.models
+            }
 
-                        items(
-                            items = models,
-                            key = { model -> "${section.title}_${model.id}" },
-                        ) { model ->
-                            DesktopModelCard(
-                                model = model,
-                                onClick = { onModelClick(model.id) },
-                                nsfwBlurSettings = nsfwBlurSettings,
-                            )
-                        }
-                    }
-                }
+            items(
+                items = models,
+                key = { model -> "${section.title}_${model.id}" },
+            ) { model ->
+                DesktopModelCard(
+                    model = model,
+                    onClick = { onModelClick(model.id) },
+                    nsfwBlurSettings = nsfwBlurSettings,
+                )
             }
         }
     }

--- a/desktopApp/src/jvmMain/kotlin/com/riox432/civitdeck/ui/history/DesktopBrowsingHistoryScreen.kt
+++ b/desktopApp/src/jvmMain/kotlin/com/riox432/civitdeck/ui/history/DesktopBrowsingHistoryScreen.kt
@@ -66,33 +66,13 @@ fun DesktopBrowsingHistoryScreen(
         )
 
         if (state.isEmpty) {
-            Column(
-                modifier = Modifier.fillMaxSize(),
-                horizontalAlignment = Alignment.CenterHorizontally,
-                verticalArrangement = Arrangement.Center,
-            ) {
-                Text(
-                    text = "No browsing history",
-                    style = MaterialTheme.typography.bodyLarge,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                )
-            }
+            EmptyHistoryMessage()
         } else {
-            Column(
-                modifier = Modifier
-                    .fillMaxSize()
-                    .verticalScroll(rememberScrollState())
-                    .padding(Spacing.lg),
-                verticalArrangement = Arrangement.spacedBy(Spacing.md),
-            ) {
-                state.groups.forEach { group ->
-                    HistoryGroupCard(
-                        group = group,
-                        onModelClick = onModelClick,
-                        onDelete = viewModel::deleteItem,
-                    )
-                }
-            }
+            HistoryGroupList(
+                groups = state.groups,
+                onModelClick = onModelClick,
+                onDelete = viewModel::deleteItem,
+            )
         }
     }
 
@@ -104,6 +84,44 @@ fun DesktopBrowsingHistoryScreen(
             },
             onDismiss = { showClearDialog = false },
         )
+    }
+}
+
+@Composable
+private fun EmptyHistoryMessage() {
+    Column(
+        modifier = Modifier.fillMaxSize(),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center,
+    ) {
+        Text(
+            text = "No browsing history",
+            style = MaterialTheme.typography.bodyLarge,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+    }
+}
+
+@Composable
+private fun HistoryGroupList(
+    groups: List<DateGroup>,
+    onModelClick: (Long) -> Unit,
+    onDelete: (Long) -> Unit,
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .verticalScroll(rememberScrollState())
+            .padding(Spacing.lg),
+        verticalArrangement = Arrangement.spacedBy(Spacing.md),
+    ) {
+        groups.forEach { group ->
+            HistoryGroupCard(
+                group = group,
+                onModelClick = onModelClick,
+                onDelete = onDelete,
+            )
+        }
     }
 }
 

--- a/desktopApp/src/jvmMain/kotlin/com/riox432/civitdeck/ui/history/DesktopBrowsingHistoryScreen.kt
+++ b/desktopApp/src/jvmMain/kotlin/com/riox432/civitdeck/ui/history/DesktopBrowsingHistoryScreen.kt
@@ -44,7 +44,6 @@ import com.riox432.civitdeck.ui.desktopFocusRing
 import com.riox432.civitdeck.ui.theme.Elevation
 import com.riox432.civitdeck.ui.theme.Spacing
 
-@Suppress("LongMethod")
 @Composable
 fun DesktopBrowsingHistoryScreen(
     viewModel: BrowsingHistoryViewModel,
@@ -98,21 +97,32 @@ fun DesktopBrowsingHistoryScreen(
     }
 
     if (showClearDialog) {
-        AlertDialog(
-            onDismissRequest = { showClearDialog = false },
-            title = { Text("Clear All History") },
-            text = { Text("Are you sure? This cannot be undone.") },
-            confirmButton = {
-                TextButton(onClick = {
-                    viewModel.clearAll()
-                    showClearDialog = false
-                }) { Text("Clear") }
+        ClearHistoryDialog(
+            onConfirm = {
+                viewModel.clearAll()
+                showClearDialog = false
             },
-            dismissButton = {
-                TextButton(onClick = { showClearDialog = false }) { Text("Cancel") }
-            },
+            onDismiss = { showClearDialog = false },
         )
     }
+}
+
+@Composable
+private fun ClearHistoryDialog(
+    onConfirm: () -> Unit,
+    onDismiss: () -> Unit,
+) {
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text("Clear All History") },
+        text = { Text("Are you sure? This cannot be undone.") },
+        confirmButton = {
+            TextButton(onClick = onConfirm) { Text("Clear") }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) { Text("Cancel") }
+        },
+    )
 }
 
 @Composable

--- a/desktopApp/src/jvmMain/kotlin/com/riox432/civitdeck/ui/search/DesktopSearchScreen.kt
+++ b/desktopApp/src/jvmMain/kotlin/com/riox432/civitdeck/ui/search/DesktopSearchScreen.kt
@@ -90,40 +90,60 @@ fun DesktopSearchScreen(
             onResetFilters = viewModel::resetFilters,
         )
 
-        when {
-            uiState.isLoading && uiState.models.isEmpty() -> {
-                Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
-                    CircularProgressIndicator()
-                }
+        SearchResultsArea(
+            uiState = uiState,
+            displayState = displayState,
+            contentFilterState = contentFilterState,
+            gridState = gridState,
+            onModelClick = onModelClick,
+            onRetry = viewModel::onSearch,
+        )
+    }
+}
+
+@Suppress("LongParameterList")
+@Composable
+private fun SearchResultsArea(
+    uiState: com.riox432.civitdeck.feature.search.presentation.ModelSearchUiState,
+    displayState: com.riox432.civitdeck.feature.settings.presentation.DisplaySettingsUiState,
+    contentFilterState: com.riox432.civitdeck.feature.settings.presentation.ContentFilterSettingsUiState,
+    gridState: androidx.compose.foundation.lazy.grid.LazyGridState,
+    onModelClick: (Long) -> Unit,
+    onRetry: () -> Unit,
+) {
+    when {
+        uiState.isLoading && uiState.models.isEmpty() -> {
+            Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                CircularProgressIndicator()
             }
-            uiState.error != null && uiState.models.isEmpty() -> {
-                SearchErrorState(error = uiState.error, onRetry = viewModel::onSearch)
-            }
-            !uiState.isLoading && uiState.error == null && uiState.models.isEmpty() -> {
-                Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
-                    Text(
-                        text = "No models found",
-                        style = MaterialTheme.typography.bodyLarge,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    )
-                }
-            }
-            else -> {
-                val nsfwFilterLevel = contentFilterState.nsfwFilterLevel
-                val filteredModels = if (nsfwFilterLevel == NsfwFilterLevel.All) {
-                    uiState.models.filter { !it.nsfw }
-                } else {
-                    uiState.models
-                }
-                SearchResultsGrid(
-                    models = filteredModels,
-                    columns = displayState.gridColumns,
-                    isLoadingMore = uiState.isLoadingMore,
-                    gridState = gridState,
-                    nsfwBlurSettings = contentFilterState.nsfwBlurSettings,
-                    onModelClick = onModelClick,
+        }
+        uiState.error != null && uiState.models.isEmpty() -> {
+            SearchErrorState(error = uiState.error, onRetry = onRetry)
+        }
+        !uiState.isLoading && uiState.error == null && uiState.models.isEmpty() -> {
+            Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                Text(
+                    text = "No models found",
+                    style = MaterialTheme.typography.bodyLarge,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
                 )
             }
+        }
+        else -> {
+            val nsfwFilterLevel = contentFilterState.nsfwFilterLevel
+            val filteredModels = if (nsfwFilterLevel == NsfwFilterLevel.All) {
+                uiState.models.filter { !it.nsfw }
+            } else {
+                uiState.models
+            }
+            SearchResultsGrid(
+                models = filteredModels,
+                columns = displayState.gridColumns,
+                isLoadingMore = uiState.isLoadingMore,
+                gridState = gridState,
+                nsfwBlurSettings = contentFilterState.nsfwBlurSettings,
+                onModelClick = onModelClick,
+            )
         }
     }
 }

--- a/desktopApp/src/jvmMain/kotlin/com/riox432/civitdeck/ui/search/DesktopSearchScreen.kt
+++ b/desktopApp/src/jvmMain/kotlin/com/riox432/civitdeck/ui/search/DesktopSearchScreen.kt
@@ -39,7 +39,7 @@ import com.riox432.civitdeck.ui.desktopFocusRing
 import com.riox432.civitdeck.ui.theme.Spacing
 import org.koin.compose.viewmodel.koinViewModel
 
-@Suppress("LongMethod", "CyclomaticComplexMethod", "UnusedParameter")
+@Suppress("CyclomaticComplexMethod", "UnusedParameter")
 @Composable
 fun DesktopSearchScreen(
     viewModel: ModelSearchViewModel,
@@ -70,30 +70,14 @@ fun DesktopSearchScreen(
     }
 
     Column(modifier = modifier.fillMaxSize()) {
-        Row(
-            verticalAlignment = Alignment.CenterVertically,
-            modifier = Modifier.fillMaxWidth(),
-        ) {
-            DesktopSearchBar(
-                query = uiState.query,
-                onQueryChange = viewModel::onQueryChange,
-                onSearch = viewModel::onSearch,
-                focusRequester = searchFocusRequester,
-                modifier = Modifier.weight(1f),
-            )
-            IconButton(onClick = onQRCodeClick, modifier = Modifier.desktopFocusRing()) {
-                Icon(
-                    Icons.Default.QrCode,
-                    contentDescription = "QR Code",
-                )
-            }
-            IconButton(onClick = onUrlImportClick, modifier = Modifier.desktopFocusRing()) {
-                Icon(
-                    Icons.Default.Link,
-                    contentDescription = "Import from URL",
-                )
-            }
-        }
+        SearchTopBar(
+            query = uiState.query,
+            onQueryChange = viewModel::onQueryChange,
+            onSearch = viewModel::onSearch,
+            onQRCodeClick = onQRCodeClick,
+            onUrlImportClick = onUrlImportClick,
+            searchFocusRequester = searchFocusRequester,
+        )
 
         DesktopFilterBar(
             uiState = uiState,
@@ -113,17 +97,7 @@ fun DesktopSearchScreen(
                 }
             }
             uiState.error != null && uiState.models.isEmpty() -> {
-                Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
-                    Column(horizontalAlignment = Alignment.CenterHorizontally) {
-                        Text(
-                            text = uiState.error ?: "Unknown error",
-                            color = MaterialTheme.colorScheme.error,
-                        )
-                        TextButton(onClick = viewModel::onSearch) {
-                            Text("Retry")
-                        }
-                    }
-                }
+                SearchErrorState(error = uiState.error, onRetry = viewModel::onSearch)
             }
             !uiState.isLoading && uiState.error == null && uiState.models.isEmpty() -> {
                 Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
@@ -135,49 +109,118 @@ fun DesktopSearchScreen(
                 }
             }
             else -> {
-                val columns = displayState.gridColumns
                 val nsfwFilterLevel = contentFilterState.nsfwFilterLevel
                 val filteredModels = if (nsfwFilterLevel == NsfwFilterLevel.All) {
                     uiState.models.filter { !it.nsfw }
                 } else {
                     uiState.models
                 }
-                val nsfwBlurSettings = contentFilterState.nsfwBlurSettings
+                SearchResultsGrid(
+                    models = filteredModels,
+                    columns = displayState.gridColumns,
+                    isLoadingMore = uiState.isLoadingMore,
+                    gridState = gridState,
+                    nsfwBlurSettings = contentFilterState.nsfwBlurSettings,
+                    onModelClick = onModelClick,
+                )
+            }
+        }
+    }
+}
 
-                LazyVerticalGrid(
-                    columns = if (columns > 0) {
-                        GridCells.Fixed(
-                            columns
-                        )
-                    } else {
-                        GridCells.Adaptive(minSize = CARD_MIN_WIDTH)
-                    },
-                    state = gridState,
-                    contentPadding = PaddingValues(Spacing.md),
-                    horizontalArrangement = Arrangement.spacedBy(Spacing.sm),
-                    verticalArrangement = Arrangement.spacedBy(Spacing.sm),
-                    modifier = Modifier.fillMaxSize(),
+@Composable
+private fun SearchTopBar(
+    query: String,
+    onQueryChange: (String) -> Unit,
+    onSearch: () -> Unit,
+    onQRCodeClick: () -> Unit,
+    onUrlImportClick: () -> Unit,
+    searchFocusRequester: FocusRequester,
+) {
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        modifier = Modifier.fillMaxWidth(),
+    ) {
+        DesktopSearchBar(
+            query = query,
+            onQueryChange = onQueryChange,
+            onSearch = onSearch,
+            focusRequester = searchFocusRequester,
+            modifier = Modifier.weight(1f),
+        )
+        IconButton(onClick = onQRCodeClick, modifier = Modifier.desktopFocusRing()) {
+            Icon(
+                Icons.Default.QrCode,
+                contentDescription = "QR Code",
+            )
+        }
+        IconButton(onClick = onUrlImportClick, modifier = Modifier.desktopFocusRing()) {
+            Icon(
+                Icons.Default.Link,
+                contentDescription = "Import from URL",
+            )
+        }
+    }
+}
+
+@Composable
+private fun SearchErrorState(
+    error: String?,
+    onRetry: () -> Unit,
+) {
+    Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+        Column(horizontalAlignment = Alignment.CenterHorizontally) {
+            Text(
+                text = error ?: "Unknown error",
+                color = MaterialTheme.colorScheme.error,
+            )
+            TextButton(onClick = onRetry) {
+                Text("Retry")
+            }
+        }
+    }
+}
+
+@Composable
+private fun SearchResultsGrid(
+    models: List<com.riox432.civitdeck.domain.model.Model>,
+    columns: Int,
+    isLoadingMore: Boolean,
+    gridState: androidx.compose.foundation.lazy.grid.LazyGridState,
+    nsfwBlurSettings: com.riox432.civitdeck.domain.model.NsfwBlurSettings,
+    onModelClick: (Long) -> Unit,
+) {
+    LazyVerticalGrid(
+        columns = if (columns > 0) {
+            GridCells.Fixed(
+                columns
+            )
+        } else {
+            GridCells.Adaptive(minSize = CARD_MIN_WIDTH)
+        },
+        state = gridState,
+        contentPadding = PaddingValues(Spacing.md),
+        horizontalArrangement = Arrangement.spacedBy(Spacing.sm),
+        verticalArrangement = Arrangement.spacedBy(Spacing.sm),
+        modifier = Modifier.fillMaxSize(),
+    ) {
+        itemsIndexed(
+            items = models,
+            key = { _, model -> model.id },
+        ) { _, model ->
+            DesktopModelCard(
+                model = model,
+                onClick = { onModelClick(model.id) },
+                nsfwBlurSettings = nsfwBlurSettings,
+            )
+        }
+        if (isLoadingMore) {
+            item(span = { GridItemSpan(maxLineSpan) }) {
+                Box(
+                    modifier = Modifier.fillMaxWidth().padding(Spacing.lg),
+                    contentAlignment = Alignment.Center,
                 ) {
-                    itemsIndexed(
-                        items = filteredModels,
-                        key = { _, model -> model.id },
-                    ) { _, model ->
-                        DesktopModelCard(
-                            model = model,
-                            onClick = { onModelClick(model.id) },
-                            nsfwBlurSettings = nsfwBlurSettings,
-                        )
-                    }
-                    if (uiState.isLoadingMore) {
-                        item(span = { GridItemSpan(maxLineSpan) }) {
-                            Box(
-                                modifier = Modifier.fillMaxWidth().padding(Spacing.lg),
-                                contentAlignment = Alignment.Center,
-                            ) {
-                                CircularProgressIndicator()
-                            }
-                        }
-                    }
+                    CircularProgressIndicator()
                 }
             }
         }

--- a/desktopApp/src/jvmMain/kotlin/com/riox432/civitdeck/ui/settings/DesktopExternalServerSection.kt
+++ b/desktopApp/src/jvmMain/kotlin/com/riox432/civitdeck/ui/settings/DesktopExternalServerSection.kt
@@ -24,7 +24,6 @@ import com.riox432.civitdeck.feature.externalserver.presentation.ExternalServerG
 import com.riox432.civitdeck.feature.externalserver.presentation.ExternalServerSettingsViewModel
 import com.riox432.civitdeck.ui.theme.Spacing
 
-@Suppress("LongMethod")
 @Composable
 fun ExternalServerSettingsSection(viewModel: ExternalServerSettingsViewModel) {
     val state by viewModel.uiState.collectAsState()

--- a/desktopApp/src/jvmMain/kotlin/com/riox432/civitdeck/ui/settings/DesktopExternalServerSection.kt
+++ b/desktopApp/src/jvmMain/kotlin/com/riox432/civitdeck/ui/settings/DesktopExternalServerSection.kt
@@ -39,48 +39,8 @@ fun ExternalServerSettingsSection(viewModel: ExternalServerSettingsViewModel) {
         )
         Spacer(modifier = Modifier.height(Spacing.sm))
 
-        state.activeConfig?.let { active ->
-            Text(
-                text = "Active: ${active.name} (${active.baseUrl})",
-                style = MaterialTheme.typography.bodySmall,
-            )
-            Spacer(modifier = Modifier.height(Spacing.sm))
-            OutlinedButton(
-                onClick = viewModel::onTestConnection,
-                enabled = !state.isTesting,
-            ) {
-                Text(if (state.isTesting) "Testing..." else "Test Connection")
-            }
-            state.testError?.let { error ->
-                Text(error, color = MaterialTheme.colorScheme.error, style = MaterialTheme.typography.bodySmall)
-            }
-        }
-
-        if (state.configs.isNotEmpty()) {
-            Spacer(modifier = Modifier.height(Spacing.sm))
-            Text("Saved Configs:", style = MaterialTheme.typography.labelMedium)
-            state.configs.forEach { config ->
-                Row(
-                    modifier = Modifier.fillMaxWidth(),
-                    horizontalArrangement = Arrangement.SpaceBetween,
-                    verticalAlignment = Alignment.CenterVertically,
-                ) {
-                    Text(
-                        "${config.name} - ${config.baseUrl}",
-                        style = MaterialTheme.typography.bodySmall,
-                        modifier = Modifier.weight(1f),
-                    )
-                    Row {
-                        TextButton(onClick = { viewModel.onActivateConfig(config.id) }) {
-                            Text("Activate")
-                        }
-                        TextButton(onClick = { viewModel.onDeleteConfig(config.id) }) {
-                            Text("Delete")
-                        }
-                    }
-                }
-            }
-        }
+        ExternalServerActiveConfig(state = state, viewModel = viewModel)
+        ExternalServerSavedConfigs(state = state, viewModel = viewModel)
 
         Spacer(modifier = Modifier.height(Spacing.sm))
         Text("Add Server:", style = MaterialTheme.typography.labelMedium)
@@ -118,6 +78,61 @@ fun ExternalServerSettingsSection(viewModel: ExternalServerSettingsViewModel) {
             enabled = nameInput.isNotBlank() && urlInput.isNotBlank(),
         ) {
             Text("Save Config")
+        }
+    }
+}
+
+@Composable
+private fun ExternalServerActiveConfig(
+    state: com.riox432.civitdeck.feature.externalserver.presentation.ExternalServerSettingsUiState,
+    viewModel: ExternalServerSettingsViewModel,
+) {
+    state.activeConfig?.let { active ->
+        Text(
+            text = "Active: ${active.name} (${active.baseUrl})",
+            style = MaterialTheme.typography.bodySmall,
+        )
+        Spacer(modifier = Modifier.height(Spacing.sm))
+        OutlinedButton(
+            onClick = viewModel::onTestConnection,
+            enabled = !state.isTesting,
+        ) {
+            Text(if (state.isTesting) "Testing..." else "Test Connection")
+        }
+        state.testError?.let { error ->
+            Text(error, color = MaterialTheme.colorScheme.error, style = MaterialTheme.typography.bodySmall)
+        }
+    }
+}
+
+@Composable
+private fun ExternalServerSavedConfigs(
+    state: com.riox432.civitdeck.feature.externalserver.presentation.ExternalServerSettingsUiState,
+    viewModel: ExternalServerSettingsViewModel,
+) {
+    if (state.configs.isNotEmpty()) {
+        Spacer(modifier = Modifier.height(Spacing.sm))
+        Text("Saved Configs:", style = MaterialTheme.typography.labelMedium)
+        state.configs.forEach { config ->
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Text(
+                    "${config.name} - ${config.baseUrl}",
+                    style = MaterialTheme.typography.bodySmall,
+                    modifier = Modifier.weight(1f),
+                )
+                Row {
+                    TextButton(onClick = { viewModel.onActivateConfig(config.id) }) {
+                        Text("Activate")
+                    }
+                    TextButton(onClick = { viewModel.onDeleteConfig(config.id) }) {
+                        Text("Delete")
+                    }
+                }
+            }
         }
     }
 }

--- a/desktopApp/src/jvmMain/kotlin/com/riox432/civitdeck/ui/settings/DesktopSDWebUISection.kt
+++ b/desktopApp/src/jvmMain/kotlin/com/riox432/civitdeck/ui/settings/DesktopSDWebUISection.kt
@@ -44,89 +44,127 @@ fun SDWebUISettingsSection(viewModel: SDWebUISettingsViewModel) {
         )
         Spacer(modifier = Modifier.height(Spacing.sm))
 
-        state.activeConnection?.let { active ->
-            Text(
-                text = "Active: ${active.name} (${active.hostname}:${active.port})",
-                style = MaterialTheme.typography.bodySmall,
-            )
-            Spacer(modifier = Modifier.height(Spacing.sm))
-            OutlinedButton(
-                onClick = viewModel::onTestConnection,
-                enabled = !state.isTesting,
-            ) {
-                Text(if (state.isTesting) "Testing..." else "Test")
-            }
-            state.testError?.let { error ->
-                Text(error, color = MaterialTheme.colorScheme.error, style = MaterialTheme.typography.bodySmall)
-            }
-        }
+        SDWebUIActiveConnection(state = state, viewModel = viewModel)
+        SDWebUISavedConnections(state = state, viewModel = viewModel)
 
-        if (state.connections.isNotEmpty()) {
-            Spacer(modifier = Modifier.height(Spacing.sm))
-            Text("Saved Connections:", style = MaterialTheme.typography.labelMedium)
-            state.connections.forEach { conn ->
-                Row(
-                    modifier = Modifier.fillMaxWidth(),
-                    horizontalArrangement = Arrangement.SpaceBetween,
-                    verticalAlignment = Alignment.CenterVertically,
-                ) {
-                    Text(
-                        "${conn.name} (${conn.hostname}:${conn.port})",
-                        style = MaterialTheme.typography.bodySmall,
-                        modifier = Modifier.weight(1f),
-                    )
-                    Row {
-                        TextButton(onClick = { viewModel.onActivateConnection(conn.id) }) {
-                            Text("Activate")
-                        }
-                        TextButton(onClick = { viewModel.onDeleteConnection(conn.id) }) {
-                            Text("Delete")
-                        }
+        Spacer(modifier = Modifier.height(Spacing.sm))
+        SDWebUIAddConnectionForm(
+            nameInput = nameInput,
+            hostInput = hostInput,
+            portInput = portInput,
+            onNameChange = { nameInput = it },
+            onHostChange = { hostInput = it },
+            onPortChange = { portInput = it },
+            onSave = {
+                portInput.toIntOrNull()?.let { port ->
+                    viewModel.onSaveConnection(nameInput, hostInput, port)
+                    nameInput = ""
+                    hostInput = ComfyUiConnectionDefaults.DEFAULT_HOST
+                    portInput = SDWebUIConnection.DEFAULT_SDWEBUI_PORT.toString()
+                }
+            },
+        )
+    }
+}
+
+@Composable
+@Suppress("LongParameterList")
+private fun SDWebUIAddConnectionForm(
+    nameInput: String,
+    hostInput: String,
+    portInput: String,
+    onNameChange: (String) -> Unit,
+    onHostChange: (String) -> Unit,
+    onPortChange: (String) -> Unit,
+    onSave: () -> Unit,
+) {
+    Text("Add Connection:", style = MaterialTheme.typography.labelMedium)
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.spacedBy(Spacing.sm),
+    ) {
+        OutlinedTextField(
+            value = nameInput,
+            onValueChange = onNameChange,
+            label = { Text("Name") },
+            singleLine = true,
+            modifier = Modifier.weight(1f),
+        )
+        OutlinedTextField(
+            value = hostInput,
+            onValueChange = onHostChange,
+            label = { Text("Host") },
+            singleLine = true,
+            modifier = Modifier.weight(1f),
+        )
+        OutlinedTextField(
+            value = portInput,
+            onValueChange = onPortChange,
+            label = { Text("Port") },
+            singleLine = true,
+            modifier = Modifier.width(Spacing.xxl * 3),
+        )
+    }
+    Spacer(modifier = Modifier.height(Spacing.sm))
+    Button(
+        onClick = onSave,
+        enabled = nameInput.isNotBlank() && hostInput.isNotBlank(),
+    ) {
+        Text("Save Connection")
+    }
+}
+
+@Composable
+private fun SDWebUIActiveConnection(
+    state: com.riox432.civitdeck.feature.comfyui.presentation.SDWebUISettingsUiState,
+    viewModel: SDWebUISettingsViewModel,
+) {
+    state.activeConnection?.let { active ->
+        Text(
+            text = "Active: ${active.name} (${active.hostname}:${active.port})",
+            style = MaterialTheme.typography.bodySmall,
+        )
+        Spacer(modifier = Modifier.height(Spacing.sm))
+        OutlinedButton(
+            onClick = viewModel::onTestConnection,
+            enabled = !state.isTesting,
+        ) {
+            Text(if (state.isTesting) "Testing..." else "Test")
+        }
+        state.testError?.let { error ->
+            Text(error, color = MaterialTheme.colorScheme.error, style = MaterialTheme.typography.bodySmall)
+        }
+    }
+}
+
+@Composable
+private fun SDWebUISavedConnections(
+    state: com.riox432.civitdeck.feature.comfyui.presentation.SDWebUISettingsUiState,
+    viewModel: SDWebUISettingsViewModel,
+) {
+    if (state.connections.isNotEmpty()) {
+        Spacer(modifier = Modifier.height(Spacing.sm))
+        Text("Saved Connections:", style = MaterialTheme.typography.labelMedium)
+        state.connections.forEach { conn ->
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Text(
+                    "${conn.name} (${conn.hostname}:${conn.port})",
+                    style = MaterialTheme.typography.bodySmall,
+                    modifier = Modifier.weight(1f),
+                )
+                Row {
+                    TextButton(onClick = { viewModel.onActivateConnection(conn.id) }) {
+                        Text("Activate")
+                    }
+                    TextButton(onClick = { viewModel.onDeleteConnection(conn.id) }) {
+                        Text("Delete")
                     }
                 }
             }
-        }
-
-        Spacer(modifier = Modifier.height(Spacing.sm))
-        Text("Add Connection:", style = MaterialTheme.typography.labelMedium)
-        Row(
-            modifier = Modifier.fillMaxWidth(),
-            horizontalArrangement = Arrangement.spacedBy(Spacing.sm),
-        ) {
-            OutlinedTextField(
-                value = nameInput,
-                onValueChange = { nameInput = it },
-                label = { Text("Name") },
-                singleLine = true,
-                modifier = Modifier.weight(1f),
-            )
-            OutlinedTextField(
-                value = hostInput,
-                onValueChange = { hostInput = it },
-                label = { Text("Host") },
-                singleLine = true,
-                modifier = Modifier.weight(1f),
-            )
-            OutlinedTextField(
-                value = portInput,
-                onValueChange = { portInput = it },
-                label = { Text("Port") },
-                singleLine = true,
-                modifier = Modifier.width(Spacing.xxl * 3),
-            )
-        }
-        Spacer(modifier = Modifier.height(Spacing.sm))
-        Button(
-            onClick = {
-                val port = portInput.toIntOrNull() ?: return@Button
-                viewModel.onSaveConnection(nameInput, hostInput, port)
-                nameInput = ""
-                hostInput = ComfyUiConnectionDefaults.DEFAULT_HOST
-                portInput = SDWebUIConnection.DEFAULT_SDWEBUI_PORT.toString()
-            },
-            enabled = nameInput.isNotBlank() && hostInput.isNotBlank(),
-        ) {
-            Text("Save Connection")
         }
     }
 }
@@ -139,124 +177,171 @@ fun SDWebUIGenerationSection(viewModel: SDWebUIGenerationViewModel) {
         if (state.isLoading) {
             Text("Loading resources...", style = MaterialTheme.typography.bodySmall)
         } else {
-            if (state.models.isNotEmpty()) {
-                SettingsDropdown(
-                    label = "Model",
-                    selected = state.selectedModel.ifEmpty { "Select..." },
-                    options = state.models,
-                    onSelected = viewModel::onModelSelected,
-                )
-                Spacer(modifier = Modifier.height(Spacing.sm))
-            }
-            if (state.samplers.isNotEmpty()) {
-                SettingsDropdown(
-                    label = "Sampler",
-                    selected = state.selectedSampler,
-                    options = state.samplers,
-                    onSelected = viewModel::onSamplerSelected,
-                )
-                Spacer(modifier = Modifier.height(Spacing.sm))
-            }
-            OutlinedTextField(
-                value = state.prompt,
-                onValueChange = viewModel::onPromptChanged,
-                label = { Text("Prompt") },
-                modifier = Modifier.fillMaxWidth(),
-                minLines = 3,
-                maxLines = 5,
-            )
+            SDWebUIResourceSelectors(state = state, viewModel = viewModel)
+            SDWebUIPromptFields(state = state, viewModel = viewModel)
             Spacer(modifier = Modifier.height(Spacing.sm))
-            OutlinedTextField(
-                value = state.negativePrompt,
-                onValueChange = viewModel::onNegativePromptChanged,
-                label = { Text("Negative Prompt") },
-                modifier = Modifier.fillMaxWidth(),
-                minLines = 2,
-                maxLines = 3,
-            )
+            SDWebUIGenerationParams(state = state, viewModel = viewModel)
             Spacer(modifier = Modifier.height(Spacing.sm))
-            Row(horizontalArrangement = Arrangement.spacedBy(Spacing.md)) {
-                Column(modifier = Modifier.weight(1f)) {
-                    SliderSetting(
-                        label = "Steps",
-                        value = state.steps.toFloat(),
-                        valueRange = 1f..150f,
-                        steps = 148,
-                        valueLabel = state.steps.toString(),
-                        onValueChange = { viewModel.onStepsChanged(it.toInt()) },
-                    )
-                }
-                Column(modifier = Modifier.weight(1f)) {
-                    SliderSetting(
-                        label = "CFG Scale",
-                        value = state.cfgScale.toFloat(),
-                        valueRange = 1f..30f,
-                        steps = 28,
-                        valueLabel = "%.1f".format(state.cfgScale),
-                        onValueChange = { viewModel.onCfgChanged(it.toDouble()) },
-                    )
-                }
-            }
-            Spacer(modifier = Modifier.height(Spacing.sm))
-            Row(horizontalArrangement = Arrangement.spacedBy(Spacing.md)) {
-                OutlinedTextField(
-                    value = state.width.toString(),
-                    onValueChange = { it.toIntOrNull()?.let(viewModel::onWidthChanged) },
-                    label = { Text("Width") },
-                    singleLine = true,
-                    modifier = Modifier.weight(1f),
-                )
-                OutlinedTextField(
-                    value = state.height.toString(),
-                    onValueChange = { it.toIntOrNull()?.let(viewModel::onHeightChanged) },
-                    label = { Text("Height") },
-                    singleLine = true,
-                    modifier = Modifier.weight(1f),
-                )
-                OutlinedTextField(
-                    value = if (state.seed == -1L) "" else state.seed.toString(),
-                    onValueChange = { viewModel.onSeedChanged(it.toLongOrNull() ?: -1L) },
-                    label = { Text("Seed (-1 = random)") },
-                    singleLine = true,
-                    modifier = Modifier.weight(1f),
-                )
-            }
+            SDWebUIDimensionFields(state = state, viewModel = viewModel)
             Spacer(modifier = Modifier.height(Spacing.md))
-            if (state.isGenerating) {
-                LinearProgressIndicator(
-                    progress = { state.progress.toFloat() },
-                    modifier = Modifier.fillMaxWidth(),
-                )
-                Spacer(modifier = Modifier.height(Spacing.sm))
-                Row(horizontalArrangement = Arrangement.spacedBy(Spacing.sm)) {
-                    Text(
-                        "Generating... ${(state.progress * 100).toInt()}%",
-                        style = MaterialTheme.typography.bodySmall,
-                    )
-                    OutlinedButton(onClick = viewModel::onInterrupt) {
-                        Text("Interrupt")
-                    }
-                }
-            } else {
-                Button(
-                    onClick = viewModel::onGenerate,
-                    enabled = state.prompt.isNotBlank(),
-                ) {
-                    Text("Generate")
-                }
-            }
-            state.error?.let { error ->
-                Spacer(modifier = Modifier.height(Spacing.sm))
-                Text(error, color = MaterialTheme.colorScheme.error, style = MaterialTheme.typography.bodySmall)
-            }
-            if (state.generatedImages.isNotEmpty()) {
-                Spacer(modifier = Modifier.height(Spacing.sm))
-                Text(
-                    "${state.generatedImages.size} image(s) generated",
-                    style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.primary,
-                )
+            SDWebUIGenerateControls(state = state, viewModel = viewModel)
+            SDWebUIGenerationFooter(state = state)
+        }
+    }
+}
+
+@Composable
+private fun SDWebUIResourceSelectors(
+    state: com.riox432.civitdeck.feature.comfyui.presentation.SDWebUIGenerationUiState,
+    viewModel: SDWebUIGenerationViewModel,
+) {
+    if (state.models.isNotEmpty()) {
+        SettingsDropdown(
+            label = "Model",
+            selected = state.selectedModel.ifEmpty { "Select..." },
+            options = state.models,
+            onSelected = viewModel::onModelSelected,
+        )
+        Spacer(modifier = Modifier.height(Spacing.sm))
+    }
+    if (state.samplers.isNotEmpty()) {
+        SettingsDropdown(
+            label = "Sampler",
+            selected = state.selectedSampler,
+            options = state.samplers,
+            onSelected = viewModel::onSamplerSelected,
+        )
+        Spacer(modifier = Modifier.height(Spacing.sm))
+    }
+}
+
+@Composable
+private fun SDWebUIPromptFields(
+    state: com.riox432.civitdeck.feature.comfyui.presentation.SDWebUIGenerationUiState,
+    viewModel: SDWebUIGenerationViewModel,
+) {
+    OutlinedTextField(
+        value = state.prompt,
+        onValueChange = viewModel::onPromptChanged,
+        label = { Text("Prompt") },
+        modifier = Modifier.fillMaxWidth(),
+        minLines = 3,
+        maxLines = 5,
+    )
+    Spacer(modifier = Modifier.height(Spacing.sm))
+    OutlinedTextField(
+        value = state.negativePrompt,
+        onValueChange = viewModel::onNegativePromptChanged,
+        label = { Text("Negative Prompt") },
+        modifier = Modifier.fillMaxWidth(),
+        minLines = 2,
+        maxLines = 3,
+    )
+}
+
+@Composable
+private fun SDWebUIGenerationParams(
+    state: com.riox432.civitdeck.feature.comfyui.presentation.SDWebUIGenerationUiState,
+    viewModel: SDWebUIGenerationViewModel,
+) {
+    Row(horizontalArrangement = Arrangement.spacedBy(Spacing.md)) {
+        Column(modifier = Modifier.weight(1f)) {
+            SliderSetting(
+                label = "Steps",
+                value = state.steps.toFloat(),
+                valueRange = 1f..150f,
+                steps = 148,
+                valueLabel = state.steps.toString(),
+                onValueChange = { viewModel.onStepsChanged(it.toInt()) },
+            )
+        }
+        Column(modifier = Modifier.weight(1f)) {
+            SliderSetting(
+                label = "CFG Scale",
+                value = state.cfgScale.toFloat(),
+                valueRange = 1f..30f,
+                steps = 28,
+                valueLabel = "%.1f".format(state.cfgScale),
+                onValueChange = { viewModel.onCfgChanged(it.toDouble()) },
+            )
+        }
+    }
+}
+
+@Composable
+private fun SDWebUIDimensionFields(
+    state: com.riox432.civitdeck.feature.comfyui.presentation.SDWebUIGenerationUiState,
+    viewModel: SDWebUIGenerationViewModel,
+) {
+    Row(horizontalArrangement = Arrangement.spacedBy(Spacing.md)) {
+        OutlinedTextField(
+            value = state.width.toString(),
+            onValueChange = { it.toIntOrNull()?.let(viewModel::onWidthChanged) },
+            label = { Text("Width") },
+            singleLine = true,
+            modifier = Modifier.weight(1f),
+        )
+        OutlinedTextField(
+            value = state.height.toString(),
+            onValueChange = { it.toIntOrNull()?.let(viewModel::onHeightChanged) },
+            label = { Text("Height") },
+            singleLine = true,
+            modifier = Modifier.weight(1f),
+        )
+        OutlinedTextField(
+            value = if (state.seed == -1L) "" else state.seed.toString(),
+            onValueChange = { viewModel.onSeedChanged(it.toLongOrNull() ?: -1L) },
+            label = { Text("Seed (-1 = random)") },
+            singleLine = true,
+            modifier = Modifier.weight(1f),
+        )
+    }
+}
+
+@Composable
+private fun SDWebUIGenerateControls(
+    state: com.riox432.civitdeck.feature.comfyui.presentation.SDWebUIGenerationUiState,
+    viewModel: SDWebUIGenerationViewModel,
+) {
+    if (state.isGenerating) {
+        LinearProgressIndicator(
+            progress = { state.progress.toFloat() },
+            modifier = Modifier.fillMaxWidth(),
+        )
+        Spacer(modifier = Modifier.height(Spacing.sm))
+        Row(horizontalArrangement = Arrangement.spacedBy(Spacing.sm)) {
+            Text(
+                "Generating... ${(state.progress * 100).toInt()}%",
+                style = MaterialTheme.typography.bodySmall,
+            )
+            OutlinedButton(onClick = viewModel::onInterrupt) {
+                Text("Interrupt")
             }
         }
+    } else {
+        Button(
+            onClick = viewModel::onGenerate,
+            enabled = state.prompt.isNotBlank(),
+        ) {
+            Text("Generate")
+        }
+    }
+}
+
+@Composable
+private fun SDWebUIGenerationFooter(
+    state: com.riox432.civitdeck.feature.comfyui.presentation.SDWebUIGenerationUiState,
+) {
+    state.error?.let { error ->
+        Spacer(modifier = Modifier.height(Spacing.sm))
+        Text(error, color = MaterialTheme.colorScheme.error, style = MaterialTheme.typography.bodySmall)
+    }
+    if (state.generatedImages.isNotEmpty()) {
+        Spacer(modifier = Modifier.height(Spacing.sm))
+        Text(
+            "${state.generatedImages.size} image(s) generated",
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.primary,
+        )
     }
 }

--- a/desktopApp/src/jvmMain/kotlin/com/riox432/civitdeck/ui/settings/DesktopSDWebUISection.kt
+++ b/desktopApp/src/jvmMain/kotlin/com/riox432/civitdeck/ui/settings/DesktopSDWebUISection.kt
@@ -29,7 +29,6 @@ import com.riox432.civitdeck.feature.comfyui.presentation.SDWebUIGenerationViewM
 import com.riox432.civitdeck.feature.comfyui.presentation.SDWebUISettingsViewModel
 import com.riox432.civitdeck.ui.theme.Spacing
 
-@Suppress("LongMethod")
 @Composable
 fun SDWebUISettingsSection(viewModel: SDWebUISettingsViewModel) {
     val state by viewModel.uiState.collectAsState()
@@ -132,7 +131,6 @@ fun SDWebUISettingsSection(viewModel: SDWebUISettingsViewModel) {
     }
 }
 
-@Suppress("LongMethod")
 @Composable
 fun SDWebUIGenerationSection(viewModel: SDWebUIGenerationViewModel) {
     val state by viewModel.uiState.collectAsState()

--- a/desktopApp/src/jvmMain/kotlin/com/riox432/civitdeck/ui/settings/DesktopStorageSection.kt
+++ b/desktopApp/src/jvmMain/kotlin/com/riox432/civitdeck/ui/settings/DesktopStorageSection.kt
@@ -57,28 +57,49 @@ internal fun StorageSection(viewModel: StorageSettingsViewModel) {
         }
     }
 
+    StorageClearDialogs(
+        viewModel = viewModel,
+        showClearCacheDialog = showClearCacheDialog,
+        showClearSearchDialog = showClearSearchDialog,
+        showClearHistoryDialog = showClearHistoryDialog,
+        onDismissCache = { showClearCacheDialog = false },
+        onDismissSearch = { showClearSearchDialog = false },
+        onDismissHistory = { showClearHistoryDialog = false },
+    )
+}
+
+@Composable
+private fun StorageClearDialogs(
+    viewModel: StorageSettingsViewModel,
+    showClearCacheDialog: Boolean,
+    showClearSearchDialog: Boolean,
+    showClearHistoryDialog: Boolean,
+    onDismissCache: () -> Unit,
+    onDismissSearch: () -> Unit,
+    onDismissHistory: () -> Unit,
+) {
     ClearCacheDialog(
         visible = showClearCacheDialog,
-        onDismiss = { showClearCacheDialog = false },
+        onDismiss = onDismissCache,
         onConfirm = {
             viewModel.onClearCache()
-            showClearCacheDialog = false
+            onDismissCache()
         },
     )
     ClearSearchDialog(
         visible = showClearSearchDialog,
-        onDismiss = { showClearSearchDialog = false },
+        onDismiss = onDismissSearch,
         onConfirm = {
             viewModel.onClearSearchHistory()
-            showClearSearchDialog = false
+            onDismissSearch()
         },
     )
     ClearHistoryDialog(
         visible = showClearHistoryDialog,
-        onDismiss = { showClearHistoryDialog = false },
+        onDismiss = onDismissHistory,
         onConfirm = {
             viewModel.onClearBrowsingHistory()
-            showClearHistoryDialog = false
+            onDismissHistory()
         },
     )
 }

--- a/desktopApp/src/jvmMain/kotlin/com/riox432/civitdeck/ui/settings/DesktopStorageSection.kt
+++ b/desktopApp/src/jvmMain/kotlin/com/riox432/civitdeck/ui/settings/DesktopStorageSection.kt
@@ -19,7 +19,6 @@ import androidx.compose.ui.Modifier
 import com.riox432.civitdeck.feature.settings.presentation.StorageSettingsViewModel
 import com.riox432.civitdeck.ui.theme.Spacing
 
-@Suppress("LongMethod")
 @Composable
 internal fun StorageSection(viewModel: StorageSettingsViewModel) {
     val state by viewModel.uiState.collectAsState()

--- a/desktopApp/src/jvmMain/kotlin/com/riox432/civitdeck/ui/viewer/DesktopImageViewer.kt
+++ b/desktopApp/src/jvmMain/kotlin/com/riox432/civitdeck/ui/viewer/DesktopImageViewer.kt
@@ -39,7 +39,6 @@ import coil3.compose.SubcomposeAsyncImage
 import com.riox432.civitdeck.ui.components.ImageErrorPlaceholder
 import com.riox432.civitdeck.ui.theme.Spacing
 
-@Suppress("LongMethod")
 @OptIn(ExperimentalComposeUiApi::class)
 @Composable
 fun DesktopImageViewer(

--- a/desktopApp/src/jvmMain/kotlin/com/riox432/civitdeck/ui/viewer/DesktopImageViewer.kt
+++ b/desktopApp/src/jvmMain/kotlin/com/riox432/civitdeck/ui/viewer/DesktopImageViewer.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.focusable
 import androidx.compose.foundation.gestures.detectDragGestures
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxScope
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
@@ -48,24 +49,7 @@ fun DesktopImageViewer(
     modifier: Modifier = Modifier,
 ) {
     if (imageUrls.isEmpty()) {
-        Box(
-            modifier = modifier
-                .fillMaxSize()
-                .background(MaterialTheme.colorScheme.scrim.copy(alpha = OVERLAY_ALPHA)),
-            contentAlignment = Alignment.Center,
-        ) {
-            Text("No images available", color = MaterialTheme.colorScheme.onSurface)
-            IconButton(
-                onClick = onClose,
-                modifier = Modifier.align(Alignment.TopEnd).padding(Spacing.lg),
-            ) {
-                Icon(
-                    Icons.Default.Close,
-                    contentDescription = "Close",
-                    tint = MaterialTheme.colorScheme.onSurface,
-                )
-            }
-        }
+        EmptyImageViewer(onClose = onClose, modifier = modifier)
         return
     }
 
@@ -91,80 +75,186 @@ fun DesktopImageViewer(
             .background(MaterialTheme.colorScheme.scrim.copy(alpha = OVERLAY_ALPHA))
             .focusRequester(focusRequester)
             .focusable()
-            .onKeyEvent { keyEvent ->
-                if (keyEvent.type == KeyEventType.KeyDown) {
-                    when (keyEvent.key) {
-                        Key.Escape -> {
-                            onClose()
-                            true
-                        }
-                        Key.DirectionLeft -> {
-                            if (currentIndex > 0) currentIndex--
-                            true
-                        }
-                        Key.DirectionRight -> {
-                            if (currentIndex < imageUrls.lastIndex) currentIndex++
-                            true
-                        }
-                        else -> false
-                    }
-                } else {
-                    false
-                }
-            }
-            .onPointerEvent(PointerEventType.Scroll) { event ->
-                val scrollDelta = event.changes.firstOrNull()?.scrollDelta?.y ?: 0f
-                val zoomFactor = if (scrollDelta < 0) ZOOM_IN_FACTOR else ZOOM_OUT_FACTOR
-                scale = (scale * zoomFactor).coerceIn(MIN_SCALE, MAX_SCALE)
-            }
-            .pointerInput(Unit) {
-                detectDragGestures { change, dragAmount ->
-                    change.consume()
-                    offsetX += dragAmount.x
-                    offsetY += dragAmount.y
-                }
-            },
+            .imageViewerGestures(
+                onKey = { keyEvent ->
+                    handleViewerKeyEvent(
+                        keyEvent = keyEvent,
+                        onClose = onClose,
+                        canGoPrevious = currentIndex > 0,
+                        canGoNext = currentIndex < imageUrls.lastIndex,
+                        onPrevious = { currentIndex-- },
+                        onNext = { currentIndex++ },
+                    )
+                },
+                onZoom = { zoomFactor -> scale = (scale * zoomFactor).coerceIn(MIN_SCALE, MAX_SCALE) },
+                onDrag = { dx, dy ->
+                    offsetX += dx
+                    offsetY += dy
+                },
+            ),
         contentAlignment = Alignment.Center,
     ) {
-        SubcomposeAsyncImage(
-            model = imageUrls[currentIndex],
-            contentDescription = "Image ${currentIndex + 1} of ${imageUrls.size}",
-            modifier = Modifier
-                .fillMaxSize()
-                .graphicsLayer {
-                    scaleX = scale
-                    scaleY = scale
-                    translationX = offsetX
-                    translationY = offsetY
-                },
-            contentScale = ContentScale.Fit,
-            loading = {
-                Box(
-                    modifier = Modifier.fillMaxSize(),
-                    contentAlignment = Alignment.Center,
-                ) {
-                    CircularProgressIndicator(color = MaterialTheme.colorScheme.onSurface)
-                }
-            },
-            error = { ImageErrorPlaceholder(modifier = Modifier.fillMaxSize()) },
+        ImageViewerBody(
+            imageUrls = imageUrls,
+            currentIndex = currentIndex,
+            scale = scale,
+            offsetX = offsetX,
+            offsetY = offsetY,
+            onClose = onClose,
         )
+    }
+}
 
-        IconButton(
-            onClick = onClose,
-            modifier = Modifier.align(Alignment.TopEnd).padding(Spacing.lg),
-        ) {
-            Icon(
-                Icons.Default.Close,
-                contentDescription = "Close",
-                tint = MaterialTheme.colorScheme.onSurface,
-            )
+@Composable
+@Suppress("LongParameterList")
+private fun BoxScope.ImageViewerBody(
+    imageUrls: List<String>,
+    currentIndex: Int,
+    scale: Float,
+    offsetX: Float,
+    offsetY: Float,
+    onClose: () -> Unit,
+) {
+    ZoomableViewerImage(
+        url = imageUrls[currentIndex],
+        contentDescription = "Image ${currentIndex + 1} of ${imageUrls.size}",
+        scale = scale,
+        offsetX = offsetX,
+        offsetY = offsetY,
+    )
+    ImageViewerControls(
+        indexLabel = "${currentIndex + 1} / ${imageUrls.size}",
+        onClose = onClose,
+    )
+}
+
+@OptIn(ExperimentalComposeUiApi::class)
+private fun Modifier.imageViewerGestures(
+    onKey: (androidx.compose.ui.input.key.KeyEvent) -> Boolean,
+    onZoom: (Float) -> Unit,
+    onDrag: (Float, Float) -> Unit,
+): Modifier = this
+    .onKeyEvent(onKey)
+    .onPointerEvent(PointerEventType.Scroll) { event ->
+        val scrollDelta = event.changes.firstOrNull()?.scrollDelta?.y ?: 0f
+        val zoomFactor = if (scrollDelta < 0) ZOOM_IN_FACTOR else ZOOM_OUT_FACTOR
+        onZoom(zoomFactor)
+    }
+    .pointerInput(Unit) {
+        detectDragGestures { change, dragAmount ->
+            change.consume()
+            onDrag(dragAmount.x, dragAmount.y)
         }
+    }
 
-        Text(
-            text = "${currentIndex + 1} / ${imageUrls.size}",
-            color = MaterialTheme.colorScheme.onSurface,
-            style = MaterialTheme.typography.labelLarge,
-            modifier = Modifier.align(Alignment.BottomCenter).padding(Spacing.lg),
+@Composable
+private fun BoxScope.ImageViewerControls(
+    indexLabel: String,
+    onClose: () -> Unit,
+) {
+    ImageViewerCloseButton(
+        onClose = onClose,
+        modifier = Modifier.align(Alignment.TopEnd),
+    )
+
+    Text(
+        text = indexLabel,
+        color = MaterialTheme.colorScheme.onSurface,
+        style = MaterialTheme.typography.labelLarge,
+        modifier = Modifier.align(Alignment.BottomCenter).padding(Spacing.lg),
+    )
+}
+
+@Composable
+private fun ZoomableViewerImage(
+    url: String,
+    contentDescription: String,
+    scale: Float,
+    offsetX: Float,
+    offsetY: Float,
+) {
+    SubcomposeAsyncImage(
+        model = url,
+        contentDescription = contentDescription,
+        modifier = Modifier
+            .fillMaxSize()
+            .graphicsLayer {
+                scaleX = scale
+                scaleY = scale
+                translationX = offsetX
+                translationY = offsetY
+            },
+        contentScale = ContentScale.Fit,
+        loading = {
+            Box(
+                modifier = Modifier.fillMaxSize(),
+                contentAlignment = Alignment.Center,
+            ) {
+                CircularProgressIndicator(color = MaterialTheme.colorScheme.onSurface)
+            }
+        },
+        error = { ImageErrorPlaceholder(modifier = Modifier.fillMaxSize()) },
+    )
+}
+
+private fun handleViewerKeyEvent(
+    keyEvent: androidx.compose.ui.input.key.KeyEvent,
+    onClose: () -> Unit,
+    canGoPrevious: Boolean,
+    canGoNext: Boolean,
+    onPrevious: () -> Unit,
+    onNext: () -> Unit,
+): Boolean {
+    if (keyEvent.type != KeyEventType.KeyDown) return false
+    return when (keyEvent.key) {
+        Key.Escape -> {
+            onClose()
+            true
+        }
+        Key.DirectionLeft -> {
+            if (canGoPrevious) onPrevious()
+            true
+        }
+        Key.DirectionRight -> {
+            if (canGoNext) onNext()
+            true
+        }
+        else -> false
+    }
+}
+
+@Composable
+private fun EmptyImageViewer(
+    onClose: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Box(
+        modifier = modifier
+            .fillMaxSize()
+            .background(MaterialTheme.colorScheme.scrim.copy(alpha = OVERLAY_ALPHA)),
+        contentAlignment = Alignment.Center,
+    ) {
+        Text("No images available", color = MaterialTheme.colorScheme.onSurface)
+        ImageViewerCloseButton(
+            onClose = onClose,
+            modifier = Modifier.align(Alignment.TopEnd),
+        )
+    }
+}
+
+@Composable
+private fun ImageViewerCloseButton(
+    onClose: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    IconButton(
+        onClick = onClose,
+        modifier = modifier.padding(Spacing.lg),
+    ) {
+        Icon(
+            Icons.Default.Close,
+            contentDescription = "Close",
+            tint = MaterialTheme.colorScheme.onSurface,
         )
     }
 }

--- a/feature/feature-collections/src/commonMain/kotlin/com/riox432/civitdeck/feature/collections/presentation/DatasetDetailViewModel.kt
+++ b/feature/feature-collections/src/commonMain/kotlin/com/riox432/civitdeck/feature/collections/presentation/DatasetDetailViewModel.kt
@@ -24,7 +24,7 @@ import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 
-@Suppress("LongParameterList", "TooManyFunctions")
+@Suppress("LongParameterList")
 class DatasetDetailViewModel(
     val datasetId: Long,
     observeDatasetImagesUseCase: ObserveDatasetImagesUseCase,

--- a/feature/feature-comfyui/src/commonMain/kotlin/com/riox432/civitdeck/feature/comfyui/data/repository/ComfyUIGenerationRepositoryImpl.kt
+++ b/feature/feature-comfyui/src/commonMain/kotlin/com/riox432/civitdeck/feature/comfyui/data/repository/ComfyUIGenerationRepositoryImpl.kt
@@ -135,7 +135,6 @@ class ComfyUIGenerationRepositoryImpl(
         api.setBaseUrl("$scheme://${active.hostname}:${active.port}")
     }
 
-    @Suppress("LongMethod")
     private fun buildWorkflow(params: ComfyUIGenerationParams): JsonObject {
         // If custom workflow JSON is provided, use it directly
         val customJson = params.customWorkflowJson
@@ -187,7 +186,6 @@ class ComfyUIGenerationRepositoryImpl(
         }
     }
 
-    @Suppress("LongMethod")
     private fun buildInpaintingWorkflow(params: ComfyUIGenerationParams): JsonObject {
         val loraChain = buildLoraChain(params.loraSelections)
         val finalModelNodeId = loraChain.lastOrNull()?.nodeId ?: "3"
@@ -202,47 +200,11 @@ class ComfyUIGenerationRepositoryImpl(
                 put(loraNode.nodeId, loraNode.jsonNode)
             }
             // Load init image
-            put(
-                "30",
-                buildJsonObject {
-                    put("class_type", "LoadImage")
-                    put(
-                        "inputs",
-                        buildJsonObject {
-                            put("image", requireNotNull(params.initImageFilename))
-                        }
-                    )
-                },
-            )
+            put("30", buildLoadImageNode(requireNotNull(params.initImageFilename)))
             // Load mask image
-            put(
-                "31",
-                buildJsonObject {
-                    put("class_type", "LoadImage")
-                    put(
-                        "inputs",
-                        buildJsonObject {
-                            put("image", requireNotNull(params.maskImageFilename))
-                        }
-                    )
-                },
-            )
+            put("31", buildLoadImageNode(requireNotNull(params.maskImageFilename)))
             // Set latent via VAEEncode with mask
-            put(
-                "32",
-                buildJsonObject {
-                    put("class_type", "VAEEncodeForInpaint")
-                    put(
-                        "inputs",
-                        buildJsonObject {
-                            put("pixels", nodeLink("30", 0))
-                            put("vae", nodeLink("3", 2))
-                            put("mask", nodeLink("31", 0))
-                            put("grow_mask_by", 6)
-                        }
-                    )
-                },
-            )
+            put("32", buildVaeEncodeForInpaint())
             // Conditioning
             put("6", buildClipEncode(params.prompt, finalClipNodeId, finalClipOutput))
             put("7", buildClipEncode(params.negativePrompt, finalClipNodeId, finalClipOutput))
@@ -270,6 +232,24 @@ class ComfyUIGenerationRepositoryImpl(
     private fun buildCheckpointNode(checkpoint: String) = buildJsonObject {
         put("class_type", "CheckpointLoaderSimple")
         put("inputs", buildJsonObject { put("ckpt_name", checkpoint) })
+    }
+
+    private fun buildLoadImageNode(filename: String) = buildJsonObject {
+        put("class_type", "LoadImage")
+        put("inputs", buildJsonObject { put("image", filename) })
+    }
+
+    private fun buildVaeEncodeForInpaint() = buildJsonObject {
+        put("class_type", "VAEEncodeForInpaint")
+        put(
+            "inputs",
+            buildJsonObject {
+                put("pixels", nodeLink("30", 0))
+                put("vae", nodeLink("3", 2))
+                put("mask", nodeLink("31", 0))
+                put("grow_mask_by", 6)
+            }
+        )
     }
 
     private fun buildClipEncode(text: String, clipNodeId: String, clipOutput: Int) =

--- a/feature/feature-comfyui/src/commonMain/kotlin/com/riox432/civitdeck/feature/comfyui/data/repository/ComfyUIRepositoryImpl.kt
+++ b/feature/feature-comfyui/src/commonMain/kotlin/com/riox432/civitdeck/feature/comfyui/data/repository/ComfyUIRepositoryImpl.kt
@@ -13,7 +13,6 @@ import com.riox432.civitdeck.domain.model.DomainException
 import com.riox432.civitdeck.domain.model.GenerationProgress
 import com.riox432.civitdeck.domain.model.GenerationResult
 import com.riox432.civitdeck.domain.model.GenerationStatus
-import com.riox432.civitdeck.domain.model.LoraSelection
 import com.riox432.civitdeck.domain.model.QueueJob
 import com.riox432.civitdeck.domain.model.QueueJobStatus
 import com.riox432.civitdeck.domain.repository.ComfyUIConnectionRepository
@@ -29,21 +28,18 @@ import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonObject
-import kotlinx.serialization.json.JsonPrimitive
-import kotlinx.serialization.json.buildJsonArray
-import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.jsonPrimitive
-import kotlinx.serialization.json.put
 
 private const val TAG = "ComfyUIRepositoryImpl"
 
-@Suppress("TooManyFunctions")
 class ComfyUIRepositoryImpl(
     private val dao: ComfyUIConnectionDao,
     private val api: ComfyUIApi,
     private val webSocketApi: ComfyUIWebSocketApi,
     private val json: Json,
 ) : ComfyUIConnectionRepository, ComfyUIGenerationRepository, ComfyUIQueueRepository {
+
+    private val workflowBuilder = ComfyUIWorkflowBuilder(json)
 
     override fun observeConnections(): Flow<List<ComfyUIConnection>> =
         dao.observeAll().map { list -> list.map { it.toDomain() } }
@@ -244,164 +240,8 @@ class ComfyUIRepositoryImpl(
         return "$scheme://${entity.hostname}:${entity.port}"
     }
 
-    private fun buildWorkflow(params: ComfyUIGenerationParams): JsonObject {
-        // If custom workflow JSON is provided, use it directly
-        val customJson = params.customWorkflowJson
-        if (customJson != null) {
-            return json.decodeFromString(customJson)
-        }
-
-        val loraChain = buildLoraChain(params.loraSelections)
-        val finalModelNodeId = loraChain.lastOrNull()?.nodeId ?: "3"
-        val finalClipNodeId = loraChain.lastOrNull()?.nodeId ?: "3"
-        val positiveCondId =
-            if (params.controlNetEnabled && params.controlNetModel.isNotBlank()) "21" else "6"
-
-        return buildJsonObject {
-            put("3", buildCheckpointNode(params.checkpoint))
-            loraChain.forEach { put(it.nodeId, it.jsonNode) }
-            put("6", buildClipTextNode(params.prompt, finalClipNodeId))
-            put("7", buildClipTextNode(params.negativePrompt, finalClipNodeId))
-            if (params.controlNetEnabled && params.controlNetModel.isNotBlank()) {
-                buildControlNetNodes(params).forEach { (id, node) -> put(id, node) }
-            }
-            put("5", buildLatentImageNode(params.width, params.height))
-            put("4", buildKSamplerNode(params, finalModelNodeId, positiveCondId))
-            put("8", buildVAEDecodeNode())
-            put("9", buildSaveImageNode())
-        }
-    }
-
-    private fun buildCheckpointNode(checkpoint: String) = buildJsonObject {
-        put("class_type", "CheckpointLoaderSimple")
-        put("inputs", buildJsonObject { put("ckpt_name", checkpoint) })
-    }
-
-    private fun buildClipTextNode(text: String, clipNodeId: String) = buildJsonObject {
-        put("class_type", "CLIPTextEncode")
-        put(
-            "inputs",
-            buildJsonObject {
-                put("text", text)
-                put("clip", nodeLink(clipNodeId, 1))
-            }
-        )
-    }
-
-    private fun buildControlNetNodes(
-        params: ComfyUIGenerationParams,
-    ): List<Pair<String, JsonObject>> {
-        val loader = buildJsonObject {
-            put("class_type", "ControlNetLoader")
-            put("inputs", buildJsonObject { put("control_net_name", params.controlNetModel) })
-        }
-        val apply = buildJsonObject {
-            put("class_type", "ControlNetApply")
-            put(
-                "inputs",
-                buildJsonObject {
-                    put("conditioning", nodeLink("6", 0))
-                    put("control_net", nodeLink("20", 0))
-                    put("image", buildJsonArray { })
-                    put("strength", params.controlNetStrength.toDouble())
-                }
-            )
-        }
-        return listOf("20" to loader, "21" to apply)
-    }
-
-    private fun buildLatentImageNode(width: Int, height: Int) = buildJsonObject {
-        put("class_type", "EmptyLatentImage")
-        put(
-            "inputs",
-            buildJsonObject {
-                put("width", width)
-                put("height", height)
-                put("batch_size", 1)
-            }
-        )
-    }
-
-    private fun buildKSamplerNode(
-        params: ComfyUIGenerationParams,
-        modelNodeId: String,
-        positiveCondId: String,
-    ) = buildJsonObject {
-        put("class_type", "KSampler")
-        put(
-            "inputs",
-            buildJsonObject {
-                put("seed", params.seed)
-                put("steps", params.steps)
-                put("cfg", params.cfgScale)
-                put("sampler_name", params.samplerName)
-                put("scheduler", params.scheduler)
-                put("denoise", 1.0)
-                put("model", nodeLink(modelNodeId, 0))
-                put("positive", nodeLink(positiveCondId, 0))
-                put("negative", nodeLink("7", 0))
-                put("latent_image", nodeLink("5", 0))
-            }
-        )
-    }
-
-    private fun buildVAEDecodeNode() = buildJsonObject {
-        put("class_type", "VAEDecode")
-        put(
-            "inputs",
-            buildJsonObject {
-                put("samples", nodeLink("4", 0))
-                put("vae", nodeLink("3", 2))
-            }
-        )
-    }
-
-    private fun buildSaveImageNode() = buildJsonObject {
-        put("class_type", "SaveImage")
-        put(
-            "inputs",
-            buildJsonObject {
-                put("filename_prefix", "CivitDeck")
-                put("images", nodeLink("8", 0))
-            }
-        )
-    }
-
-    /**
-     * Builds a chain of LoraLoader nodes. Each LoRA takes the model/clip output
-     * of the previous node (or the checkpoint loader for the first LoRA).
-     * Returns a list of (nodeId, jsonNode) pairs.
-     */
-    private data class LoraNodeEntry(val nodeId: String, val jsonNode: JsonObject)
-
-    private fun buildLoraChain(loras: List<LoraSelection>): List<LoraNodeEntry> {
-        if (loras.isEmpty()) return emptyList()
-        val entries = mutableListOf<LoraNodeEntry>()
-        loras.forEachIndexed { index, lora ->
-            val nodeId = (10 + index).toString()
-            val prevNodeId = if (index == 0) "3" else (10 + index - 1).toString()
-            val node = buildJsonObject {
-                put("class_type", "LoraLoader")
-                put(
-                    "inputs",
-                    buildJsonObject {
-                        put("lora_name", lora.name)
-                        put("strength_model", lora.strengthModel.toDouble())
-                        put("strength_clip", lora.strengthClip.toDouble())
-                        put("model", nodeLink(prevNodeId, 0))
-                        put("clip", nodeLink(prevNodeId, 1))
-                    }
-                )
-            }
-            entries.add(LoraNodeEntry(nodeId, node))
-        }
-        return entries
-    }
-
-    private fun nodeLink(nodeId: String, outputIndex: Int) = buildJsonArray {
-        add(JsonPrimitive(nodeId))
-        add(JsonPrimitive(outputIndex))
-    }
+    private fun buildWorkflow(params: ComfyUIGenerationParams): JsonObject =
+        workflowBuilder.buildWorkflow(params)
 
     private fun ComfyUIConnectionEntity.toDomain() = ComfyUIConnection(
         id = id,

--- a/feature/feature-comfyui/src/commonMain/kotlin/com/riox432/civitdeck/feature/comfyui/data/repository/ComfyUIWorkflowBuilder.kt
+++ b/feature/feature-comfyui/src/commonMain/kotlin/com/riox432/civitdeck/feature/comfyui/data/repository/ComfyUIWorkflowBuilder.kt
@@ -1,0 +1,177 @@
+package com.riox432.civitdeck.feature.comfyui.data.repository
+
+import com.riox432.civitdeck.domain.model.ComfyUIGenerationParams
+import com.riox432.civitdeck.domain.model.LoraSelection
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonArray
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
+
+/**
+ * Builds ComfyUI prompt graph JSON from [ComfyUIGenerationParams].
+ * Extracted from [ComfyUIRepositoryImpl] to keep the repository focused on
+ * connection/generation/queue responsibilities.
+ */
+internal class ComfyUIWorkflowBuilder(private val json: Json) {
+
+    fun buildWorkflow(params: ComfyUIGenerationParams): JsonObject {
+        // If custom workflow JSON is provided, use it directly
+        val customJson = params.customWorkflowJson
+        if (customJson != null) {
+            return json.decodeFromString(customJson)
+        }
+
+        val loraChain = buildLoraChain(params.loraSelections)
+        val finalModelNodeId = loraChain.lastOrNull()?.nodeId ?: "3"
+        val finalClipNodeId = loraChain.lastOrNull()?.nodeId ?: "3"
+        val positiveCondId =
+            if (params.controlNetEnabled && params.controlNetModel.isNotBlank()) "21" else "6"
+
+        return buildJsonObject {
+            put("3", buildCheckpointNode(params.checkpoint))
+            loraChain.forEach { put(it.nodeId, it.jsonNode) }
+            put("6", buildClipTextNode(params.prompt, finalClipNodeId))
+            put("7", buildClipTextNode(params.negativePrompt, finalClipNodeId))
+            if (params.controlNetEnabled && params.controlNetModel.isNotBlank()) {
+                buildControlNetNodes(params).forEach { (id, node) -> put(id, node) }
+            }
+            put("5", buildLatentImageNode(params.width, params.height))
+            put("4", buildKSamplerNode(params, finalModelNodeId, positiveCondId))
+            put("8", buildVAEDecodeNode())
+            put("9", buildSaveImageNode())
+        }
+    }
+
+    private fun buildCheckpointNode(checkpoint: String) = buildJsonObject {
+        put("class_type", "CheckpointLoaderSimple")
+        put("inputs", buildJsonObject { put("ckpt_name", checkpoint) })
+    }
+
+    private fun buildClipTextNode(text: String, clipNodeId: String) = buildJsonObject {
+        put("class_type", "CLIPTextEncode")
+        put(
+            "inputs",
+            buildJsonObject {
+                put("text", text)
+                put("clip", nodeLink(clipNodeId, 1))
+            }
+        )
+    }
+
+    private fun buildControlNetNodes(
+        params: ComfyUIGenerationParams,
+    ): List<Pair<String, JsonObject>> {
+        val loader = buildJsonObject {
+            put("class_type", "ControlNetLoader")
+            put("inputs", buildJsonObject { put("control_net_name", params.controlNetModel) })
+        }
+        val apply = buildJsonObject {
+            put("class_type", "ControlNetApply")
+            put(
+                "inputs",
+                buildJsonObject {
+                    put("conditioning", nodeLink("6", 0))
+                    put("control_net", nodeLink("20", 0))
+                    put("image", buildJsonArray { })
+                    put("strength", params.controlNetStrength.toDouble())
+                }
+            )
+        }
+        return listOf("20" to loader, "21" to apply)
+    }
+
+    private fun buildLatentImageNode(width: Int, height: Int) = buildJsonObject {
+        put("class_type", "EmptyLatentImage")
+        put(
+            "inputs",
+            buildJsonObject {
+                put("width", width)
+                put("height", height)
+                put("batch_size", 1)
+            }
+        )
+    }
+
+    private fun buildKSamplerNode(
+        params: ComfyUIGenerationParams,
+        modelNodeId: String,
+        positiveCondId: String,
+    ) = buildJsonObject {
+        put("class_type", "KSampler")
+        put(
+            "inputs",
+            buildJsonObject {
+                put("seed", params.seed)
+                put("steps", params.steps)
+                put("cfg", params.cfgScale)
+                put("sampler_name", params.samplerName)
+                put("scheduler", params.scheduler)
+                put("denoise", 1.0)
+                put("model", nodeLink(modelNodeId, 0))
+                put("positive", nodeLink(positiveCondId, 0))
+                put("negative", nodeLink("7", 0))
+                put("latent_image", nodeLink("5", 0))
+            }
+        )
+    }
+
+    private fun buildVAEDecodeNode() = buildJsonObject {
+        put("class_type", "VAEDecode")
+        put(
+            "inputs",
+            buildJsonObject {
+                put("samples", nodeLink("4", 0))
+                put("vae", nodeLink("3", 2))
+            }
+        )
+    }
+
+    private fun buildSaveImageNode() = buildJsonObject {
+        put("class_type", "SaveImage")
+        put(
+            "inputs",
+            buildJsonObject {
+                put("filename_prefix", "CivitDeck")
+                put("images", nodeLink("8", 0))
+            }
+        )
+    }
+
+    /**
+     * Builds a chain of LoraLoader nodes. Each LoRA takes the model/clip output
+     * of the previous node (or the checkpoint loader for the first LoRA).
+     * Returns a list of (nodeId, jsonNode) pairs.
+     */
+    private data class LoraNodeEntry(val nodeId: String, val jsonNode: JsonObject)
+
+    private fun buildLoraChain(loras: List<LoraSelection>): List<LoraNodeEntry> {
+        if (loras.isEmpty()) return emptyList()
+        val entries = mutableListOf<LoraNodeEntry>()
+        loras.forEachIndexed { index, lora ->
+            val nodeId = (10 + index).toString()
+            val prevNodeId = if (index == 0) "3" else (10 + index - 1).toString()
+            val node = buildJsonObject {
+                put("class_type", "LoraLoader")
+                put(
+                    "inputs",
+                    buildJsonObject {
+                        put("lora_name", lora.name)
+                        put("strength_model", lora.strengthModel.toDouble())
+                        put("strength_clip", lora.strengthClip.toDouble())
+                        put("model", nodeLink(prevNodeId, 0))
+                        put("clip", nodeLink(prevNodeId, 1))
+                    }
+                )
+            }
+            entries.add(LoraNodeEntry(nodeId, node))
+        }
+        return entries
+    }
+
+    private fun nodeLink(nodeId: String, outputIndex: Int) = buildJsonArray {
+        add(JsonPrimitive(nodeId))
+        add(JsonPrimitive(outputIndex))
+    }
+}

--- a/feature/feature-comfyui/src/commonMain/kotlin/com/riox432/civitdeck/feature/comfyui/presentation/ComfyUIGenerationViewModel.kt
+++ b/feature/feature-comfyui/src/commonMain/kotlin/com/riox432/civitdeck/feature/comfyui/presentation/ComfyUIGenerationViewModel.kt
@@ -24,12 +24,9 @@ import com.riox432.civitdeck.feature.comfyui.domain.usecase.InterruptComfyUIGene
 import com.riox432.civitdeck.feature.comfyui.domain.usecase.ObserveGenerationProgressUseCase
 import com.riox432.civitdeck.feature.comfyui.domain.usecase.PollComfyUIResultUseCase
 import com.riox432.civitdeck.feature.comfyui.domain.usecase.SubmitComfyUIGenerationUseCase
-import com.riox432.civitdeck.util.Logger
-import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.update
-import kotlinx.coroutines.launch
 
 data class GenerationUiState(
     val checkpoints: List<String> = emptyList(),
@@ -80,7 +77,7 @@ data class GenerationUiState(
         get() = if (totalSteps > 0) currentStep.toFloat() / totalSteps.toFloat() else 0f
 }
 
-@Suppress("LongParameterList", "TooManyFunctions")
+@Suppress("LongParameterList")
 class ComfyUIGenerationViewModel(
     private val fetchCheckpoints: FetchComfyUICheckpointsUseCase,
     private val fetchLoras: FetchComfyUILorasUseCase,
@@ -119,49 +116,20 @@ class ComfyUIGenerationViewModel(
         observeGenNotifEnabled = observeGenNotifEnabled,
     )
 
+    private val resourceLoader = GenerationResourceLoader(
+        scope = viewModelScope,
+        uiState = _uiState,
+        fetchCheckpoints = fetchCheckpoints,
+        fetchLoras = fetchLoras,
+        fetchControlNets = fetchControlNets,
+        fetchObjectInfo = fetchObjectInfo,
+        extractParameters = extractParameters,
+    )
+
     init {
-        loadCheckpoints()
-        loadLoras()
-        loadControlNets()
-    }
-
-    private fun loadCheckpoints() {
-        _uiState.update { it.copy(isLoadingCheckpoints = true) }
-        launchWithErrorHandling(
-            tag = "Failed to load checkpoints",
-            onError = { e -> _uiState.update { it.copy(isLoadingCheckpoints = false, error = e.message) } },
-        ) {
-            val list = fetchCheckpoints()
-            _uiState.update {
-                it.copy(
-                    checkpoints = list,
-                    selectedCheckpoint = list.firstOrNull() ?: "",
-                    isLoadingCheckpoints = false,
-                )
-            }
-        }
-    }
-
-    private fun loadLoras() {
-        _uiState.update { it.copy(isLoadingLoras = true) }
-        launchWithErrorHandling(
-            tag = "Failed to fetch loras",
-            onError = { _uiState.update { it.copy(isLoadingLoras = false) } },
-        ) {
-            val list = fetchLoras()
-            _uiState.update { it.copy(availableLoras = list, isLoadingLoras = false) }
-        }
-    }
-
-    private fun loadControlNets() {
-        _uiState.update { it.copy(isLoadingControlNets = true) }
-        launchWithErrorHandling(
-            tag = "Failed to fetch control nets",
-            onError = { _uiState.update { it.copy(isLoadingControlNets = false) } },
-        ) {
-            val list = fetchControlNets()
-            _uiState.update { it.copy(availableControlNets = list, isLoadingControlNets = false) }
-        }
+        resourceLoader.loadCheckpoints()
+        resourceLoader.loadLoras()
+        resourceLoader.loadControlNets()
     }
 
     fun onCheckpointSelected(checkpoint: String) {
@@ -245,7 +213,7 @@ class ComfyUIGenerationViewModel(
         try {
             val validated = importWorkflow(jsonInput)
             _uiState.update { it.copy(customWorkflowJson = validated, workflowImportError = null) }
-            extractWorkflowParameters(validated)
+            resourceLoader.extractWorkflowParameters(validated)
         } catch (e: IllegalStateException) {
             _uiState.update { it.copy(workflowImportError = e.message) }
         }
@@ -279,19 +247,7 @@ class ComfyUIGenerationViewModel(
 
     fun onRefreshParameters() {
         val json = _uiState.value.customWorkflowJson ?: return
-        extractWorkflowParameters(json)
-    }
-
-    private fun extractWorkflowParameters(workflowJson: String) {
-        _uiState.update { it.copy(isLoadingParameters = true) }
-        launchWithErrorHandling(
-            tag = "Failed to extract workflow parameters",
-            onError = { _uiState.update { it.copy(isLoadingParameters = false) } },
-        ) {
-            val objectInfoJson = fetchObjectInfo()
-            val params = extractParameters(workflowJson, objectInfoJson)
-            _uiState.update { it.copy(extractedParameters = params, isLoadingParameters = false) }
-        }
+        resourceLoader.extractWorkflowParameters(json)
     }
 
     // -- Inpainting mask --
@@ -357,26 +313,5 @@ class ComfyUIGenerationViewModel(
             maskImageFilename = state.maskImageFilename,
             denoiseStrength = state.denoiseStrength,
         )
-    }
-
-    private inline fun launchWithErrorHandling(
-        tag: String,
-        crossinline onError: (Exception) -> Unit,
-        crossinline block: suspend () -> Unit,
-    ) {
-        viewModelScope.launch {
-            try {
-                block()
-            } catch (e: CancellationException) {
-                throw e
-            } catch (@Suppress("TooGenericExceptionCaught") e: Exception) {
-                Logger.e(TAG, "$tag: ${e.message}")
-                onError(e)
-            }
-        }
-    }
-
-    companion object {
-        private const val TAG = "ComfyUIGenerationVM"
     }
 }

--- a/feature/feature-comfyui/src/commonMain/kotlin/com/riox432/civitdeck/feature/comfyui/presentation/GenerationResourceLoader.kt
+++ b/feature/feature-comfyui/src/commonMain/kotlin/com/riox432/civitdeck/feature/comfyui/presentation/GenerationResourceLoader.kt
@@ -1,0 +1,101 @@
+package com.riox432.civitdeck.feature.comfyui.presentation
+
+import com.riox432.civitdeck.feature.comfyui.domain.usecase.ExtractWorkflowParametersUseCase
+import com.riox432.civitdeck.feature.comfyui.domain.usecase.FetchComfyUICheckpointsUseCase
+import com.riox432.civitdeck.feature.comfyui.domain.usecase.FetchComfyUIControlNetsUseCase
+import com.riox432.civitdeck.feature.comfyui.domain.usecase.FetchComfyUILorasUseCase
+import com.riox432.civitdeck.feature.comfyui.domain.usecase.FetchObjectInfoUseCase
+import com.riox432.civitdeck.util.Logger
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+
+/**
+ * Loads ComfyUI server resources (checkpoints, LoRAs, ControlNets) and extracts dynamic
+ * workflow parameters. Extracted from [ComfyUIGenerationViewModel] to reduce function count.
+ */
+@Suppress("LongParameterList")
+internal class GenerationResourceLoader(
+    private val scope: CoroutineScope,
+    private val uiState: MutableStateFlow<GenerationUiState>,
+    private val fetchCheckpoints: FetchComfyUICheckpointsUseCase,
+    private val fetchLoras: FetchComfyUILorasUseCase,
+    private val fetchControlNets: FetchComfyUIControlNetsUseCase,
+    private val fetchObjectInfo: FetchObjectInfoUseCase,
+    private val extractParameters: ExtractWorkflowParametersUseCase,
+) {
+
+    fun loadCheckpoints() {
+        uiState.update { it.copy(isLoadingCheckpoints = true) }
+        launchWithErrorHandling(
+            tag = "Failed to load checkpoints",
+            onError = { e -> uiState.update { it.copy(isLoadingCheckpoints = false, error = e.message) } },
+        ) {
+            val list = fetchCheckpoints()
+            uiState.update {
+                it.copy(
+                    checkpoints = list,
+                    selectedCheckpoint = list.firstOrNull() ?: "",
+                    isLoadingCheckpoints = false,
+                )
+            }
+        }
+    }
+
+    fun loadLoras() {
+        uiState.update { it.copy(isLoadingLoras = true) }
+        launchWithErrorHandling(
+            tag = "Failed to fetch loras",
+            onError = { uiState.update { it.copy(isLoadingLoras = false) } },
+        ) {
+            val list = fetchLoras()
+            uiState.update { it.copy(availableLoras = list, isLoadingLoras = false) }
+        }
+    }
+
+    fun loadControlNets() {
+        uiState.update { it.copy(isLoadingControlNets = true) }
+        launchWithErrorHandling(
+            tag = "Failed to fetch control nets",
+            onError = { uiState.update { it.copy(isLoadingControlNets = false) } },
+        ) {
+            val list = fetchControlNets()
+            uiState.update { it.copy(availableControlNets = list, isLoadingControlNets = false) }
+        }
+    }
+
+    fun extractWorkflowParameters(workflowJson: String) {
+        uiState.update { it.copy(isLoadingParameters = true) }
+        launchWithErrorHandling(
+            tag = "Failed to extract workflow parameters",
+            onError = { uiState.update { it.copy(isLoadingParameters = false) } },
+        ) {
+            val objectInfoJson = fetchObjectInfo()
+            val params = extractParameters(workflowJson, objectInfoJson)
+            uiState.update { it.copy(extractedParameters = params, isLoadingParameters = false) }
+        }
+    }
+
+    private inline fun launchWithErrorHandling(
+        tag: String,
+        crossinline onError: (Exception) -> Unit,
+        crossinline block: suspend () -> Unit,
+    ) {
+        scope.launch {
+            try {
+                block()
+            } catch (e: CancellationException) {
+                throw e
+            } catch (@Suppress("TooGenericExceptionCaught") e: Exception) {
+                Logger.e(TAG, "$tag: ${e.message}")
+                onError(e)
+            }
+        }
+    }
+
+    companion object {
+        private const val TAG = "GenerationResourceLoader"
+    }
+}

--- a/feature/feature-comfyui/src/commonMain/kotlin/com/riox432/civitdeck/feature/comfyui/presentation/WorkflowTemplateViewModel.kt
+++ b/feature/feature-comfyui/src/commonMain/kotlin/com/riox432/civitdeck/feature/comfyui/presentation/WorkflowTemplateViewModel.kt
@@ -142,7 +142,6 @@ class WorkflowTemplateViewModel(
                 createdAt = 0L,
             )
 
-        @Suppress("LongMethod")
         fun defaultVariablesFor(type: WorkflowTemplateType): List<TemplateVariable> =
             when (type) {
                 WorkflowTemplateType.TXT2IMG -> txt2imgVariables()

--- a/feature/feature-detail/src/commonMain/kotlin/com/riox432/civitdeck/feature/detail/presentation/DetailObserversDelegate.kt
+++ b/feature/feature-detail/src/commonMain/kotlin/com/riox432/civitdeck/feature/detail/presentation/DetailObserversDelegate.kt
@@ -1,0 +1,88 @@
+package com.riox432.civitdeck.feature.detail.presentation
+
+import com.riox432.civitdeck.domain.usecase.ObserveIsFavoriteUseCase
+import com.riox432.civitdeck.domain.usecase.ObserveModelDownloadsUseCase
+import com.riox432.civitdeck.domain.usecase.ObserveModelNoteUseCase
+import com.riox432.civitdeck.domain.usecase.ObserveNsfwFilterUseCase
+import com.riox432.civitdeck.domain.usecase.ObservePersonalTagsUseCase
+import com.riox432.civitdeck.domain.usecase.ObservePowerUserModeUseCase
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+
+/**
+ * Collects the reactive preference/state flows (favorite, NSFW filter, power-user mode, note,
+ * personal tags, downloads) and reflects them into [ModelDetailUiState].
+ * Extracted from [ModelDetailViewModel] to reduce its function count.
+ */
+@Suppress("LongParameterList")
+internal class DetailObserversDelegate(
+    private val modelId: Long,
+    private val scope: CoroutineScope,
+    private val uiState: MutableStateFlow<ModelDetailUiState>,
+    private val observeIsFavorite: ObserveIsFavoriteUseCase,
+    private val observeNsfwFilter: ObserveNsfwFilterUseCase,
+    private val observePowerUserMode: ObservePowerUserModeUseCase,
+    private val observeModelNote: ObserveModelNoteUseCase,
+    private val observePersonalTags: ObservePersonalTagsUseCase,
+    private val observeModelDownloads: ObserveModelDownloadsUseCase,
+) {
+
+    fun start() {
+        observeFavorite()
+        observeNsfwFilterLevel()
+        observePowerUser()
+        observeNote()
+        observeTags()
+        observeDownloads()
+    }
+
+    private fun observeFavorite() {
+        scope.launch {
+            observeIsFavorite(modelId).collect { isFavorite ->
+                uiState.update { it.copy(isFavorite = isFavorite) }
+            }
+        }
+    }
+
+    private fun observeNsfwFilterLevel() {
+        scope.launch {
+            observeNsfwFilter().collect { level ->
+                uiState.update { it.copy(nsfwFilterLevel = level) }
+            }
+        }
+    }
+
+    private fun observePowerUser() {
+        scope.launch {
+            observePowerUserMode().collect { enabled ->
+                uiState.update { it.copy(powerUserMode = enabled) }
+            }
+        }
+    }
+
+    private fun observeNote() {
+        scope.launch {
+            observeModelNote(modelId).collect { note ->
+                uiState.update { it.copy(note = note) }
+            }
+        }
+    }
+
+    private fun observeTags() {
+        scope.launch {
+            observePersonalTags(modelId).collect { tags ->
+                uiState.update { it.copy(personalTags = tags) }
+            }
+        }
+    }
+
+    private fun observeDownloads() {
+        scope.launch {
+            observeModelDownloads(modelId).collect { downloads ->
+                uiState.update { it.copy(downloads = downloads) }
+            }
+        }
+    }
+}

--- a/feature/feature-detail/src/commonMain/kotlin/com/riox432/civitdeck/feature/detail/presentation/ModelDetailViewModel.kt
+++ b/feature/feature-detail/src/commonMain/kotlin/com/riox432/civitdeck/feature/detail/presentation/ModelDetailViewModel.kt
@@ -57,7 +57,6 @@ data class ModelDetailUiState(
     val fileVramCompatibility: Map<Long, VramCompatibility> = emptyMap(),
 ) : UiLoadingState
 
-@Suppress("TooManyFunctions")
 class ModelDetailViewModel(
     private val modelId: Long,
     private val modelUseCases: ModelUseCases,
@@ -120,10 +119,21 @@ class ModelDetailViewModel(
         downloadEnqueuedEvent = _downloadEnqueuedEvent,
     )
 
+    private val observersDelegate = DetailObserversDelegate(
+        modelId = modelId,
+        scope = viewModelScope,
+        uiState = _uiState,
+        observeIsFavorite = modelUseCases.observeIsFavorite,
+        observeNsfwFilter = modelUseCases.observeNsfwFilter,
+        observePowerUserMode = modelUseCases.observePowerUserMode,
+        observeModelNote = notesTagsUseCases.observeModelNote,
+        observePersonalTags = notesTagsUseCases.observePersonalTags,
+        observeModelDownloads = downloadUseCases.observeModelDownloads,
+    )
+
     init {
         loadModel()
-        observeFavorite()
-        startObservers()
+        observersDelegate.start()
         reviewDelegate.loadReviews()
         fetchSystemStats()
     }
@@ -259,66 +269,6 @@ class ModelDetailViewModel(
                 if (v.id == versionId) v.copy(images = enriched) else v
             }
             current.copy(model = currentModel.copy(modelVersions = updatedVersions))
-        }
-    }
-
-    // endregion
-
-    // region Private — Observers
-
-    private fun startObservers() {
-        observeNsfwFilter()
-        observePowerUserMode()
-        observeNote()
-        observePersonalTags()
-        observeDownloads()
-    }
-
-    private fun observeFavorite() {
-        viewModelScope.launch {
-            modelUseCases.observeIsFavorite(modelId).collect { isFavorite ->
-                _uiState.update { it.copy(isFavorite = isFavorite) }
-            }
-        }
-    }
-
-    private fun observeNsfwFilter() {
-        viewModelScope.launch {
-            modelUseCases.observeNsfwFilter().collect { level ->
-                _uiState.update { it.copy(nsfwFilterLevel = level) }
-            }
-        }
-    }
-
-    private fun observePowerUserMode() {
-        viewModelScope.launch {
-            modelUseCases.observePowerUserMode().collect { enabled ->
-                _uiState.update { it.copy(powerUserMode = enabled) }
-            }
-        }
-    }
-
-    private fun observeNote() {
-        viewModelScope.launch {
-            notesTagsUseCases.observeModelNote(modelId).collect { note ->
-                _uiState.update { it.copy(note = note) }
-            }
-        }
-    }
-
-    private fun observePersonalTags() {
-        viewModelScope.launch {
-            notesTagsUseCases.observePersonalTags(modelId).collect { tags ->
-                _uiState.update { it.copy(personalTags = tags) }
-            }
-        }
-    }
-
-    private fun observeDownloads() {
-        viewModelScope.launch {
-            downloadUseCases.observeModelDownloads(modelId).collect { downloads ->
-                _uiState.update { it.copy(downloads = downloads) }
-            }
         }
     }
 

--- a/feature/feature-detail/src/commonTest/kotlin/com/riox432/civitdeck/feature/detail/presentation/ModelDetailViewModelTest.kt
+++ b/feature/feature-detail/src/commonTest/kotlin/com/riox432/civitdeck/feature/detail/presentation/ModelDetailViewModelTest.kt
@@ -199,7 +199,6 @@ class ModelDetailViewModelTest {
         val browsingRepo: FakeBrowsingHistoryRepository,
     )
 
-    @Suppress("LongMethod")
     private fun createViewModel(
         scope: TestScope,
         model: Model = testModel(),

--- a/feature/feature-search/src/commonTest/kotlin/com/riox432/civitdeck/feature/search/presentation/ModelSearchViewModelTest.kt
+++ b/feature/feature-search/src/commonTest/kotlin/com/riox432/civitdeck/feature/search/presentation/ModelSearchViewModelTest.kt
@@ -141,7 +141,6 @@ class ModelSearchViewModelTest {
         val nsfwPrefs: FakeContentFilterPreferencesRepository,
     )
 
-    @Suppress("LongMethod")
     private fun TestScope.createViewModel(): TestDeps {
         // StandardTestDispatcher defers the ViewModel's init coroutines until the
         // scheduler is advanced — this avoids the eager-construction NPE where

--- a/feature/feature-settings/src/commonMain/kotlin/com/riox432/civitdeck/feature/settings/data/repository/UserPreferencesRepositoryImpl.kt
+++ b/feature/feature-settings/src/commonMain/kotlin/com/riox432/civitdeck/feature/settings/data/repository/UserPreferencesRepositoryImpl.kt
@@ -21,6 +21,13 @@ import com.riox432.civitdeck.domain.repository.StoragePreferencesRepository
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
 
+/**
+ * Single-row preferences facade. It implements five cohesive preference-domain interfaces
+ * (content-filter, display, auth, app-behavior, storage) all backed by the same single-row
+ * [UserPreferencesDao]. Splitting into five classes would duplicate identical DAO boilerplate
+ * and fan out Koin bindings with no cohesion or behavioral benefit, so the high function count
+ * is suppressed deliberately.
+ */
 @Suppress("TooManyFunctions")
 class UserPreferencesRepositoryImpl(
     private val dao: UserPreferencesDao,

--- a/shared/src/commonMain/kotlin/com/riox432/civitdeck/di/Phase3ViewModelModule.kt
+++ b/shared/src/commonMain/kotlin/com/riox432/civitdeck/di/Phase3ViewModelModule.kt
@@ -66,7 +66,6 @@ import com.riox432.civitdeck.presentation.plugin.PluginManagementViewModel
 import org.koin.core.module.dsl.viewModel
 import org.koin.dsl.module
 
-@Suppress("LongMethod")
 val phase3ViewModelModule = module {
     viewModel { AnalyticsViewModel(get<GetBrowsingStatsUseCase>()) }
     viewModel {

--- a/shared/src/commonMain/kotlin/com/riox432/civitdeck/di/SettingsViewModelModule.kt
+++ b/shared/src/commonMain/kotlin/com/riox432/civitdeck/di/SettingsViewModelModule.kt
@@ -56,7 +56,6 @@ import com.riox432.civitdeck.feature.settings.presentation.StorageSettingsViewMo
 import org.koin.core.module.dsl.viewModel
 import org.koin.dsl.module
 
-@Suppress("LongMethod")
 val settingsViewModelModule = module {
     viewModel {
         ContentFilterSettingsViewModel(

--- a/shared/src/commonTest/kotlin/com/riox432/civitdeck/domain/usecase/UserPreferencesUseCasesTest.kt
+++ b/shared/src/commonTest/kotlin/com/riox432/civitdeck/domain/usecase/UserPreferencesUseCasesTest.kt
@@ -21,7 +21,6 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNull
 
-@Suppress("TooManyFunctions")
 class UserPreferencesUseCasesTest {
 
     private class FakeUserPreferencesRepository :


### PR DESCRIPTION
Closes #933

## Summary
Follows the extraction pattern established by PR #964 (which split `ComfyUISettingsScreen` 807→169 into 5 section composables). Splits the remaining oversized composables/ViewModels and removes the corresponding `@Suppress` annotations by **actual refactoring** rather than keeping the suppressions. Pure structural refactor — behavior preserved exactly.

## What changed
- **Removed all 31 inline `@Suppress("LongMethod")`** — every flagged function now sits under detekt's 60-line limit via section/helper extraction. Several were precautionary (already <60) and simply dropped.
- **Removed 5 of 6 inline `@Suppress("TooManyFunctions")`** by extracting cohesive responsibilities into delegates/builders:
  - `ComfyUIRepositoryImpl` (36→25 fns): workflow-graph builders extracted to new `ComfyUIWorkflowBuilder`.
  - `ComfyUIGenerationViewModel` (32→27 fns): resource loading (checkpoints/LoRAs/ControlNets/params) extracted to new `GenerationResourceLoader` (mirrors the existing `GenerationExecutionDelegate`).
  - `ModelDetailViewModel` (30→23 fns): reactive observers extracted to new `DetailObserversDelegate`.
  - `DatasetDetailViewModel` (collections), test files, and DI modules: suppress removed (they pass detekt without it).
- **Composable splits** across androidApp screens (`ModelDetailScreen`, `ModelSearchScreen`, `CivitDeckNavGraph`, `DatasetDetailScreen`, `ComfyUIAddConnectionDialog`) and all 17 desktopApp screen files (`DesktopSearchScreen`, `DesktopImageViewer`, `DesktopSDWebUISection`, `Main`, `DesktopApp`, etc.) into smaller section composables.
- `ComfyUIGenerationRepositoryImpl.buildInpaintingWorkflow` shrunk via `buildLoadImageNode`/`buildVaeEncodeForInpaint` helpers.

## Remaining suppression (justified)
- `UserPreferencesRepositoryImpl` keeps `@Suppress("TooManyFunctions")`. It is a single-row preferences facade implementing five cohesive preference-domain interfaces (content-filter, display, auth, app-behavior, storage), all backed by the same single-row DAO. Splitting into five classes would duplicate identical DAO boilerplate and fan out Koin bindings with no cohesion or behavioral benefit — splitting here would be harmful, not helpful.

## Out of scope
- File-level `@file:Suppress("TooManyFunctions")` on Compose screen files (a separate, larger set of ~30 idiomatic suppressions for screens with many small composables) is intentionally not touched — out of this issue's stated scope.
- No use-case injection/bundling changes were made on `ModelSearchViewModel`/`ModelDetailViewModel` (that is #936's territory); only long-method splitting and function-count reduction.

## Verification (local CI-equivalent)
- `./gradlew detekt` (×2) — clean (zero LongMethod/TooManyFunctions)
- `:androidApp:assembleDebug` — pass
- `:shared / :core-data / feature-{search,detail,gallery,prompts,creator,externalserver}:testAndroidHostTest` — pass
- `:core:core-database:jvmTest`, `:feature:feature-comfyui:jvmTest` — pass
- `:desktopApp:compileKotlinJvm` — pass

No iOS files touched.