### PR TITLE
Raise use-case unit test coverage (part of #974)

### DIFF
--- a/build-logic/convention/src/main/kotlin/CivitDeckKmpLibraryPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/CivitDeckKmpLibraryPlugin.kt
@@ -32,6 +32,10 @@ class CivitDeckKmpLibraryPlugin : Plugin<Project> {
                         // commonTest runs on the androidHostTest compilation.
                         withHostTest {
                             isIncludeAndroidResources = true
+                            // Unmocked android.util.Log calls (via Logger) throw by
+                            // default on the JVM host test runtime. Returning defaults
+                            // turns them into no-ops so use-case logic can be unit tested.
+                            isReturnDefaultValues = true
                         }
                     }
             }

--- a/core/core-domain/src/commonTest/kotlin/com/riox432/civitdeck/domain/usecase/BatchEditTagsUseCaseTest.kt
+++ b/core/core-domain/src/commonTest/kotlin/com/riox432/civitdeck/domain/usecase/BatchEditTagsUseCaseTest.kt
@@ -1,0 +1,73 @@
+package com.riox432.civitdeck.domain.usecase
+
+import com.riox432.civitdeck.domain.model.ImageTag
+import com.riox432.civitdeck.domain.repository.ImageTagRepository
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+/**
+ * Covers [BatchEditTagsUseCase]: it forwards add/remove only when the respective
+ * tag list is non-empty, so empty lists never trigger a repository write.
+ */
+class BatchEditTagsUseCaseTest {
+
+    @Test
+    fun applies_both_add_and_remove_when_both_lists_are_non_empty() = runTest {
+        val repo = RecordingImageTagRepo()
+        val useCase = BatchEditTagsUseCase(repo)
+
+        useCase(imageIds = listOf(1L, 2L), addTags = listOf("a"), removeTags = listOf("b"))
+
+        assertEquals(listOf(1L, 2L) to listOf("a"), repo.added)
+        assertEquals(listOf(1L, 2L) to listOf("b"), repo.removed)
+    }
+
+    @Test
+    fun skips_add_when_add_list_is_empty() = runTest {
+        val repo = RecordingImageTagRepo()
+        val useCase = BatchEditTagsUseCase(repo)
+
+        useCase(imageIds = listOf(1L), addTags = emptyList(), removeTags = listOf("b"))
+
+        assertNull(repo.added)
+        assertEquals(listOf(1L) to listOf("b"), repo.removed)
+    }
+
+    @Test
+    fun skips_remove_when_remove_list_is_empty() = runTest {
+        val repo = RecordingImageTagRepo()
+        val useCase = BatchEditTagsUseCase(repo)
+
+        useCase(imageIds = listOf(1L), addTags = listOf("a"), removeTags = emptyList())
+
+        assertEquals(listOf(1L) to listOf("a"), repo.added)
+        assertNull(repo.removed)
+    }
+
+    @Test
+    fun writes_nothing_when_both_lists_are_empty() = runTest {
+        val repo = RecordingImageTagRepo()
+        val useCase = BatchEditTagsUseCase(repo)
+
+        useCase(imageIds = listOf(1L), addTags = emptyList(), removeTags = emptyList())
+
+        assertNull(repo.added)
+        assertNull(repo.removed)
+    }
+
+    private class RecordingImageTagRepo : ImageTagRepository {
+        var added: Pair<List<Long>, List<String>>? = null
+        var removed: Pair<List<Long>, List<String>>? = null
+        override suspend fun addTagsToImages(imageIds: List<Long>, tags: List<String>) {
+            added = imageIds to tags
+        }
+        override suspend fun removeTagsFromImages(imageIds: List<Long>, tags: List<String>) {
+            removed = imageIds to tags
+        }
+        override suspend fun getTagsForImage(datasetImageId: Long): List<ImageTag> = emptyList()
+        override suspend fun getTagSuggestions(datasetId: Long, prefix: String): List<String> =
+            emptyList()
+    }
+}

--- a/core/core-domain/src/commonTest/kotlin/com/riox432/civitdeck/domain/usecase/CheckAndStoreModelUpdatesUseCaseTest.kt
+++ b/core/core-domain/src/commonTest/kotlin/com/riox432/civitdeck/domain/usecase/CheckAndStoreModelUpdatesUseCaseTest.kt
@@ -1,0 +1,203 @@
+package com.riox432.civitdeck.domain.usecase
+
+import com.riox432.civitdeck.domain.model.FeedItem
+import com.riox432.civitdeck.domain.model.FollowedCreator
+import com.riox432.civitdeck.domain.model.Model
+import com.riox432.civitdeck.domain.model.ModelImage
+import com.riox432.civitdeck.domain.model.ModelLicenseInfo
+import com.riox432.civitdeck.domain.model.ModelSearchQuery
+import com.riox432.civitdeck.domain.model.ModelStats
+import com.riox432.civitdeck.domain.model.ModelType
+import com.riox432.civitdeck.domain.model.ModelUpdate
+import com.riox432.civitdeck.domain.model.ModelUpdateNotification
+import com.riox432.civitdeck.domain.model.ModelVersion
+import com.riox432.civitdeck.domain.model.PaginatedResult
+import com.riox432.civitdeck.domain.model.UpdateSource
+import com.riox432.civitdeck.domain.repository.CreatorFollowRepository
+import com.riox432.civitdeck.domain.repository.FavoriteRepository
+import com.riox432.civitdeck.domain.repository.ModelRepository
+import com.riox432.civitdeck.domain.repository.ModelUpdateNotificationRepository
+import com.riox432.civitdeck.domain.repository.ModelVersionCheckpointRepository
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Covers [CheckAndStoreModelUpdatesUseCase]: it splits detected updates by
+ * [UpdateSource], persists each group, and triggers cleanup only when there is
+ * something to store.
+ */
+class CheckAndStoreModelUpdatesUseCaseTest {
+
+    @Test
+    fun stores_favorite_and_followed_updates_separately_then_cleans_up() = runTest {
+        // Arrange: model 1 is a favorite with a newer version; model 2 comes from a
+        // followed creator's feed (and is not a favorite) and also has a newer version.
+        val favorites = FakeFavoriteRepository(ids = setOf(1L))
+        val models = FakeModelRepo(
+            mapOf(
+                1L to model(id = 1L, versionId = 200L),
+                2L to model(id = 2L, versionId = 400L),
+            ),
+        )
+        val checkpoints = FakeCheckpointRepo(
+            mutableMapOf(1L to (100L to 0L), 2L to (300L to 0L)),
+        )
+        val follows = FakeCreatorFollowRepo(
+            creators = listOf(creator("alice")),
+            feed = listOf(feedItem(2L)),
+        )
+        val inner = CheckModelUpdatesUseCase(favorites, models, checkpoints, follows)
+        val notifications = FakeNotificationRepo()
+        val useCase = CheckAndStoreModelUpdatesUseCase(inner, notifications)
+
+        // Act
+        val result = useCase()
+
+        // Assert: both updates returned, each saved under its own source, cleanup ran once.
+        assertEquals(setOf(1L, 2L), result.map { it.modelId }.toSet())
+        assertEquals(listOf(1L), notifications.savedBySource[UpdateSource.FAVORITE]?.map { it.modelId })
+        assertEquals(listOf(2L), notifications.savedBySource[UpdateSource.FOLLOWED]?.map { it.modelId })
+        assertEquals(1, notifications.cleanupCount)
+    }
+
+    @Test
+    fun does_not_save_or_clean_up_when_there_are_no_updates() = runTest {
+        // Arrange: the single favorite is already at its checkpoint version -> no updates.
+        val favorites = FakeFavoriteRepository(ids = setOf(1L))
+        val models = FakeModelRepo(mapOf(1L to model(id = 1L, versionId = 100L)))
+        val checkpoints = FakeCheckpointRepo(mutableMapOf(1L to (100L to 0L)))
+        val inner = CheckModelUpdatesUseCase(favorites, models, checkpoints, NoFollows())
+        val notifications = FakeNotificationRepo()
+        val useCase = CheckAndStoreModelUpdatesUseCase(inner, notifications)
+
+        // Act
+        val result = useCase()
+
+        // Assert: empty result, nothing persisted, no cleanup.
+        assertTrue(result.isEmpty())
+        assertTrue(notifications.savedBySource.isEmpty())
+        assertEquals(0, notifications.cleanupCount)
+    }
+
+    // --- Fixtures & fakes ---
+
+    private fun model(id: Long, versionId: Long) = Model(
+        id = id,
+        name = "Model $id",
+        description = null,
+        type = ModelType.Checkpoint,
+        nsfw = false,
+        tags = emptyList(),
+        mode = null,
+        creator = null,
+        stats = ModelStats(0, 0, 0, 0, 0.0),
+        modelVersions = listOf(
+            ModelVersion(
+                id = versionId,
+                modelId = id,
+                name = "v$versionId",
+                description = null,
+                createdAt = "",
+                baseModel = null,
+                trainedWords = emptyList(),
+                downloadUrl = "",
+                files = emptyList(),
+                images = emptyList<ModelImage>(),
+                stats = null,
+            ),
+        ),
+    )
+
+    private fun feedItem(modelId: Long) = FeedItem(
+        modelId = modelId,
+        creatorUsername = "alice",
+        title = "Item $modelId",
+        thumbnailUrl = null,
+        type = ModelType.Checkpoint,
+        publishedAt = "",
+        isUnread = true,
+    )
+
+    private fun creator(username: String) = FollowedCreator(
+        username = username,
+        displayName = username,
+        avatarUrl = null,
+        followedAt = 0L,
+        lastCheckedAt = 0L,
+    )
+
+    private class FakeFavoriteRepository(private val ids: Set<Long>) : FavoriteRepository {
+        override fun observeFavorites() = throw NotImplementedError()
+        override fun observeIsFavorite(modelId: Long) = throw NotImplementedError()
+        override suspend fun toggleFavorite(model: Model) = throw NotImplementedError()
+        override suspend fun addFavorite(model: Model) = throw NotImplementedError()
+        override suspend fun removeFavorite(modelId: Long) = throw NotImplementedError()
+        override suspend fun getAllFavoriteIds(): Set<Long> = ids
+        override suspend fun getFavoriteTypeCounts(): Map<String, Int> = emptyMap()
+    }
+
+    private class FakeModelRepo(private val available: Map<Long, Model>) : ModelRepository {
+        override suspend fun getModels(query: ModelSearchQuery): PaginatedResult<Model> =
+            throw NotImplementedError()
+        override suspend fun getModel(id: Long): Model = available.getValue(id)
+        override suspend fun getModelVersion(id: Long): ModelVersion = throw NotImplementedError()
+        override suspend fun getModelVersionByHash(hash: String): ModelVersion =
+            throw NotImplementedError()
+        override suspend fun getModelLicense(versionId: Long): ModelLicenseInfo? =
+            throw NotImplementedError()
+    }
+
+    private class FakeCheckpointRepo(
+        private val initial: MutableMap<Long, Pair<Long, Long>> = mutableMapOf(),
+    ) : ModelVersionCheckpointRepository {
+        override suspend fun getCheckpoint(modelId: Long): Long? = initial[modelId]?.first
+        override suspend fun getAllCheckpoints(): Map<Long, Pair<Long, Long>> = initial
+        override suspend fun saveCheckpoint(modelId: Long, versionId: Long) = Unit
+        override suspend fun saveCheckpoints(checkpoints: Map<Long, Long>) = Unit
+        override suspend fun deleteStaleCheckpoints(activeModelIds: Set<Long>) = Unit
+    }
+
+    private class NoFollows : CreatorFollowRepository {
+        override suspend fun followCreator(username: String, displayName: String, avatarUrl: String?) =
+            throw NotImplementedError()
+        override suspend fun unfollowCreator(username: String) = throw NotImplementedError()
+        override fun isFollowing(username: String): Flow<Boolean> = throw NotImplementedError()
+        override fun getFollowedCreators(): Flow<List<FollowedCreator>> = flowOf(emptyList())
+        override suspend fun getFeed(forceRefresh: Boolean): List<FeedItem> = emptyList()
+        override suspend fun markFeedAsRead() = throw NotImplementedError()
+        override fun getUnreadCount(): Flow<Int> = throw NotImplementedError()
+    }
+
+    private class FakeCreatorFollowRepo(
+        private val creators: List<FollowedCreator>,
+        private val feed: List<FeedItem>,
+    ) : CreatorFollowRepository {
+        override suspend fun followCreator(username: String, displayName: String, avatarUrl: String?) =
+            throw NotImplementedError()
+        override suspend fun unfollowCreator(username: String) = throw NotImplementedError()
+        override fun isFollowing(username: String): Flow<Boolean> = throw NotImplementedError()
+        override fun getFollowedCreators(): Flow<List<FollowedCreator>> = flowOf(creators)
+        override suspend fun getFeed(forceRefresh: Boolean): List<FeedItem> = feed
+        override suspend fun markFeedAsRead() = throw NotImplementedError()
+        override fun getUnreadCount(): Flow<Int> = throw NotImplementedError()
+    }
+
+    private class FakeNotificationRepo : ModelUpdateNotificationRepository {
+        val savedBySource = mutableMapOf<UpdateSource, List<ModelUpdate>>()
+        var cleanupCount = 0
+        override fun observeNotifications(): Flow<List<ModelUpdateNotification>> = flowOf(emptyList())
+        override fun observeUnreadCount(): Flow<Int> = flowOf(0)
+        override suspend fun saveNotifications(updates: List<ModelUpdate>, source: UpdateSource) {
+            savedBySource[source] = updates
+        }
+        override suspend fun markRead(notificationId: Long) = Unit
+        override suspend fun markAllRead() = Unit
+        override suspend fun cleanupOldNotifications() {
+            cleanupCount++
+        }
+    }
+}

--- a/core/core-domain/src/commonTest/kotlin/com/riox432/civitdeck/domain/usecase/CheckModelUpdatesUseCaseTest.kt
+++ b/core/core-domain/src/commonTest/kotlin/com/riox432/civitdeck/domain/usecase/CheckModelUpdatesUseCaseTest.kt
@@ -1,0 +1,256 @@
+package com.riox432.civitdeck.domain.usecase
+
+import com.riox432.civitdeck.domain.model.FeedItem
+import com.riox432.civitdeck.domain.model.FollowedCreator
+import com.riox432.civitdeck.domain.model.Model
+import com.riox432.civitdeck.domain.model.ModelImage
+import com.riox432.civitdeck.domain.model.ModelLicenseInfo
+import com.riox432.civitdeck.domain.model.ModelSearchQuery
+import com.riox432.civitdeck.domain.model.ModelStats
+import com.riox432.civitdeck.domain.model.ModelType
+import com.riox432.civitdeck.domain.model.ModelVersion
+import com.riox432.civitdeck.domain.model.PaginatedResult
+import com.riox432.civitdeck.domain.model.UpdateSource
+import com.riox432.civitdeck.domain.repository.CreatorFollowRepository
+import com.riox432.civitdeck.domain.repository.FavoriteRepository
+import com.riox432.civitdeck.domain.repository.ModelRepository
+import com.riox432.civitdeck.domain.repository.ModelVersionCheckpointRepository
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class CheckModelUpdatesUseCaseTest {
+
+    @Test
+    fun reports_update_when_latest_version_differs_from_checkpoint() = runTest {
+        // Arrange: model 1 is favorited; checkpoint records version 100 but the model now
+        // has version 200 -> should be reported as a FAVORITE update.
+        val favorites = FakeFavoriteRepository(ids = setOf(1L))
+        val models = FakeModelRepo(mapOf(1L to model(id = 1L, versionId = 200L)))
+        val checkpoints = FakeCheckpointRepo(mutableMapOf(1L to (100L to 0L)))
+        val useCase = CheckModelUpdatesUseCase(favorites, models, checkpoints, NoFollows())
+
+        val updates = useCase()
+
+        assertEquals(1, updates.size)
+        assertEquals(1L, updates[0].modelId)
+        assertEquals(200L, updates[0].newVersionId)
+        assertEquals(UpdateSource.FAVORITE, updates[0].source)
+    }
+
+    @Test
+    fun does_not_report_when_version_matches_checkpoint() = runTest {
+        val favorites = FakeFavoriteRepository(ids = setOf(1L))
+        val models = FakeModelRepo(mapOf(1L to model(id = 1L, versionId = 100L)))
+        val checkpoints = FakeCheckpointRepo(mutableMapOf(1L to (100L to 0L)))
+        val useCase = CheckModelUpdatesUseCase(favorites, models, checkpoints, NoFollows())
+
+        val updates = useCase()
+
+        assertTrue(updates.isEmpty())
+    }
+
+    @Test
+    fun first_seen_model_records_checkpoint_without_reporting_update() = runTest {
+        // No prior checkpoint -> the use case stores the current version but reports nothing.
+        val favorites = FakeFavoriteRepository(ids = setOf(7L))
+        val models = FakeModelRepo(mapOf(7L to model(id = 7L, versionId = 55L)))
+        val checkpoints = FakeCheckpointRepo()
+        val useCase = CheckModelUpdatesUseCase(favorites, models, checkpoints, NoFollows())
+
+        val updates = useCase()
+
+        assertTrue(updates.isEmpty())
+        assertEquals(55L, checkpoints.saved[7L])
+    }
+
+    @Test
+    fun continues_when_one_model_fetch_throws() = runTest {
+        // Model 2 fails to fetch; the use case must skip it and still report model 1.
+        val favorites = FakeFavoriteRepository(ids = setOf(1L, 2L))
+        val models = FakeModelRepo(
+            available = mapOf(1L to model(id = 1L, versionId = 200L)),
+            failing = setOf(2L),
+        )
+        val checkpoints = FakeCheckpointRepo(
+            mutableMapOf(1L to (100L to 0L), 2L to (300L to 0L)),
+        )
+        val useCase = CheckModelUpdatesUseCase(favorites, models, checkpoints, NoFollows())
+
+        val updates = useCase()
+
+        assertEquals(listOf(1L), updates.map { it.modelId })
+    }
+
+    @Test
+    fun returns_empty_when_no_favorites_and_no_follows() = runTest {
+        val useCase = CheckModelUpdatesUseCase(
+            FakeFavoriteRepository(ids = emptySet()),
+            FakeModelRepo(emptyMap()),
+            FakeCheckpointRepo(),
+            NoFollows(),
+        )
+
+        assertTrue(useCase().isEmpty())
+    }
+
+    @Test
+    fun deletes_stale_checkpoints_for_favorites() = runTest {
+        // Checkpoint exists for model 9 which is no longer favorited -> should be pruned.
+        val favorites = FakeFavoriteRepository(ids = setOf(1L))
+        val models = FakeModelRepo(mapOf(1L to model(id = 1L, versionId = 100L)))
+        val checkpoints = FakeCheckpointRepo(mutableMapOf(1L to (100L to 0L), 9L to (10L to 0L)))
+        val useCase = CheckModelUpdatesUseCase(favorites, models, checkpoints, NoFollows())
+
+        useCase()
+
+        assertEquals(setOf(1L), checkpoints.lastStaleKeepIds)
+    }
+
+    @Test
+    fun reports_followed_creator_models_excluding_favorites() = runTest {
+        // Feed has models 1 and 2; model 1 is also a favorite and must not be double-counted
+        // as a FOLLOWED update.
+        val favorites = FakeFavoriteRepository(ids = setOf(1L))
+        val models = FakeModelRepo(
+            mapOf(
+                1L to model(id = 1L, versionId = 100L),
+                2L to model(id = 2L, versionId = 222L),
+            ),
+        )
+        val checkpoints = FakeCheckpointRepo(
+            mutableMapOf(1L to (100L to 0L), 2L to (111L to 0L)),
+        )
+        val follows = FakeCreatorFollowRepo(
+            creators = listOf(creator("alice")),
+            feed = listOf(feedItem(1L), feedItem(2L)),
+        )
+        val useCase = CheckModelUpdatesUseCase(favorites, models, checkpoints, follows)
+
+        val updates = useCase()
+
+        // Only model 2 reported (as FOLLOWED); model 1 unchanged + excluded from follow set.
+        assertEquals(listOf(2L), updates.map { it.modelId })
+        assertEquals(UpdateSource.FOLLOWED, updates.single().source)
+    }
+
+    // --- Fixtures & fakes ---
+
+    private fun model(id: Long, versionId: Long) = Model(
+        id = id,
+        name = "Model $id",
+        description = null,
+        type = ModelType.Checkpoint,
+        nsfw = false,
+        tags = emptyList(),
+        mode = null,
+        creator = null,
+        stats = ModelStats(0, 0, 0, 0, 0.0),
+        modelVersions = listOf(
+            ModelVersion(
+                id = versionId,
+                modelId = id,
+                name = "v$versionId",
+                description = null,
+                createdAt = "",
+                baseModel = null,
+                trainedWords = emptyList(),
+                downloadUrl = "",
+                files = emptyList(),
+                images = emptyList<ModelImage>(),
+                stats = null,
+            ),
+        ),
+    )
+
+    private fun feedItem(modelId: Long) = FeedItem(
+        modelId = modelId,
+        creatorUsername = "alice",
+        title = "Item $modelId",
+        thumbnailUrl = null,
+        type = ModelType.Checkpoint,
+        publishedAt = "",
+        isUnread = true,
+    )
+
+    private fun creator(username: String) = FollowedCreator(
+        username = username,
+        displayName = username,
+        avatarUrl = null,
+        followedAt = 0L,
+        lastCheckedAt = 0L,
+    )
+
+    private class FakeFavoriteRepository(private val ids: Set<Long>) : FavoriteRepository {
+        override fun observeFavorites() = throw NotImplementedError()
+        override fun observeIsFavorite(modelId: Long) = throw NotImplementedError()
+        override suspend fun toggleFavorite(model: Model) = throw NotImplementedError()
+        override suspend fun addFavorite(model: Model) = throw NotImplementedError()
+        override suspend fun removeFavorite(modelId: Long) = throw NotImplementedError()
+        override suspend fun getAllFavoriteIds(): Set<Long> = ids
+        override suspend fun getFavoriteTypeCounts(): Map<String, Int> = emptyMap()
+    }
+
+    private class FakeModelRepo(
+        private val available: Map<Long, Model>,
+        private val failing: Set<Long> = emptySet(),
+    ) : ModelRepository {
+        override suspend fun getModels(query: ModelSearchQuery): PaginatedResult<Model> =
+            throw NotImplementedError()
+        override suspend fun getModel(id: Long): Model {
+            if (id in failing) error("fetch failed for $id")
+            return available.getValue(id)
+        }
+        override suspend fun getModelVersion(id: Long): ModelVersion = throw NotImplementedError()
+        override suspend fun getModelVersionByHash(hash: String): ModelVersion =
+            throw NotImplementedError()
+        override suspend fun getModelLicense(versionId: Long): ModelLicenseInfo? =
+            throw NotImplementedError()
+    }
+
+    private class FakeCheckpointRepo(
+        private val initial: MutableMap<Long, Pair<Long, Long>> = mutableMapOf(),
+    ) : ModelVersionCheckpointRepository {
+        val saved = mutableMapOf<Long, Long>()
+        var lastStaleKeepIds: Set<Long>? = null
+        override suspend fun getCheckpoint(modelId: Long): Long? = initial[modelId]?.first
+        override suspend fun getAllCheckpoints(): Map<Long, Pair<Long, Long>> = initial
+        override suspend fun saveCheckpoint(modelId: Long, versionId: Long) {
+            saved[modelId] = versionId
+        }
+        override suspend fun saveCheckpoints(checkpoints: Map<Long, Long>) {
+            saved.putAll(checkpoints)
+        }
+        override suspend fun deleteStaleCheckpoints(activeModelIds: Set<Long>) {
+            lastStaleKeepIds = activeModelIds
+        }
+    }
+
+    private class NoFollows : CreatorFollowRepository {
+        override suspend fun followCreator(username: String, displayName: String, avatarUrl: String?) =
+            throw NotImplementedError()
+        override suspend fun unfollowCreator(username: String) = throw NotImplementedError()
+        override fun isFollowing(username: String): Flow<Boolean> = throw NotImplementedError()
+        override fun getFollowedCreators(): Flow<List<FollowedCreator>> = flowOf(emptyList())
+        override suspend fun getFeed(forceRefresh: Boolean): List<FeedItem> = emptyList()
+        override suspend fun markFeedAsRead() = throw NotImplementedError()
+        override fun getUnreadCount(): Flow<Int> = throw NotImplementedError()
+    }
+
+    private class FakeCreatorFollowRepo(
+        private val creators: List<FollowedCreator>,
+        private val feed: List<FeedItem>,
+    ) : CreatorFollowRepository {
+        override suspend fun followCreator(username: String, displayName: String, avatarUrl: String?) =
+            throw NotImplementedError()
+        override suspend fun unfollowCreator(username: String) = throw NotImplementedError()
+        override fun isFollowing(username: String): Flow<Boolean> = throw NotImplementedError()
+        override fun getFollowedCreators(): Flow<List<FollowedCreator>> = flowOf(creators)
+        override suspend fun getFeed(forceRefresh: Boolean): List<FeedItem> = feed
+        override suspend fun markFeedAsRead() = throw NotImplementedError()
+        override fun getUnreadCount(): Flow<Int> = throw NotImplementedError()
+    }
+}

--- a/core/core-domain/src/commonTest/kotlin/com/riox432/civitdeck/domain/usecase/CleanupBrowsingHistoryUseCaseTest.kt
+++ b/core/core-domain/src/commonTest/kotlin/com/riox432/civitdeck/domain/usecase/CleanupBrowsingHistoryUseCaseTest.kt
@@ -1,0 +1,70 @@
+package com.riox432.civitdeck.domain.usecase
+
+import com.riox432.civitdeck.domain.model.InteractionType
+import com.riox432.civitdeck.domain.model.RecentlyViewedModel
+import com.riox432.civitdeck.domain.repository.BrowsingHistoryRepository
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * Covers [CleanupBrowsingHistoryUseCase], whose only logic is deriving the
+ * retention cutoff (now - 90 days) and forwarding the fixed max-entries cap.
+ */
+class CleanupBrowsingHistoryUseCaseTest {
+
+    @Test
+    fun derives_cutoff_90_days_before_now_and_caps_entries() = runTest {
+        // Arrange: a fixed "now"; the cutoff must be exactly 90 days earlier in millis.
+        val now = 1_000_000_000_000L
+        val ninetyDaysMs = 90L * 86_400_000L
+        val repo = RecordingBrowsingHistoryRepo()
+        val useCase = CleanupBrowsingHistoryUseCase(repo)
+
+        // Act
+        useCase(nowMillis = now)
+
+        // Assert: cutoff = now - 90d, and the 5000-entry cap is forwarded.
+        assertEquals(now - ninetyDaysMs, repo.lastCutoff)
+        assertEquals(5000, repo.lastMaxEntries)
+    }
+
+    private class RecordingBrowsingHistoryRepo : BrowsingHistoryRepository {
+        var lastCutoff: Long? = null
+        var lastMaxEntries: Int? = null
+
+        override suspend fun cleanup(cutoffMillis: Long, maxEntries: Int) {
+            lastCutoff = cutoffMillis
+            lastMaxEntries = maxEntries
+        }
+
+        // --- unused members ---
+        override suspend fun trackView(
+            modelId: Long,
+            modelName: String,
+            modelType: String,
+            creatorName: String?,
+            thumbnailUrl: String?,
+            tags: List<String>,
+        ) = Unit
+        override suspend fun getRecentTypes(limit: Int): Map<String, Int> = emptyMap()
+        override suspend fun getRecentCreators(limit: Int): Map<String, Int> = emptyMap()
+        override suspend fun getRecentTags(limit: Int): Map<String, Int> = emptyMap()
+        override suspend fun getRecentModelIds(limit: Int): List<Long> = emptyList()
+        override suspend fun getAllViewedModelIds(): Set<Long> = emptySet()
+        override suspend fun clearAll() = Unit
+        override suspend fun deleteById(historyId: Long) = Unit
+        override fun observeRecentlyViewed(limit: Int): Flow<List<RecentlyViewedModel>> =
+            flowOf(emptyList())
+        override suspend fun getWeightedTypes(limit: Int): Map<String, Double> = emptyMap()
+        override suspend fun getWeightedTags(limit: Int): Map<String, Double> = emptyMap()
+        override suspend fun getWeightedCreators(limit: Int): Map<String, Double> = emptyMap()
+        override suspend fun updateViewDuration(modelId: Long, durationMs: Long) = Unit
+        override suspend fun trackInteraction(modelId: Long, interactionType: InteractionType) = Unit
+        override suspend fun getAverageViewDurationMs(): Long? = null
+        override suspend fun getRecommendationClickCount(sinceMillis: Long): Int = 0
+        override suspend fun getInteractionCountByType(type: InteractionType, sinceMillis: Long): Int = 0
+    }
+}

--- a/core/core-domain/src/commonTest/kotlin/com/riox432/civitdeck/domain/usecase/DatasetImageUseCasesTest.kt
+++ b/core/core-domain/src/commonTest/kotlin/com/riox432/civitdeck/domain/usecase/DatasetImageUseCasesTest.kt
@@ -1,0 +1,133 @@
+package com.riox432.civitdeck.domain.usecase
+
+import com.riox432.civitdeck.domain.model.DatasetCollection
+import com.riox432.civitdeck.domain.model.DatasetImage
+import com.riox432.civitdeck.domain.model.ImageSource
+import com.riox432.civitdeck.domain.repository.DatasetCollectionRepository
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Covers the two dataset use cases that transform the observed image stream:
+ * [DetectDuplicatesUseCase] (pHash Hamming grouping) and
+ * [FilterByResolutionUseCase] (resolution predicate).
+ */
+class DatasetImageUseCasesTest {
+
+    @Test
+    fun detect_duplicates_groups_images_within_hamming_threshold() = runTest {
+        // 1 & 2 differ by 1 bit (distance 1), 3 is far. With threshold 1, only {1,2} group.
+        val repo = FakeDatasetRepo(
+            listOf(
+                image(id = 1L, pHash = "0000"),
+                image(id = 2L, pHash = "0001"),
+                image(id = 3L, pHash = "1111"),
+            ),
+        )
+        val useCase = DetectDuplicatesUseCase(repo)
+
+        val groups = useCase(datasetId = 1L, threshold = 1).first()
+
+        assertEquals(1, groups.size)
+        assertEquals(listOf(1L, 2L), groups[0].images.map { it.id })
+    }
+
+    @Test
+    fun detect_duplicates_ignores_images_without_phash() = runTest {
+        val repo = FakeDatasetRepo(
+            listOf(
+                image(id = 1L, pHash = "0000"),
+                image(id = 2L, pHash = null),
+                image(id = 3L, pHash = "0000"),
+            ),
+        )
+        val useCase = DetectDuplicatesUseCase(repo)
+
+        val groups = useCase(datasetId = 1L, threshold = 0).first()
+
+        // Only the two hashable identical images group; the null-pHash one is excluded.
+        assertEquals(1, groups.size)
+        assertEquals(listOf(1L, 3L), groups[0].images.map { it.id })
+    }
+
+    @Test
+    fun detect_duplicates_returns_empty_when_no_pair_is_within_threshold() = runTest {
+        val repo = FakeDatasetRepo(
+            listOf(image(id = 1L, pHash = "0000"), image(id = 2L, pHash = "1111")),
+        )
+        val useCase = DetectDuplicatesUseCase(repo)
+
+        val groups = useCase(datasetId = 1L, threshold = 1).first()
+
+        assertTrue(groups.isEmpty())
+    }
+
+    @Test
+    fun filter_by_resolution_returns_only_images_below_minimum() = runTest {
+        val repo = FakeDatasetRepo(
+            listOf(
+                image(id = 1L, width = 512, height = 512), // below 1024x1024 -> kept
+                image(id = 2L, width = 2048, height = 2048), // above -> dropped
+                image(id = 3L, width = 2048, height = 256), // height below -> kept
+                image(id = 4L, width = null, height = null), // unknown dims -> dropped
+            ),
+        )
+        val useCase = FilterByResolutionUseCase(repo)
+
+        val result = useCase(datasetId = 1L, minWidth = 1024, minHeight = 1024).first()
+
+        assertEquals(listOf(1L, 3L), result.map { it.id })
+    }
+
+    private fun image(
+        id: Long,
+        pHash: String? = null,
+        width: Int? = null,
+        height: Int? = null,
+    ) = DatasetImage(
+        id = id,
+        datasetId = 1L,
+        imageUrl = "url$id",
+        sourceType = ImageSource.CIVITAI,
+        addedAt = 0L,
+        pHash = pHash,
+        width = width,
+        height = height,
+    )
+
+    private class FakeDatasetRepo(private val images: List<DatasetImage>) :
+        DatasetCollectionRepository {
+        override fun observeImages(datasetId: Long): Flow<List<DatasetImage>> = flowOf(images)
+
+        override fun observeCollections(): Flow<List<DatasetCollection>> = throw NotImplementedError()
+        override suspend fun createCollection(name: String, description: String): Long =
+            throw NotImplementedError()
+        override suspend fun renameCollection(id: Long, name: String) = throw NotImplementedError()
+        override suspend fun deleteCollection(id: Long) = throw NotImplementedError()
+        override suspend fun addImage(
+            datasetId: Long,
+            imageUrl: String,
+            sourceType: ImageSource,
+            trainable: Boolean,
+            tags: List<String>,
+        ): Long = throw NotImplementedError()
+        override suspend fun removeImage(imageId: Long) = throw NotImplementedError()
+        override suspend fun removeImages(imageIds: List<Long>) = throw NotImplementedError()
+        override suspend fun updateTrainable(imageId: Long, trainable: Boolean) =
+            throw NotImplementedError()
+        override suspend fun updateLicenseNote(imageId: Long, licenseNote: String?) =
+            throw NotImplementedError()
+        override suspend fun getNonTrainableImages(datasetId: Long): List<DatasetImage> =
+            throw NotImplementedError()
+        override suspend fun updatePHash(imageId: Long, pHash: String?) = throw NotImplementedError()
+        override suspend fun markExcluded(imageId: Long, excluded: Boolean) =
+            throw NotImplementedError()
+        override suspend fun updateDimensions(imageId: Long, width: Int, height: Int) =
+            throw NotImplementedError()
+    }
+}

--- a/core/core-domain/src/commonTest/kotlin/com/riox432/civitdeck/domain/usecase/EmbeddingSearchUseCasesTest.kt
+++ b/core/core-domain/src/commonTest/kotlin/com/riox432/civitdeck/domain/usecase/EmbeddingSearchUseCasesTest.kt
@@ -1,0 +1,171 @@
+package com.riox432.civitdeck.domain.usecase
+
+import com.riox432.civitdeck.domain.ml.ImageEmbeddingModel
+import com.riox432.civitdeck.domain.ml.TextEmbeddingModel
+import com.riox432.civitdeck.domain.model.ModelEmbedding
+import com.riox432.civitdeck.domain.model.SimilarModelHit
+import com.riox432.civitdeck.domain.repository.ModelEmbeddingRepository
+import com.riox432.civitdeck.domain.repository.ThumbnailDownloader
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * Covers the short-circuit / branching logic of the embedding-driven search use cases:
+ * [TextSearchUseCase] and [EmbedOnBrowseUseCase].
+ */
+class EmbeddingSearchUseCasesTest {
+
+    // --- TextSearchUseCase ---
+
+    @Test
+    fun text_search_returns_empty_when_encoder_unavailable() = runTest {
+        val text = FakeTextEmbeddingModel(available = false)
+        val repo = RecordingEmbeddingRepo()
+        val useCase = TextSearchUseCase(text, repo)
+
+        val result = useCase("a cat", limit = 5)
+
+        assertTrue(result.isEmpty())
+        // Must short-circuit before touching the repository.
+        assertNull(repo.lastFindQuery)
+    }
+
+    @Test
+    fun text_search_embeds_query_and_delegates_to_repository() = runTest {
+        val vector = floatArrayOf(0.1f, 0.2f, 0.3f)
+        val text = FakeTextEmbeddingModel(available = true, vector = vector)
+        val repo = RecordingEmbeddingRepo(
+            hits = listOf(SimilarModelHit(modelId = 42L, score = 0.9f)),
+        )
+        val useCase = TextSearchUseCase(text, repo)
+
+        val result = useCase("a cat", limit = 7)
+
+        assertEquals(listOf(42L), result.map { it.modelId })
+        assertEquals(vector.toList(), repo.lastFindQuery?.toList())
+        assertEquals("test-encoder", repo.lastFindModel)
+        assertEquals(7, repo.lastFindLimit)
+    }
+
+    @Test
+    fun text_search_exposes_encoder_availability() {
+        assertTrue(TextSearchUseCase(FakeTextEmbeddingModel(available = true), RecordingEmbeddingRepo()).isAvailable)
+        assertTrue(!TextSearchUseCase(FakeTextEmbeddingModel(available = false), RecordingEmbeddingRepo()).isAvailable)
+    }
+
+    // --- EmbedOnBrowseUseCase ---
+
+    @Test
+    fun embed_on_browse_no_ops_when_embedder_unavailable() = runTest {
+        val repo = RecordingEmbeddingRepo()
+        val downloader = RecordingDownloader()
+        val useCase = EmbedOnBrowseUseCase(
+            embeddingRepository = repo,
+            embedImage = EmbedImageUseCase(FakeImageEmbeddingModel(available = false)),
+            downloader = downloader,
+        )
+
+        useCase(modelId = 1L, thumbnailUrl = "url")
+
+        assertNull(downloader.lastUrl)
+        assertTrue(repo.cached.isEmpty())
+    }
+
+    @Test
+    fun embed_on_browse_skips_when_already_cached() = runTest {
+        val repo = RecordingEmbeddingRepo().apply {
+            preset[1L] = ModelEmbedding(1L, "m", floatArrayOf(1f), cachedAt = 0L)
+        }
+        val downloader = RecordingDownloader()
+        val useCase = EmbedOnBrowseUseCase(
+            embeddingRepository = repo,
+            embedImage = EmbedImageUseCase(FakeImageEmbeddingModel(available = true)),
+            downloader = downloader,
+        )
+
+        useCase(modelId = 1L, thumbnailUrl = "url")
+
+        // Cached already -> no download, no new cache write.
+        assertNull(downloader.lastUrl)
+        assertTrue(repo.cached.isEmpty())
+    }
+
+    @Test
+    fun embed_on_browse_downloads_embeds_and_caches() = runTest {
+        val embedded = floatArrayOf(0.5f, 0.5f)
+        val repo = RecordingEmbeddingRepo()
+        val downloader = RecordingDownloader(bytes = byteArrayOf(1, 2, 3))
+        val useCase = EmbedOnBrowseUseCase(
+            embeddingRepository = repo,
+            embedImage = EmbedImageUseCase(FakeImageEmbeddingModel(available = true, vector = embedded)),
+            downloader = downloader,
+        )
+
+        useCase(modelId = 99L, thumbnailUrl = "https://thumb")
+
+        assertEquals("https://thumb", downloader.lastUrl)
+        val cached = repo.cached.single()
+        assertEquals(99L, cached.modelId)
+        assertEquals(embedded.toList(), cached.vector.toList())
+    }
+
+    // --- Fakes ---
+
+    private class FakeTextEmbeddingModel(
+        private val available: Boolean,
+        private val vector: FloatArray = floatArrayOf(),
+    ) : TextEmbeddingModel {
+        override val isAvailable: Boolean = available
+        override val embeddingModelId: String = "test-encoder"
+        override suspend fun embed(text: String): FloatArray = vector
+    }
+
+    private class FakeImageEmbeddingModel(
+        private val available: Boolean,
+        private val vector: FloatArray = floatArrayOf(),
+    ) : ImageEmbeddingModel {
+        override val isAvailable: Boolean = available
+        override suspend fun embed(imageBytes: ByteArray): FloatArray = vector
+    }
+
+    private class RecordingDownloader(private val bytes: ByteArray = ByteArray(0)) :
+        ThumbnailDownloader {
+        var lastUrl: String? = null
+        override suspend fun download(url: String): ByteArray {
+            lastUrl = url
+            return bytes
+        }
+    }
+
+    private class RecordingEmbeddingRepo(
+        private val hits: List<SimilarModelHit> = emptyList(),
+    ) : ModelEmbeddingRepository {
+        val preset = mutableMapOf<Long, ModelEmbedding>()
+        val cached = mutableListOf<ModelEmbedding>()
+        var lastFindQuery: FloatArray? = null
+        var lastFindModel: String? = null
+        var lastFindLimit: Int? = null
+
+        override suspend fun get(modelId: Long): ModelEmbedding? = preset[modelId]
+        override suspend fun count(embeddingModel: String): Int = 0
+        override suspend fun cache(embedding: ModelEmbedding) {
+            cached.add(embedding)
+        }
+        override suspend fun findSimilar(
+            query: FloatArray,
+            embeddingModel: String,
+            limit: Int,
+            excludeModelId: Long?,
+        ): List<SimilarModelHit> {
+            lastFindQuery = query
+            lastFindModel = embeddingModel
+            lastFindLimit = limit
+            return hits
+        }
+        override suspend fun deleteStale(keepModel: String): Int = 0
+        override suspend fun clear() = Unit
+    }
+}

--- a/core/core-domain/src/commonTest/kotlin/com/riox432/civitdeck/domain/usecase/EnqueueDownloadUseCaseTest.kt
+++ b/core/core-domain/src/commonTest/kotlin/com/riox432/civitdeck/domain/usecase/EnqueueDownloadUseCaseTest.kt
@@ -1,0 +1,80 @@
+package com.riox432.civitdeck.domain.usecase
+
+import com.riox432.civitdeck.domain.model.DownloadStatus
+import com.riox432.civitdeck.domain.model.ModelDownload
+import com.riox432.civitdeck.domain.repository.ModelDownloadRepository
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * Covers [EnqueueDownloadUseCase]: enqueueing is idempotent per fileId — an
+ * already-queued file returns the existing row id instead of inserting a duplicate.
+ */
+class EnqueueDownloadUseCaseTest {
+
+    @Test
+    fun enqueues_and_returns_new_id_when_file_is_not_already_queued() = runTest {
+        val repo = FakeDownloadRepo(existingByFileId = emptyMap(), newId = 42L)
+        val useCase = EnqueueDownloadUseCase(repo)
+
+        val id = useCase(download(fileId = 7L))
+
+        assertEquals(42L, id)
+        assertTrue(repo.enqueueCalled)
+    }
+
+    @Test
+    fun returns_existing_id_without_re_enqueueing_when_file_already_queued() = runTest {
+        val existing = download(id = 99L, fileId = 7L)
+        val repo = FakeDownloadRepo(existingByFileId = mapOf(7L to existing), newId = 42L)
+        val useCase = EnqueueDownloadUseCase(repo)
+
+        val id = useCase(download(fileId = 7L))
+
+        // Idempotent: the existing row id is returned and no new insert happens.
+        assertEquals(99L, id)
+        assertFalse(repo.enqueueCalled)
+    }
+
+    private fun download(id: Long = 0L, fileId: Long) = ModelDownload(
+        id = id,
+        modelId = 1L,
+        modelName = "Model",
+        versionId = 1L,
+        versionName = "v1",
+        fileId = fileId,
+        fileName = "model.safetensors",
+        fileUrl = "https://example.com/model.safetensors",
+        fileSizeBytes = 1000L,
+        modelType = "Checkpoint",
+    )
+
+    private class FakeDownloadRepo(
+        private val existingByFileId: Map<Long, ModelDownload>,
+        private val newId: Long,
+    ) : ModelDownloadRepository {
+        var enqueueCalled = false
+        override suspend fun getDownloadByFileId(fileId: Long): ModelDownload? =
+            existingByFileId[fileId]
+        override suspend fun enqueueDownload(download: ModelDownload): Long {
+            enqueueCalled = true
+            return newId
+        }
+        override fun observeAllDownloads(): Flow<List<ModelDownload>> = flowOf(emptyList())
+        override fun observeDownloadsForModel(modelId: Long): Flow<List<ModelDownload>> =
+            flowOf(emptyList())
+        override suspend fun getDownloadById(id: Long): ModelDownload? = null
+        override suspend fun updateStatus(id: Long, status: DownloadStatus, errorMessage: String?) =
+            Unit
+        override suspend fun updateProgress(id: Long, downloadedBytes: Long) = Unit
+        override suspend fun updateDestinationPath(id: Long, path: String) = Unit
+        override suspend fun deleteDownload(id: Long) = Unit
+        override suspend fun updateHashVerified(id: Long, verified: Boolean) = Unit
+        override suspend fun clearCompletedDownloads() = Unit
+    }
+}

--- a/core/core-domain/src/commonTest/kotlin/com/riox432/civitdeck/domain/usecase/VerifyDownloadHashUseCaseTest.kt
+++ b/core/core-domain/src/commonTest/kotlin/com/riox432/civitdeck/domain/usecase/VerifyDownloadHashUseCaseTest.kt
@@ -1,0 +1,77 @@
+package com.riox432.civitdeck.domain.usecase
+
+import com.riox432.civitdeck.domain.model.DownloadStatus
+import com.riox432.civitdeck.domain.model.ModelDownload
+import com.riox432.civitdeck.domain.repository.ModelDownloadRepository
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+
+class VerifyDownloadHashUseCaseTest {
+
+    @Test
+    fun returns_not_found_when_download_missing() = runTest {
+        val useCase = VerifyDownloadHashUseCase(FakeDownloadRepo(download = null))
+
+        val result = useCase(downloadId = 1L, expectedSha256 = "abc")
+
+        assertEquals(HashVerificationResult.NotFound, result)
+    }
+
+    @Test
+    fun returns_no_file_when_destination_path_is_null() = runTest {
+        val download = download(id = 1L, destinationPath = null)
+        val useCase = VerifyDownloadHashUseCase(FakeDownloadRepo(download))
+
+        val result = useCase(downloadId = 1L, expectedSha256 = "abc")
+
+        assertEquals(HashVerificationResult.NoFile, result)
+    }
+
+    @Test
+    fun returns_pending_with_path_and_expected_hash() = runTest {
+        val download = download(id = 1L, destinationPath = "/models/file.safetensors")
+        val useCase = VerifyDownloadHashUseCase(FakeDownloadRepo(download))
+
+        val result = useCase(downloadId = 1L, expectedSha256 = "EXPECTED")
+
+        val pending = assertIs<HashVerificationResult.Pending>(result)
+        assertEquals("/models/file.safetensors", pending.filePath)
+        assertEquals("EXPECTED", pending.expectedHash)
+    }
+
+    private fun download(id: Long, destinationPath: String?) = ModelDownload(
+        id = id,
+        modelId = 10L,
+        modelName = "M",
+        versionId = 20L,
+        versionName = "v",
+        fileId = 30L,
+        fileName = "f.safetensors",
+        fileUrl = "url",
+        fileSizeBytes = 100L,
+        modelType = "Checkpoint",
+        destinationPath = destinationPath,
+    )
+
+    private class FakeDownloadRepo(private val download: ModelDownload?) : ModelDownloadRepository {
+        override suspend fun enqueueDownload(download: ModelDownload): Long = throw NotImplementedError()
+        override fun observeAllDownloads(): Flow<List<ModelDownload>> = throw NotImplementedError()
+        override fun observeDownloadsForModel(modelId: Long): Flow<List<ModelDownload>> =
+            throw NotImplementedError()
+        override suspend fun getDownloadById(id: Long): ModelDownload? = download
+        override suspend fun getDownloadByFileId(fileId: Long): ModelDownload? =
+            throw NotImplementedError()
+        override suspend fun updateStatus(id: Long, status: DownloadStatus, errorMessage: String?) =
+            throw NotImplementedError()
+        override suspend fun updateProgress(id: Long, downloadedBytes: Long) =
+            throw NotImplementedError()
+        override suspend fun updateDestinationPath(id: Long, path: String) = throw NotImplementedError()
+        override suspend fun deleteDownload(id: Long) = throw NotImplementedError()
+        override suspend fun updateHashVerified(id: Long, verified: Boolean) =
+            throw NotImplementedError()
+        override suspend fun clearCompletedDownloads() = throw NotImplementedError()
+    }
+}

--- a/core/core-plugin/src/commonTest/kotlin/com/riox432/civitdeck/plugin/usecase/ActivateThemePluginUseCaseTest.kt
+++ b/core/core-plugin/src/commonTest/kotlin/com/riox432/civitdeck/plugin/usecase/ActivateThemePluginUseCaseTest.kt
@@ -1,0 +1,286 @@
+package com.riox432.civitdeck.plugin.usecase
+
+import com.riox432.civitdeck.domain.model.InstalledPlugin
+import com.riox432.civitdeck.domain.model.InstalledPluginState
+import com.riox432.civitdeck.domain.repository.PluginRepository
+import com.riox432.civitdeck.plugin.InMemoryPluginRegistry
+import com.riox432.civitdeck.plugin.Plugin
+import com.riox432.civitdeck.plugin.ThemePlugin
+import com.riox432.civitdeck.plugin.ThemeColorScheme
+import com.riox432.civitdeck.plugin.capability.ThemeCapability
+import com.riox432.civitdeck.plugin.model.PluginManifest
+import com.riox432.civitdeck.plugin.model.PluginState
+import com.riox432.civitdeck.plugin.model.PluginType
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class ActivateThemePluginUseCaseTest {
+
+    // --- fakes ---
+
+    /**
+     * A mutable ThemePlugin whose state transitions when activate/deactivate are called.
+     * Tracks call counts so tests can assert interaction behaviour.
+     */
+    private class FakeThemePlugin(
+        override val manifest: PluginManifest,
+        initialState: PluginState = PluginState.INSTALLED,
+    ) : ThemePlugin {
+
+        private var _state = initialState
+        override val state: PluginState get() = _state
+
+        var activateCalls = 0
+        var deactivateCalls = 0
+
+        override val themeCapabilities: Set<ThemeCapability> = emptySet()
+
+        override fun getColorScheme(isDark: Boolean): ThemeColorScheme = ThemeColorScheme(
+            primary = 0L, onPrimary = 0L, primaryContainer = 0L, onPrimaryContainer = 0L,
+            secondary = 0L, onSecondary = 0L, secondaryContainer = 0L, onSecondaryContainer = 0L,
+            tertiary = 0L, onTertiary = 0L, tertiaryContainer = 0L, onTertiaryContainer = 0L,
+            background = 0L, onBackground = 0L, surface = 0L, onSurface = 0L,
+            surfaceVariant = 0L, onSurfaceVariant = 0L,
+            error = 0L, onError = 0L, errorContainer = 0L, onErrorContainer = 0L,
+            outline = 0L, outlineVariant = 0L,
+        )
+
+        override suspend fun initialize() {}
+
+        override suspend fun activate() {
+            activateCalls++
+            _state = PluginState.ACTIVE
+        }
+
+        override suspend fun deactivate() {
+            deactivateCalls++
+            _state = PluginState.INACTIVE
+        }
+
+        override suspend fun destroy() {}
+    }
+
+    /**
+     * A non-theme plugin registered alongside themes to confirm the use case ignores other types.
+     */
+    private class FakeWorkflowPlugin(
+        override val manifest: PluginManifest,
+        override val state: PluginState = PluginState.ACTIVE,
+    ) : Plugin {
+        var deactivateCalls = 0
+        override suspend fun initialize() {}
+        override suspend fun activate() {}
+        override suspend fun deactivate() { deactivateCalls++ }
+        override suspend fun destroy() {}
+    }
+
+    /** Records updateState calls for assertion. */
+    private class FakePluginRepository : PluginRepository {
+        data class StateUpdate(val pluginId: String, val state: InstalledPluginState)
+
+        val stateUpdates = mutableListOf<StateUpdate>()
+
+        override fun observeAll(): Flow<List<InstalledPlugin>> = flowOf(emptyList())
+        override fun observeById(pluginId: String): Flow<InstalledPlugin?> = flowOf(null)
+        override suspend fun getById(pluginId: String): InstalledPlugin? = null
+        override suspend fun install(plugin: InstalledPlugin) {}
+        override suspend fun uninstall(pluginId: String) {}
+        override suspend fun updateState(pluginId: String, state: InstalledPluginState) {
+            stateUpdates.add(StateUpdate(pluginId, state))
+        }
+        override suspend fun getConfig(pluginId: String): String = "{}"
+        override suspend fun updateConfig(pluginId: String, configJson: String) {}
+    }
+
+    // --- helpers ---
+
+    private fun themeManifest(id: String) = PluginManifest(
+        id = id,
+        name = "Theme $id",
+        version = "1.0.0",
+        author = "Test",
+        description = "Test theme",
+        pluginType = PluginType.THEME,
+        capabilities = emptyList(),
+    )
+
+    private fun buildUseCase(
+        vararg plugins: Plugin,
+        repository: FakePluginRepository = FakePluginRepository(),
+    ): Triple<ActivateThemePluginUseCase, InMemoryPluginRegistry, FakePluginRepository> {
+        val registry = InMemoryPluginRegistry()
+        plugins.forEach { registry.register(it) }
+        return Triple(ActivateThemePluginUseCase(registry, repository), registry, repository)
+    }
+
+    // --- tests ---
+
+    @Test
+    fun invoke_withActiveTheme_deactivatesItAndActivatesTarget() = runTest {
+        // Arrange: one currently-active theme, one inactive theme
+        val active = FakeThemePlugin(themeManifest("active-theme"), PluginState.ACTIVE)
+        val target = FakeThemePlugin(themeManifest("target-theme"), PluginState.INACTIVE)
+        val repo = FakePluginRepository()
+        val (useCase, _, _) = buildUseCase(active, target, repository = repo)
+
+        // Act
+        useCase.invoke("target-theme")
+
+        // Assert — previously-active theme was deactivated
+        assertEquals(1, active.deactivateCalls, "Previously active theme must be deactivated exactly once")
+        assertEquals(PluginState.INACTIVE, active.state, "Active theme state must become INACTIVE")
+
+        // Assert — target theme was activated
+        assertEquals(1, target.activateCalls, "Target theme must be activated exactly once")
+        assertEquals(PluginState.ACTIVE, target.state, "Target theme state must become ACTIVE")
+
+        // Assert — repository received the correct updateState calls
+        assertTrue(
+            repo.stateUpdates.any { it.pluginId == "active-theme" && it.state == InstalledPluginState.INACTIVE },
+            "Repository must record INACTIVE update for previously-active theme",
+        )
+        assertTrue(
+            repo.stateUpdates.any { it.pluginId == "target-theme" && it.state == InstalledPluginState.ACTIVE },
+            "Repository must record ACTIVE update for target theme",
+        )
+    }
+
+    @Test
+    fun invoke_withMultipleActiveThemes_deactivatesAllBeforeActivatingTarget() = runTest {
+        // Arrange: two simultaneously-active themes (edge case — should not happen at runtime
+        // but the use case must handle it defensively)
+        val active1 = FakeThemePlugin(themeManifest("a"), PluginState.ACTIVE)
+        val active2 = FakeThemePlugin(themeManifest("b"), PluginState.ACTIVE)
+        val target = FakeThemePlugin(themeManifest("c"), PluginState.INACTIVE)
+        val repo = FakePluginRepository()
+        val (useCase, _, _) = buildUseCase(active1, active2, target, repository = repo)
+
+        // Act
+        useCase.invoke("c")
+
+        // Assert — both previously-active themes were deactivated
+        assertEquals(1, active1.deactivateCalls)
+        assertEquals(1, active2.deactivateCalls)
+        assertEquals(1, target.activateCalls)
+        assertEquals(
+            3,
+            repo.stateUpdates.size,
+            "Two INACTIVE + one ACTIVE update expected",
+        )
+    }
+
+    @Test
+    fun invoke_withNullPluginId_deactivatesAllThemesAndActivatesNone() = runTest {
+        // Arrange: one active theme, null passed to revert to built-in theme
+        val active = FakeThemePlugin(themeManifest("theme-x"), PluginState.ACTIVE)
+        val repo = FakePluginRepository()
+        val (useCase, _, _) = buildUseCase(active, repository = repo)
+
+        // Act
+        useCase.invoke(null)
+
+        // Assert — active theme was deactivated
+        assertEquals(1, active.deactivateCalls)
+        assertEquals(PluginState.INACTIVE, active.state)
+
+        // Assert — no activation calls were made
+        assertEquals(0, active.activateCalls)
+
+        // Assert — only one update: INACTIVE for the formerly-active theme
+        assertEquals(1, repo.stateUpdates.size)
+        assertEquals(InstalledPluginState.INACTIVE, repo.stateUpdates.first().state)
+
+        // Assert — no ACTIVE update was written
+        assertTrue(
+            repo.stateUpdates.none { it.state == InstalledPluginState.ACTIVE },
+            "Null pluginId must not produce any ACTIVE state update",
+        )
+    }
+
+    @Test
+    fun invoke_withUnknownPluginId_deactivatesActiveThemesButSkipsActivation() = runTest {
+        // Arrange: one active theme, request an id that is not in the registry
+        val active = FakeThemePlugin(themeManifest("existing"), PluginState.ACTIVE)
+        val repo = FakePluginRepository()
+        val (useCase, _, _) = buildUseCase(active, repository = repo)
+
+        // Act
+        useCase.invoke("nonexistent-id")
+
+        // Assert — existing active theme was still deactivated
+        assertEquals(1, active.deactivateCalls)
+
+        // Assert — no plugin was activated because the target was not found
+        assertEquals(0, active.activateCalls)
+
+        // Assert — repository has no ACTIVE update
+        assertTrue(
+            repo.stateUpdates.none { it.state == InstalledPluginState.ACTIVE },
+            "Unknown pluginId must not produce any ACTIVE state update",
+        )
+    }
+
+    @Test
+    fun invoke_withNonThemePluginAsTarget_doesNotActivateIt() = runTest {
+        // Arrange: target id exists in the registry but is a workflow plugin, not a ThemePlugin
+        val workflowPlugin = FakeWorkflowPlugin(
+            PluginManifest(
+                id = "workflow-x",
+                name = "Workflow",
+                version = "1.0",
+                author = "Test",
+                description = "A workflow plugin",
+                pluginType = PluginType.WORKFLOW_ENGINE,
+                capabilities = emptyList(),
+            ),
+            state = PluginState.INACTIVE,
+        )
+        val repo = FakePluginRepository()
+        val registry = InMemoryPluginRegistry()
+        registry.register(workflowPlugin)
+        val useCase = ActivateThemePluginUseCase(registry, repo)
+
+        // Act
+        useCase.invoke("workflow-x")
+
+        // Assert — use case checks `target is ThemePlugin`, so a workflow plugin is ignored
+        assertTrue(
+            repo.stateUpdates.none { it.state == InstalledPluginState.ACTIVE },
+            "Non-ThemePlugin target must not be activated",
+        )
+    }
+
+    @Test
+    fun invoke_whenNoThemesRegistered_completesWithoutErrors() = runTest {
+        // Arrange: empty registry, no plugins at all
+        val repo = FakePluginRepository()
+        val registry = InMemoryPluginRegistry()
+        val useCase = ActivateThemePluginUseCase(registry, repo)
+
+        // Act & Assert — must not throw
+        useCase.invoke("any-id")
+
+        assertTrue(repo.stateUpdates.isEmpty(), "No updates expected when registry is empty")
+    }
+
+    @Test
+    fun invoke_withInactiveTargetTheme_doesNotDeactivateItPrematurely() = runTest {
+        // Arrange: the target theme is already INACTIVE (the only theme registered)
+        val target = FakeThemePlugin(themeManifest("t"), PluginState.INACTIVE)
+        val repo = FakePluginRepository()
+        val (useCase, _, _) = buildUseCase(target, repository = repo)
+
+        // Act
+        useCase.invoke("t")
+
+        // Assert — the INACTIVE plugin was NOT deactivated again (only ACTIVE ones are deactivated)
+        assertEquals(0, target.deactivateCalls, "An already-inactive theme must not be deactivated")
+
+        // Assert — it was activated
+        assertEquals(1, target.activateCalls)
+    }
+}

--- a/feature/feature-collections/src/commonTest/kotlin/com/riox432/civitdeck/feature/collections/domain/usecase/ExportWithPluginUseCaseTest.kt
+++ b/feature/feature-collections/src/commonTest/kotlin/com/riox432/civitdeck/feature/collections/domain/usecase/ExportWithPluginUseCaseTest.kt
@@ -1,0 +1,341 @@
+package com.riox432.civitdeck.feature.collections.domain.usecase
+
+import app.cash.turbine.test
+import com.riox432.civitdeck.domain.model.ExportProgress
+import com.riox432.civitdeck.plugin.ExportFormatPlugin
+import com.riox432.civitdeck.plugin.InMemoryPluginRegistry
+import com.riox432.civitdeck.plugin.Plugin
+import com.riox432.civitdeck.plugin.PluginExportFormat
+import com.riox432.civitdeck.plugin.PluginExportProgress
+import com.riox432.civitdeck.plugin.model.PluginManifest
+import com.riox432.civitdeck.plugin.model.PluginState
+import com.riox432.civitdeck.plugin.model.PluginType
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+
+class ExportWithPluginUseCaseTest {
+
+    // --- fakes ---
+
+    /**
+     * A controllable ExportFormatPlugin whose export() return value is set per-test.
+     */
+    private class FakeExportPlugin(
+        override val manifest: PluginManifest,
+        override val state: PluginState = PluginState.ACTIVE,
+        override val supportedFormats: List<PluginExportFormat>,
+        private val exportFlow: Flow<PluginExportProgress> = flowOf(),
+    ) : ExportFormatPlugin {
+
+        var lastExportDatasetId: Long? = null
+        var lastExportFormatId: String? = null
+        var lastExportOptions: Map<String, String>? = null
+
+        override fun export(
+            datasetId: Long,
+            formatId: String,
+            options: Map<String, String>,
+        ): Flow<PluginExportProgress> {
+            lastExportDatasetId = datasetId
+            lastExportFormatId = formatId
+            lastExportOptions = options
+            return exportFlow
+        }
+
+        override suspend fun initialize() {}
+        override suspend fun activate() {}
+        override suspend fun deactivate() {}
+        override suspend fun destroy() {}
+    }
+
+    /**
+     * A non-export plugin registered alongside export plugins to confirm the use case
+     * ignores plugins of the wrong type during format discovery.
+     */
+    private class FakeWorkflowPlugin(id: String) : Plugin {
+        override val manifest = PluginManifest(
+            id = id,
+            name = "Workflow $id",
+            version = "1.0.0",
+            author = "Test",
+            description = "A workflow plugin",
+            pluginType = PluginType.WORKFLOW_ENGINE,
+            capabilities = emptyList(),
+        )
+        override val state: PluginState = PluginState.ACTIVE
+        override suspend fun initialize() {}
+        override suspend fun activate() {}
+        override suspend fun deactivate() {}
+        override suspend fun destroy() {}
+    }
+
+    // --- helpers ---
+
+    private fun exportManifest(id: String) = PluginManifest(
+        id = id,
+        name = "Export $id",
+        version = "1.0.0",
+        author = "Test",
+        description = "Test export plugin",
+        pluginType = PluginType.EXPORT_FORMAT,
+        capabilities = emptyList(),
+    )
+
+    private fun format(id: String) = PluginExportFormat(
+        id = id,
+        name = id,
+        description = "Format $id",
+        fileExtension = "zip",
+        mimeType = "application/zip",
+    )
+
+    private fun buildUseCase(vararg plugins: Plugin): ExportWithPluginUseCase {
+        val registry = InMemoryPluginRegistry()
+        plugins.forEach { registry.register(it) }
+        return ExportWithPluginUseCase(registry)
+    }
+
+    // --- tests ---
+
+    @Test
+    fun invoke_foundPlugin_emitsMappedPreparingProgress() = runTest {
+        // Arrange: active plugin supporting "kohya-zip", emitting Preparing
+        val plugin = FakeExportPlugin(
+            manifest = exportManifest("kohya"),
+            supportedFormats = listOf(format("kohya-zip")),
+            exportFlow = flowOf(PluginExportProgress.Preparing),
+        )
+        val useCase = buildUseCase(plugin)
+
+        // Act & Assert
+        useCase.invoke(datasetId = 1L, formatId = "kohya-zip").test {
+            assertIs<ExportProgress.Preparing>(awaitItem())
+            awaitComplete()
+        }
+    }
+
+    @Test
+    fun invoke_foundPlugin_mapsDownloadingProgressWithCounts() = runTest {
+        // Arrange: plugin emits a Downloading event
+        val plugin = FakeExportPlugin(
+            manifest = exportManifest("kohya"),
+            supportedFormats = listOf(format("kohya-zip")),
+            exportFlow = flowOf(PluginExportProgress.Downloading(current = 5, total = 20)),
+        )
+        val useCase = buildUseCase(plugin)
+
+        // Act & Assert
+        useCase.invoke(datasetId = 10L, formatId = "kohya-zip").test {
+            val item = awaitItem()
+            assertIs<ExportProgress.Downloading>(item)
+            assertEquals(5, item.current)
+            assertEquals(20, item.total)
+            awaitComplete()
+        }
+    }
+
+    @Test
+    fun invoke_foundPlugin_mapsWritingManifestProgress() = runTest {
+        // Arrange
+        val plugin = FakeExportPlugin(
+            manifest = exportManifest("p"),
+            supportedFormats = listOf(format("jsonl")),
+            exportFlow = flowOf(PluginExportProgress.WritingManifest),
+        )
+        val useCase = buildUseCase(plugin)
+
+        // Act & Assert
+        useCase.invoke(datasetId = 1L, formatId = "jsonl").test {
+            assertIs<ExportProgress.WritingManifest>(awaitItem())
+            awaitComplete()
+        }
+    }
+
+    @Test
+    fun invoke_foundPlugin_mapsCompletedProgressWithOutputPath() = runTest {
+        // Arrange
+        val plugin = FakeExportPlugin(
+            manifest = exportManifest("p"),
+            supportedFormats = listOf(format("kohya-zip")),
+            exportFlow = flowOf(PluginExportProgress.Completed(outputPath = "/tmp/export.zip", warningCount = 3)),
+        )
+        val useCase = buildUseCase(plugin)
+
+        // Act & Assert
+        useCase.invoke(datasetId = 5L, formatId = "kohya-zip").test {
+            val item = awaitItem()
+            assertIs<ExportProgress.Completed>(item)
+            assertEquals("/tmp/export.zip", item.outputPath)
+            assertEquals(3, item.warningCount)
+            awaitComplete()
+        }
+    }
+
+    @Test
+    fun invoke_foundPlugin_mapsFailedProgressWithMessage() = runTest {
+        // Arrange
+        val plugin = FakeExportPlugin(
+            manifest = exportManifest("p"),
+            supportedFormats = listOf(format("kohya-zip")),
+            exportFlow = flowOf(PluginExportProgress.Failed("disk full")),
+        )
+        val useCase = buildUseCase(plugin)
+
+        // Act & Assert
+        useCase.invoke(datasetId = 1L, formatId = "kohya-zip").test {
+            val item = awaitItem()
+            assertIs<ExportProgress.Failed>(item)
+            assertEquals("disk full", item.message)
+            awaitComplete()
+        }
+    }
+
+    @Test
+    fun invoke_foundPlugin_emitsFullProgressSequence() = runTest {
+        // Arrange: a realistic sequence emitted by a plugin
+        val plugin = FakeExportPlugin(
+            manifest = exportManifest("p"),
+            supportedFormats = listOf(format("kohya-zip")),
+            exportFlow = flowOf(
+                PluginExportProgress.Preparing,
+                PluginExportProgress.Downloading(current = 1, total = 3),
+                PluginExportProgress.Downloading(current = 2, total = 3),
+                PluginExportProgress.Downloading(current = 3, total = 3),
+                PluginExportProgress.WritingManifest,
+                PluginExportProgress.Completed(outputPath = "/out/archive.zip", warningCount = 0),
+            ),
+        )
+        val useCase = buildUseCase(plugin)
+
+        // Act & Assert
+        useCase.invoke(datasetId = 99L, formatId = "kohya-zip").test {
+            assertIs<ExportProgress.Preparing>(awaitItem())
+            assertIs<ExportProgress.Downloading>(awaitItem())
+            assertIs<ExportProgress.Downloading>(awaitItem())
+            assertIs<ExportProgress.Downloading>(awaitItem())
+            assertIs<ExportProgress.WritingManifest>(awaitItem())
+            val last = awaitItem()
+            assertIs<ExportProgress.Completed>(last)
+            assertEquals("/out/archive.zip", last.outputPath)
+            awaitComplete()
+        }
+    }
+
+    @Test
+    fun invoke_foundPlugin_forwardsDatasetIdAndOptionsToPlugin() = runTest {
+        // Arrange
+        val plugin = FakeExportPlugin(
+            manifest = exportManifest("p"),
+            supportedFormats = listOf(format("kohya-zip")),
+            exportFlow = flowOf(PluginExportProgress.Preparing),
+        )
+        val useCase = buildUseCase(plugin)
+        val options = mapOf("resolution" to "512", "caption_ext" to "txt")
+
+        // Act
+        useCase.invoke(datasetId = 42L, formatId = "kohya-zip", options = options).test {
+            awaitItem()
+            awaitComplete()
+        }
+
+        // Assert — the exact arguments were forwarded to the plugin
+        assertEquals(42L, plugin.lastExportDatasetId)
+        assertEquals("kohya-zip", plugin.lastExportFormatId)
+        assertEquals(options, plugin.lastExportOptions)
+    }
+
+    @Test
+    fun invoke_noMatchingPlugin_emitsSingleFailedEvent() = runTest {
+        // Arrange: registry has no plugins at all
+        val useCase = ExportWithPluginUseCase(InMemoryPluginRegistry())
+
+        // Act & Assert
+        useCase.invoke(datasetId = 1L, formatId = "unknown-format").test {
+            val item = awaitItem()
+            assertIs<ExportProgress.Failed>(item)
+            assertEquals("No export plugin found for format: unknown-format", item.message)
+            awaitComplete()
+        }
+    }
+
+    @Test
+    fun invoke_pluginExistsButFormatNotSupported_emitsFailed() = runTest {
+        // Arrange: plugin supports "kohya-zip" but "jsonl" is requested
+        val plugin = FakeExportPlugin(
+            manifest = exportManifest("p"),
+            supportedFormats = listOf(format("kohya-zip")),
+        )
+        val useCase = buildUseCase(plugin)
+
+        // Act & Assert
+        useCase.invoke(datasetId = 1L, formatId = "jsonl").test {
+            assertIs<ExportProgress.Failed>(awaitItem())
+            awaitComplete()
+        }
+    }
+
+    @Test
+    fun invoke_pluginInactiveForRequestedFormat_emitsFailed() = runTest {
+        // Arrange: plugin supports the format but is INACTIVE — it must be ignored
+        val inactivePlugin = FakeExportPlugin(
+            manifest = exportManifest("inactive-plugin"),
+            state = PluginState.INACTIVE,
+            supportedFormats = listOf(format("kohya-zip")),
+        )
+        val useCase = buildUseCase(inactivePlugin)
+
+        // Act & Assert
+        useCase.invoke(datasetId = 1L, formatId = "kohya-zip").test {
+            val item = awaitItem()
+            assertIs<ExportProgress.Failed>(item)
+            // error message references the format id
+            assertEquals("No export plugin found for format: kohya-zip", item.message)
+            awaitComplete()
+        }
+    }
+
+    @Test
+    fun invoke_nonExportPluginsIgnored_emitsFailed() = runTest {
+        // Arrange: only a workflow plugin registered — it should never match export format lookup
+        val workflowPlugin = FakeWorkflowPlugin("wf-only")
+        val useCase = buildUseCase(workflowPlugin)
+
+        // Act & Assert
+        useCase.invoke(datasetId = 1L, formatId = "kohya-zip").test {
+            assertIs<ExportProgress.Failed>(awaitItem())
+            awaitComplete()
+        }
+    }
+
+    @Test
+    fun invoke_picksFirstActivePluginMatchingFormat_whenMultipleRegistered() = runTest {
+        // Arrange: two plugins both support "kohya-zip"; only the ACTIVE one should be used
+        val activePlugin = FakeExportPlugin(
+            manifest = exportManifest("active-plugin"),
+            state = PluginState.ACTIVE,
+            supportedFormats = listOf(format("kohya-zip")),
+            exportFlow = flowOf(PluginExportProgress.Preparing),
+        )
+        val inactivePlugin = FakeExportPlugin(
+            manifest = exportManifest("inactive-plugin"),
+            state = PluginState.INACTIVE,
+            supportedFormats = listOf(format("kohya-zip")),
+            exportFlow = flowOf(PluginExportProgress.Preparing),
+        )
+        val useCase = buildUseCase(activePlugin, inactivePlugin)
+
+        // Act & Assert
+        useCase.invoke(datasetId = 1L, formatId = "kohya-zip").test {
+            assertIs<ExportProgress.Preparing>(awaitItem())
+            awaitComplete()
+        }
+
+        // Only the active plugin was called
+        assertEquals("kohya-zip", activePlugin.lastExportFormatId)
+        assertEquals(null, inactivePlugin.lastExportFormatId, "Inactive plugin must not be called")
+    }
+}

--- a/feature/feature-comfyui/src/commonTest/kotlin/com/riox432/civitdeck/feature/comfyui/domain/usecase/ApplyWorkflowTemplateUseCaseTest.kt
+++ b/feature/feature-comfyui/src/commonTest/kotlin/com/riox432/civitdeck/feature/comfyui/domain/usecase/ApplyWorkflowTemplateUseCaseTest.kt
@@ -1,0 +1,93 @@
+package com.riox432.civitdeck.feature.comfyui.domain.usecase
+
+import com.riox432.civitdeck.domain.model.ComfyUIGenerationParams
+import com.riox432.civitdeck.domain.model.TemplateVariable
+import com.riox432.civitdeck.domain.model.TemplateVariableType
+import com.riox432.civitdeck.domain.model.WorkflowTemplate
+import com.riox432.civitdeck.domain.model.WorkflowTemplateType
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * Covers [ApplyWorkflowTemplateUseCase]: value resolution precedence
+ * (provided value > template default > empty) and numeric parsing with
+ * fallback to the [ComfyUIGenerationParams] defaults.
+ */
+class ApplyWorkflowTemplateUseCaseTest {
+
+    private val useCase = ApplyWorkflowTemplateUseCase()
+
+    private fun variable(name: String, default: String) = TemplateVariable(
+        name = name,
+        type = TemplateVariableType.TEXT,
+        defaultValue = default,
+    )
+
+    private fun template(vararg variables: TemplateVariable) = WorkflowTemplate(
+        id = 1L,
+        name = "T",
+        type = WorkflowTemplateType.TXT2IMG,
+        variables = variables.toList(),
+        isBuiltIn = false,
+        createdAt = 0L,
+    )
+
+    @Test
+    fun provided_values_take_precedence_over_template_defaults() {
+        val tpl = template(
+            variable("positive_prompt", "default prompt"),
+            variable("steps", "10"),
+        )
+
+        val params = useCase(
+            tpl,
+            mapOf("positive_prompt" to "user prompt", "steps" to "25"),
+        )
+
+        assertEquals("user prompt", params.prompt)
+        assertEquals(25, params.steps)
+    }
+
+    @Test
+    fun falls_back_to_template_default_when_value_not_provided() {
+        val tpl = template(
+            variable("positive_prompt", "default prompt"),
+            variable("cfg", "8.5"),
+        )
+
+        val params = useCase(tpl, emptyMap())
+
+        assertEquals("default prompt", params.prompt)
+        assertEquals(8.5, params.cfgScale)
+    }
+
+    @Test
+    fun uses_generation_param_defaults_when_numeric_value_is_unparseable() {
+        val tpl = template(
+            variable("steps", "not-a-number"),
+            variable("cfg", "abc"),
+            variable("width", ""),
+            variable("seed", "xyz"),
+        )
+
+        val params = useCase(tpl, emptyMap())
+
+        assertEquals(ComfyUIGenerationParams.DEFAULT_STEPS, params.steps)
+        assertEquals(ComfyUIGenerationParams.DEFAULT_CFG, params.cfgScale)
+        assertEquals(ComfyUIGenerationParams.DEFAULT_DIMENSION, params.width)
+        // Seed has its own sentinel default of -1 (randomize) rather than a constant.
+        assertEquals(-1L, params.seed)
+    }
+
+    @Test
+    fun absent_variables_resolve_to_empty_string_for_text_fields() {
+        // Template defines nothing; checkpoint/prompt are unfilled -> empty strings.
+        val params = useCase(template(), emptyMap())
+
+        assertEquals("", params.checkpoint)
+        assertEquals("", params.prompt)
+        assertEquals("", params.negativePrompt)
+        // Numeric fields still get their type defaults.
+        assertEquals(ComfyUIGenerationParams.DEFAULT_STEPS, params.steps)
+    }
+}

--- a/feature/feature-comfyui/src/commonTest/kotlin/com/riox432/civitdeck/feature/comfyui/domain/usecase/FetchObjectInfoUseCaseTest.kt
+++ b/feature/feature-comfyui/src/commonTest/kotlin/com/riox432/civitdeck/feature/comfyui/domain/usecase/FetchObjectInfoUseCaseTest.kt
@@ -1,0 +1,169 @@
+package com.riox432.civitdeck.feature.comfyui.domain.usecase
+
+import com.riox432.civitdeck.data.local.LocalCacheDataSource
+import com.riox432.civitdeck.data.local.dao.CachedApiResponseDao
+import com.riox432.civitdeck.data.local.entity.CachedApiResponseEntity
+import com.riox432.civitdeck.domain.model.ComfyUIGenerationParams
+import com.riox432.civitdeck.domain.model.GenerationResult
+import com.riox432.civitdeck.domain.repository.ComfyUIGenerationRepository
+import com.riox432.civitdeck.domain.util.currentTimeMillis
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.emptyFlow
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * Covers [FetchObjectInfoUseCase] caching behavior: cache-hit short-circuit within
+ * TTL, fetch-and-store on a miss, forceRefresh bypass, and stale-cache fallback when
+ * the network call fails.
+ */
+class FetchObjectInfoUseCaseTest {
+
+    private val cacheKey = "comfyui_object_info"
+
+    @Test
+    fun returns_cached_value_without_fetching_when_within_ttl() = runTest {
+        // Fresh cache entry (cachedAt = now) -> served directly, repository untouched.
+        val dao = FakeCacheDao()
+        dao.entity = entity(json = "cached", cachedAt = now())
+        val repo = FakeGenerationRepo(fresh = "fresh")
+        val useCase = FetchObjectInfoUseCase(repo, LocalCacheDataSource(dao))
+
+        val result = useCase()
+
+        assertEquals("cached", result)
+        assertFalse(repo.fetched)
+    }
+
+    @Test
+    fun fetches_and_caches_when_no_cache_present() = runTest {
+        val dao = FakeCacheDao()
+        val repo = FakeGenerationRepo(fresh = "fresh")
+        val useCase = FetchObjectInfoUseCase(repo, LocalCacheDataSource(dao))
+
+        val result = useCase()
+
+        assertEquals("fresh", result)
+        assertTrue(repo.fetched)
+        // The fresh response was written to cache.
+        assertEquals("fresh", dao.entity?.responseJson)
+    }
+
+    @Test
+    fun fetches_when_cache_is_stale_beyond_ttl() = runTest {
+        // Entry older than the 30-minute TTL -> getCached returns null -> fetch.
+        val staleAt = now() - (31L * 60L * 1000L)
+        val dao = FakeCacheDao()
+        dao.entity = entity(json = "stale", cachedAt = staleAt)
+        val repo = FakeGenerationRepo(fresh = "fresh")
+        val useCase = FetchObjectInfoUseCase(repo, LocalCacheDataSource(dao))
+
+        val result = useCase()
+
+        assertEquals("fresh", result)
+        assertTrue(repo.fetched)
+    }
+
+    @Test
+    fun forceRefresh_bypasses_fresh_cache() = runTest {
+        val dao = FakeCacheDao()
+        dao.entity = entity(json = "cached", cachedAt = now())
+        val repo = FakeGenerationRepo(fresh = "fresh")
+        val useCase = FetchObjectInfoUseCase(repo, LocalCacheDataSource(dao))
+
+        val result = useCase(forceRefresh = true)
+
+        assertEquals("fresh", result)
+        assertTrue(repo.fetched)
+    }
+
+    @Test
+    fun falls_back_to_stale_cache_when_fetch_fails() = runTest {
+        // Stale entry + network error -> use case returns the stale cached JSON.
+        val staleAt = now() - (31L * 60L * 1000L)
+        val dao = FakeCacheDao()
+        dao.entity = entity(json = "stale", cachedAt = staleAt)
+        val repo = FakeGenerationRepo(fresh = null, failFetch = true)
+        val useCase = FetchObjectInfoUseCase(repo, LocalCacheDataSource(dao))
+
+        val result = useCase(forceRefresh = true)
+
+        assertEquals("stale", result)
+        assertTrue(repo.fetched)
+    }
+
+    @Test
+    fun returns_null_when_fetch_fails_and_no_cache_exists() = runTest {
+        val dao = FakeCacheDao()
+        val repo = FakeGenerationRepo(fresh = null, failFetch = true)
+        val useCase = FetchObjectInfoUseCase(repo, LocalCacheDataSource(dao))
+
+        assertNull(useCase())
+    }
+
+    // --- helpers & fakes ---
+
+    // Use the same wall clock LocalCacheDataSource reads so freshness math is consistent.
+    private fun now(): Long = currentTimeMillis()
+
+    private fun entity(json: String, cachedAt: Long) = CachedApiResponseEntity(
+        cacheKey = cacheKey,
+        responseJson = json,
+        cachedAt = cachedAt,
+    )
+
+    /**
+     * Single-entry in-memory DAO. Note [LocalCacheDataSource.getCached] uses the real
+     * wall clock, so freshness is controlled via the entity's `cachedAt` relative to now().
+     */
+    private class FakeCacheDao : CachedApiResponseDao {
+        var entity: CachedApiResponseEntity? = null
+        override suspend fun getByKey(key: String): CachedApiResponseEntity? =
+            entity?.takeIf { it.cacheKey == key }
+        override suspend fun insert(entity: CachedApiResponseEntity) {
+            this.entity = entity
+        }
+        override suspend fun deleteByKey(key: String): Int = 0
+        override suspend fun deleteExpired(expiryTime: Long): Int = 0
+        override suspend fun deleteAll(): Int = 0
+        override suspend fun setPinned(key: String, pinned: Boolean): Int = 0
+        override suspend fun getTotalCacheSizeBytes(): Long? = null
+        override suspend fun getEntryCount(): Int = if (entity == null) 0 else 1
+        override suspend fun deleteOldestUnpinned(count: Int): Int = 0
+    }
+
+    private class FakeGenerationRepo(
+        private val fresh: String?,
+        private val failFetch: Boolean = false,
+    ) : ComfyUIGenerationRepository {
+        var fetched = false
+        override suspend fun fetchObjectInfo(): String {
+            fetched = true
+            if (failFetch) error("network down")
+            return fresh ?: error("no fresh value configured")
+        }
+        override suspend fun fetchCheckpoints(): List<String> = emptyList()
+        override suspend fun fetchLoras(): List<String> = emptyList()
+        override suspend fun fetchControlNets(): List<String> = emptyList()
+        override suspend fun submitGeneration(params: ComfyUIGenerationParams): String = ""
+        override suspend fun pollGenerationResult(promptId: String): GenerationResult =
+            error("not used")
+        override fun observeGenerationProgress(
+            promptId: String,
+            host: String,
+            port: Int,
+        ): Flow<com.riox432.civitdeck.domain.model.GenerationProgress> = emptyFlow()
+        override fun observeGenerationProgress(
+            promptId: String,
+            baseUrl: String,
+            wsScheme: String,
+        ): Flow<com.riox432.civitdeck.domain.model.GenerationProgress> = emptyFlow()
+        override fun getImageUrl(filename: String, subfolder: String, type: String): String = ""
+        override suspend fun interruptGeneration() = Unit
+        override suspend fun uploadMaskImage(maskPngBytes: ByteArray): String = ""
+    }
+}

--- a/feature/feature-comfyui/src/commonTest/kotlin/com/riox432/civitdeck/feature/comfyui/domain/usecase/FetchSystemStatsUseCaseTest.kt
+++ b/feature/feature-comfyui/src/commonTest/kotlin/com/riox432/civitdeck/feature/comfyui/domain/usecase/FetchSystemStatsUseCaseTest.kt
@@ -1,0 +1,86 @@
+package com.riox432.civitdeck.feature.comfyui.domain.usecase
+
+import com.riox432.civitdeck.data.api.comfyui.ComfyUIApi
+import com.riox432.civitdeck.feature.comfyui.data.repository.mockClient
+import com.riox432.civitdeck.feature.comfyui.data.repository.okJson
+import com.riox432.civitdeck.feature.comfyui.data.repository.testJson
+import io.ktor.client.engine.mock.respondError
+import io.ktor.http.HttpStatusCode
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+/**
+ * Covers [FetchSystemStatsUseCase]: it maps the /system_stats response into a
+ * [com.riox432.civitdeck.domain.model.SystemStats] domain model (first device,
+ * bytes -> MB), substitutes defaults when no device is present, and returns null
+ * when the request fails.
+ */
+class FetchSystemStatsUseCaseTest {
+
+    private fun api(
+        handler: suspend io.ktor.client.engine.mock.MockRequestHandleScope.(io.ktor.client.request.HttpRequestData) -> io.ktor.client.request.HttpResponseData,
+    ): ComfyUIApi = ComfyUIApi(mockClient(handler), testJson).apply { setBaseUrl("http://localhost:8188") }
+
+    @Test
+    fun maps_first_device_and_converts_bytes_to_megabytes() = runTest {
+        // 1 device with 8 GiB total / 4 GiB free VRAM; system has 16 GiB / 8 GiB RAM.
+        val body = """
+            {
+              "system": {
+                "os": "Linux",
+                "ram_total": 17179869184,
+                "ram_free": 8589934592,
+                "comfyui_version": "0.2.0",
+                "pytorch_version": "2.3.0"
+              },
+              "devices": [
+                {"name": "RTX 4090", "type": "cuda", "vram_total": 8589934592, "vram_free": 4294967296, "index": 0},
+                {"name": "RTX 3060", "type": "cuda", "vram_total": 1, "vram_free": 1, "index": 1}
+              ]
+            }
+        """.trimIndent()
+        val useCase = FetchSystemStatsUseCase(api { okJson(body) })
+
+        val stats = useCase()
+
+        requireNotNull(stats)
+        // Only the FIRST device is used.
+        assertEquals("RTX 4090", stats.gpuName)
+        assertEquals("cuda", stats.gpuType)
+        assertEquals(8192L, stats.vramTotalMB)
+        assertEquals(4096L, stats.vramFreeMB)
+        assertEquals(16384L, stats.ramTotalMB)
+        assertEquals(8192L, stats.ramFreeMB)
+        assertEquals("Linux", stats.os)
+        assertEquals("0.2.0", stats.comfyuiVersion)
+        assertEquals("2.3.0", stats.pytorchVersion)
+    }
+
+    @Test
+    fun substitutes_unknown_and_zero_when_no_devices_present() = runTest {
+        val body = """
+            {"system": {"os": "Windows", "ram_total": 1048576, "ram_free": 0}, "devices": []}
+        """.trimIndent()
+        val useCase = FetchSystemStatsUseCase(api { okJson(body) })
+
+        val stats = useCase()
+
+        requireNotNull(stats)
+        assertEquals("Unknown", stats.gpuName)
+        assertEquals("Unknown", stats.gpuType)
+        assertEquals(0L, stats.vramTotalMB)
+        assertEquals(0L, stats.vramFreeMB)
+        assertEquals(1L, stats.ramTotalMB)
+    }
+
+    @Test
+    fun returns_null_when_request_fails() = runTest {
+        val useCase = FetchSystemStatsUseCase(
+            api { respondError(HttpStatusCode.NotFound) },
+        )
+
+        assertNull(useCase())
+    }
+}

--- a/feature/feature-comfyui/src/commonTest/kotlin/com/riox432/civitdeck/feature/comfyui/domain/usecase/ImportWorkflowTemplateUseCaseTest.kt
+++ b/feature/feature-comfyui/src/commonTest/kotlin/com/riox432/civitdeck/feature/comfyui/domain/usecase/ImportWorkflowTemplateUseCaseTest.kt
@@ -1,0 +1,113 @@
+package com.riox432.civitdeck.feature.comfyui.domain.usecase
+
+import com.riox432.civitdeck.domain.model.ImageGenerationMeta
+import com.riox432.civitdeck.domain.model.SavedPrompt
+import com.riox432.civitdeck.domain.repository.SavedPromptRepository
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
+
+/**
+ * Covers the legacy ImportDto path of [ImportWorkflowTemplateUseCase] (path 3):
+ * JSON that is neither APP mode nor a raw node workflow is decoded as an explicit
+ * template definition, with type/category resolution and failure handling.
+ */
+class ImportWorkflowTemplateUseCaseTest {
+
+    private fun useCase(repo: SavedPromptRepository): ImportWorkflowTemplateUseCase {
+        val parseAppMode = ParseAppModeMetadataUseCase()
+        val extract = ExtractWorkflowParametersUseCase(parseAppMode)
+        return ImportWorkflowTemplateUseCase(repo, parseAppMode, extract)
+    }
+
+    @Test
+    fun imports_legacy_dto_and_saves_template_with_resolved_type_and_category() = runTest {
+        val repo = RecordingPromptRepo()
+        val json = """
+            {
+              "name": "My Upscaler",
+              "description": "desc",
+              "type": "UPSCALE",
+              "category": "ANIME",
+              "version": 3,
+              "author": "me",
+              "variables": [
+                {"name": "scale", "type": "NUMBER", "defaultValue": "2"}
+              ]
+            }
+        """.trimIndent()
+
+        useCase(repo).invoke(json)
+
+        val saved = repo.saved.single()
+        assertEquals("My Upscaler", saved.templateName)
+        assertEquals("UPSCALE", saved.templateType)
+        assertTrue(saved.isTemplate)
+        // Category is embedded in the metadata JSON blob.
+        assertTrue(saved.templateMetadata!!.contains("ANIME"))
+    }
+
+    @Test
+    fun falls_back_to_general_category_when_category_is_unknown() = runTest {
+        val repo = RecordingPromptRepo()
+        val json = """
+            {"name": "X", "type": "TXT2IMG", "category": "NOPE",
+             "variables": [{"name": "a", "type": "TEXT", "defaultValue": ""}]}
+        """.trimIndent()
+
+        useCase(repo).invoke(json)
+
+        assertTrue(repo.saved.single().templateMetadata!!.contains("GENERAL"))
+    }
+
+    @Test
+    fun throws_when_template_type_is_unknown() = runTest {
+        val repo = RecordingPromptRepo()
+        val json = """
+            {"name": "X", "type": "BOGUS",
+             "variables": [{"name": "a", "type": "TEXT", "defaultValue": ""}]}
+        """.trimIndent()
+
+        val error = assertFailsWith<IllegalStateException> { useCase(repo).invoke(json) }
+        assertTrue(error.message!!.contains("Unknown template type"))
+        assertTrue(repo.saved.isEmpty())
+    }
+
+    @Test
+    fun throws_when_json_is_blank() = runTest {
+        val repo = RecordingPromptRepo()
+
+        assertFailsWith<IllegalStateException> { useCase(repo).invoke("   ") }
+        assertTrue(repo.saved.isEmpty())
+    }
+
+    @Test
+    fun throws_when_dto_is_structurally_invalid() = runTest {
+        val repo = RecordingPromptRepo()
+        // Not a node workflow and missing required DTO fields (name/type/variables).
+        val json = """{"unrelated": 1}"""
+
+        assertFailsWith<IllegalStateException> { useCase(repo).invoke(json) }
+        assertTrue(repo.saved.isEmpty())
+    }
+
+    private class RecordingPromptRepo : SavedPromptRepository {
+        val saved = mutableListOf<SavedPrompt>()
+        override suspend fun saveTemplate(prompt: SavedPrompt) {
+            saved.add(prompt)
+        }
+        override fun observeAll(): Flow<List<SavedPrompt>> = flowOf(emptyList())
+        override fun observeTemplates(): Flow<List<SavedPrompt>> = flowOf(emptyList())
+        override fun observeHistory(): Flow<List<SavedPrompt>> = flowOf(emptyList())
+        override fun search(query: String): Flow<List<SavedPrompt>> = flowOf(emptyList())
+        override suspend fun save(meta: ImageGenerationMeta, sourceImageUrl: String?) = Unit
+        override suspend fun autoSave(meta: ImageGenerationMeta, sourceImageUrl: String?) = Unit
+        override suspend fun toggleTemplate(id: Long, isTemplate: Boolean, templateName: String?) =
+            Unit
+        override suspend fun delete(id: Long) = Unit
+    }
+}

--- a/feature/feature-comfyui/src/commonTest/kotlin/com/riox432/civitdeck/feature/comfyui/domain/usecase/InjectWorkflowParametersUseCaseTest.kt
+++ b/feature/feature-comfyui/src/commonTest/kotlin/com/riox432/civitdeck/feature/comfyui/domain/usecase/InjectWorkflowParametersUseCaseTest.kt
@@ -1,0 +1,149 @@
+package com.riox432.civitdeck.feature.comfyui.domain.usecase
+
+import com.riox432.civitdeck.feature.comfyui.domain.model.ExtractedParameter
+import com.riox432.civitdeck.feature.comfyui.domain.model.ParameterType
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.boolean
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * Covers [InjectWorkflowParametersUseCase]: parameter values are written back into
+ * the workflow JSON with the correct primitive type per [ParameterType], untouched
+ * nodes/inputs are preserved, and malformed JSON is returned unchanged.
+ */
+class InjectWorkflowParametersUseCaseTest {
+
+    private val useCase = InjectWorkflowParametersUseCase()
+
+    private fun param(
+        nodeId: String,
+        paramName: String,
+        type: ParameterType,
+        value: String,
+    ) = ExtractedParameter(
+        nodeId = nodeId,
+        nodeTitle = "",
+        nodeClassType = "",
+        paramName = paramName,
+        paramType = type,
+        currentValue = value,
+    )
+
+    @Test
+    fun injects_seed_as_long_and_number_as_long_when_integral() {
+        val workflow = """
+            {"3":{"class_type":"KSampler","inputs":{"seed":1,"steps":10}}}
+        """.trimIndent()
+
+        val result = useCase(
+            workflow,
+            listOf(
+                param("3", "seed", ParameterType.SEED, "999"),
+                param("3", "steps", ParameterType.NUMBER, "30"),
+            ),
+        )
+
+        val inputs = Json.parseToJsonElement(result).jsonObject["3"]!!
+            .jsonObject["inputs"]!!.jsonObject
+        // SEED and integral NUMBER both serialize as JSON integers (no decimal point).
+        assertEquals("999", inputs["seed"]!!.jsonPrimitive.content)
+        assertEquals("30", inputs["steps"]!!.jsonPrimitive.content)
+    }
+
+    @Test
+    fun injects_non_integral_number_as_double() {
+        val workflow = """{"4":{"inputs":{"cfg":7}}}"""
+
+        val result = useCase(workflow, listOf(param("4", "cfg", ParameterType.NUMBER, "7.5")))
+
+        val cfg = Json.parseToJsonElement(result).jsonObject["4"]!!
+            .jsonObject["inputs"]!!.jsonObject["cfg"]!!.jsonPrimitive.content
+        assertEquals("7.5", cfg)
+    }
+
+    @Test
+    fun injects_boolean_from_true_string_and_numeric_one() {
+        val workflow = """{"5":{"inputs":{"a":false,"b":false}}}"""
+
+        val result = useCase(
+            workflow,
+            listOf(
+                param("5", "a", ParameterType.BOOLEAN, "true"),
+                param("5", "b", ParameterType.BOOLEAN, "1"),
+            ),
+        )
+
+        val inputs = Json.parseToJsonElement(result).jsonObject["5"]!!
+            .jsonObject["inputs"]!!.jsonObject
+        assertTrue((inputs["a"] as JsonPrimitive).boolean)
+        assertTrue((inputs["b"] as JsonPrimitive).boolean)
+    }
+
+    @Test
+    fun boolean_is_false_for_any_other_string() {
+        val workflow = """{"5":{"inputs":{"a":true}}}"""
+
+        val result = useCase(workflow, listOf(param("5", "a", ParameterType.BOOLEAN, "no")))
+
+        val a = Json.parseToJsonElement(result).jsonObject["5"]!!
+            .jsonObject["inputs"]!!.jsonObject["a"] as JsonPrimitive
+        assertFalse(a.boolean)
+    }
+
+    @Test
+    fun leaves_unmatched_inputs_and_nodes_untouched() {
+        val workflow = """
+            {"3":{"inputs":{"seed":1,"keep":"x"}},"9":{"inputs":{"foo":"bar"}}}
+        """.trimIndent()
+
+        val result = useCase(workflow, listOf(param("3", "seed", ParameterType.SEED, "5")))
+
+        val parsed = Json.parseToJsonElement(result).jsonObject
+        val node3Inputs = parsed["3"]!!.jsonObject["inputs"]!!.jsonObject
+        // Edited input changed, sibling input preserved verbatim.
+        assertEquals("5", node3Inputs["seed"]!!.jsonPrimitive.content)
+        assertEquals("x", node3Inputs["keep"]!!.jsonPrimitive.content)
+        // Unrelated node untouched.
+        val node9 = parsed["9"]!!.jsonObject["inputs"]!!.jsonObject
+        assertEquals("bar", node9["foo"]!!.jsonPrimitive.content)
+    }
+
+    @Test
+    fun returns_input_unchanged_when_workflow_json_is_malformed() {
+        val malformed = "not json {"
+
+        val result = useCase(malformed, listOf(param("3", "seed", ParameterType.SEED, "5")))
+
+        assertEquals(malformed, result)
+    }
+
+    @Test
+    fun injects_text_value_as_string() {
+        val workflow = """{"2":{"inputs":{"text":"old"}}}"""
+
+        val result = useCase(workflow, listOf(param("2", "text", ParameterType.TEXT, "new prompt")))
+
+        val text = Json.parseToJsonElement(result).jsonObject["2"]!!
+            .jsonObject["inputs"]!!.jsonObject["text"]!!.jsonPrimitive.content
+        assertEquals("new prompt", text)
+    }
+
+    @Test
+    fun preserves_node_without_inputs_object() {
+        // A node whose "inputs" is missing should pass through even if a param targets it.
+        val workflow = """{"7":{"class_type":"Note"}}"""
+
+        val result = useCase(workflow, listOf(param("7", "anything", ParameterType.TEXT, "v")))
+
+        val node = Json.parseToJsonElement(result).jsonObject["7"]!!.jsonObject
+        assertEquals("Note", node["class_type"]!!.jsonPrimitive.content)
+        // No inputs were fabricated.
+        assertEquals(null, node["inputs"])
+    }
+}

--- a/feature/feature-search/src/commonTest/kotlin/com/riox432/civitdeck/feature/search/domain/usecase/MultiSourceSearchUseCaseTest.kt
+++ b/feature/feature-search/src/commonTest/kotlin/com/riox432/civitdeck/feature/search/domain/usecase/MultiSourceSearchUseCaseTest.kt
@@ -1,0 +1,297 @@
+package com.riox432.civitdeck.feature.search.domain.usecase
+
+import com.riox432.civitdeck.domain.model.Model
+import com.riox432.civitdeck.domain.model.ModelSearchQuery
+import com.riox432.civitdeck.domain.model.ModelSource
+import com.riox432.civitdeck.domain.model.PageMetadata
+import com.riox432.civitdeck.domain.model.PaginatedResult
+import com.riox432.civitdeck.domain.repository.HuggingFaceRepository
+import com.riox432.civitdeck.domain.repository.ModelRepository
+import com.riox432.civitdeck.domain.repository.TensorArtRepository
+import com.riox432.civitdeck.testing.testModel
+import com.riox432.civitdeck.testing.testPaginatedResult
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertSame
+import kotlin.test.assertTrue
+
+class MultiSourceSearchUseCaseTest {
+
+    // --- Fake repositories ---
+
+    private class FakeModelRepository(
+        private val result: PaginatedResult<Model> = testPaginatedResult(),
+        private val error: Throwable? = null,
+    ) : ModelRepository {
+        var callCount = 0
+        var lastQuery: ModelSearchQuery? = null
+
+        override suspend fun getModels(query: ModelSearchQuery): PaginatedResult<Model> {
+            callCount++
+            lastQuery = query
+            error?.let { throw it }
+            return result
+        }
+
+        override suspend fun getModel(id: Long): Model = error("not used")
+        override suspend fun getModelVersion(id: Long) = error("not used")
+        override suspend fun getModelVersionByHash(hash: String) = error("not used")
+        override suspend fun getModelLicense(versionId: Long) = null
+    }
+
+    private class FakeHuggingFaceRepository(
+        private val result: List<Model> = emptyList(),
+        private val error: Throwable? = null,
+    ) : HuggingFaceRepository {
+        var callCount = 0
+
+        override suspend fun searchModels(query: String?, limit: Int, offset: Int): List<Model> {
+            callCount++
+            error?.let { throw it }
+            return result
+        }
+    }
+
+    private class FakeTensorArtRepository(
+        private val result: List<Model> = emptyList(),
+        private val error: Throwable? = null,
+    ) : TensorArtRepository {
+        var callCount = 0
+
+        override suspend fun searchModels(query: String, page: Int, pageSize: Int): List<Model> {
+            callCount++
+            error?.let { throw it }
+            return result
+        }
+    }
+
+    // --- Tests ---
+
+    @Test
+    fun invoke_onlyCivitaiSelected_returnsOnlyCivitaiModels() = runTest {
+        // Arrange: CivitAI returns 2 models; secondary sources return models too but are NOT selected
+        val civitaiModels = listOf(testModel(id = 1L), testModel(id = 2L))
+        val civitaiRepo = FakeModelRepository(testPaginatedResult(items = civitaiModels))
+        val hfRepo = FakeHuggingFaceRepository(result = listOf(testModel(id = 10L)))
+        val taRepo = FakeTensorArtRepository(result = listOf(testModel(id = 20L)))
+        val useCase = MultiSourceSearchUseCase(civitaiRepo, hfRepo, taRepo)
+
+        // Act
+        val result = useCase(
+            query = "anime",
+            selectedSources = setOf(ModelSource.CIVITAI),
+        )
+
+        // Assert: only CivitAI results are included; secondary repos are never called
+        assertEquals(civitaiModels, result.models)
+        assertEquals(0, hfRepo.callCount)
+        assertEquals(0, taRepo.callCount)
+        assertFalse(result.hasPartialFailure)
+    }
+
+    @Test
+    fun invoke_allSourcesSelected_mergesCivitaiFirstThenInterleaved() = runTest {
+        // Arrange: each source returns distinct models
+        val civitaiModels = listOf(testModel(id = 1L), testModel(id = 2L))
+        val hfModels = listOf(testModel(id = 10L), testModel(id = 11L))
+        val taModels = listOf(testModel(id = 20L), testModel(id = 21L))
+        val civitaiRepo = FakeModelRepository(testPaginatedResult(items = civitaiModels))
+        val hfRepo = FakeHuggingFaceRepository(result = hfModels)
+        val taRepo = FakeTensorArtRepository(result = taModels)
+        val useCase = MultiSourceSearchUseCase(civitaiRepo, hfRepo, taRepo)
+
+        // Act
+        val result = useCase(
+            selectedSources = setOf(ModelSource.CIVITAI, ModelSource.HUGGING_FACE, ModelSource.TENSOR_ART),
+        )
+
+        // Assert: CivitAI items lead, then HF and TA interleaved (HF[0], TA[0], HF[1], TA[1])
+        val expected = listOf(
+            testModel(id = 1L),
+            testModel(id = 2L),
+            testModel(id = 10L), // HF first (interleave)
+            testModel(id = 20L), // TA second
+            testModel(id = 11L),
+            testModel(id = 21L),
+        )
+        assertEquals(expected.map { it.id }, result.models.map { it.id })
+        assertFalse(result.hasPartialFailure)
+    }
+
+    @Test
+    fun invoke_secondarySourceFails_errorCapturedAndOtherSourcesStillReturn() = runTest {
+        // Arrange: HuggingFace throws; CivitAI and TensorArt succeed
+        val civitaiModels = listOf(testModel(id = 1L))
+        val taModels = listOf(testModel(id = 20L))
+        val hfError = RuntimeException("HF network error")
+        val civitaiRepo = FakeModelRepository(testPaginatedResult(items = civitaiModels))
+        val hfRepo = FakeHuggingFaceRepository(error = hfError)
+        val taRepo = FakeTensorArtRepository(result = taModels)
+        val useCase = MultiSourceSearchUseCase(civitaiRepo, hfRepo, taRepo)
+
+        // Act
+        val result = useCase(
+            selectedSources = setOf(ModelSource.CIVITAI, ModelSource.HUGGING_FACE, ModelSource.TENSOR_ART),
+        )
+
+        // Assert: results still contain CivitAI + TensorArt; HF error is recorded
+        assertEquals(listOf(1L, 20L), result.models.map { it.id })
+        assertTrue(result.hasPartialFailure)
+        assertEquals(hfError, result.sourceErrors[ModelSource.HUGGING_FACE])
+        assertNull(result.sourceErrors[ModelSource.CIVITAI])
+        assertNull(result.sourceErrors[ModelSource.TENSOR_ART])
+    }
+
+    @Test
+    fun invoke_civitaiSourceFails_errorCapturedAndSecondarySourcesStillReturn() = runTest {
+        // Arrange: CivitAI throws; HuggingFace and TensorArt succeed
+        val hfModels = listOf(testModel(id = 10L))
+        val taModels = listOf(testModel(id = 20L))
+        val civitaiError = RuntimeException("CivitAI 503")
+        val civitaiRepo = FakeModelRepository(error = civitaiError)
+        val hfRepo = FakeHuggingFaceRepository(result = hfModels)
+        val taRepo = FakeTensorArtRepository(result = taModels)
+        val useCase = MultiSourceSearchUseCase(civitaiRepo, hfRepo, taRepo)
+
+        // Act
+        val result = useCase(
+            selectedSources = setOf(ModelSource.CIVITAI, ModelSource.HUGGING_FACE, ModelSource.TENSOR_ART),
+        )
+
+        // Assert: secondary results are still returned; CivitAI error is captured
+        assertEquals(listOf(10L, 20L), result.models.map { it.id })
+        assertTrue(result.hasPartialFailure)
+        assertEquals(civitaiError, result.sourceErrors[ModelSource.CIVITAI])
+        assertNull(result.nextCursor) // no cursor when CivitAI fails
+    }
+
+    @Test
+    fun invoke_onlySecondarySourcesSelected_civitaiIsNotQueried() = runTest {
+        // Arrange: only HuggingFace and TensorArt are selected
+        val hfModels = listOf(testModel(id = 10L))
+        val taModels = listOf(testModel(id = 20L))
+        val civitaiRepo = FakeModelRepository()
+        val hfRepo = FakeHuggingFaceRepository(result = hfModels)
+        val taRepo = FakeTensorArtRepository(result = taModels)
+        val useCase = MultiSourceSearchUseCase(civitaiRepo, hfRepo, taRepo)
+
+        // Act
+        val result = useCase(
+            selectedSources = setOf(ModelSource.HUGGING_FACE, ModelSource.TENSOR_ART),
+        )
+
+        // Assert: CivitAI is never called; secondary results are interleaved
+        assertEquals(0, civitaiRepo.callCount)
+        assertEquals(listOf(10L, 20L), result.models.map { it.id })
+        assertNull(result.nextCursor) // cursor is always sourced from CivitAI
+        assertFalse(result.hasPartialFailure)
+    }
+
+    @Test
+    fun invoke_noSourcesSelected_returnsEmptyResult() = runTest {
+        // Arrange: empty source set — all deferred are null
+        val civitaiRepo = FakeModelRepository()
+        val hfRepo = FakeHuggingFaceRepository()
+        val taRepo = FakeTensorArtRepository()
+        val useCase = MultiSourceSearchUseCase(civitaiRepo, hfRepo, taRepo)
+
+        // Act
+        val result = useCase(selectedSources = emptySet())
+
+        // Assert: no calls made; empty result with no errors
+        assertEquals(0, civitaiRepo.callCount)
+        assertEquals(0, hfRepo.callCount)
+        assertEquals(0, taRepo.callCount)
+        assertTrue(result.models.isEmpty())
+        assertFalse(result.hasPartialFailure)
+    }
+
+    @Test
+    fun invoke_nextCursorPropagatdFromCivitai() = runTest {
+        // Arrange: CivitAI response carries a next cursor for pagination
+        val civitaiResult = PaginatedResult(
+            items = listOf(testModel(id = 1L)),
+            metadata = PageMetadata(nextCursor = "cursor-abc", nextPage = null),
+        )
+        val civitaiRepo = FakeModelRepository(result = civitaiResult)
+        val hfRepo = FakeHuggingFaceRepository()
+        val taRepo = FakeTensorArtRepository()
+        val useCase = MultiSourceSearchUseCase(civitaiRepo, hfRepo, taRepo)
+
+        // Act
+        val result = useCase(selectedSources = setOf(ModelSource.CIVITAI))
+
+        // Assert: cursor from CivitAI metadata is forwarded
+        assertEquals("cursor-abc", result.nextCursor)
+    }
+
+    @Test
+    fun invoke_passesQueryAndCursorToCivitai() = runTest {
+        // Arrange
+        val civitaiRepo = FakeModelRepository(testPaginatedResult())
+        val hfRepo = FakeHuggingFaceRepository()
+        val taRepo = FakeTensorArtRepository()
+        val useCase = MultiSourceSearchUseCase(civitaiRepo, hfRepo, taRepo)
+
+        // Act
+        useCase(
+            query = "checkpoint",
+            selectedSources = setOf(ModelSource.CIVITAI),
+            cursor = "cursor-xyz",
+            limit = 10,
+        )
+
+        // Assert: the exact query parameters are forwarded to the repository
+        val q = civitaiRepo.lastQuery
+        assertEquals("checkpoint", q?.query)
+        assertEquals("cursor-xyz", q?.cursor)
+        assertEquals(10, q?.limit)
+    }
+
+    @Test
+    fun invoke_allSourcesFail_resultHasAllErrorsAndEmptyModels() = runTest {
+        // Arrange: every source throws
+        val civitaiError = RuntimeException("CivitAI error")
+        val hfError = RuntimeException("HF error")
+        val taError = RuntimeException("TA error")
+        val civitaiRepo = FakeModelRepository(error = civitaiError)
+        val hfRepo = FakeHuggingFaceRepository(error = hfError)
+        val taRepo = FakeTensorArtRepository(error = taError)
+        val useCase = MultiSourceSearchUseCase(civitaiRepo, hfRepo, taRepo)
+
+        // Act
+        val result = useCase(
+            selectedSources = setOf(ModelSource.CIVITAI, ModelSource.HUGGING_FACE, ModelSource.TENSOR_ART),
+        )
+
+        // Assert: models list is empty; all three errors are captured
+        assertTrue(result.models.isEmpty())
+        assertTrue(result.hasPartialFailure)
+        assertEquals(civitaiError, result.sourceErrors[ModelSource.CIVITAI])
+        assertEquals(hfError, result.sourceErrors[ModelSource.HUGGING_FACE])
+        assertEquals(taError, result.sourceErrors[ModelSource.TENSOR_ART])
+    }
+
+    @Test
+    fun invoke_unevenSecondaryLists_interleavesFully() = runTest {
+        // Arrange: HuggingFace returns 3 items, TensorArt returns 1 — interleave should not drop items
+        val hfModels = listOf(testModel(id = 10L), testModel(id = 11L), testModel(id = 12L))
+        val taModels = listOf(testModel(id = 20L))
+        val civitaiRepo = FakeModelRepository(testPaginatedResult())
+        val hfRepo = FakeHuggingFaceRepository(result = hfModels)
+        val taRepo = FakeTensorArtRepository(result = taModels)
+        val useCase = MultiSourceSearchUseCase(civitaiRepo, hfRepo, taRepo)
+
+        // Act
+        val result = useCase(
+            selectedSources = setOf(ModelSource.CIVITAI, ModelSource.HUGGING_FACE, ModelSource.TENSOR_ART),
+        )
+
+        // Assert: interleave produces HF[0], TA[0], HF[1], HF[2] (remainder of longer list appended)
+        assertEquals(listOf(10L, 20L, 11L, 12L), result.models.map { it.id })
+    }
+}

--- a/feature/feature-search/src/commonTest/kotlin/com/riox432/civitdeck/feature/search/domain/usecase/MultiSourceSearchUseCaseTest.kt
+++ b/feature/feature-search/src/commonTest/kotlin/com/riox432/civitdeck/feature/search/domain/usecase/MultiSourceSearchUseCaseTest.kt
@@ -16,7 +16,6 @@ import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
-import kotlin.test.assertSame
 import kotlin.test.assertTrue
 
 class MultiSourceSearchUseCaseTest {
@@ -141,7 +140,9 @@ class MultiSourceSearchUseCaseTest {
         // Assert: results still contain CivitAI + TensorArt; HF error is recorded
         assertEquals(listOf(1L, 20L), result.models.map { it.id })
         assertTrue(result.hasPartialFailure)
-        assertEquals(hfError, result.sourceErrors[ModelSource.HUGGING_FACE])
+        // Verify error key presence and message; reference identity not guaranteed across coroutine boundaries
+        assertNotNull(result.sourceErrors[ModelSource.HUGGING_FACE])
+        assertEquals(hfError.message, result.sourceErrors[ModelSource.HUGGING_FACE]?.message)
         assertNull(result.sourceErrors[ModelSource.CIVITAI])
         assertNull(result.sourceErrors[ModelSource.TENSOR_ART])
     }
@@ -165,7 +166,8 @@ class MultiSourceSearchUseCaseTest {
         // Assert: secondary results are still returned; CivitAI error is captured
         assertEquals(listOf(10L, 20L), result.models.map { it.id })
         assertTrue(result.hasPartialFailure)
-        assertEquals(civitaiError, result.sourceErrors[ModelSource.CIVITAI])
+        // Reference identity is not preserved across the coroutine boundary; match on message.
+        assertEquals(civitaiError.message, result.sourceErrors[ModelSource.CIVITAI]?.message)
         assertNull(result.nextCursor) // no cursor when CivitAI fails
     }
 
@@ -271,9 +273,10 @@ class MultiSourceSearchUseCaseTest {
         // Assert: models list is empty; all three errors are captured
         assertTrue(result.models.isEmpty())
         assertTrue(result.hasPartialFailure)
-        assertEquals(civitaiError, result.sourceErrors[ModelSource.CIVITAI])
-        assertEquals(hfError, result.sourceErrors[ModelSource.HUGGING_FACE])
-        assertEquals(taError, result.sourceErrors[ModelSource.TENSOR_ART])
+        // Reference identity is not preserved across coroutine boundaries; match on message.
+        assertEquals(civitaiError.message, result.sourceErrors[ModelSource.CIVITAI]?.message)
+        assertEquals(hfError.message, result.sourceErrors[ModelSource.HUGGING_FACE]?.message)
+        assertEquals(taError.message, result.sourceErrors[ModelSource.TENSOR_ART]?.message)
     }
 
     @Test


### PR DESCRIPTION
## Summary

Part of #974 — raises unit-test coverage for logic-bearing use cases across the
domain layer. This continues prior partial work on this branch (the initial 4 test
files in commit `ec45b86`) and adds tests for every **logic-bearing** use case found
to be untested in the modules triaged, following the #965/#970 pattern (AAA,
behavior-describing names, English comments, `:core:core-testing` fakes + Turbine).

**#974 is intentionally left OPEN** — this is a partial pass (see "Remaining" below).

## Infra fix

- `CivitDeckKmpLibraryPlugin`: enable `withHostTest { isReturnDefaultValues = true }`.
  Use cases that call `Logger.w/d` hit Android `Log` on the JVM host-test runtime,
  which previously threw `Method ... not mocked`. Returning defaults makes those
  calls no-ops so the logic can be unit-tested. Verified safe across all existing
  CI module test suites.

## Tests added (logic-bearing, previously untested)

| Use case | Module | Logic covered |
|---|---|---|
| CheckAndStoreModelUpdatesUseCase | core-domain | split updates by source, conditional save + cleanup |
| CleanupBrowsingHistoryUseCase | core-domain | 90-day retention cutoff + max-entries cap |
| BatchEditTagsUseCase | core-domain | add/remove only when list non-empty |
| EnqueueDownloadUseCase | core-domain | idempotency by fileId |
| InjectWorkflowParametersUseCase | feature-comfyui | per-type JSON value injection, passthrough, malformed-JSON guard |
| FetchSystemStatsUseCase | feature-comfyui | response mapping, bytes→MB, defaults, error→null |
| ImportWorkflowTemplateUseCase | feature-comfyui | legacy DTO path: type/category resolution + failure handling |
| ApplyWorkflowTemplateUseCase | feature-comfyui | value precedence + numeric parse fallbacks |
| FetchObjectInfoUseCase | feature-comfyui | cache-hit TTL, fetch+cache, forceRefresh, stale fallback |
| MultiSourceSearchUseCase | feature-search | parallel merge, per-source error capture, source selection |
| ActivateThemePluginUseCase | core-plugin | exclusive activation (deactivate others) |
| ExportWithPluginUseCase | feature-collections | plugin discovery + progress mapping, missing-plugin path |

Plus the 4 pre-existing files on the branch (CheckModelUpdates, DatasetImage,
EmbeddingSearch, VerifyDownloadHash).

## Skipped (pure pass-through wrappers — no logic)

~150 use cases are single forwarded repo/DAO calls (all `Observe*`/`Set*` settings
use cases, `Add*`/`Remove*`/`Delete*`/`Get*` CRUD wrappers, single Flow forwards,
etc.). These have no branching/mapping/error-handling and are not worth unit tests;
their repositories are already covered by repository-impl tests. Representative
examples: `ParseBackupUseCase`, `GetTagSuggestionsUseCase`, `GetCreatorFeedUseCase`,
all `Observe*PreferenceUseCase` / `Set*PreferenceUseCase`, `ScanModelDirectoriesUseCase`,
`EvictCacheUseCase`, the `SDWebUIUseCases`/`CivitaiLinkUseCases`/`ComfyHubUseCases`/
`ExternalServerUseCases` bundles, `ExportWorkflowTemplateUseCase`, `UploadMaskUseCase`,
`SaveGeneratedImageUseCase`, etc.

## Already covered (not re-tested)

Many core-domain use cases are exercised from `shared/commonTest`
(BrowsingHistory, Favorite, Model, UserPreferences, Image, SavedPrompt,
EnrichModelImages, GetRecommendations, ComfyUI) and feature `commonTest`
(ExtractWorkflowParameters, ParseAppModeMetadata, ExcludedTag, HiddenModel,
SearchHistory, Plugin, QualityScore). `feature-search`'s `GetRecommendationsUseCase`
is already covered by `shared/.../GetRecommendationsUseCaseTest.kt` (10 cases) — not duplicated.

## Remaining (so #974 stays open)

Logic-bearing use cases NOT yet covered by this PR (candidates for a follow-up pass):

- **TrackRecommendationClickUseCase** edge cases (mostly passthrough; low value)
- Deeper coverage of **ImportWorkflowTemplateUseCase** paths 1 & 2 (APP-mode and
  raw-workflow extraction branches) — only the legacy DTO path (path 3) is tested here.
- **ExtractWorkflowParametersUseCase** has tests but additional schema/link-reference
  edge cases could be added.

No other modules were triaged beyond core-domain, core-plugin, and the listed feature
modules; a future pass should sweep any remaining feature modules' `domain/usecase`
not enumerated here.

## Verification (CI-equivalent, all PASS)

- `:core:core-domain:testAndroidHostTest` ✅
- `:core:core-plugin:testAndroidHostTest` ✅
- `:feature:feature-search:testAndroidHostTest` ✅
- `:feature:feature-collections:testAndroidHostTest` ✅
- `:feature:feature-comfyui:jvmTest` ✅
- Regression check — `:shared`, `:core:core-data`, `:feature:{detail,gallery,prompts,creator,externalserver}:testAndroidHostTest`, `:core:core-database:jvmTest` ✅
- `./gradlew detekt` ×2 ✅ (note: detekt scans only main source sets, not commonTest)
- `:androidApp:assembleDebug` ✅
