### PR TITLE
Finish use-case unit-test coverage tail (logic-bearing use cases)

### DIFF
--- a/core/core-plugin/src/commonTest/kotlin/com/riox432/civitdeck/plugin/usecase/GetActiveThemeUseCaseTest.kt
+++ b/core/core-plugin/src/commonTest/kotlin/com/riox432/civitdeck/plugin/usecase/GetActiveThemeUseCaseTest.kt
@@ -1,0 +1,141 @@
+package com.riox432.civitdeck.plugin.usecase
+
+import app.cash.turbine.test
+import com.riox432.civitdeck.plugin.InMemoryPluginRegistry
+import com.riox432.civitdeck.plugin.Plugin
+import com.riox432.civitdeck.plugin.ThemeColorScheme
+import com.riox432.civitdeck.plugin.ThemePlugin
+import com.riox432.civitdeck.plugin.capability.ThemeCapability
+import com.riox432.civitdeck.plugin.model.PluginManifest
+import com.riox432.civitdeck.plugin.model.PluginState
+import com.riox432.civitdeck.plugin.model.PluginType
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+/**
+ * Verifies that [GetActiveThemeUseCase] filters the THEME plugin stream down to the
+ * single ACTIVE ThemePlugin, ignoring non-theme and non-active plugins, and exposes
+ * its color scheme.
+ */
+class GetActiveThemeUseCaseTest {
+
+    private class FakeThemePlugin(
+        override val manifest: PluginManifest,
+        override val state: PluginState,
+        private val darkPrimary: Long = 1L,
+        private val lightPrimary: Long = 2L,
+    ) : ThemePlugin {
+        override val themeCapabilities: Set<ThemeCapability> = emptySet()
+        override fun getColorScheme(isDark: Boolean): ThemeColorScheme =
+            scheme(primary = if (isDark) darkPrimary else lightPrimary)
+        override suspend fun initialize() {}
+        override suspend fun activate() {}
+        override suspend fun deactivate() {}
+        override suspend fun destroy() {}
+    }
+
+    private class FakeWorkflowPlugin(id: String) : Plugin {
+        override val manifest = manifest(id, PluginType.WORKFLOW_ENGINE)
+        override val state: PluginState = PluginState.ACTIVE
+        override suspend fun initialize() {}
+        override suspend fun activate() {}
+        override suspend fun deactivate() {}
+        override suspend fun destroy() {}
+    }
+
+    @Test
+    fun emitsActiveThemePlugin_whenOneIsActive() = runTest {
+        val active = FakeThemePlugin(manifest("active", PluginType.THEME), PluginState.ACTIVE)
+        val inactive = FakeThemePlugin(manifest("inactive", PluginType.THEME), PluginState.INACTIVE)
+        val useCase = buildUseCase(active, inactive)
+
+        useCase().test {
+            assertEquals("active", awaitItem()?.manifest?.id)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun emitsNull_whenNoThemeIsActive() = runTest {
+        val installed = FakeThemePlugin(manifest("t", PluginType.THEME), PluginState.INSTALLED)
+        val useCase = buildUseCase(installed)
+
+        useCase().test {
+            assertNull(awaitItem())
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun ignoresActiveNonThemePlugins() = runTest {
+        // An ACTIVE workflow plugin must never be returned as the active theme.
+        val workflow = FakeWorkflowPlugin("wf")
+        // observePluginsByType(THEME) only returns THEME plugins, but assert defensively anyway.
+        val useCase = buildUseCase(workflow)
+
+        useCase().test {
+            assertNull(awaitItem())
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun observeColorScheme_returnsActiveThemeSchemeForRequestedMode() = runTest {
+        val active = FakeThemePlugin(
+            manifest("active", PluginType.THEME),
+            PluginState.ACTIVE,
+            darkPrimary = 100L,
+            lightPrimary = 200L,
+        )
+        val useCase = buildUseCase(active)
+
+        useCase.observeColorScheme(isDark = true).test {
+            assertEquals(100L, awaitItem()?.primary)
+            cancelAndIgnoreRemainingEvents()
+        }
+        useCase.observeColorScheme(isDark = false).test {
+            assertEquals(200L, awaitItem()?.primary)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun observeColorScheme_returnsNull_whenNoActiveTheme() = runTest {
+        val useCase = buildUseCase()
+
+        useCase.observeColorScheme(isDark = true).test {
+            assertNull(awaitItem())
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    private fun buildUseCase(vararg plugins: Plugin): GetActiveThemeUseCase {
+        val registry = InMemoryPluginRegistry()
+        plugins.forEach { registry.register(it) }
+        return GetActiveThemeUseCase(registry)
+    }
+
+    private companion object {
+        fun manifest(id: String, type: PluginType) = PluginManifest(
+            id = id,
+            name = "Plugin $id",
+            version = "1.0.0",
+            author = "Test",
+            description = "Test plugin",
+            pluginType = type,
+            capabilities = emptyList(),
+        )
+
+        fun scheme(primary: Long) = ThemeColorScheme(
+            primary = primary, onPrimary = 0L, primaryContainer = 0L, onPrimaryContainer = 0L,
+            secondary = 0L, onSecondary = 0L, secondaryContainer = 0L, onSecondaryContainer = 0L,
+            tertiary = 0L, onTertiary = 0L, tertiaryContainer = 0L, onTertiaryContainer = 0L,
+            background = 0L, onBackground = 0L, surface = 0L, onSurface = 0L,
+            surfaceVariant = 0L, onSurfaceVariant = 0L,
+            error = 0L, onError = 0L, errorContainer = 0L, onErrorContainer = 0L,
+            outline = 0L, outlineVariant = 0L,
+        )
+    }
+}

--- a/core/core-plugin/src/commonTest/kotlin/com/riox432/civitdeck/plugin/usecase/ImportThemeUseCaseTest.kt
+++ b/core/core-plugin/src/commonTest/kotlin/com/riox432/civitdeck/plugin/usecase/ImportThemeUseCaseTest.kt
@@ -1,0 +1,113 @@
+package com.riox432.civitdeck.plugin.usecase
+
+import com.riox432.civitdeck.domain.model.InstalledPlugin
+import com.riox432.civitdeck.domain.model.InstalledPluginState
+import com.riox432.civitdeck.domain.model.InstalledPluginType
+import com.riox432.civitdeck.domain.repository.PluginRepository
+import com.riox432.civitdeck.plugin.InMemoryPluginRegistry
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Verifies [ImportThemeUseCase]: a valid JSON theme is parsed, persisted to the repository
+ * (with the derived plugin id and THEME type), and registered in memory. Invalid JSON yields
+ * a failed Result and persists nothing.
+ */
+class ImportThemeUseCaseTest {
+
+    private class RecordingPluginRepository : PluginRepository {
+        val installed = mutableListOf<InstalledPlugin>()
+        override fun observeAll(): Flow<List<InstalledPlugin>> = flowOf(emptyList())
+        override fun observeById(pluginId: String): Flow<InstalledPlugin?> = flowOf(null)
+        override suspend fun getById(pluginId: String): InstalledPlugin? = null
+        override suspend fun install(plugin: InstalledPlugin) {
+            installed.add(plugin)
+        }
+        override suspend fun uninstall(pluginId: String) {}
+        override suspend fun updateState(pluginId: String, state: InstalledPluginState) {}
+        override suspend fun getConfig(pluginId: String): String = "{}"
+        override suspend fun updateConfig(pluginId: String, configJson: String) {}
+    }
+
+    @Test
+    fun importsValidTheme_persistsAndRegisters() = runTest {
+        val repo = RecordingPluginRepository()
+        val registry = InMemoryPluginRegistry()
+        val useCase = ImportThemeUseCase(repo, registry)
+
+        val result = useCase(validThemeJson(id = "midnight", name = "Midnight"))
+
+        assertTrue(result.isSuccess)
+        // Plugin id is namespaced by JsonThemePlugin: "theme.<definition.id>".
+        assertEquals("theme.midnight", result.getOrNull())
+
+        // Persisted with the resolved id, name and THEME type.
+        val saved = repo.installed.single()
+        assertEquals("theme.midnight", saved.id)
+        assertEquals("Midnight", saved.name)
+        assertEquals(InstalledPluginType.THEME, saved.pluginType)
+        assertEquals(InstalledPluginState.INSTALLED, saved.state)
+        // configJson preserves the original JSON for re-loading.
+        assertTrue(saved.configJson.contains("midnight"))
+
+        // Registered in the in-memory registry so it is immediately usable.
+        assertTrue(registry.getPlugin("theme.midnight") != null)
+    }
+
+    @Test
+    fun invalidJson_returnsFailureAndPersistsNothing() = runTest {
+        val repo = RecordingPluginRepository()
+        val registry = InMemoryPluginRegistry()
+        val useCase = ImportThemeUseCase(repo, registry)
+
+        val result = useCase("{ not a theme }")
+
+        assertTrue(result.isFailure)
+        assertTrue(repo.installed.isEmpty())
+    }
+
+    @Test
+    fun missingRequiredColorFields_returnsFailure() = runTest {
+        val repo = RecordingPluginRepository()
+        val useCase = ImportThemeUseCase(repo, InMemoryPluginRegistry())
+
+        // Has id/name but the "light"/"dark" color blocks are absent.
+        val result = useCase("""{"id":"x","name":"X"}""")
+
+        assertTrue(result.isFailure)
+        assertTrue(repo.installed.isEmpty())
+    }
+
+    private fun validThemeJson(id: String, name: String): String {
+        val colors = """
+            {
+              "primary": "#FF000001", "onPrimary": "#FF000002",
+              "primaryContainer": "#FF000003", "onPrimaryContainer": "#FF000004",
+              "secondary": "#FF000005", "onSecondary": "#FF000006",
+              "secondaryContainer": "#FF000007", "onSecondaryContainer": "#FF000008",
+              "tertiary": "#FF000009", "onTertiary": "#FF00000A",
+              "tertiaryContainer": "#FF00000B", "onTertiaryContainer": "#FF00000C",
+              "background": "#FF00000D", "onBackground": "#FF00000E",
+              "surface": "#FF00000F", "onSurface": "#FF000010",
+              "surfaceVariant": "#FF000011", "onSurfaceVariant": "#FF000012",
+              "error": "#FF000013", "onError": "#FF000014",
+              "errorContainer": "#FF000015", "onErrorContainer": "#FF000016",
+              "outline": "#FF000017", "outlineVariant": "#FF000018"
+            }
+        """.trimIndent()
+        return """
+            {
+              "id": "$id",
+              "name": "$name",
+              "author": "Tester",
+              "version": "1.0",
+              "light": $colors,
+              "dark": $colors
+            }
+        """.trimIndent()
+    }
+}

--- a/core/core-plugin/src/commonTest/kotlin/com/riox432/civitdeck/plugin/usecase/ObserveThemePluginsUseCaseTest.kt
+++ b/core/core-plugin/src/commonTest/kotlin/com/riox432/civitdeck/plugin/usecase/ObserveThemePluginsUseCaseTest.kt
@@ -1,0 +1,77 @@
+package com.riox432.civitdeck.plugin.usecase
+
+import app.cash.turbine.test
+import com.riox432.civitdeck.plugin.InMemoryPluginRegistry
+import com.riox432.civitdeck.plugin.Plugin
+import com.riox432.civitdeck.plugin.ThemeColorScheme
+import com.riox432.civitdeck.plugin.ThemePlugin
+import com.riox432.civitdeck.plugin.capability.ThemeCapability
+import com.riox432.civitdeck.plugin.model.PluginManifest
+import com.riox432.civitdeck.plugin.model.PluginState
+import com.riox432.civitdeck.plugin.model.PluginType
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Verifies that [ObserveThemePluginsUseCase] narrows the THEME plugin stream to only
+ * ThemePlugin instances (regardless of state).
+ */
+class ObserveThemePluginsUseCaseTest {
+
+    private class FakeThemePlugin(override val manifest: PluginManifest) : ThemePlugin {
+        override val state: PluginState = PluginState.INSTALLED
+        override val themeCapabilities: Set<ThemeCapability> = emptySet()
+        override fun getColorScheme(isDark: Boolean): ThemeColorScheme = ThemeColorScheme(
+            primary = 0L, onPrimary = 0L, primaryContainer = 0L, onPrimaryContainer = 0L,
+            secondary = 0L, onSecondary = 0L, secondaryContainer = 0L, onSecondaryContainer = 0L,
+            tertiary = 0L, onTertiary = 0L, tertiaryContainer = 0L, onTertiaryContainer = 0L,
+            background = 0L, onBackground = 0L, surface = 0L, onSurface = 0L,
+            surfaceVariant = 0L, onSurfaceVariant = 0L,
+            error = 0L, onError = 0L, errorContainer = 0L, onErrorContainer = 0L,
+            outline = 0L, outlineVariant = 0L,
+        )
+        override suspend fun initialize() {}
+        override suspend fun activate() {}
+        override suspend fun deactivate() {}
+        override suspend fun destroy() {}
+    }
+
+    @Test
+    fun emitsAllRegisteredThemePlugins() = runTest {
+        val a = FakeThemePlugin(manifest("a"))
+        val b = FakeThemePlugin(manifest("b"))
+        val registry = InMemoryPluginRegistry()
+        registry.register(a)
+        registry.register(b)
+        val useCase = ObserveThemePluginsUseCase(registry)
+
+        useCase().test {
+            val ids = awaitItem().map { it.manifest.id }
+            assertEquals(2, ids.size)
+            assertTrue(ids.containsAll(listOf("a", "b")))
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun emitsEmptyList_whenNoThemePluginsRegistered() = runTest {
+        val useCase = ObserveThemePluginsUseCase(InMemoryPluginRegistry())
+
+        useCase().test {
+            assertTrue(awaitItem().isEmpty())
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    private fun manifest(id: String) = PluginManifest(
+        id = id,
+        name = "Theme $id",
+        version = "1.0.0",
+        author = "Test",
+        description = "Test theme",
+        pluginType = PluginType.THEME,
+        capabilities = emptyList(),
+    )
+}

--- a/feature/feature-collections/src/commonTest/kotlin/com/riox432/civitdeck/feature/collections/domain/usecase/GetAvailableExportFormatsUseCaseTest.kt
+++ b/feature/feature-collections/src/commonTest/kotlin/com/riox432/civitdeck/feature/collections/domain/usecase/GetAvailableExportFormatsUseCaseTest.kt
@@ -1,0 +1,106 @@
+package com.riox432.civitdeck.feature.collections.domain.usecase
+
+import app.cash.turbine.test
+import com.riox432.civitdeck.plugin.ExportFormatPlugin
+import com.riox432.civitdeck.plugin.InMemoryPluginRegistry
+import com.riox432.civitdeck.plugin.Plugin
+import com.riox432.civitdeck.plugin.PluginExportFormat
+import com.riox432.civitdeck.plugin.PluginExportProgress
+import com.riox432.civitdeck.plugin.model.PluginManifest
+import com.riox432.civitdeck.plugin.model.PluginState
+import com.riox432.civitdeck.plugin.model.PluginType
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Verifies [GetAvailableExportFormatsUseCase] flattens the supported formats of all ACTIVE
+ * ExportFormatPlugins, skipping inactive plugins and plugins of other types.
+ */
+class GetAvailableExportFormatsUseCaseTest {
+
+    private class FakeExportPlugin(
+        override val manifest: PluginManifest,
+        override val state: PluginState,
+        override val supportedFormats: List<PluginExportFormat>,
+    ) : ExportFormatPlugin {
+        override fun export(
+            datasetId: Long,
+            formatId: String,
+            options: Map<String, String>,
+        ): Flow<PluginExportProgress> = flowOf()
+        override suspend fun initialize() {}
+        override suspend fun activate() {}
+        override suspend fun deactivate() {}
+        override suspend fun destroy() {}
+    }
+
+    @Test
+    fun flattensFormatsOfAllActiveExportPlugins() = runTest {
+        val a = FakeExportPlugin(
+            manifest("a"), PluginState.ACTIVE,
+            listOf(format("kohya-zip"), format("jsonl")),
+        )
+        val b = FakeExportPlugin(manifest("b"), PluginState.ACTIVE, listOf(format("csv")))
+        val useCase = buildUseCase(a, b)
+
+        useCase().test {
+            val ids = awaitItem().map { it.id }
+            assertEquals(3, ids.size)
+            assertTrue(ids.containsAll(listOf("kohya-zip", "jsonl", "csv")))
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun excludesFormatsFromInactivePlugins() = runTest {
+        val active = FakeExportPlugin(manifest("a"), PluginState.ACTIVE, listOf(format("kohya-zip")))
+        val inactive = FakeExportPlugin(
+            manifest("b"), PluginState.INACTIVE, listOf(format("should-not-appear")),
+        )
+        val useCase = buildUseCase(active, inactive)
+
+        useCase().test {
+            val ids = awaitItem().map { it.id }
+            assertEquals(listOf("kohya-zip"), ids)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun emitsEmptyList_whenNoActiveExportPlugins() = runTest {
+        val useCase = buildUseCase()
+
+        useCase().test {
+            assertTrue(awaitItem().isEmpty())
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    private fun buildUseCase(vararg plugins: Plugin): GetAvailableExportFormatsUseCase {
+        val registry = InMemoryPluginRegistry()
+        plugins.forEach { registry.register(it) }
+        return GetAvailableExportFormatsUseCase(registry)
+    }
+
+    private fun manifest(id: String) = PluginManifest(
+        id = id,
+        name = "Export $id",
+        version = "1.0.0",
+        author = "Test",
+        description = "Test export plugin",
+        pluginType = PluginType.EXPORT_FORMAT,
+        capabilities = emptyList(),
+    )
+
+    private fun format(id: String) = PluginExportFormat(
+        id = id,
+        name = id,
+        description = "Format $id",
+        fileExtension = "zip",
+        mimeType = "application/zip",
+    )
+}

--- a/feature/feature-comfyui/src/commonTest/kotlin/com/riox432/civitdeck/data/image/SaveGeneratedImageUseCaseTest.kt
+++ b/feature/feature-comfyui/src/commonTest/kotlin/com/riox432/civitdeck/data/image/SaveGeneratedImageUseCaseTest.kt
@@ -1,0 +1,69 @@
+package com.riox432.civitdeck.data.image
+
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.http.HttpStatusCode
+import io.ktor.utils.io.ByteReadChannel
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * Verifies [SaveGeneratedImageUseCase] downloads bytes and forwards them to [ImageSaver],
+ * returning the saver's result, and returns false (without throwing) when the download fails.
+ */
+class SaveGeneratedImageUseCaseTest {
+
+    private class RecordingImageSaver(private val result: Boolean = true) : ImageSaver {
+        var lastBytes: ByteArray? = null
+        var lastFilename: String? = null
+        override suspend fun saveToGallery(imageBytes: ByteArray, filename: String): Boolean {
+            lastBytes = imageBytes
+            lastFilename = filename
+            return result
+        }
+    }
+
+    @Test
+    fun downloadsBytesAndForwardsToSaver() = runTest {
+        val payload = byteArrayOf(1, 2, 3, 4)
+        val client = HttpClient(MockEngine { respond(ByteReadChannel(payload), HttpStatusCode.OK) })
+        val saver = RecordingImageSaver(result = true)
+        val useCase = SaveGeneratedImageUseCase(client, saver)
+
+        val success = useCase(url = "https://example.com/img.png", filename = "my_image")
+
+        assertTrue(success)
+        assertEquals("my_image", saver.lastFilename)
+        assertTrue(payload.contentEquals(saver.lastBytes))
+    }
+
+    @Test
+    fun returnsSaverResult_whenSaverReportsFailure() = runTest {
+        val client = HttpClient(MockEngine { respond(ByteReadChannel(byteArrayOf(0)), HttpStatusCode.OK) })
+        val saver = RecordingImageSaver(result = false)
+        val useCase = SaveGeneratedImageUseCase(client, saver)
+
+        val success = useCase(url = "https://example.com/img.png")
+
+        assertFalse(success)
+    }
+
+    @Test
+    fun returnsFalseWithoutThrowing_whenDownloadFails() = runTest {
+        // Engine throws (e.g. network failure) so the use case must catch it.
+        val client = HttpClient(MockEngine { throw RuntimeException("network down") })
+        val saver = RecordingImageSaver()
+        val useCase = SaveGeneratedImageUseCase(client, saver)
+
+        val success = useCase(url = "https://example.com/missing.png")
+
+        // The use case swallows the exception and reports failure.
+        assertFalse(success)
+        // Saver must not have been invoked since the download threw.
+        assertEquals(null, saver.lastBytes)
+    }
+}

--- a/feature/feature-comfyui/src/commonTest/kotlin/com/riox432/civitdeck/feature/comfyui/domain/usecase/ComfyUIBridgeUseCasesTest.kt
+++ b/feature/feature-comfyui/src/commonTest/kotlin/com/riox432/civitdeck/feature/comfyui/domain/usecase/ComfyUIBridgeUseCasesTest.kt
@@ -1,0 +1,129 @@
+package com.riox432.civitdeck.feature.comfyui.domain.usecase
+
+import com.riox432.civitdeck.domain.model.ComfyUIGenerationParams
+import com.riox432.civitdeck.domain.repository.ModelFileHashRepository
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * Covers the logic-bearing CivitAI<->ComfyUI bridge use cases in ComfyUIUseCases.kt:
+ * workflow JSON validation, case-insensitive local hash matching, and metadata->params mapping.
+ */
+class ComfyUIBridgeUseCasesTest {
+
+    // region ImportWorkflowUseCase
+
+    @Test
+    fun importWorkflow_returnsTrimmedJson_forValidObject() {
+        val json = """  {"3": {"class_type": "KSampler"}}  """
+        val result = ImportWorkflowUseCase()(json)
+        assertEquals("""{"3": {"class_type": "KSampler"}}""", result)
+    }
+
+    @Test
+    fun importWorkflow_throwsForBlankInput() {
+        val error = assertFailsWith<IllegalStateException> { ImportWorkflowUseCase()("   ") }
+        assertTrue(error.message!!.contains("empty"))
+    }
+
+    @Test
+    fun importWorkflow_throwsForInvalidJson() {
+        val error = assertFailsWith<IllegalStateException> { ImportWorkflowUseCase()("not json") }
+        assertTrue(error.message!!.contains("Invalid JSON"))
+    }
+
+    @Test
+    fun importWorkflow_throwsWhenNotAJsonObject() {
+        val error = assertFailsWith<IllegalStateException> { ImportWorkflowUseCase()("[1, 2, 3]") }
+        assertTrue(error.message!!.contains("must be a JSON object"))
+    }
+
+    @Test
+    fun importWorkflow_throwsForEmptyObject() {
+        val error = assertFailsWith<IllegalStateException> { ImportWorkflowUseCase()("{}") }
+        assertTrue(error.message!!.contains("no nodes"))
+    }
+
+    // endregion
+
+    // region FindMatchingLocalModelUseCase
+
+    @Test
+    fun findMatchingLocalModel_matchesHashCaseInsensitively() = runTest {
+        val repo = FakeHashRepo(setOf("abc123def"))
+        val useCase = FindMatchingLocalModelUseCase(repo)
+
+        // Query hash differs only by case — must still match.
+        val result = useCase("ABC123DEF")
+
+        assertEquals("ABC123DEF", result)
+    }
+
+    @Test
+    fun findMatchingLocalModel_returnsNullWhenNoMatch() = runTest {
+        val repo = FakeHashRepo(setOf("abc123"))
+        val useCase = FindMatchingLocalModelUseCase(repo)
+
+        assertNull(useCase("ffffff"))
+    }
+
+    // endregion
+
+    // region PopulateGenerationFromModelUseCase
+
+    @Test
+    fun populateGeneration_appliesDefaultsForNullMetadata() {
+        val params = PopulateGenerationFromModelUseCase()(
+            prompt = null,
+            negativePrompt = null,
+            steps = null,
+            cfgScale = null,
+            seed = null,
+            sampler = null,
+            checkpointName = "model.safetensors",
+        )
+
+        assertEquals("model.safetensors", params.checkpoint)
+        assertEquals("", params.prompt)
+        assertEquals(ComfyUIGenerationParams.DEFAULT_STEPS, params.steps)
+        assertEquals(ComfyUIGenerationParams.DEFAULT_CFG, params.cfgScale)
+        assertEquals(-1L, params.seed)
+        assertEquals(ComfyUIGenerationParams.DEFAULT_SAMPLER, params.samplerName)
+    }
+
+    @Test
+    fun populateGeneration_normalizesSamplerName() {
+        val params = PopulateGenerationFromModelUseCase()(
+            prompt = "a cat",
+            negativePrompt = "blurry",
+            steps = 30,
+            cfgScale = 8.0,
+            seed = 42L,
+            sampler = "DPM++ 2M Karras",
+            checkpointName = "ckpt",
+        )
+
+        // Lowercased, spaces and dashes converted to underscores.
+        assertEquals("dpm++_2m_karras", params.samplerName)
+        assertEquals("a cat", params.prompt)
+        assertEquals(30, params.steps)
+        assertEquals(42L, params.seed)
+    }
+
+    // endregion
+
+    private class FakeHashRepo(private val owned: Set<String>) : ModelFileHashRepository {
+        override suspend fun getOwnedHashes(): Set<String> = owned
+        override suspend fun verifyFileHash(fileId: Long, sha256Hash: String) = Unit
+        override fun observeOwnedHashes(): Flow<Set<String>> = flowOf(owned)
+        override fun observeFileCount(): Flow<Int> = flowOf(0)
+        override fun observeMatchedCount(): Flow<Int> = flowOf(0)
+        override fun observeUpdatesAvailableCount(): Flow<Int> = flowOf(0)
+    }
+}

--- a/feature/feature-comfyui/src/commonTest/kotlin/com/riox432/civitdeck/feature/comfyui/domain/usecase/ConnectCivitaiLinkUseCaseTest.kt
+++ b/feature/feature-comfyui/src/commonTest/kotlin/com/riox432/civitdeck/feature/comfyui/domain/usecase/ConnectCivitaiLinkUseCaseTest.kt
@@ -1,0 +1,66 @@
+package com.riox432.civitdeck.feature.comfyui.domain.usecase
+
+import com.riox432.civitdeck.domain.model.CivitaiLinkActivity
+import com.riox432.civitdeck.domain.model.CivitaiLinkResource
+import com.riox432.civitdeck.domain.model.CivitaiLinkStatus
+import com.riox432.civitdeck.domain.repository.AuthPreferencesRepository
+import com.riox432.civitdeck.domain.repository.CivitaiLinkRepository
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * Verifies [ConnectCivitaiLinkUseCase] connects only when a stored link key exists, and
+ * reports failure (without calling the repository) when no key is configured.
+ */
+class ConnectCivitaiLinkUseCaseTest {
+
+    @Test
+    fun connectsWithStoredKey() = runTest {
+        val repo = RecordingLinkRepo()
+        val useCase = ConnectCivitaiLinkUseCase(repo, FakePrefs(linkKey = "secret-key"))
+
+        val result = useCase()
+
+        assertTrue(result)
+        assertEquals("secret-key", repo.connectedKey)
+    }
+
+    @Test
+    fun returnsFalseAndDoesNotConnectWhenKeyMissing() = runTest {
+        val repo = RecordingLinkRepo()
+        val useCase = ConnectCivitaiLinkUseCase(repo, FakePrefs(linkKey = null))
+
+        val result = useCase()
+
+        assertFalse(result)
+        assertNull(repo.connectedKey)
+    }
+
+    private class RecordingLinkRepo : CivitaiLinkRepository {
+        var connectedKey: String? = null
+        override suspend fun connect(key: String) {
+            connectedKey = key
+        }
+        override fun observeStatus(): Flow<CivitaiLinkStatus> = flowOf(CivitaiLinkStatus.Disconnected)
+        override fun observeActivities(): Flow<List<CivitaiLinkActivity>> = flowOf(emptyList())
+        override fun disconnect() {}
+        override suspend fun sendResourceToPC(resource: CivitaiLinkResource) = Unit
+        override suspend fun cancelActivity(activityId: String) = Unit
+        override fun isConnected(): Boolean = false
+    }
+
+    private class FakePrefs(private val linkKey: String?) : AuthPreferencesRepository {
+        override suspend fun getCivitaiLinkKey(): String? = linkKey
+        override fun observeApiKey(): Flow<String?> = flowOf(null)
+        override suspend fun setApiKey(apiKey: String?) = Unit
+        override suspend fun getApiKey(): String? = null
+        override fun observeCivitaiLinkKey(): Flow<String?> = flowOf(linkKey)
+        override suspend fun setCivitaiLinkKey(key: String?) = Unit
+    }
+}

--- a/feature/feature-comfyui/src/commonTest/kotlin/com/riox432/civitdeck/feature/comfyui/domain/usecase/ExportWorkflowTemplateUseCaseTest.kt
+++ b/feature/feature-comfyui/src/commonTest/kotlin/com/riox432/civitdeck/feature/comfyui/domain/usecase/ExportWorkflowTemplateUseCaseTest.kt
@@ -1,0 +1,102 @@
+package com.riox432.civitdeck.feature.comfyui.domain.usecase
+
+import com.riox432.civitdeck.domain.model.ImageGenerationMeta
+import com.riox432.civitdeck.domain.model.SavedPrompt
+import com.riox432.civitdeck.domain.model.TemplateVariable
+import com.riox432.civitdeck.domain.model.TemplateVariableType
+import com.riox432.civitdeck.domain.model.WorkflowTemplate
+import com.riox432.civitdeck.domain.model.WorkflowTemplateCategory
+import com.riox432.civitdeck.domain.model.WorkflowTemplateType
+import com.riox432.civitdeck.domain.repository.SavedPromptRepository
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Verifies [ExportWorkflowTemplateUseCase] serializes a [WorkflowTemplate] into export DTO JSON
+ * and that the output round-trips back through [ImportWorkflowTemplateUseCase] (legacy path).
+ */
+class ExportWorkflowTemplateUseCaseTest {
+
+    private val export = ExportWorkflowTemplateUseCase()
+
+    @Test
+    fun serializesTemplateFieldsAndVariables() {
+        val template = template(
+            name = "My Upscaler",
+            type = WorkflowTemplateType.UPSCALE,
+            category = WorkflowTemplateCategory.ANIME,
+            variables = listOf(
+                TemplateVariable(name = "scale", type = TemplateVariableType.NUMBER, defaultValue = "2"),
+            ),
+        )
+
+        val json = export(template)
+
+        assertTrue(json.contains("\"name\": \"My Upscaler\""))
+        assertTrue(json.contains("\"type\": \"UPSCALE\""))
+        assertTrue(json.contains("\"category\": \"ANIME\""))
+        assertTrue(json.contains("\"scale\""))
+    }
+
+    @Test
+    fun exportedJsonImportsBackToEquivalentTemplate() = runTest {
+        val original = template(
+            name = "Round Trip",
+            type = WorkflowTemplateType.TXT2IMG,
+            category = WorkflowTemplateCategory.GENERAL,
+            variables = listOf(
+                TemplateVariable(name = "a", type = TemplateVariableType.TEXT, defaultValue = "x"),
+            ),
+        )
+        val json = export(original)
+        val repo = RecordingPromptRepo()
+        val import = ImportWorkflowTemplateUseCase(
+            repo,
+            ParseAppModeMetadataUseCase(),
+            ExtractWorkflowParametersUseCase(ParseAppModeMetadataUseCase()),
+        )
+
+        import(json)
+
+        val saved = repo.saved.single()
+        assertEquals("Round Trip", saved.templateName)
+        assertEquals("TXT2IMG", saved.templateType)
+    }
+
+    private fun template(
+        name: String,
+        type: WorkflowTemplateType,
+        category: WorkflowTemplateCategory,
+        variables: List<TemplateVariable>,
+    ) = WorkflowTemplate(
+        id = 1L,
+        name = name,
+        description = "desc",
+        type = type,
+        category = category,
+        variables = variables,
+        isBuiltIn = false,
+        version = 1,
+        author = "me",
+        createdAt = 0L,
+    )
+
+    private class RecordingPromptRepo : SavedPromptRepository {
+        val saved = mutableListOf<SavedPrompt>()
+        override suspend fun saveTemplate(prompt: SavedPrompt) {
+            saved.add(prompt)
+        }
+        override fun observeAll(): Flow<List<SavedPrompt>> = flowOf(emptyList())
+        override fun observeTemplates(): Flow<List<SavedPrompt>> = flowOf(emptyList())
+        override fun observeHistory(): Flow<List<SavedPrompt>> = flowOf(emptyList())
+        override fun search(query: String): Flow<List<SavedPrompt>> = flowOf(emptyList())
+        override suspend fun save(meta: ImageGenerationMeta, sourceImageUrl: String?) = Unit
+        override suspend fun autoSave(meta: ImageGenerationMeta, sourceImageUrl: String?) = Unit
+        override suspend fun toggleTemplate(id: Long, isTemplate: Boolean, templateName: String?) = Unit
+        override suspend fun delete(id: Long) = Unit
+    }
+}

--- a/feature/feature-comfyui/src/commonTest/kotlin/com/riox432/civitdeck/feature/comfyui/domain/usecase/ExtractWorkflowParametersUseCaseTest.kt
+++ b/feature/feature-comfyui/src/commonTest/kotlin/com/riox432/civitdeck/feature/comfyui/domain/usecase/ExtractWorkflowParametersUseCaseTest.kt
@@ -231,6 +231,177 @@ class ExtractWorkflowParametersUseCaseTest {
 
     // endregion
 
+    // region Schema / parameter-type resolution edge cases
+
+    @Test
+    fun legacyResolvesSelectTypeFromSchemaOptions() {
+        val workflow = """
+        {
+            "4": {
+                "class_type": "CheckpointLoaderSimple",
+                "inputs": {"ckpt_name": "sd_xl.safetensors"},
+                "_meta": {"title": "Load Checkpoint"}
+            }
+        }
+        """.trimIndent()
+        // object_info exposes ckpt_name as a list of options -> SELECT.
+        val objectInfo = """
+        {
+            "CheckpointLoaderSimple": {
+                "input": {
+                    "required": {
+                        "ckpt_name": [["sd_xl.safetensors", "sd_15.safetensors"]]
+                    }
+                }
+            }
+        }
+        """.trimIndent()
+
+        val params = useCase(workflow, objectInfo)
+
+        val ckpt = params.single { it.paramName == "ckpt_name" }
+        assertEquals(ParameterType.SELECT, ckpt.paramType)
+        assertEquals(listOf("sd_xl.safetensors", "sd_15.safetensors"), ckpt.options)
+    }
+
+    @Test
+    fun appModeResolvesBooleanTypeFromSchema() {
+        // BOOLEAN type comes from the schema type descriptor, not the param name.
+        val workflow = """
+        {
+            "12": {
+                "class_type": "KSamplerAdvanced",
+                "inputs": {"my_flag": true},
+                "_meta": {"title": "Sampler"}
+            },
+            "extra": {
+                "linearData": {"inputs": [["12", "my_flag"]], "outputs": []},
+                "linearMode": true
+            }
+        }
+        """.trimIndent()
+        val objectInfo = """
+        {
+            "KSamplerAdvanced": {
+                "input": {
+                    "required": {
+                        "my_flag": ["BOOLEAN", {"default": true}]
+                    }
+                }
+            }
+        }
+        """.trimIndent()
+
+        val params = useCase(workflow, objectInfo)
+
+        assertEquals(ParameterType.BOOLEAN, params.single().paramType)
+    }
+
+    @Test
+    fun resolvesSchemaFromOptionalBlockWhenNotInRequired() {
+        // The schema constraint for "denoise" lives under "optional", not "required".
+        val workflow = """
+        {
+            "3": {
+                "class_type": "KSampler",
+                "inputs": {"denoise": 0.5},
+                "_meta": {"title": "KSampler"}
+            }
+        }
+        """.trimIndent()
+        val objectInfo = """
+        {
+            "KSampler": {
+                "input": {
+                    "required": {},
+                    "optional": {
+                        "denoise": ["FLOAT", {"min": 0.0, "max": 1.0, "step": 0.01}]
+                    }
+                }
+            }
+        }
+        """.trimIndent()
+
+        val params = useCase(workflow, objectInfo)
+
+        val denoise = params.single { it.paramName == "denoise" }
+        assertEquals(0.0, denoise.min)
+        assertEquals(1.0, denoise.max)
+        assertEquals(0.01, denoise.step)
+    }
+
+    @Test
+    fun appModeDetectsImageParamByName() {
+        // "image" is a known image param even without schema.
+        val workflow = """
+        {
+            "20": {
+                "class_type": "LoadImage",
+                "inputs": {"image": "photo.png"},
+                "_meta": {"title": "Load Image"}
+            },
+            "extra": {
+                "linearData": {"inputs": [["20", "image"]], "outputs": []},
+                "linearMode": true
+            }
+        }
+        """.trimIndent()
+
+        val params = useCase(workflow)
+
+        assertEquals(ParameterType.IMAGE, params.single().paramType)
+    }
+
+    @Test
+    fun legacySortsByNodePriorityThenNodeId() {
+        // CLIPTextEncode (priority 1) must sort before CheckpointLoaderSimple (priority 2),
+        // even though the checkpoint node id is numerically smaller.
+        val workflow = """
+        {
+            "1": {
+                "class_type": "CheckpointLoaderSimple",
+                "inputs": {"ckpt_name": "model.safetensors"},
+                "_meta": {"title": "Checkpoint"}
+            },
+            "6": {
+                "class_type": "CLIPTextEncode",
+                "inputs": {"text": "a cat"},
+                "_meta": {"title": "Prompt"}
+            }
+        }
+        """.trimIndent()
+
+        val params = useCase(workflow)
+
+        assertEquals("CLIPTextEncode", params.first().nodeClassType)
+        assertEquals("CheckpointLoaderSimple", params.last().nodeClassType)
+    }
+
+    @Test
+    fun appModeSkipsInputWhenNodeMissing() {
+        // A designated input pointing at a non-existent node yields no parameter.
+        val workflow = """
+        {
+            "6": {
+                "class_type": "CLIPTextEncode",
+                "inputs": {"text": "a cat"},
+                "_meta": {"title": "Prompt"}
+            },
+            "extra": {
+                "linearData": {"inputs": [["6", "text"], ["999", "seed"]], "outputs": []},
+                "linearMode": true
+            }
+        }
+        """.trimIndent()
+
+        val params = useCase(workflow)
+
+        assertEquals(1, params.size)
+        assertEquals("text", params.single().paramName)
+    }
+
+    // endregion
+
     // region Error handling
 
     @Test

--- a/feature/feature-comfyui/src/commonTest/kotlin/com/riox432/civitdeck/feature/comfyui/domain/usecase/GetWorkflowTemplatesUseCaseTest.kt
+++ b/feature/feature-comfyui/src/commonTest/kotlin/com/riox432/civitdeck/feature/comfyui/domain/usecase/GetWorkflowTemplatesUseCaseTest.kt
@@ -1,0 +1,84 @@
+package com.riox432.civitdeck.feature.comfyui.domain.usecase
+
+import app.cash.turbine.test
+import com.riox432.civitdeck.domain.model.ImageGenerationMeta
+import com.riox432.civitdeck.domain.model.SavedPrompt
+import com.riox432.civitdeck.domain.model.WorkflowTemplate
+import com.riox432.civitdeck.domain.model.WorkflowTemplateType
+import com.riox432.civitdeck.domain.repository.SavedPromptRepository
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Verifies [GetWorkflowTemplatesUseCase] maps stored prompts to templates (dropping unparseable
+ * rows) and sorts built-in templates first, then newest-created first.
+ */
+class GetWorkflowTemplatesUseCaseTest {
+
+    @Test
+    fun sortsBuiltInFirstThenNewestCreated() = runTest {
+        // id < 0 => built-in (per SavedPrompt.toWorkflowTemplate mapping).
+        val builtIn = templatePrompt(id = -1L, name = "BuiltIn", createdAt = 100L)
+        val newUser = templatePrompt(id = 1L, name = "NewUser", createdAt = 300L)
+        val oldUser = templatePrompt(id = 2L, name = "OldUser", createdAt = 200L)
+        val useCase = GetWorkflowTemplatesUseCase(FakeRepo(listOf(oldUser, newUser, builtIn)))
+
+        useCase().test {
+            val names = awaitItem().map { it.name }
+            // Built-in first, then user templates by createdAt descending.
+            assertEquals(listOf("BuiltIn", "NewUser", "OldUser"), names)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun dropsRowsThatDoNotParseAsTemplates() = runTest {
+        val valid = templatePrompt(id = 1L, name = "Valid", createdAt = 1L)
+        // templateType null => toWorkflowTemplate returns null and the row is dropped.
+        val invalid = valid.copy(id = 2L, templateName = "Broken", templateType = null)
+        val useCase = GetWorkflowTemplatesUseCase(FakeRepo(listOf(valid, invalid)))
+
+        useCase().test {
+            val result = awaitItem()
+            assertEquals(1, result.size)
+            assertEquals("Valid", result.single().name)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun emitsEmptyListWhenNoTemplates() = runTest {
+        val useCase = GetWorkflowTemplatesUseCase(FakeRepo(emptyList()))
+
+        useCase().test {
+            assertTrue(awaitItem().isEmpty())
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    private fun templatePrompt(id: Long, name: String, createdAt: Long): SavedPrompt =
+        WorkflowTemplate(
+            id = id,
+            name = name,
+            type = WorkflowTemplateType.TXT2IMG,
+            variables = emptyList(),
+            isBuiltIn = id < 0L,
+            createdAt = createdAt,
+        ).toSavedPrompt().copy(id = id, savedAt = createdAt)
+
+    private class FakeRepo(private val templates: List<SavedPrompt>) : SavedPromptRepository {
+        override fun observeTemplates(): Flow<List<SavedPrompt>> = flowOf(templates)
+        override suspend fun saveTemplate(prompt: SavedPrompt) = Unit
+        override fun observeAll(): Flow<List<SavedPrompt>> = flowOf(emptyList())
+        override fun observeHistory(): Flow<List<SavedPrompt>> = flowOf(emptyList())
+        override fun search(query: String): Flow<List<SavedPrompt>> = flowOf(emptyList())
+        override suspend fun save(meta: ImageGenerationMeta, sourceImageUrl: String?) = Unit
+        override suspend fun autoSave(meta: ImageGenerationMeta, sourceImageUrl: String?) = Unit
+        override suspend fun toggleTemplate(id: Long, isTemplate: Boolean, templateName: String?) = Unit
+        override suspend fun delete(id: Long) = Unit
+    }
+}

--- a/feature/feature-comfyui/src/commonTest/kotlin/com/riox432/civitdeck/feature/comfyui/domain/usecase/ImportWorkflowTemplateUseCaseTest.kt
+++ b/feature/feature-comfyui/src/commonTest/kotlin/com/riox432/civitdeck/feature/comfyui/domain/usecase/ImportWorkflowTemplateUseCaseTest.kt
@@ -9,12 +9,14 @@ import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
 /**
- * Covers the legacy ImportDto path of [ImportWorkflowTemplateUseCase] (path 3):
- * JSON that is neither APP mode nor a raw node workflow is decoded as an explicit
- * template definition, with type/category resolution and failure handling.
+ * Covers all three import paths of [ImportWorkflowTemplateUseCase]:
+ * - Path 1: raw ComfyUI workflow with APP mode metadata -> auto template from designated inputs
+ * - Path 2: raw ComfyUI workflow without APP mode -> auto template from PRIORITY_NODES
+ * - Path 3: legacy ImportDto -> explicit template with type/category resolution
  */
 class ImportWorkflowTemplateUseCaseTest {
 
@@ -23,6 +25,153 @@ class ImportWorkflowTemplateUseCaseTest {
         val extract = ExtractWorkflowParametersUseCase(parseAppMode)
         return ImportWorkflowTemplateUseCase(repo, parseAppMode, extract)
     }
+
+    // region Path 1: APP mode extraction
+
+    @Test
+    fun imports_app_mode_workflow_as_auto_template_with_app_mode_flag() = runTest {
+        val repo = RecordingPromptRepo()
+        val json = """
+            {
+              "3": {
+                "class_type": "KSampler",
+                "inputs": {"seed": 42, "steps": 20, "cfg": 7.0},
+                "_meta": {"title": "KSampler"}
+              },
+              "6": {
+                "class_type": "CLIPTextEncode",
+                "inputs": {"text": "a cat"},
+                "_meta": {"title": "Prompt"}
+              },
+              "extra": {
+                "linearData": {"inputs": [["3", "seed"], ["6", "text"]], "outputs": []},
+                "linearMode": true
+              }
+            }
+        """.trimIndent()
+
+        useCase(repo).invoke(json)
+
+        val saved = repo.saved.single()
+        assertTrue(saved.isAppMode)
+        assertTrue(saved.isTemplate)
+        // The raw workflow JSON is preserved for later re-injection.
+        assertEquals(json, saved.rawWorkflowJson)
+        // Two designated inputs become two template variables.
+        assertTrue(saved.templateMetadata!!.contains("Auto-detected from APP mode"))
+    }
+
+    @Test
+    fun app_mode_template_name_resolves_from_extra_title() = runTest {
+        val repo = RecordingPromptRepo()
+        val json = """
+            {
+              "6": {
+                "class_type": "CLIPTextEncode",
+                "inputs": {"text": "a cat"},
+                "_meta": {"title": "Prompt"}
+              },
+              "extra": {
+                "title": "My Portrait Workflow",
+                "linearData": {"inputs": [["6", "text"]], "outputs": []},
+                "linearMode": true
+              }
+            }
+        """.trimIndent()
+
+        useCase(repo).invoke(json)
+
+        assertEquals("My Portrait Workflow", repo.saved.single().templateName)
+    }
+
+    @Test
+    fun app_mode_with_no_extractable_inputs_falls_through_to_legacy_dto() = runTest {
+        val repo = RecordingPromptRepo()
+        // APP mode metadata is present, but the designated input references a node
+        // that does not exist, so extraction yields no params and path 1 is skipped.
+        // The workflow has no priority nodes either, so path 2 also yields nothing,
+        // and the DTO parse on path 3 fails because this is not a valid ImportDto.
+        val json = """
+            {
+              "extra": {
+                "linearData": {"inputs": [["999", "text"]], "outputs": []},
+                "linearMode": true
+              }
+            }
+        """.trimIndent()
+
+        assertFailsWith<IllegalStateException> { useCase(repo).invoke(json) }
+        assertTrue(repo.saved.isEmpty())
+    }
+
+    // endregion
+
+    // region Path 2: raw workflow extraction (PRIORITY_NODES, no APP mode)
+
+    @Test
+    fun imports_raw_workflow_as_auto_template_without_app_mode() = runTest {
+        val repo = RecordingPromptRepo()
+        val json = """
+            {
+              "3": {
+                "class_type": "KSampler",
+                "inputs": {"seed": 42, "steps": 20, "cfg": 7.0},
+                "_meta": {"title": "KSampler"}
+              }
+            }
+        """.trimIndent()
+
+        useCase(repo).invoke(json)
+
+        val saved = repo.saved.single()
+        assertFalse(saved.isAppMode)
+        assertTrue(saved.isTemplate)
+        assertEquals(json, saved.rawWorkflowJson)
+        assertTrue(saved.templateMetadata!!.contains("Auto-extracted from workflow"))
+        // Default name when no extra.title is present.
+        assertEquals("Imported Workflow", saved.templateName)
+    }
+
+    @Test
+    fun raw_workflow_infers_lora_type_from_node_class() = runTest {
+        val repo = RecordingPromptRepo()
+        val json = """
+            {
+              "5": {
+                "class_type": "LoraLoader",
+                "inputs": {"lora_name": "anime.safetensors", "strength_model": 0.8},
+                "_meta": {"title": "Lora"}
+              }
+            }
+        """.trimIndent()
+
+        useCase(repo).invoke(json)
+
+        assertEquals("LORA", repo.saved.single().templateType)
+    }
+
+    @Test
+    fun raw_workflow_without_priority_nodes_falls_through_to_legacy_dto() = runTest {
+        val repo = RecordingPromptRepo()
+        // Has class_type nodes (looks like a raw workflow) but none are PRIORITY_NODES,
+        // so extraction is empty and path 2 is skipped; path 3 DTO parse then fails.
+        val json = """
+            {
+              "10": {
+                "class_type": "CustomNode",
+                "inputs": {"my_param": "value"},
+                "_meta": {"title": "Custom"}
+              }
+            }
+        """.trimIndent()
+
+        assertFailsWith<IllegalStateException> { useCase(repo).invoke(json) }
+        assertTrue(repo.saved.isEmpty())
+    }
+
+    // endregion
+
+    // region Path 3: legacy ImportDto
 
     @Test
     fun imports_legacy_dto_and_saves_template_with_resolved_type_and_category() = runTest {
@@ -94,6 +243,8 @@ class ImportWorkflowTemplateUseCaseTest {
         assertFailsWith<IllegalStateException> { useCase(repo).invoke(json) }
         assertTrue(repo.saved.isEmpty())
     }
+
+    // endregion
 
     private class RecordingPromptRepo : SavedPromptRepository {
         val saved = mutableListOf<SavedPrompt>()

--- a/feature/feature-comfyui/src/commonTest/kotlin/com/riox432/civitdeck/feature/comfyui/domain/usecase/ParseConnectionUrlUseCaseTest.kt
+++ b/feature/feature-comfyui/src/commonTest/kotlin/com/riox432/civitdeck/feature/comfyui/domain/usecase/ParseConnectionUrlUseCaseTest.kt
@@ -1,0 +1,73 @@
+package com.riox432.civitdeck.feature.comfyui.domain.usecase
+
+import com.riox432.civitdeck.domain.model.ComfyUIConnection
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+/**
+ * Verifies [ParseConnectionUrlUseCase] extracts host/port/scheme from QR or manual strings,
+ * applies scheme-aware default ports, and rejects malformed input.
+ */
+class ParseConnectionUrlUseCaseTest {
+
+    private val useCase = ParseConnectionUrlUseCase()
+
+    @Test
+    fun parsesHttpUrlWithExplicitPort() {
+        val conn = useCase("http://192.168.1.20:8188")
+
+        assertEquals("192.168.1.20", conn?.hostname)
+        assertEquals(8188, conn?.port)
+        assertEquals(false, conn?.useHttps)
+    }
+
+    @Test
+    fun parsesHttpsUrlAndDefaultsToPort443() {
+        val conn = useCase("https://comfy.example.com")
+
+        assertEquals("comfy.example.com", conn?.hostname)
+        assertEquals(443, conn?.port)
+        assertEquals(true, conn?.useHttps)
+    }
+
+    @Test
+    fun bareHostDefaultsToComfyuiPort() {
+        val conn = useCase("192.168.1.20")
+
+        assertEquals("192.168.1.20", conn?.hostname)
+        assertEquals(ComfyUIConnection.DEFAULT_COMFYUI_PORT, conn?.port)
+        assertEquals(false, conn?.useHttps)
+    }
+
+    @Test
+    fun stripsPathAndQueryKeepingAuthorityOnly() {
+        val conn = useCase("http://host:8188/prompt?foo=bar")
+
+        assertEquals("host", conn?.hostname)
+        assertEquals(8188, conn?.port)
+    }
+
+    @Test
+    fun returnsNullForBlankInput() {
+        assertNull(useCase("   "))
+    }
+
+    @Test
+    fun returnsNullForOutOfRangePort() {
+        // 70000 exceeds the valid 1..65535 range.
+        assertNull(useCase("host:70000"))
+    }
+
+    @Test
+    fun returnsNullForNonNumericPort() {
+        assertNull(useCase("host:abc"))
+    }
+
+    @Test
+    fun usesHostAsConnectionName() {
+        val conn = useCase("http://10.0.0.5:8188")
+
+        assertEquals("10.0.0.5", conn?.name)
+    }
+}

--- a/feature/feature-comfyui/src/commonTest/kotlin/com/riox432/civitdeck/feature/comfyui/domain/usecase/SaveWorkflowTemplateUseCaseTest.kt
+++ b/feature/feature-comfyui/src/commonTest/kotlin/com/riox432/civitdeck/feature/comfyui/domain/usecase/SaveWorkflowTemplateUseCaseTest.kt
@@ -1,0 +1,65 @@
+package com.riox432.civitdeck.feature.comfyui.domain.usecase
+
+import com.riox432.civitdeck.domain.model.ImageGenerationMeta
+import com.riox432.civitdeck.domain.model.SavedPrompt
+import com.riox432.civitdeck.domain.model.WorkflowTemplate
+import com.riox432.civitdeck.domain.model.WorkflowTemplateType
+import com.riox432.civitdeck.domain.repository.SavedPromptRepository
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Verifies [SaveWorkflowTemplateUseCase] injects a creation timestamp only when one is absent
+ * and persists the template via the repository.
+ */
+class SaveWorkflowTemplateUseCaseTest {
+
+    @Test
+    fun injectsCreatedAtWhenZero() = runTest {
+        val repo = RecordingPromptRepo()
+        val useCase = SaveWorkflowTemplateUseCase(repo)
+
+        useCase(template(name = "Fresh", createdAt = 0L))
+
+        // savedAt carries the injected timestamp; it must be non-zero now.
+        assertTrue(repo.saved.single().savedAt > 0L)
+    }
+
+    @Test
+    fun preservesExistingCreatedAt() = runTest {
+        val repo = RecordingPromptRepo()
+        val useCase = SaveWorkflowTemplateUseCase(repo)
+
+        useCase(template(name = "Existing", createdAt = 42L))
+
+        assertEquals(42L, repo.saved.single().savedAt)
+    }
+
+    private fun template(name: String, createdAt: Long) = WorkflowTemplate(
+        id = 1L,
+        name = name,
+        type = WorkflowTemplateType.TXT2IMG,
+        variables = emptyList(),
+        isBuiltIn = false,
+        createdAt = createdAt,
+    )
+
+    private class RecordingPromptRepo : SavedPromptRepository {
+        val saved = mutableListOf<SavedPrompt>()
+        override suspend fun saveTemplate(prompt: SavedPrompt) {
+            saved.add(prompt)
+        }
+        override fun observeAll(): Flow<List<SavedPrompt>> = flowOf(emptyList())
+        override fun observeTemplates(): Flow<List<SavedPrompt>> = flowOf(emptyList())
+        override fun observeHistory(): Flow<List<SavedPrompt>> = flowOf(emptyList())
+        override fun search(query: String): Flow<List<SavedPrompt>> = flowOf(emptyList())
+        override suspend fun save(meta: ImageGenerationMeta, sourceImageUrl: String?) = Unit
+        override suspend fun autoSave(meta: ImageGenerationMeta, sourceImageUrl: String?) = Unit
+        override suspend fun toggleTemplate(id: Long, isTemplate: Boolean, templateName: String?) = Unit
+        override suspend fun delete(id: Long) = Unit
+    }
+}

--- a/feature/feature-comfyui/src/commonTest/kotlin/com/riox432/civitdeck/feature/comfyui/domain/usecase/TestSDWebUIConnectionUseCaseTest.kt
+++ b/feature/feature-comfyui/src/commonTest/kotlin/com/riox432/civitdeck/feature/comfyui/domain/usecase/TestSDWebUIConnectionUseCaseTest.kt
@@ -1,0 +1,55 @@
+package com.riox432.civitdeck.feature.comfyui.domain.usecase
+
+import com.riox432.civitdeck.domain.model.SDWebUIConnection
+import com.riox432.civitdeck.domain.repository.SDWebUIConnectionRepository
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * Verifies [TestSDWebUIConnectionUseCase] returns the connectivity result and persists it only
+ * for saved connections (id != 0), not for unsaved drafts (id == 0).
+ */
+class TestSDWebUIConnectionUseCaseTest {
+
+    @Test
+    fun persistsResultForSavedConnection() = runTest {
+        val repo = RecordingSDWebUIRepo(testResult = true)
+        val useCase = TestSDWebUIConnectionUseCase(repo)
+
+        val success = useCase(SDWebUIConnection(id = 5L, name = "Home", hostname = "10.0.0.1"))
+
+        assertTrue(success)
+        assertEquals(5L to true, repo.lastUpdate)
+    }
+
+    @Test
+    fun doesNotPersistResultForUnsavedDraft() = runTest {
+        val repo = RecordingSDWebUIRepo(testResult = false)
+        val useCase = TestSDWebUIConnectionUseCase(repo)
+
+        val success = useCase(SDWebUIConnection(id = 0L, name = "Draft", hostname = "10.0.0.2"))
+
+        assertFalse(success)
+        // id == 0 => updateTestResult must not be called.
+        assertEquals(null, repo.lastUpdate)
+    }
+
+    private class RecordingSDWebUIRepo(private val testResult: Boolean) : SDWebUIConnectionRepository {
+        var lastUpdate: Pair<Long, Boolean>? = null
+        override suspend fun testConnection(connection: SDWebUIConnection): Boolean = testResult
+        override suspend fun updateTestResult(id: Long, success: Boolean) {
+            lastUpdate = id to success
+        }
+        override fun observeConnections(): Flow<List<SDWebUIConnection>> = flowOf(emptyList())
+        override fun observeActiveConnection(): Flow<SDWebUIConnection?> = flowOf(null)
+        override suspend fun getActiveConnection(): SDWebUIConnection? = null
+        override suspend fun saveConnection(connection: SDWebUIConnection): Long = 1L
+        override suspend fun deleteConnection(id: Long) = Unit
+        override suspend fun activateConnection(id: Long) = Unit
+    }
+}

--- a/feature/feature-creator/src/commonTest/kotlin/com/riox432/civitdeck/feature/creator/domain/usecase/GetCreatorModelsUseCaseTest.kt
+++ b/feature/feature-creator/src/commonTest/kotlin/com/riox432/civitdeck/feature/creator/domain/usecase/GetCreatorModelsUseCaseTest.kt
@@ -1,0 +1,43 @@
+package com.riox432.civitdeck.feature.creator.domain.usecase
+
+import com.riox432.civitdeck.testing.FakeModelRepository
+import com.riox432.civitdeck.testing.testModel
+import com.riox432.civitdeck.testing.testPaginatedResult
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * Verifies [GetCreatorModelsUseCase] bundles its parameters into a username-scoped
+ * [com.riox432.civitdeck.domain.model.ModelSearchQuery] and returns the repository result.
+ */
+class GetCreatorModelsUseCaseTest {
+
+    @Test
+    fun buildsUsernameScopedQueryAndReturnsResult() = runTest {
+        val models = listOf(testModel(id = 1L), testModel(id = 2L))
+        val repo = FakeModelRepository(listOf(testPaginatedResult(items = models)))
+        val useCase = GetCreatorModelsUseCase(repo)
+
+        val result = useCase(username = "alice", cursor = "c1", limit = 30)
+
+        assertEquals(models, result.items)
+        val query = repo.lastQuery!!
+        assertEquals("alice", query.username)
+        assertEquals("c1", query.cursor)
+        assertEquals(30, query.limit)
+    }
+
+    @Test
+    fun forwardsNullCursorAndLimitByDefault() = runTest {
+        val repo = FakeModelRepository(listOf(testPaginatedResult()))
+        val useCase = GetCreatorModelsUseCase(repo)
+
+        useCase(username = "bob")
+
+        val query = repo.lastQuery!!
+        assertEquals("bob", query.username)
+        assertEquals(null, query.cursor)
+        assertEquals(null, query.limit)
+    }
+}

--- a/feature/feature-externalserver/src/commonTest/kotlin/com/riox432/civitdeck/feature/externalserver/domain/usecase/DeleteServerImagesUseCaseTest.kt
+++ b/feature/feature-externalserver/src/commonTest/kotlin/com/riox432/civitdeck/feature/externalserver/domain/usecase/DeleteServerImagesUseCaseTest.kt
@@ -1,0 +1,76 @@
+package com.riox432.civitdeck.feature.externalserver.domain.usecase
+
+import com.riox432.civitdeck.feature.externalserver.domain.model.ExternalServerImageFilters
+import com.riox432.civitdeck.feature.externalserver.domain.model.GenerationChoice
+import com.riox432.civitdeck.feature.externalserver.domain.model.GenerationJob
+import com.riox432.civitdeck.feature.externalserver.domain.model.GenerationOption
+import com.riox432.civitdeck.feature.externalserver.domain.model.PaginatedImagesResponse
+import com.riox432.civitdeck.feature.externalserver.domain.model.ServerCapabilities
+import com.riox432.civitdeck.feature.externalserver.domain.repository.ExternalServerImagesRepository
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * Verifies [DeleteServerImagesUseCase] routes a single key to the singular delete endpoint and
+ * multiple keys to the batch endpoint.
+ */
+class DeleteServerImagesUseCaseTest {
+
+    @Test
+    fun singleKeyUsesSingularDeleteEndpoint() = runTest {
+        val repo = RecordingImagesRepo()
+        val useCase = DeleteServerImagesUseCase(repo)
+
+        useCase(listOf("key-1"))
+
+        assertEquals("key-1", repo.deletedSingle)
+        assertEquals(null, repo.deletedBatch)
+    }
+
+    @Test
+    fun multipleKeysUseBatchDeleteEndpoint() = runTest {
+        val repo = RecordingImagesRepo()
+        val useCase = DeleteServerImagesUseCase(repo)
+
+        useCase(listOf("key-1", "key-2", "key-3"))
+
+        assertEquals(null, repo.deletedSingle)
+        assertEquals(listOf("key-1", "key-2", "key-3"), repo.deletedBatch)
+    }
+
+    @Test
+    fun emptyKeysUseBatchEndpoint() = runTest {
+        val repo = RecordingImagesRepo()
+        val useCase = DeleteServerImagesUseCase(repo)
+
+        useCase(emptyList())
+
+        // size != 1 takes the batch branch.
+        assertEquals(null, repo.deletedSingle)
+        assertEquals(emptyList(), repo.deletedBatch)
+    }
+
+    private class RecordingImagesRepo : ExternalServerImagesRepository {
+        var deletedSingle: String? = null
+        var deletedBatch: List<String>? = null
+
+        override suspend fun deleteImage(cloudKey: String) {
+            deletedSingle = cloudKey
+        }
+        override suspend fun deleteImages(cloudKeys: List<String>) {
+            deletedBatch = cloudKeys
+        }
+        override suspend fun getCapabilities(): ServerCapabilities = error("not used")
+        override suspend fun getImages(
+            page: Int,
+            perPage: Int,
+            filters: ExternalServerImageFilters,
+        ): PaginatedImagesResponse = error("not used")
+        override suspend fun testConnection(): Boolean = error("not used")
+        override suspend fun getGenerationOptions(): List<GenerationOption> = error("not used")
+        override suspend fun getDependentChoices(endpoint: String): List<GenerationChoice> = error("not used")
+        override suspend fun executeGeneration(params: Map<String, String>): GenerationJob = error("not used")
+        override suspend fun getGenerationStatus(jobId: String): GenerationJob = error("not used")
+    }
+}

--- a/feature/feature-externalserver/src/commonTest/kotlin/com/riox432/civitdeck/feature/externalserver/domain/usecase/TestExternalServerConnectionUseCaseTest.kt
+++ b/feature/feature-externalserver/src/commonTest/kotlin/com/riox432/civitdeck/feature/externalserver/domain/usecase/TestExternalServerConnectionUseCaseTest.kt
@@ -1,0 +1,85 @@
+package com.riox432.civitdeck.feature.externalserver.domain.usecase
+
+import com.riox432.civitdeck.domain.model.ExternalServerConfig
+import com.riox432.civitdeck.feature.externalserver.domain.model.ExternalServerImageFilters
+import com.riox432.civitdeck.feature.externalserver.domain.model.GenerationChoice
+import com.riox432.civitdeck.feature.externalserver.domain.model.GenerationJob
+import com.riox432.civitdeck.feature.externalserver.domain.model.GenerationOption
+import com.riox432.civitdeck.feature.externalserver.domain.model.PaginatedImagesResponse
+import com.riox432.civitdeck.feature.externalserver.domain.model.ServerCapabilities
+import com.riox432.civitdeck.feature.externalserver.domain.repository.ExternalServerConfigRepository
+import com.riox432.civitdeck.feature.externalserver.domain.repository.ExternalServerImagesRepository
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * Verifies [TestExternalServerConnectionUseCase] returns the connectivity result and persists it
+ * to the config repository only for saved configs (id != 0), not for unsaved drafts.
+ */
+class TestExternalServerConnectionUseCaseTest {
+
+    @Test
+    fun persistsResultForSavedConfig() = runTest {
+        val configRepo = RecordingConfigRepo()
+        val imagesRepo = FakeImagesRepo(testResult = true)
+        val useCase = TestExternalServerConnectionUseCase(configRepo, imagesRepo)
+
+        val success = useCase(config(id = 7L))
+
+        assertTrue(success)
+        assertEquals(7L to true, configRepo.lastUpdate)
+    }
+
+    @Test
+    fun doesNotPersistResultForUnsavedDraft() = runTest {
+        val configRepo = RecordingConfigRepo()
+        val imagesRepo = FakeImagesRepo(testResult = false)
+        val useCase = TestExternalServerConnectionUseCase(configRepo, imagesRepo)
+
+        val success = useCase(config(id = 0L))
+
+        assertFalse(success)
+        // id == 0 => updateTestResult must not be called.
+        assertEquals(null, configRepo.lastUpdate)
+    }
+
+    private fun config(id: Long) = ExternalServerConfig(
+        id = id,
+        name = "Server",
+        baseUrl = "http://10.0.0.1",
+        createdAt = 0L,
+    )
+
+    private class RecordingConfigRepo : ExternalServerConfigRepository {
+        var lastUpdate: Pair<Long, Boolean>? = null
+        override suspend fun updateTestResult(id: Long, success: Boolean) {
+            lastUpdate = id to success
+        }
+        override fun observeConfigs(): Flow<List<ExternalServerConfig>> = flowOf(emptyList())
+        override fun observeActiveConfig(): Flow<ExternalServerConfig?> = flowOf(null)
+        override suspend fun saveConfig(config: ExternalServerConfig): Long = 1L
+        override suspend fun deleteConfig(id: Long) = Unit
+        override suspend fun activateConfig(id: Long) = Unit
+    }
+
+    private class FakeImagesRepo(private val testResult: Boolean) : ExternalServerImagesRepository {
+        override suspend fun testConnection(): Boolean = testResult
+        override suspend fun deleteImage(cloudKey: String) = Unit
+        override suspend fun deleteImages(cloudKeys: List<String>) = Unit
+        override suspend fun getCapabilities(): ServerCapabilities = error("not used")
+        override suspend fun getImages(
+            page: Int,
+            perPage: Int,
+            filters: ExternalServerImageFilters,
+        ): PaginatedImagesResponse = error("not used")
+        override suspend fun getGenerationOptions(): List<GenerationOption> = error("not used")
+        override suspend fun getDependentChoices(endpoint: String): List<GenerationChoice> = error("not used")
+        override suspend fun executeGeneration(params: Map<String, String>): GenerationJob = error("not used")
+        override suspend fun getGenerationStatus(jobId: String): GenerationJob = error("not used")
+    }
+}

--- a/feature/feature-search/src/commonTest/kotlin/com/riox432/civitdeck/feature/search/domain/usecase/GetDiscoveryModelsUseCaseTest.kt
+++ b/feature/feature-search/src/commonTest/kotlin/com/riox432/civitdeck/feature/search/domain/usecase/GetDiscoveryModelsUseCaseTest.kt
@@ -1,0 +1,51 @@
+package com.riox432.civitdeck.feature.search.domain.usecase
+
+import com.riox432.civitdeck.domain.model.SortOrder
+import com.riox432.civitdeck.testing.FakeModelRepository
+import com.riox432.civitdeck.testing.testModel
+import com.riox432.civitdeck.testing.testPaginatedResult
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * Verifies [GetDiscoveryModelsUseCase] queries with the Newest sort order and unwraps the
+ * paginated result into a plain list of models.
+ */
+class GetDiscoveryModelsUseCaseTest {
+
+    @Test
+    fun queriesNewestSortAndReturnsItems() = runTest {
+        val models = listOf(testModel(id = 1L), testModel(id = 2L))
+        val repo = FakeModelRepository(listOf(testPaginatedResult(items = models)))
+        val useCase = GetDiscoveryModelsUseCase(repo)
+
+        val result = useCase()
+
+        // The unwrapped list is returned (not the PaginatedResult wrapper).
+        assertEquals(models, result)
+        assertEquals(SortOrder.Newest, repo.lastQuery!!.sort)
+    }
+
+    @Test
+    fun forwardsCursorAndLimit() = runTest {
+        val repo = FakeModelRepository(listOf(testPaginatedResult()))
+        val useCase = GetDiscoveryModelsUseCase(repo)
+
+        useCase(cursor = "next-page", limit = 50)
+
+        val query = repo.lastQuery!!
+        assertEquals("next-page", query.cursor)
+        assertEquals(50, query.limit)
+    }
+
+    @Test
+    fun usesDefaultLimitOf20() = runTest {
+        val repo = FakeModelRepository(listOf(testPaginatedResult()))
+        val useCase = GetDiscoveryModelsUseCase(repo)
+
+        useCase()
+
+        assertEquals(20, repo.lastQuery!!.limit)
+    }
+}


### PR DESCRIPTION
## Summary

Completes the use-case unit-test coverage tail for #974 (follow-up to #931/#970/#976). #976 covered the bulk of logic-bearing use cases; this PR finishes the remaining ones so that **every use case with non-trivial logic now has a behavior-describing unit test**, leaving only documented pure pass-throughs untested.

## What changed

New `commonTest` coverage (owning module, `:core:core-testing` fakes + Turbine, AAA, behavior-describing names, English comments) for:

**feature-comfyui**
- `ImportWorkflowTemplateUseCase` — APP-mode (path 1) and raw-workflow PRIORITY_NODES extraction (path 2) branches, plus fall-through cases (only legacy DTO path 3 was tested before)
- `ExtractWorkflowParametersUseCase` — added schema-options (SELECT), schema BOOLEAN, `optional`-block schema resolution, image-by-name, legacy priority sorting, and missing-node skip edge cases
- `ExportWorkflowTemplateUseCase` — DTO serialization + round-trip back through import
- `GetWorkflowTemplatesUseCase` — `mapNotNull` drop of unparseable rows + built-in-first / newest-first sort
- `SaveWorkflowTemplateUseCase` — conditional `createdAt` injection
- `SaveGeneratedImageUseCase` — HTTP download → gallery save + failure swallowing (Ktor MockEngine)
- `ParseConnectionUrlUseCase` — URL/host/port/scheme parsing, default ports, validation
- `ImportWorkflowUseCase` / `FindMatchingLocalModelUseCase` / `PopulateGenerationFromModelUseCase` (ComfyUIUseCases.kt) — JSON validation, case-insensitive hash match, metadata→params mapping with sampler normalization
- `ConnectCivitaiLinkUseCase` — connect-only-when-key-present branch
- `TestSDWebUIConnectionUseCase` — conditional test-result persistence

**core-plugin**
- `GetActiveThemeUseCase` — active-ThemePlugin filtering + color-scheme exposure
- `ObserveThemePluginsUseCase` — type narrowing
- `ImportThemeUseCase` — JSON parse + persist + register, with failure paths

**feature-collections** — `GetAvailableExportFormatsUseCase` (active-plugin flatMap)
**feature-creator** — `GetCreatorModelsUseCase` (username-scoped query)
**feature-search** — `GetDiscoveryModelsUseCase` (Newest sort + unwrap)
**feature-externalserver** — `DeleteServerImagesUseCase` (single vs batch routing), `TestExternalServerConnectionUseCase` (conditional persistence)

## Coverage method

Enumerated every `*UseCase` class across all feature modules and `:core:core-domain`, cross-checked against existing test files, and read the body of every untested class. Three independent classification passes were reconciled and each flagged logic-bearing candidate was personally verified before testing.

### Intentionally untested (documented pass-throughs)

The remaining untested use cases are single-forward wrappers with no logic (filtering/branching/mapping/combining). Representative examples: all `Observe*`/`Set*`/`Get*` settings accessors, `Add*/Remove*/Delete*/Rename*` CRUD forwards, `Fetch*` asset lists, `Bulk{Move,Remove}ModelsUseCase`, `Create/Restore/ParseBackupUseCase` (parsing lives in the repo), `ScanModelDirectoriesUseCase`, `ObserveGenerationProgressUseCase` (overloads forwarding to repo overloads), `ExportDatasetUseCase`, `ValidateApiKeyUseCase`, `VerifyModelHashUseCase`, `UploadMaskUseCase`, cache use cases, dataset metadata mutators, notification mark/count forwards. These match #931/#974's de-prioritization of pure pass-throughs.

## Verification (CI-equivalent, local)

- `:core:core-plugin:testAndroidHostTest` — PASS
- `:feature:feature-collections:testAndroidHostTest` — PASS
- `:feature:feature-creator:testAndroidHostTest` — PASS
- `:feature:feature-search:testAndroidHostTest` — PASS
- `:feature:feature-externalserver:testAndroidHostTest` — PASS
- `:feature:feature-comfyui:jvmTest` — PASS
- `./gradlew detekt` ×2 — PASS (no autoCorrect diffs)
- `:androidApp:assembleDebug` — PASS

Closes #974
