### PR TITLE
Resolve 30 file-level TooManyFunctions suppressions on Compose/DI files

### DIFF
--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/analytics/AnalyticsScreen.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/analytics/AnalyticsScreen.kt
@@ -1,5 +1,3 @@
-@file:Suppress("TooManyFunctions")
-
 package com.riox432.civitdeck.ui.analytics
 
 import androidx.compose.foundation.Canvas

--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/comfyui/ComfyUIGenerationScreen.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/comfyui/ComfyUIGenerationScreen.kt
@@ -1,5 +1,3 @@
-@file:Suppress("TooManyFunctions")
-
 package com.riox432.civitdeck.ui.comfyui
 
 import androidx.compose.foundation.layout.Arrangement

--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/comfyui/ComfyUIHistoryScreen.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/comfyui/ComfyUIHistoryScreen.kt
@@ -1,5 +1,3 @@
-@file:Suppress("TooManyFunctions")
-
 package com.riox432.civitdeck.ui.comfyui
 
 import androidx.compose.foundation.ExperimentalFoundationApi

--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/comfyui/ComfyUIOutputDetailScreen.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/comfyui/ComfyUIOutputDetailScreen.kt
@@ -1,5 +1,3 @@
-@file:Suppress("TooManyFunctions")
-
 package com.riox432.civitdeck.ui.comfyui
 
 import androidx.compose.foundation.clickable

--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/comfyui/MaskEditorScreen.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/comfyui/MaskEditorScreen.kt
@@ -1,5 +1,3 @@
-@file:Suppress("TooManyFunctions")
-
 package com.riox432.civitdeck.ui.comfyui
 
 import androidx.compose.foundation.layout.Arrangement

--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/comfyui/SDWebUIGenerationScreen.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/comfyui/SDWebUIGenerationScreen.kt
@@ -1,5 +1,3 @@
-@file:Suppress("TooManyFunctions")
-
 package com.riox432.civitdeck.ui.comfyui
 
 import android.graphics.BitmapFactory

--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/comfyui/TemplateParameterScreen.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/comfyui/TemplateParameterScreen.kt
@@ -1,5 +1,3 @@
-@file:Suppress("TooManyFunctions")
-
 package com.riox432.civitdeck.ui.comfyui
 
 import androidx.compose.foundation.layout.Arrangement

--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/comfyui/WorkflowParameterSheet.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/comfyui/WorkflowParameterSheet.kt
@@ -1,5 +1,3 @@
-@file:Suppress("TooManyFunctions")
-
 package com.riox432.civitdeck.ui.comfyui
 
 import androidx.compose.foundation.border

--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/comfyui/WorkflowTemplateEditorScreen.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/comfyui/WorkflowTemplateEditorScreen.kt
@@ -1,5 +1,3 @@
-@file:Suppress("TooManyFunctions")
-
 package com.riox432.civitdeck.ui.comfyui
 
 import androidx.compose.foundation.layout.Arrangement

--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/comfyui/WorkflowTemplateScreen.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/comfyui/WorkflowTemplateScreen.kt
@@ -1,5 +1,3 @@
-@file:Suppress("TooManyFunctions")
-
 package com.riox432.civitdeck.ui.comfyui
 
 import androidx.compose.foundation.background

--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/dataset/BatchTagEditorScreen.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/dataset/BatchTagEditorScreen.kt
@@ -1,5 +1,3 @@
-@file:Suppress("TooManyFunctions")
-
 package com.riox432.civitdeck.ui.dataset
 
 import androidx.compose.foundation.ExperimentalFoundationApi

--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/dataset/DuplicateReviewScreen.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/dataset/DuplicateReviewScreen.kt
@@ -1,5 +1,3 @@
-@file:Suppress("TooManyFunctions")
-
 package com.riox432.civitdeck.ui.dataset
 
 import androidx.compose.foundation.background

--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/detail/ModelDetailContent.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/detail/ModelDetailContent.kt
@@ -1,5 +1,3 @@
-@file:Suppress("TooManyFunctions")
-
 package com.riox432.civitdeck.ui.detail
 
 import androidx.compose.animation.AnimatedContent

--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/plugin/PluginDetailScreen.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/plugin/PluginDetailScreen.kt
@@ -1,5 +1,3 @@
-@file:Suppress("TooManyFunctions")
-
 package com.riox432.civitdeck.ui.plugin
 
 import androidx.compose.foundation.layout.Arrangement

--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/plugin/PluginManagementScreen.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/plugin/PluginManagementScreen.kt
@@ -1,5 +1,3 @@
-@file:Suppress("TooManyFunctions")
-
 package com.riox432.civitdeck.ui.plugin
 
 import androidx.compose.foundation.background

--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/search/FilterChipComponents.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/search/FilterChipComponents.kt
@@ -1,5 +1,3 @@
-@file:Suppress("TooManyFunctions")
-
 package com.riox432.civitdeck.ui.search
 
 import androidx.compose.animation.animateColorAsState

--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/search/ModelGridSection.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/search/ModelGridSection.kt
@@ -1,5 +1,3 @@
-@file:Suppress("TooManyFunctions")
-
 package com.riox432.civitdeck.ui.search
 
 import androidx.compose.animation.AnimatedVisibility

--- a/config/detekt/detekt.yml
+++ b/config/detekt/detekt.yml
@@ -13,6 +13,11 @@ complexity:
     thresholdInInterfaces: 30
     thresholdInObjects: 30
     thresholdInEnums: 30
+    # Compose screen files cohesively group one screen with many small @Composable
+    # section sub-functions. Splitting cohesive UI for the linter's sake hurts
+    # readability, so exempt @Composable functions from the file/class threshold.
+    ignoreAnnotatedFunctions:
+      - Composable
 
 exceptions:
   TooGenericExceptionCaught:

--- a/desktopApp/src/jvmMain/kotlin/com/riox432/civitdeck/ui/comfyui/mask/DesktopMaskEditorScreen.kt
+++ b/desktopApp/src/jvmMain/kotlin/com/riox432/civitdeck/ui/comfyui/mask/DesktopMaskEditorScreen.kt
@@ -1,5 +1,3 @@
-@file:Suppress("TooManyFunctions")
-
 package com.riox432.civitdeck.ui.comfyui.mask
 
 import androidx.compose.foundation.Canvas

--- a/desktopApp/src/jvmMain/kotlin/com/riox432/civitdeck/ui/comfyui/template/DesktopTemplateParameterScreen.kt
+++ b/desktopApp/src/jvmMain/kotlin/com/riox432/civitdeck/ui/comfyui/template/DesktopTemplateParameterScreen.kt
@@ -1,5 +1,3 @@
-@file:Suppress("TooManyFunctions")
-
 package com.riox432.civitdeck.ui.comfyui.template
 
 import androidx.compose.foundation.layout.Arrangement

--- a/desktopApp/src/jvmMain/kotlin/com/riox432/civitdeck/ui/comfyui/template/DesktopWorkflowTemplateEditorScreen.kt
+++ b/desktopApp/src/jvmMain/kotlin/com/riox432/civitdeck/ui/comfyui/template/DesktopWorkflowTemplateEditorScreen.kt
@@ -1,5 +1,3 @@
-@file:Suppress("TooManyFunctions")
-
 package com.riox432.civitdeck.ui.comfyui.template
 
 import androidx.compose.foundation.layout.Arrangement

--- a/desktopApp/src/jvmMain/kotlin/com/riox432/civitdeck/ui/comfyui/template/DesktopWorkflowTemplateScreen.kt
+++ b/desktopApp/src/jvmMain/kotlin/com/riox432/civitdeck/ui/comfyui/template/DesktopWorkflowTemplateScreen.kt
@@ -1,5 +1,3 @@
-@file:Suppress("TooManyFunctions")
-
 package com.riox432.civitdeck.ui.comfyui.template
 
 import androidx.compose.foundation.background

--- a/desktopApp/src/jvmMain/kotlin/com/riox432/civitdeck/ui/dataset/DesktopDatasetDetailScreen.kt
+++ b/desktopApp/src/jvmMain/kotlin/com/riox432/civitdeck/ui/dataset/DesktopDatasetDetailScreen.kt
@@ -1,5 +1,3 @@
-@file:Suppress("TooManyFunctions")
-
 package com.riox432.civitdeck.ui.dataset
 
 import androidx.compose.foundation.ExperimentalFoundationApi

--- a/desktopApp/src/jvmMain/kotlin/com/riox432/civitdeck/ui/downloadqueue/DesktopDownloadQueueScreen.kt
+++ b/desktopApp/src/jvmMain/kotlin/com/riox432/civitdeck/ui/downloadqueue/DesktopDownloadQueueScreen.kt
@@ -1,5 +1,3 @@
-@file:Suppress("TooManyFunctions")
-
 package com.riox432.civitdeck.ui.downloadqueue
 
 import androidx.compose.foundation.layout.Arrangement

--- a/desktopApp/src/jvmMain/kotlin/com/riox432/civitdeck/ui/plugin/DesktopPluginDetailScreen.kt
+++ b/desktopApp/src/jvmMain/kotlin/com/riox432/civitdeck/ui/plugin/DesktopPluginDetailScreen.kt
@@ -1,5 +1,3 @@
-@file:Suppress("TooManyFunctions")
-
 package com.riox432.civitdeck.ui.plugin
 
 import androidx.compose.foundation.layout.Arrangement

--- a/feature/feature-comfyui/src/iosMain/kotlin/com/riox432/civitdeck/feature/comfyui/data/encoder/MaskPngEncoderImpl.kt
+++ b/feature/feature-comfyui/src/iosMain/kotlin/com/riox432/civitdeck/feature/comfyui/data/encoder/MaskPngEncoderImpl.kt
@@ -1,5 +1,3 @@
-@file:Suppress("TooManyFunctions")
-
 package com.riox432.civitdeck.feature.comfyui.data.encoder
 
 import com.riox432.civitdeck.feature.comfyui.domain.model.PathSegment

--- a/shared/src/iosMain/kotlin/com/riox432/civitdeck/di/KoinHelperCollections.kt
+++ b/shared/src/iosMain/kotlin/com/riox432/civitdeck/di/KoinHelperCollections.kt
@@ -1,3 +1,4 @@
+// iOS Koin factory bridge: many cohesive single-line ViewModel accessors for Swift interop.
 @file:Suppress("TooManyFunctions")
 
 package com.riox432.civitdeck.di

--- a/shared/src/iosMain/kotlin/com/riox432/civitdeck/di/KoinHelperComfyUI.kt
+++ b/shared/src/iosMain/kotlin/com/riox432/civitdeck/di/KoinHelperComfyUI.kt
@@ -1,3 +1,4 @@
+// iOS Koin factory bridge: many cohesive single-line ViewModel accessors for Swift interop.
 @file:Suppress("TooManyFunctions")
 
 package com.riox432.civitdeck.di

--- a/shared/src/iosMain/kotlin/com/riox432/civitdeck/di/KoinHelperDetail.kt
+++ b/shared/src/iosMain/kotlin/com/riox432/civitdeck/di/KoinHelperDetail.kt
@@ -1,3 +1,4 @@
+// iOS Koin factory bridge: many cohesive single-line ViewModel accessors for Swift interop.
 @file:Suppress("TooManyFunctions", "MaxLineLength")
 
 package com.riox432.civitdeck.di

--- a/shared/src/iosMain/kotlin/com/riox432/civitdeck/di/KoinHelperSettings.kt
+++ b/shared/src/iosMain/kotlin/com/riox432/civitdeck/di/KoinHelperSettings.kt
@@ -1,3 +1,4 @@
+// iOS Koin factory bridge: many cohesive single-line ViewModel accessors for Swift interop.
 @file:Suppress("TooManyFunctions")
 
 package com.riox432.civitdeck.di

--- a/shared/src/iosMain/kotlin/com/riox432/civitdeck/di/KoinHelperViewModels.kt
+++ b/shared/src/iosMain/kotlin/com/riox432/civitdeck/di/KoinHelperViewModels.kt
@@ -1,3 +1,4 @@
+// iOS Koin factory bridge: many cohesive single-line ViewModel accessors for Swift interop.
 @file:Suppress("TooManyFunctions")
 
 package com.riox432.civitdeck.di


### PR DESCRIPTION
Closes #975

Follow-up to #933 (closed via #972). Resolves the 30 remaining file-level `@file:Suppress("TooManyFunctions")` annotations by applying one coherent, justified policy instead of silent blanket suppression.

## Policy (verified with Codex MCP + detekt 1.23.8 docs)

Three groups, three dispositions:

**Group A — 24 Compose screen/section files (Android + Desktop):** These cohesively group one screen with many small `@Composable` section sub-functions. Splitting cohesive UI for the linter's sake hurts readability (against `design-personality.md`'s content-first cohesion). Instead, added a **config-level exemption** so `@Composable` functions don't count toward the file/class threshold, and removed all 24 bare suppressions:

```yaml
complexity:
  TooManyFunctions:
    thresholdInFiles: 30
    ...
    ignoreAnnotatedFunctions:
      - Composable
```

`ignoreAnnotatedFunctions` is the supported option name in detekt 1.23.8 (NOT `ignoreAnnotated`, which is the option name on `FunctionNaming`). It applies to the file-level count. Source: https://detekt.dev/docs/1.23.8/rules/complexity/#toomanyfunctions

**Group B — 5 iosMain `KoinHelper*.kt` DI files:** 50+ top-level `fun KoinHelper.createXxx(): SomeViewModel = resolve()` factory extensions for Swift interop. Not `@Composable`, so the config exemption doesn't apply. Raising the global threshold would weaken the rule for genuinely bloated files, so these keep a **justified per-file suppression with an inline comment**:

```kotlin
// iOS Koin factory bridge: many cohesive single-line ViewModel accessors for Swift interop.
@file:Suppress("TooManyFunctions")
```

**Group C — 1 file (`MaskPngEncoderImpl.kt`):** Only 2-3 functions — the suppression was stale/false (cannot trip threshold 30). **Deleted** outright.

## Per-file disposition
- 24 Compose files → bare suppression removed, covered by config exemption
- 5 KoinHelper files → bare suppression replaced with justified suppression + comment
- 1 encoder file → stale suppression deleted

No file keeps a bare `@file:Suppress("TooManyFunctions")` without justification. 30/30 resolved.

## Verification (local CI-equivalent)
- `./gradlew detekt` ×2 → BUILD SUCCESSFUL, 0 TooManyFunctions violations, no autocorrect drift
- `./gradlew :androidApp:assembleDebug` → BUILD SUCCESSFUL
- `./gradlew :desktopApp:compileKotlinJvm` → BUILD SUCCESSFUL
- `./gradlew :shared:compileKotlinIosSimulatorArm64` → BUILD SUCCESSFUL (validates comment-before-`@file:` placement on K/N)

## Core Value Alignment
Indirect (UI-layer maintainability). Tech-debt; no user-facing change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GthFqjnJ65YWkmujQh47r4