### PR TITLE
docs: spike decision notes for #982/#918

### DIFF
--- a/docs/research/918-video-generation-spike.md
+++ b/docs/research/918-video-generation-spike.md
@@ -1,0 +1,189 @@
+# SPIKE #918 — Video Generation via ComfyUI (Wan / Hunyuan / LTX-2)
+
+Status: Research spike (no implementation). Decision doc only.
+Date: 2026-07-18
+
+---
+
+## Decision: GO — but as a *thin, deferred-scope* MVP, gated behind the v2.4 launch + first feedback cycle
+
+**One-liner:** Ship "trigger a user-provided video ComfyUI workflow → monitor with existing progress/notification infra → retrieve and save the resulting mp4/webm", and explicitly do NOT bundle, download, or manage any video model in-app.
+
+**Rationale**
+- The generation *submission* path is already model-agnostic (arbitrary workflow JSON is posted straight to `/prompt`), so a video workflow is genuinely "just another workflow template". The reuse claim in the issue holds up against the code.
+- The real work is small and localized: ComfyUI returns video outputs under a *different* history key (`gifs`/`videos`) than images, and the app currently only parses `images`. That is a concrete, bounded gap — not an architecture change.
+- Demand is real but the *mobile-triggered video* niche is narrower than mobile-triggered image gen, and the heavy-hardware reality means the addressable user is "someone with a capable desktop GPU who is away from it". This is a bet, so we keep the surface minimal and validate before investing further.
+- A direct competitor (Comfy Portal) already advertises video outputs on mobile, so this is a parity gap, not a moonshot.
+
+**Why "deferred / thin" rather than "full GO now":** Both prioritization axes (user requests + metrics) can't yet be confirmed for *video specifically* — we have image-gen usage but no video-gen signal from our own users. Per `ai-ops.md`, we file this as a Dev-Ready issue and let it compete, rather than committing a large build. The MVP is deliberately shaped so it costs little if the bet is wrong.
+
+---
+
+## Demand findings (cited)
+
+- ComfyUI itself now treats video as a first-class, mainstream capability: the official native Wan 2.2 workflow docs and a single-interface "supports every major video model (Wan 2.2, LTX, Seedance, LongCat...)" positioning confirm video is *the* 2026 trend, not a fringe use case. ([docs.comfy.org Wan 2.2](https://docs.comfy.org/tutorials/video/wan/wan2_2), [ComfyUI Wiki Wan2.2](https://comfyui-wiki.com/en/tutorial/advanced/video/wan2.2/wan2-2))
+- Mobile ComfyUI clients exist and are actively adding exactly this: **Comfy Portal** ("native iOS & Android client — run AI image generation workflows from your phone", connects to home or cloud/RunPod servers) explicitly added "support for multi-image and **video outputs**". This is the clearest demand + parity signal. ([Comfy Portal GitHub](https://github.com/ShunL12324/comfy-portal), [App Store](https://apps.apple.com/us/app/comfy-portal/id6741044736))
+- The "queue a long job and come back to it" workflow is a recognized ComfyUI pain point — third-party queue-manager nodes exist specifically for persistence/archiving/resume of long renders across devices. This validates the "start it, walk away, get notified" UX we already have for images being valuable for the longer video jobs. ([ComfyUI-Queue-Manager](https://comfyai.run/custom_node/ComfyUI-Queue-Manager), [forum.comfy.org queue idea](https://forum.comfy.org/t/pause-button-add-queues-without-starting-the-calculation-immediately/814))
+
+**Honest read:** demand for *remote/mobile video triggering* is inferred (competitor feature + general video-model momentum + long-job queue pain), not a loud direct chorus. Treat as "plausible, unproven for our users" — hence deferred scope.
+
+---
+
+## VRAM / accessibility reality — 2026 (cited)
+
+The "niche 40–48GB hardware" objection has softened but not disappeared. Quantization made 14B video models run on 12–16GB consumer cards, at the cost of long generation times:
+
+| Model | Naive VRAM | Quantized / offloaded reality | Speed (RTX 4090 unless noted) |
+|---|---|---|---|
+| Wan 2.2 14B | ~54 GB | GGUF Q4/Q5 + T5-CPU offload → **6–8 GB @480p, 12–16 GB @720p**; runs on RTX 3060 12GB / 4070 | 480p 5s clip: **18–22 min** on a 3060/4070; 720p **2–4 min** on RTX 5060 Ti 16GB ($429) |
+| Wan 2.2 5B | — | fits **8 GB** with native offloading | fast |
+| HunyuanVideo (8.3B) | 47 GB (official 32GB+ min) | FP8 → **~8–13.6 GB** @720p with offload | 4s 720p: **2–4 min** |
+| LTX-2 (Lightricks, Mar 2026) | official 32 GB | NVFP8 → runs on **16 GB**; 2B FP8+tiling → **6–8 GB** | 4s 720p: **<30 s** (fastest open model) |
+
+Sources: [willitrunai.com Wan VRAM](https://willitrunai.com/blog/wan-2-2-vram-requirements), [runaihome.com Wan GPU guide 2026](https://runaihome.com/blog/wan-video-local-ai-gpu-guide-2026/), [QuantStack Wan2.2 GGUF (HF)](https://huggingface.co/QuantStack/Wan2.2-I2V-A14B-GGUF), [localaimaster low-VRAM T2V](https://localaimaster.com/blog/local-text-to-video-low-vram), [willitrunai video GPU guide](https://willitrunai.com/blog/video-generation-gpu-guide-2026), [spheron GPU cloud video](https://www.spheron.network/blog/gpu-cloud-video-ai-2026/).
+
+**Implication for CivitDeck:** we are a *controller*, not the compute. The hardware burden is entirely on the user's ComfyUI box (or their RunPod/cloud instance). Accessibility has improved enough (12GB entry, LTX-2 sub-30s) that a meaningful slice of users can run this. The long generation times (minutes, not seconds, for Wan/Hunyuan) are exactly why "trigger + background + notify" mobile UX is the right — and already-built — shape. This *strengthens* the fit rather than weakening it.
+
+---
+
+## Competitor landscape (cited)
+
+- **Comfy Portal** (iOS + Android, native ComfyUI client): multi-server (local + cloud/RunPod), real-time status, and now **video outputs**. Directly overlapping and slightly ahead of us on video. ([GitHub](https://github.com/ShunL12324/comfy-portal), [App Store](https://apps.apple.com/us/app/comfy-portal/id6741044736))
+- **Comfy Cloud / Comfy.org** — first-party hosted ComfyUI, positions video models as core. Not a mobile competitor but sets the "video is mainstream" baseline. ([comfy.org/cloud](https://comfy.org/cloud/))
+- ComfyUI native + community workflows (official Wan 2.2 templates, Kijai/GGUF variants) are the "content" our users would import — i.e. the ecosystem produces the exact `.json` workflows our custom-workflow path already accepts. ([comfyui-wiki Wan2.2](https://comfyui-wiki.com/en/tutorial/advanced/video/wan2.2/wan2-2))
+
+**Takeaway:** video-on-mobile is table stakes among ComfyUI mobile clients, and we are currently the one that can view but not generate it. This is a parity gap on a Core Value ("スマホから自宅ComfyUIを完全操作").
+
+---
+
+## Feasibility — grounded in CivitDeck code
+
+### What genuinely reuses existing infra (the issue's claim holds)
+
+1. **Submission is already model-agnostic.** `ComfyUIGenerationParams.customWorkflowJson` is decoded and POSTed verbatim to `/prompt` — no node-type awareness at all:
+   - `ComfyUIGenerationRepositoryImpl.buildWorkflow()` → `feature/feature-comfyui/.../data/repository/ComfyUIGenerationRepositoryImpl.kt:140-143` (`if (customJson != null) return json.decodeFromString(customJson)`)
+   - Same short-circuit in `ComfyUIWorkflowBuilder.kt:21`.
+   - A full template system already exists: `WorkflowTemplate` domain model with typed `variables` (`core/core-domain/.../domain/model/WorkflowTemplate.kt`), plus `ImportWorkflowTemplateUseCase`, `ExtractWorkflowParametersUseCase`, `InjectWorkflowParametersUseCase`, `ApplyWorkflowTemplateUseCase`, and app-mode metadata parsing. A Wan/LTX i2v/t2v workflow drops into this pipeline as data — **no new submission code**. The "video workflow = another template type" premise is confirmed.
+
+2. **Progress + live preview reuses fully.** `ObserveGenerationProgressUseCase` → `ComfyUIGenerationRepositoryImpl.observeGenerationProgress()` → `ComfyUIWebSocketApi.observeProgress()` handles `Progress` (step/max), `Executing`, `Executed`, `ExecutionSuccess`, `ExecutionError`, and `PreviewImage` (`core/core-network/.../ComfyUIWebSocketDto.kt`, `ComfyUIWebSocketApi.kt`). During video sampling ComfyUI still emits latent **preview frames as PreviewImage bytes** — so the existing image-preview UI shows a live per-frame preview with zero changes. Good enough for MVP; a "scrub the preview as video" nicety is a non-goal.
+
+3. **Completion notification is already robust to backgrounding / connection drop.** `NtfySubscriptionService` (`feature/feature-comfyui/.../data/NtfySubscriptionService.kt`) subscribes to an ntfy topic over an *independent* streaming connection with auto-reconnect + exponential backoff, and fires a local notification on completion. This is decoupled from the WebSocket, so a minutes-long video job that outlives a foreground WS session still notifies correctly. This is the single most important piece for long-job UX and it already exists (shipped v2.2.0).
+
+4. **Viewing the result reuses existing video support.** The app already renders `MediaContentType.VIDEO/ANIMATION`, so playing back a retrieved mp4/webm is not new capability — only the retrieval + save plumbing is.
+
+### Genuine gaps (bounded, localized)
+
+- **GAP 1 — Output retrieval only understands images (the core change).** History parsing reads *only* the `images` key:
+  - `HistoryNodeOutput` DTO has a single field `val images: List<ComfyUIOutputImage>? = null` — no `gifs`/`videos`/`animated` (`core/core-network/.../ComfyUIDto.kt:40-43`).
+  - `pollGenerationResult()` flattens `entry.outputs.values.flatMap { it.images }` and, for a successful *video* job with no `images`, returns `GenerationStatus.Error("No images generated")` (`ComfyUIGenerationRepositoryImpl.kt:62-69`).
+  - `ComfyUIHistoryRepositoryImpl.toGeneratedImages()` has the same images-only assumption.
+  - **Fix shape:** add optional `gifs` (VHS_VideoCombine emits `outputs[node].gifs = [{filename, subfolder, type, format}]`) and native `videos`/`animated` fields to the output DTO; treat any of them as a completed result; carry a media-kind flag through `GenerationResult` (currently `imageUrls: List<String>`) so the UI knows to play vs show. This is the only non-trivial change and it's contained to DTO + two parse sites + one domain model.
+
+- **GAP 2 — Saving assumes still images.** `ImageSaver.saveToGallery(imageBytes, filename)` writes image bytes to Photos/Pictures as an image (`feature/feature-comfyui/.../data/image/ImageSaver.kt`, platform impls Android MediaStore Pictures / iOS PHPhotoLibrary). Saving mp4/webm needs a video save path (MediaStore `Movies` / `PHAssetCreationRequest` video). New `expect/actual` method, mechanical per platform.
+
+- **GAP 3 — Long-job / large-output robustness (verify, likely small).**
+  - The WS flow catches `HttpRequestTimeoutException`/`ConnectTimeoutException` and retries (`ComfyUIWebSocketApi.observeProgress()` lines ~55-73). A multi-minute streaming WS must not be killed by any app-level Ktor request timeout — **verify the WS client has no finite request timeout** (or that a reconnect cleanly re-attaches without losing the terminal event; ntfy backstops completion regardless). Low risk, needs a one-line confirmation during implementation.
+  - Large mp4/webm: retrieval via the `/view` endpoint (same as `getImageUrl`) streams fine, but a naive "load whole file into `ByteArray` then save" is heavy for longer clips. A 5s 720p clip is ~2–10 MB (fine); guard against unbounded loads for long clips by streaming to a file. Playback already downsamples/streams on the VIEW path.
+
+**Net:** ~1 real feature (video output parsing + media-kind in the result model) + 1 mechanical platform save path + 1 verification. No new submission, progress, preview, notification, or connection code. The issue's feasibility premise is validated.
+
+---
+
+## Proposed MVP scope
+
+**In scope (smallest viable):**
+1. User imports/pastes a video ComfyUI workflow JSON (Wan i2v/t2v, LTX, Hunyuan — *their* file, *their* models) via the existing custom-workflow / template import path.
+2. Trigger it via the existing `/prompt` submission — unchanged.
+3. Monitor via existing WebSocket progress + latent preview frames, and existing ntfy completion notification.
+4. **New:** parse video outputs (`gifs`/`videos`) from `/history`, mark the result as video-kind.
+5. **New:** play the resulting mp4/webm using existing `MediaContentType.VIDEO` viewer, and save it to the gallery via a new video save path.
+
+**Explicit non-goals (do NOT build):**
+- No bundling, downloading, hosting, or managing of video models/checkpoints in-app (aligns with `CLAUDE.md` Won't-Do: heavy model management is ComfyUI's job).
+- No in-app or on-device video inference of any kind (Won't-Do).
+- No cloud/hosted generation service (Won't-Do) — user brings their own ComfyUI (local or their own RunPod).
+- No visual node editor / workflow authoring for video — import only, reuse existing template variables.
+- No video-specific live "preview scrubbing" — per-frame PreviewImage is sufficient for MVP.
+- No frame-interpolation / upscaling / post-processing UI — that lives in the user's workflow.
+- No curated/first-party video workflow catalog in the MVP (could follow if validated).
+
+---
+
+## Recommendation
+
+**File a follow-up Dev-Ready issue now, but keep it below image-gen polish in priority until we see a video signal.**
+
+Concretely:
+1. Create a Dev-Ready issue "Video generation: parse & retrieve ComfyUI video outputs + save mp4/webm" with a Core Value Alignment section (Core Value 3: "スマホから自宅ComfyUIを完全操作") and the MVP scope above.
+2. Scope it to the three gaps only (output DTO + result media-kind, video save path, long-WS verification). Estimate: small — reuses submission/progress/preview/notification/viewer.
+3. **Revisit trigger to prioritize:** promote it when *either* (a) our own post-launch feedback/metrics show users importing video workflows or requesting video, **or** (b) a competitor parity concern is raised (Comfy Portal video traction). Until then it stays queued, not committed — consistent with the 2-axis rule in `ai-ops.md`.
+
+The bet is de-risked because the expensive parts (submission genericity, async monitoring, background notification, video viewing) already exist; we're only teaching the app to *recognize and keep* a video that ComfyUI hands back.
+
+---
+
+## Codex cross-review (2026-07-18) — GO/defer CONFIRMED, "only 3 gaps" framing corrected
+
+Codex agreed with GO-but-defer and that no video-specific graph builder is needed, but was
+blunt that this is **not "GAP 1 + mechanical saving"** — file it as a bounded *media-output*
+feature with a compatibility matrix and a fixture-validation gate, not near-total reuse.
+Corrections the Dev-Ready issue must absorb:
+
+- **Submission genericity holds, but "user-provided workflow JSON" is under-specified.** It must
+  be **API-format** JSON (Save (API Format)), not a UI-editor export. The current importer only
+  checks "non-empty JSON object" (`ComfyUIUseCases.kt:63`) — a UI export passes validation then
+  fails at `/prompt`. MVP must validate API-format and declare a clear input-file contract:
+  support **self-contained / server-side-file** workflows (text-to-video fits); arbitrary
+  i2v/v2v/audio-conditioned workflows that reference uploaded video/audio/masks are **out of
+  scope** (existing upload plumbing is image/mask-oriented). There is no `VIDEO` template type —
+  "just another template" is misleading from a product/UI angle.
+- **GAP 1 model is too narrow.** `gifs` commonly carries `.mp4`/`.webm` (the key name does NOT
+  identify media kind); other nodes use `videos`/`video`/`images`. Replace "one media-kind flag
+  + URL list" with a **per-output item**: `GeneratedMedia(filename, subfolder, type, url,
+  mediaKind, mimeOrFormat?)`. Classify by **filename extension + `format`/MIME, not the JSON
+  key**. Preserve `subfolder`/`type` for `/view`. Select final outputs via APP-mode declared
+  outputs → `type=output` saved media, avoiding temp/preview intermediates. Update BOTH the
+  immediate-result path AND the history path (`ComfyUIGeneratedImage.kt:7`,
+  `ComfyUIHistoryRepositoryImpl.kt:38` are image-only). Fixture-test: VHS MP4 under `gifs`, VHS
+  WebM under `gifs`, native `SaveVideo`/`SaveWEBM`, multiple clips, mixed preview+final, non-empty
+  subfolder, completed-but-no-saved-media.
+- **Live preview = best-effort, not full reuse.** Latent preview frames aren't guaranteed across
+  node packs / sampler impls / server preview settings / non-sampling stages (interpolation,
+  decode, encode). **Progress is node-local**: multi-stage video graphs emit several independent
+  `value/max` sequences → the single bar jumps backward / shows "complete" while encoding
+  continues. MVP: determinate while a node emits valid steps, **indeterminate "processing/
+  encoding" between/after**, never present sampler % as whole-workflow %.
+- **ntfy is an optional second signal, NOT the completion authority** (spike overstated it).
+  `NtfySubscriptionService` starts as a side effect of collecting settings VM state (not app
+  startup), lives in-process (dies on process kill), can't be assumed alive while iOS is
+  suspended, treats **every** ntfy message as success, and uses the ntfy message ID as the prompt
+  ID with **no prompt correlation**, and needs a server-side ntfy node configured. **History by
+  `promptId` must remain authoritative.**
+- **Missed gaps (the important ones):**
+  - **Long-job reconciliation** — Ktor has 120s request/socket timeouts and WS reconnect caps at
+    5 attempts (`HttpClientConfig.kt:25`); if the socket drops and the job finishes before
+    reconnect, ComfyUI may not replay the terminal event. Reconnect MUST query history/queue and
+    reconcile — don't rely on the WS terminal event.
+  - **6-minute polling ceiling** — fallback poll is 120×3s ≈ 6 min (`GenerationExecutionDelegate.kt:246`),
+    inadequate for video. Remove/raise the fixed ceiling for video jobs.
+  - **Failure reporting** — OOM / missing nodes-models / encoder failure / interruption need the
+    server exception + node details surfaced; current polling can read an unsuccessful terminal
+    history entry as "still running" → eventually "timed out".
+  - **Playback integration is real work** — result/history screens are image grids using image
+    loaders; `MediaContentType.VIDEO` is infrastructure, not wired into these screens.
+  - **Format compatibility** — iOS AVPlayer can't be assumed to play arbitrary WebM/VP9/AV1.
+    **H.264 MP4 is the safe MVP baseline**; WebM best-effort or "unsupported — save/open externally".
+  - **Large-file transport** — stream to a temp file / MediaStore-Photos with cancellation,
+    progress, content-length, cleanup, disk-space errors; current image save reads the whole
+    response into a `ByteArray` (`SaveGeneratedImageUseCase.kt:16`). Over a remote tunnel, retries
+    + Range/resumability + interrupted-download cleanup matter.
+  - **Saving is not fully mechanical** — the ComfyUI-specific saver always writes JPEG to
+    Pictures; iOS decodes bytes as `UIImage`. Video needs a temp file + Photos asset creation.
+
+**Revised acceptance criteria for the Dev-Ready issue:** API-format + server-self-contained
+workflow only; MP4/H.264 required, WebM best-effort/unsupported on iOS; per-item media output
+model; VHS + one native save-node fixture; reconnect/history reconciliation with no fixed 6-min
+timeout; best-effort preview + node-local progress; streamed retrieval + platform video saving;
+ntfy optional, never source of truth. **Add a short fixture-validation gate before estimating.**
+Priority: still **defer below image-gen polish** — Portal parity alone isn't urgent given the
+narrower "capable-GPU-but-away-from-it" audience.

--- a/docs/research/982-server-receiver-spike.md
+++ b/docs/research/982-server-receiver-spike.md
@@ -1,0 +1,247 @@
+# SPIKE #982 — Server-side receiver for "send CivitAI model to plain ComfyUI"
+
+Status: research only (no implementation). Decision note.
+
+## Decision
+
+**Ship a tiny companion custom node (Option B) as the primary receiver. Do NOT rely on
+ComfyUI-Manager's model-install endpoint (Option A) as the general path.**
+
+The spike's original assumption was "capability-probe A, fall back to guided B." The spike
+**overturns that ordering**: Option A's `install_model` endpoint is gated by a curated
+**whitelist** (`check_whitelist_for_model`) that matches an incoming request against
+Manager's bundled `model-list.json` by `save_path` + `base` + `filename`. An arbitrary model
+a user browses on CivitAI is almost never in that list, so the endpoint returns
+`400 "Invalid model install request is detected"`. Option A therefore cannot serve as a
+general receiver for arbitrary CivitAI downloads — it only installs models Manager already
+curates. Option B (a companion node modeled on Civicomfy) resolves the target folder through
+ComfyUI's own `folder_paths` API, has no whitelist, and is the only path that actually solves
+the "wrong-folder / pure-ComfyUI user gets nothing" pain. Recommendation: **B primary; A kept
+only as documentation, not a runtime fast-path.**
+
+---
+
+## Option A findings — ComfyUI-Manager model install
+
+Verified against Manager source `glob/manager_server.py` at `pyproject.toml` **version = "3.41"**
+(current `main`).
+
+- **Endpoint:** `POST /manager/queue/install_model`
+  Source: https://github.com/Comfy-Org/ComfyUI-Manager/blob/main/glob/manager_server.py (line ~1638, `async def install_model`)
+- **Payload** (fields read by the handler / queue item): `ui_id`, `filename`, `url`, `type`,
+  `save_path`, `base`. The task is enqueued: `task_queue.put(("install-model", (ui_id, json_data)))`.
+- **Type → folder** resolved by `model_dir_name_map` (same file, line ~103):
+  ```
+  checkpoints/checkpoint/unclip → checkpoints   text_encoders/clip → text_encoders
+  vae → vae                                      lora → loras
+  t2i-adapter/t2i-style/controlnet → controlnet  clip_vision → clip_vision
+  gligen → gligen                                upscale → upscale_models
+  embedding/embeddings → embeddings              unet/diffusion_model → diffusion_models
+  ```
+  Note: keys are lowercased (`data['type'].lower()`), and there is **no `lora` plural, no
+  `hypernetwork`, no `motion*`** in this map — those types cannot be installed via Manager.
+- **Blockers (the reason A is rejected):**
+  1. **Whitelist gate** — `check_whitelist_for_model()` requires the exact
+     (`save_path`, `base`, `filename`) triple to already exist in `model-list.json`
+     (cache or local). Arbitrary CivitAI models fail with HTTP 400.
+  2. **Security-level gate** — requires `is_allowed_security_level('middle')`; non-`.safetensors`
+     filenames additionally require `'high'` AND a whitelisted URL. On a non-loopback
+     (LAN/remote) ComfyUI the default security level can reject the call with HTTP 403.
+- **Progress:** queue-based. Poll `GET /manager/queue/status`
+  (`{total_count, done_count, in_progress_count, is_processing}`), start with
+  `POST /manager/queue/start`; live updates arrive over ComfyUI's websocket as
+  `cm-queue-status` events. (Same source file, routes at ~1326 / ~1432.)
+- **Version sensitivity:** the `/manager/queue/*` queue API is the **3.x** shape. Older 2.x
+  Manager exposed a different, non-queue `install_model` handler; payloads and the
+  `task_queue` mechanism differ. Any A integration would have to pin **Manager ≥ 3.x** and
+  probe the version. Given the whitelist blocker this is moot for us.
+
+**Conclusion on A:** endpoint verified from real source, but functionally unusable for
+arbitrary CivitAI models due to the curated whitelist. Do not build on it.
+
+---
+
+## Option B findings — companion custom node (Civicomfy pattern)
+
+Verified against Civicomfy source (https://github.com/MoonGoblinDev/Civicomfy).
+
+- **Route registration** — plain aiohttp routes on ComfyUI's server instance:
+  ```python
+  import server
+  prompt_server = server.PromptServer.instance
+  @prompt_server.routes.post("/civitai/download")
+  async def route_download_model(request): ...
+  ```
+  (`server/routes/DownloadModel.py`; package auto-registers every route module via
+  `server/routes/__init__.py`.) A CivitDeck node would register e.g. `POST /civitdeck/install`.
+- **Folder resolution** — done through ComfyUI's canonical `folder_paths` API, NOT a hardcoded
+  map (`utils/helpers.py::get_model_dir` → `get_model_folder_paths` →
+  `folder_paths.get_folder_paths(key)`), with alias normalization
+  (`lora`↔`loras`, `embedding`↔`embeddings`, `upscaler`→`upscale_models`,
+  `motionmodule`→`motion_models`, `unet`→`diffusion_models`, `clip`→`text_encoders`).
+  This respects `extra_model_paths.yaml`, symlinks, and user-customized roots — the correct
+  approach and the direct fix for the "wrong-folder" pain. Falls back to
+  `models_dir/<folder_name>` when the type is unknown.
+- **Download** — chunked/multi-connection streaming into the resolved dir
+  (`downloader/chunk_downloader.py`, `downloader/manager.py` with a background queue thread).
+- **Hash verification — NOT present in Civicomfy.** `chunk_downloader.py` verifies **size**
+  only (segment size + final file size), not SHA256. So the issue's "verify sha256" is an
+  **addition CivitDeck must implement**, not something Civicomfy proves. It is trivial: CivitAI's
+  version API exposes `files[].hashes.SHA256`; the node computes `hashlib.sha256` over the
+  streamed bytes and rejects on mismatch. Low risk, but call it out as new code.
+- **Model-list refresh — essentially automatic.** ComfyUI's `folder_paths.get_filename_list()`
+  cache self-invalidates by comparing `os.path.getmtime(folder)` to the stored mtime
+  (ComfyUI `folder_paths.py::cached_filename_list_`). Writing a new file into the target folder
+  changes the folder mtime, so the next `/object_info` fetch or generation sees the new model
+  with no explicit refresh call. The node may optionally warm it by calling
+  `folder_paths.get_filename_list(folder_name)` after the write.
+  Sources: https://github.com/comfyanonymous/ComfyUI/blob/master/folder_paths.py
+- **Architectural note:** Civicomfy takes a CivitAI URL/ID and fetches metadata + download URL
+  **server-side** (needs a CivitAI API key on the box). CivitDeck can instead have the phone
+  resolve the CDN URL + SHA256 (it already holds them) and POST `{url, type, filename, sha256}`
+  to the node — the lean "receiver" shape the issue describes. Either works; the phone-resolves
+  variant avoids putting a CivitAI key on the GPU box.
+
+---
+
+## Capability probe (connect-time detection)
+
+Concrete, ordered probe from the mobile client against `ComfyUIConnection.baseUrl`:
+
+1. **Plain ComfyUI present?** `GET /system_stats` (or `GET /object_info`) → 200 confirms a
+   reachable ComfyUI. (Core ComfyUI endpoints.)
+2. **Companion node (Option B) present?** `GET /civitdeck/ping` on our own node → 200 with a
+   small version JSON. This is the authoritative probe for the receiver we control; define it
+   in the node.
+3. **ComfyUI-Manager present?** `GET /manager/version` → 200 returns Manager's version string
+   (`core.version_str`, e.g. `"3.41"`); 404 = not installed.
+   Source: https://github.com/Comfy-Org/ComfyUI-Manager/blob/main/glob/manager_server.py (`get_version`, ~line 1944).
+   Useful only to detect Manager for *messaging* ("install our node"), NOT as an install path.
+
+Client logic: (1) fails → not a ComfyUI box (guide Civitai Link / manual). (1) ok + (2) ok →
+send via companion node. (1) ok + (2) missing → guided install of the companion node (link +
+copy-paste git URL); (3) is informational only.
+
+---
+
+## ModelType → folder mapping
+
+CivitDeck `ModelType` (`core/core-domain/.../domain/model/ModelType.kt`) vs ComfyUI default
+folder names (verified in `folder_paths.py`). "Confirmed" = a ComfyUI default folder exists.
+
+| CivitDeck ModelType | Target folder            | Status | Notes |
+|---|---|---|---|
+| Checkpoint          | `checkpoints`            | ✅ confirmed | ComfyUI default |
+| TextualInversion    | `embeddings`             | ✅ confirmed | CivitAI "TextualInversion" = embedding |
+| Hypernetwork        | `hypernetworks`          | ✅ confirmed | ComfyUI default (absent from Manager map) |
+| LORA                | `loras`                  | ✅ confirmed | ComfyUI default |
+| LoCon               | `loras`                  | ✅ confirmed | LoCon/LyCORIS load from `loras` |
+| Controlnet          | `controlnet`             | ✅ confirmed | also `t2i_adapter` is part of this folder set |
+| Upscaler            | `upscale_models`         | ✅ confirmed | ComfyUI default |
+| VAE                 | `vae`                    | ✅ confirmed | ComfyUI default |
+| MotionModule        | `motion_models`          | ⚠️ needs node | NOT a ComfyUI default — AnimateDiff-Evolved custom node dir. Only valid if that node is installed |
+| AestheticGradient   | —                        | ⛔ no target | No ComfyUI concept; do not send |
+| Poses               | —                        | ⛔ no target | Not a model; some workflows drop under `controlnet/poses` or a custom dir — treat as unsupported |
+| Wildcards           | —                        | ⛔ no target | Text lists consumed by wildcard custom nodes, not a model folder |
+| Workflows           | `user/default/workflows` | ⚠️ not a model | Workflow JSON, not a `models/` file — separate flow, out of scope for the receiver |
+| Other               | —                        | ⛔ ambiguous | Require explicit user folder choice |
+
+Resolution should be done **server-side via `folder_paths.get_folder_paths()`** (Civicomfy
+pattern) with the mapping above as the type→key hint, so user-customized/extra roots are
+honored. The client sends the ComfyUI folder key (e.g. `loras`), not an absolute path.
+
+---
+
+## Open risks / what a Dev-Ready issue must specify
+
+1. **SHA256 verification is new code** (Civicomfy doesn't do it). Spec: compute over stream,
+   compare to CivitAI `files[].hashes.SHA256`, delete + fail on mismatch, surface error to phone.
+2. **Auth / abuse surface** — the node adds a write-capable HTTP endpoint on the GPU box. Spec a
+   shared token (header) and bind guidance (LAN only / behind the same reverse proxy as ComfyUI).
+   Consider refusing non-`.safetensors` by default.
+3. **Distribution of the node** — not in ComfyUI-Manager's registry initially; spec the guided
+   install UX (git URL + restart) and the `/civitdeck/ping` version handshake for compatibility.
+4. **Unsupported types** — client must gate `AestheticGradient/Poses/Wildcards/Other` (and warn
+   for `MotionModule`) before offering "send"; do not send types with no valid folder.
+5. **Progress reporting** — decide poll (`GET /civitdeck/status`) vs ComfyUI websocket custom
+   event. Civicomfy uses a background queue + status route; mirror that.
+6. **CivitAI early-access / auth'd downloads** — some CDN URLs need a CivitAI token; decide
+   whether the phone appends it to the URL or the node holds a key (prefer phone-side to keep
+   the box keyless).
+7. **Filename collisions / partial downloads** — spec `.part` temp + atomic rename, and
+   overwrite policy.
+8. **Manager fallback is out** — do not spec an A path; only `/manager/version` for messaging.
+
+---
+
+## Go / No-go
+
+**GO** for a follow-up implementation issue — scoped to **Option B (companion custom node)
+only**. The receiver design is de-risked: route registration, folder resolution, download,
+and auto-refresh are all proven by Civicomfy + ComfyUI source; the only genuinely new work is
+SHA256 verification and the auth token, both low-risk. **NO-GO** on any Option-A / ComfyUI-Manager
+install path — verified unusable for arbitrary CivitAI models due to the curated whitelist gate.
+
+---
+
+## Codex cross-review (2026-07-18) — decision CONFIRMED, scope tightened
+
+Codex validated the core architecture (Option B correct; no credible Manager-only path for
+arbitrary models was missed) but flagged that this note **understates the companion node's
+security and protocol work**. The follow-up implementation issue is a **conditional GO**: the
+items below must be specified before it is Dev-Ready.
+
+- **A is confirmed dead**, and the workarounds don't rescue it: generating a `model-list.json`
+  turns CivitDeck into a live Manager catalogue (breaks for private/early-access/renamed files);
+  patching Manager's cache is unsupported and update-fragile; weakening the security level is not
+  an acceptable prerequisite. Manager's only role is **bootstrap** — publish our node in its
+  registry to cut install friction. Pin the exact upstream commit (not "main"/approx lines).
+- **SSRF is the headline risk** (not called out before). The node becomes a remote downloader +
+  filesystem writer. Required: HTTPS-only + approved CivitAI/CDN host allowlist; **re-validate
+  every redirect** against loopback/link-local/RFC1918/cloud-metadata (defend DNS rebinding);
+  caps on size/concurrency/redirects/duration/disk.
+- **Path safety**: allowlist folder keys + extensions; reject absolute paths / unknown-folder
+  fallback; sanitize `filename` to a basename (reject traversal/separators, ignore remote
+  `Content-Disposition`, defend symlinks); temp file in destination → hash → atomic rename;
+  define overwrite/collision policy; never log signed URLs.
+- **Auth is under-specified**: "shared token" is not a design. Spec token generation, pairing,
+  storage, rotation, revocation; a bearer token over plaintext LAN HTTP is sniffable → require
+  HTTPS on untrusted networks and document the plaintext-LAN risk.
+- **Multi-root destination policy**: `folder_paths.get_folder_paths(key)` can return multiple
+  roots (`extra_model_paths.yaml`). Blindly picking the first is surprising — the node must
+  report a **deterministic writable default** (optionally user-configurable), not guess.
+- **Refresh is best-effort, not infallible**: mtime cache invalidation can miss on network /
+  coarse-timestamp filesystems. Make explicit `get_filename_list` warm-up + restart/reload the
+  recovery path; don't promise auto-refresh.
+- **Capability probe fixes**: reuse the endpoint the app already treats as authoritative —
+  **`/queue`**, not `/system_stats` (`ComfyUIConnectionTesterImpl.kt:31`) — to avoid
+  "connection works" vs "probe says not ComfyUI" disagreement. Don't equate every non-200 ping
+  with "node absent": 404-after-core-ok = absent/proxy-routed; 401/403 = auth/proxy policy;
+  TLS-fail = trust; timeout/5xx = transient; 200+HTML = captive/proxy page. `/civitdeck/ping`
+  must return protocol version + node version + supported folder keys + hash algos + auth
+  requirement (a capabilities handshake, not just a version).
+- **Reverse-proxy gap in the current model**: `ComfyUIConnection` stores only scheme/host/port —
+  no base-path prefix, no HTTP auth (`ComfyUIConnection.kt`). A proxy mounted at `/comfy/` or
+  requiring Basic/Bearer will fail broadly (not just `/ping`). Either declare unsupported or add
+  base-path + proxy-auth to scope. A proxy exposing core routes but omitting custom-node routes
+  → report "receiver route unavailable", not "node missing".
+- **Phone-resolves split is correct** (minimal data-plane node), but: signed CDN URLs may expire
+  while queued → start promptly, refresh + retry on expiry-specific 401/403; **must resolve
+  redirects phone-side to a time-limited CDN URL** — appending the raw CivitAI API key to the URL
+  sent to the node would falsify the "keyless box" claim; ensure the resolved URL is usable from
+  the GPU box (not bound to the phone's session/IP/headers); SHA256 proves integrity, NOT that
+  pickle-format models are safe; the node must not trust phone-provided type/filename beyond its
+  own allowlists.
+- **"Only path" ≠ remove fallbacks**: keep manual phone download as the fallback; "only" means
+  only automated server-side receiver.
+
+Net: the "SHA + auth are the only new work, both low-risk" line above is too optimistic —
+download security (SSRF/path/redirect), destination selection, queueing/cancellation, disk
+handling, and credential pairing are all material work the Dev-Ready issue must scope.
+
+### Sources
+- ComfyUI-Manager `manager_server.py` (v3.41): https://github.com/Comfy-Org/ComfyUI-Manager/blob/main/glob/manager_server.py
+- ComfyUI-Manager repo: https://github.com/Comfy-Org/ComfyUI-Manager
+- Civicomfy repo: https://github.com/MoonGoblinDev/Civicomfy
+  - `server/routes/DownloadModel.py`, `server/routes/__init__.py`, `server/routes/GetModelTypes.py`, `utils/helpers.py`, `downloader/manager.py`, `downloader/chunk_downloader.py`
+- ComfyUI `folder_paths.py`: https://github.com/comfyanonymous/ComfyUI/blob/master/folder_paths.py


### PR DESCRIPTION
Adds Codex-cross-reviewed spike decision docs.

- `docs/research/982-server-receiver-spike.md` — send-to-plain-ComfyUI receiver. Decision: companion custom node (Option B) only; ComfyUI-Manager (Option A) rejected (whitelist-gated). Codex-hardened security (SSRF/auth/multi-root/proxy). Follow-up: #983.
- `docs/research/918-video-generation-spike.md` — ComfyUI video generation. Decision: GO, thin/deferred MVP. Codex corrected the "only 3 gaps" framing (API-format validation, per-item media model, long-job reconciliation, ntfy-not-authoritative, iOS format matrix). Follow-up: #984.

Docs only — no code changes.

Refs #982, #918