### PR TITLE
Personalization signals: record recommendation clicks via append-only interaction event log

### DIFF
--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/search/ModelGridSection.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/search/ModelGridSection.kt
@@ -54,6 +54,8 @@ data class ModelGridCallbacks(
     val onHideModel: (Long, String) -> Unit,
     val onToggleFavorite: (Model) -> Unit,
     val onCompareModel: (Long, String) -> Unit,
+    // Recommendation-card taps: records the interaction signal, then navigates like onModelClick.
+    val onRecommendationClick: (Long, String?, String) -> Unit = onModelClick,
 )
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -277,7 +279,7 @@ private fun ModelGrid(
         horizontalArrangement = Arrangement.spacedBy(Spacing.sm),
         verticalArrangement = Arrangement.spacedBy(Spacing.sm),
     ) {
-        recommendationItems(recommendations, callbacks.onModelClick)
+        recommendationItems(recommendations, callbacks.onRecommendationClick)
         modelItems(
             models,
             ownedHashes,

--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/search/ModelSearchScreen.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/search/ModelSearchScreen.kt
@@ -52,6 +52,8 @@ import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.res.stringResource
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.compose.LifecycleEventEffect
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.riox432.civitdeck.BuildConfig
 import com.riox432.civitdeck.R
@@ -91,6 +93,14 @@ fun ModelSearchScreen(
     val headerState = rememberCollapsibleHeaderState()
 
     HeaderSnapEffect(gridState = gridState, headerState = headerState)
+
+    // Recompute recommendations when the screen resumes after navigating away (e.g. back
+    // from a detail view) so a just-recorded click reshapes the feed. Skips the first
+    // resume because init already loads recommendations.
+    var hasResumedOnce by rememberSaveable { mutableStateOf(false) }
+    LifecycleEventEffect(Lifecycle.Event.ON_RESUME) {
+        if (hasResumedOnce) viewModel.refreshRecommendations() else hasResumedOnce = true
+    }
 
     var lastHandledTrigger by rememberSaveable { mutableIntStateOf(scrollToTopTrigger) }
     LaunchedEffect(scrollToTopTrigger) {
@@ -240,6 +250,10 @@ private fun SearchScreenContentBox(
                 onHideModel = viewModel::onHideModel,
                 onToggleFavorite = onToggleFavorite,
                 onCompareModel = callbacks.onCompareModel,
+                onRecommendationClick = { id, thumbnail, suffix ->
+                    viewModel.trackRecommendationClick(id)
+                    callbacks.onModelClick(id, thumbnail, suffix)
+                },
             ),
             topPadding = topPadding,
             bottomPadding = padding.calculateBottomPadding(),

--- a/core/core-database/schemas/com.riox432.civitdeck.data.local.CivitDeckDatabase/49.json
+++ b/core/core-database/schemas/com.riox432.civitdeck.data.local.CivitDeckDatabase/49.json
@@ -1,0 +1,2109 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 49,
+    "identityHash": "2ea598593cafd1b1f6cea76434795a69",
+    "entities": [
+      {
+        "tableName": "collections",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL, `isDefault` INTEGER NOT NULL, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isDefault",
+            "columnName": "isDefault",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "collection_model_entries",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`collectionId` INTEGER NOT NULL, `modelId` INTEGER NOT NULL, `name` TEXT NOT NULL, `type` TEXT NOT NULL, `nsfw` INTEGER NOT NULL, `thumbnailUrl` TEXT, `creatorName` TEXT, `downloadCount` INTEGER NOT NULL, `favoriteCount` INTEGER NOT NULL, `rating` REAL NOT NULL, `addedAt` INTEGER NOT NULL, PRIMARY KEY(`collectionId`, `modelId`), FOREIGN KEY(`collectionId`) REFERENCES `collections`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "collectionId",
+            "columnName": "collectionId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "modelId",
+            "columnName": "modelId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "nsfw",
+            "columnName": "nsfw",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "thumbnailUrl",
+            "columnName": "thumbnailUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "creatorName",
+            "columnName": "creatorName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "downloadCount",
+            "columnName": "downloadCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "favoriteCount",
+            "columnName": "favoriteCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "rating",
+            "columnName": "rating",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "addedAt",
+            "columnName": "addedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "collectionId",
+            "modelId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_collection_model_entries_modelId",
+            "unique": false,
+            "columnNames": [
+              "modelId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_collection_model_entries_modelId` ON `${TABLE_NAME}` (`modelId`)"
+          },
+          {
+            "name": "index_collection_model_entries_collectionId",
+            "unique": false,
+            "columnNames": [
+              "collectionId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_collection_model_entries_collectionId` ON `${TABLE_NAME}` (`collectionId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "collections",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "collectionId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "cached_api_responses",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`cacheKey` TEXT NOT NULL, `responseJson` TEXT NOT NULL, `cachedAt` INTEGER NOT NULL, `isOfflinePinned` INTEGER NOT NULL, PRIMARY KEY(`cacheKey`))",
+        "fields": [
+          {
+            "fieldPath": "cacheKey",
+            "columnName": "cacheKey",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "responseJson",
+            "columnName": "responseJson",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cachedAt",
+            "columnName": "cachedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isOfflinePinned",
+            "columnName": "isOfflinePinned",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "cacheKey"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_cached_api_responses_cachedAt",
+            "unique": false,
+            "columnNames": [
+              "cachedAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_cached_api_responses_cachedAt` ON `${TABLE_NAME}` (`cachedAt`)"
+          }
+        ]
+      },
+      {
+        "tableName": "user_preferences",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `nsfwFilterLevel` TEXT NOT NULL, `defaultSortOrder` TEXT NOT NULL, `defaultTimePeriod` TEXT NOT NULL, `gridColumns` INTEGER NOT NULL, `apiKey` TEXT, `powerUserMode` INTEGER NOT NULL, `notificationsEnabled` INTEGER NOT NULL, `pollingIntervalMinutes` INTEGER NOT NULL, `nsfwBlurSoft` INTEGER NOT NULL, `nsfwBlurMature` INTEGER NOT NULL, `nsfwBlurExplicit` INTEGER NOT NULL, `offlineCacheEnabled` INTEGER NOT NULL, `cacheSizeLimitMb` INTEGER NOT NULL, `accentColor` TEXT NOT NULL, `amoledDarkMode` INTEGER NOT NULL, `seenTutorialVersion` INTEGER NOT NULL, `civitaiLinkKey` TEXT, `themeMode` TEXT NOT NULL, `customNavShortcuts` TEXT NOT NULL, `feedQualityThreshold` INTEGER NOT NULL, `generationNotificationsEnabled` INTEGER NOT NULL, `autoUpdateCheckEnabled` INTEGER NOT NULL, `lastUpdateCheckTimestamp` INTEGER NOT NULL, `frontDoorMode` TEXT NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "nsfwFilterLevel",
+            "columnName": "nsfwFilterLevel",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "defaultSortOrder",
+            "columnName": "defaultSortOrder",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "defaultTimePeriod",
+            "columnName": "defaultTimePeriod",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "gridColumns",
+            "columnName": "gridColumns",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "apiKey",
+            "columnName": "apiKey",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "powerUserMode",
+            "columnName": "powerUserMode",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "notificationsEnabled",
+            "columnName": "notificationsEnabled",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "pollingIntervalMinutes",
+            "columnName": "pollingIntervalMinutes",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "nsfwBlurSoft",
+            "columnName": "nsfwBlurSoft",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "nsfwBlurMature",
+            "columnName": "nsfwBlurMature",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "nsfwBlurExplicit",
+            "columnName": "nsfwBlurExplicit",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "offlineCacheEnabled",
+            "columnName": "offlineCacheEnabled",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cacheSizeLimitMb",
+            "columnName": "cacheSizeLimitMb",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "accentColor",
+            "columnName": "accentColor",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "amoledDarkMode",
+            "columnName": "amoledDarkMode",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "seenTutorialVersion",
+            "columnName": "seenTutorialVersion",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "civitaiLinkKey",
+            "columnName": "civitaiLinkKey",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "themeMode",
+            "columnName": "themeMode",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "customNavShortcuts",
+            "columnName": "customNavShortcuts",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "feedQualityThreshold",
+            "columnName": "feedQualityThreshold",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "generationNotificationsEnabled",
+            "columnName": "generationNotificationsEnabled",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "autoUpdateCheckEnabled",
+            "columnName": "autoUpdateCheckEnabled",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastUpdateCheckTimestamp",
+            "columnName": "lastUpdateCheckTimestamp",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "frontDoorMode",
+            "columnName": "frontDoorMode",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "saved_prompts",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `prompt` TEXT NOT NULL, `negativePrompt` TEXT, `sampler` TEXT, `steps` INTEGER, `cfgScale` REAL, `seed` INTEGER, `modelName` TEXT, `size` TEXT, `sourceImageUrl` TEXT, `savedAt` INTEGER NOT NULL, `isTemplate` INTEGER NOT NULL DEFAULT 0, `templateName` TEXT, `autoSaved` INTEGER NOT NULL DEFAULT 0, `templateVariables` TEXT, `templateType` TEXT, `templateMetadata` TEXT, `isAppMode` INTEGER NOT NULL DEFAULT 0, `rawWorkflowJson` TEXT)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "prompt",
+            "columnName": "prompt",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "negativePrompt",
+            "columnName": "negativePrompt",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "sampler",
+            "columnName": "sampler",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "steps",
+            "columnName": "steps",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "cfgScale",
+            "columnName": "cfgScale",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "seed",
+            "columnName": "seed",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "modelName",
+            "columnName": "modelName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "size",
+            "columnName": "size",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "sourceImageUrl",
+            "columnName": "sourceImageUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "savedAt",
+            "columnName": "savedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isTemplate",
+            "columnName": "isTemplate",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "templateName",
+            "columnName": "templateName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "autoSaved",
+            "columnName": "autoSaved",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "templateVariables",
+            "columnName": "templateVariables",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "templateType",
+            "columnName": "templateType",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "templateMetadata",
+            "columnName": "templateMetadata",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "isAppMode",
+            "columnName": "isAppMode",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "rawWorkflowJson",
+            "columnName": "rawWorkflowJson",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "search_history",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `query` TEXT NOT NULL, `searchedAt` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "query",
+            "columnName": "query",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "searchedAt",
+            "columnName": "searchedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "browsing_history",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `modelId` INTEGER NOT NULL, `modelName` TEXT NOT NULL, `modelType` TEXT NOT NULL, `creatorName` TEXT, `thumbnailUrl` TEXT, `tags` TEXT NOT NULL, `viewedAt` INTEGER NOT NULL, `durationMs` INTEGER, `interactionType` TEXT)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "modelId",
+            "columnName": "modelId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "modelName",
+            "columnName": "modelName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "modelType",
+            "columnName": "modelType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "creatorName",
+            "columnName": "creatorName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "thumbnailUrl",
+            "columnName": "thumbnailUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "tags",
+            "columnName": "tags",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "viewedAt",
+            "columnName": "viewedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "durationMs",
+            "columnName": "durationMs",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "interactionType",
+            "columnName": "interactionType",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_browsing_history_modelId",
+            "unique": false,
+            "columnNames": [
+              "modelId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_browsing_history_modelId` ON `${TABLE_NAME}` (`modelId`)"
+          },
+          {
+            "name": "index_browsing_history_viewedAt",
+            "unique": false,
+            "columnNames": [
+              "viewedAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_browsing_history_viewedAt` ON `${TABLE_NAME}` (`viewedAt`)"
+          }
+        ]
+      },
+      {
+        "tableName": "excluded_tags",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`tag` TEXT NOT NULL, `addedAt` INTEGER NOT NULL, PRIMARY KEY(`tag`))",
+        "fields": [
+          {
+            "fieldPath": "tag",
+            "columnName": "tag",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "addedAt",
+            "columnName": "addedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "tag"
+          ]
+        }
+      },
+      {
+        "tableName": "hidden_models",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`modelId` INTEGER NOT NULL, `modelName` TEXT NOT NULL, `hiddenAt` INTEGER NOT NULL, PRIMARY KEY(`modelId`))",
+        "fields": [
+          {
+            "fieldPath": "modelId",
+            "columnName": "modelId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "modelName",
+            "columnName": "modelName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "hiddenAt",
+            "columnName": "hiddenAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "modelId"
+          ]
+        }
+      },
+      {
+        "tableName": "model_directories",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `path` TEXT NOT NULL, `label` TEXT, `lastScannedAt` INTEGER, `isEnabled` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "path",
+            "columnName": "path",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "label",
+            "columnName": "label",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "lastScannedAt",
+            "columnName": "lastScannedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "isEnabled",
+            "columnName": "isEnabled",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "local_model_files",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `directoryId` INTEGER NOT NULL, `filePath` TEXT NOT NULL, `fileName` TEXT NOT NULL, `sha256Hash` TEXT NOT NULL, `sizeBytes` INTEGER NOT NULL, `scannedAt` INTEGER NOT NULL, `matchedModelId` INTEGER, `matchedModelName` TEXT, `matchedVersionId` INTEGER, `matchedVersionName` TEXT, `latestVersionId` INTEGER, `hasUpdate` INTEGER NOT NULL, FOREIGN KEY(`directoryId`) REFERENCES `model_directories`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "directoryId",
+            "columnName": "directoryId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "filePath",
+            "columnName": "filePath",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fileName",
+            "columnName": "fileName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sha256Hash",
+            "columnName": "sha256Hash",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sizeBytes",
+            "columnName": "sizeBytes",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "scannedAt",
+            "columnName": "scannedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "matchedModelId",
+            "columnName": "matchedModelId",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "matchedModelName",
+            "columnName": "matchedModelName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "matchedVersionId",
+            "columnName": "matchedVersionId",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "matchedVersionName",
+            "columnName": "matchedVersionName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "latestVersionId",
+            "columnName": "latestVersionId",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "hasUpdate",
+            "columnName": "hasUpdate",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_local_model_files_directoryId",
+            "unique": false,
+            "columnNames": [
+              "directoryId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_local_model_files_directoryId` ON `${TABLE_NAME}` (`directoryId`)"
+          },
+          {
+            "name": "index_local_model_files_sha256Hash",
+            "unique": false,
+            "columnNames": [
+              "sha256Hash"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_local_model_files_sha256Hash` ON `${TABLE_NAME}` (`sha256Hash`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "model_directories",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "directoryId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "model_version_checkpoints",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`modelId` INTEGER NOT NULL, `lastKnownVersionId` INTEGER NOT NULL, `lastCheckedAt` INTEGER NOT NULL, PRIMARY KEY(`modelId`))",
+        "fields": [
+          {
+            "fieldPath": "modelId",
+            "columnName": "modelId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastKnownVersionId",
+            "columnName": "lastKnownVersionId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastCheckedAt",
+            "columnName": "lastCheckedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "modelId"
+          ]
+        }
+      },
+      {
+        "tableName": "comfyui_connections",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL, `hostname` TEXT NOT NULL, `port` INTEGER NOT NULL, `isActive` INTEGER NOT NULL, `lastTestedAt` INTEGER, `lastTestSuccess` INTEGER, `createdAt` INTEGER NOT NULL, `useHttps` INTEGER NOT NULL, `acceptSelfSigned` INTEGER NOT NULL, `ntfyServerUrl` TEXT, `ntfyTopic` TEXT)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "hostname",
+            "columnName": "hostname",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "port",
+            "columnName": "port",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isActive",
+            "columnName": "isActive",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastTestedAt",
+            "columnName": "lastTestedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "lastTestSuccess",
+            "columnName": "lastTestSuccess",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "useHttps",
+            "columnName": "useHttps",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "acceptSelfSigned",
+            "columnName": "acceptSelfSigned",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ntfyServerUrl",
+            "columnName": "ntfyServerUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "ntfyTopic",
+            "columnName": "ntfyTopic",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "sdwebui_connections",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL, `hostname` TEXT NOT NULL, `port` INTEGER NOT NULL, `isActive` INTEGER NOT NULL, `lastTestedAt` INTEGER, `lastTestSuccess` INTEGER, `createdAt` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "hostname",
+            "columnName": "hostname",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "port",
+            "columnName": "port",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isActive",
+            "columnName": "isActive",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastTestedAt",
+            "columnName": "lastTestedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "lastTestSuccess",
+            "columnName": "lastTestSuccess",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "dataset_collections",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL, `description` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "dataset_images",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `datasetId` INTEGER NOT NULL, `imageUrl` TEXT NOT NULL, `sourceType` TEXT NOT NULL, `trainable` INTEGER NOT NULL, `addedAt` INTEGER NOT NULL, `licenseNote` TEXT, `pHash` TEXT, `excluded` INTEGER NOT NULL, `width` INTEGER, `height` INTEGER, FOREIGN KEY(`datasetId`) REFERENCES `dataset_collections`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "datasetId",
+            "columnName": "datasetId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "imageUrl",
+            "columnName": "imageUrl",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceType",
+            "columnName": "sourceType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "trainable",
+            "columnName": "trainable",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "addedAt",
+            "columnName": "addedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "licenseNote",
+            "columnName": "licenseNote",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "pHash",
+            "columnName": "pHash",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "excluded",
+            "columnName": "excluded",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "width",
+            "columnName": "width",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "height",
+            "columnName": "height",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_dataset_images_datasetId",
+            "unique": false,
+            "columnNames": [
+              "datasetId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_dataset_images_datasetId` ON `${TABLE_NAME}` (`datasetId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "dataset_collections",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "datasetId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "image_tags",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `datasetImageId` INTEGER NOT NULL, `tag` TEXT NOT NULL, FOREIGN KEY(`datasetImageId`) REFERENCES `dataset_images`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "datasetImageId",
+            "columnName": "datasetImageId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "tag",
+            "columnName": "tag",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_image_tags_datasetImageId",
+            "unique": false,
+            "columnNames": [
+              "datasetImageId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_image_tags_datasetImageId` ON `${TABLE_NAME}` (`datasetImageId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "dataset_images",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "datasetImageId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "captions",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`datasetImageId` INTEGER NOT NULL, `text` TEXT NOT NULL, PRIMARY KEY(`datasetImageId`), FOREIGN KEY(`datasetImageId`) REFERENCES `dataset_images`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "datasetImageId",
+            "columnName": "datasetImageId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "text",
+            "columnName": "text",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "datasetImageId"
+          ]
+        },
+        "foreignKeys": [
+          {
+            "table": "dataset_images",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "datasetImageId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "saved_search_filters",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL, `query` TEXT NOT NULL, `selectedType` TEXT, `selectedSort` TEXT NOT NULL, `selectedPeriod` TEXT NOT NULL, `selectedBaseModels` TEXT NOT NULL, `nsfwFilterLevel` TEXT NOT NULL, `isFreshFindEnabled` INTEGER NOT NULL, `excludedTags` TEXT NOT NULL, `includedTags` TEXT NOT NULL, `selectedSources` TEXT NOT NULL, `savedAt` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "query",
+            "columnName": "query",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "selectedType",
+            "columnName": "selectedType",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "selectedSort",
+            "columnName": "selectedSort",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "selectedPeriod",
+            "columnName": "selectedPeriod",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "selectedBaseModels",
+            "columnName": "selectedBaseModels",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "nsfwFilterLevel",
+            "columnName": "nsfwFilterLevel",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isFreshFindEnabled",
+            "columnName": "isFreshFindEnabled",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "excludedTags",
+            "columnName": "excludedTags",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "includedTags",
+            "columnName": "includedTags",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "selectedSources",
+            "columnName": "selectedSources",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "savedAt",
+            "columnName": "savedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "external_server_configs",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL, `baseUrl` TEXT NOT NULL, `apiKey` TEXT NOT NULL, `isActive` INTEGER NOT NULL, `lastTestedAt` INTEGER, `lastTestSuccess` INTEGER, `createdAt` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "baseUrl",
+            "columnName": "baseUrl",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "apiKey",
+            "columnName": "apiKey",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isActive",
+            "columnName": "isActive",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastTestedAt",
+            "columnName": "lastTestedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "lastTestSuccess",
+            "columnName": "lastTestSuccess",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "model_notes",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `modelId` INTEGER NOT NULL, `noteText` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "modelId",
+            "columnName": "modelId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "noteText",
+            "columnName": "noteText",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_model_notes_modelId",
+            "unique": false,
+            "columnNames": [
+              "modelId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_model_notes_modelId` ON `${TABLE_NAME}` (`modelId`)"
+          }
+        ]
+      },
+      {
+        "tableName": "personal_tags",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `modelId` INTEGER NOT NULL, `tag` TEXT NOT NULL, `addedAt` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "modelId",
+            "columnName": "modelId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "tag",
+            "columnName": "tag",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "addedAt",
+            "columnName": "addedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_personal_tags_modelId",
+            "unique": false,
+            "columnNames": [
+              "modelId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_personal_tags_modelId` ON `${TABLE_NAME}` (`modelId`)"
+          },
+          {
+            "name": "index_personal_tags_tag",
+            "unique": false,
+            "columnNames": [
+              "tag"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_personal_tags_tag` ON `${TABLE_NAME}` (`tag`)"
+          }
+        ]
+      },
+      {
+        "tableName": "followed_creators",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`username` TEXT NOT NULL, `displayName` TEXT NOT NULL, `avatarUrl` TEXT, `followedAt` INTEGER NOT NULL, `lastCheckedAt` INTEGER NOT NULL, PRIMARY KEY(`username`))",
+        "fields": [
+          {
+            "fieldPath": "username",
+            "columnName": "username",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayName",
+            "columnName": "displayName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "avatarUrl",
+            "columnName": "avatarUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "followedAt",
+            "columnName": "followedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastCheckedAt",
+            "columnName": "lastCheckedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "username"
+          ]
+        }
+      },
+      {
+        "tableName": "feed_cache",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`modelId` INTEGER NOT NULL, `creatorUsername` TEXT NOT NULL, `title` TEXT NOT NULL, `thumbnailUrl` TEXT, `type` TEXT NOT NULL, `publishedAt` TEXT NOT NULL, `cachedAt` INTEGER NOT NULL, `downloadCount` INTEGER NOT NULL, `favoriteCount` INTEGER NOT NULL, `commentCount` INTEGER NOT NULL, `ratingCount` INTEGER NOT NULL, `rating` REAL NOT NULL, PRIMARY KEY(`modelId`))",
+        "fields": [
+          {
+            "fieldPath": "modelId",
+            "columnName": "modelId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "creatorUsername",
+            "columnName": "creatorUsername",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "thumbnailUrl",
+            "columnName": "thumbnailUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "publishedAt",
+            "columnName": "publishedAt",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cachedAt",
+            "columnName": "cachedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "downloadCount",
+            "columnName": "downloadCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "favoriteCount",
+            "columnName": "favoriteCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "commentCount",
+            "columnName": "commentCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ratingCount",
+            "columnName": "ratingCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "rating",
+            "columnName": "rating",
+            "affinity": "REAL",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "modelId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_feed_cache_creatorUsername",
+            "unique": false,
+            "columnNames": [
+              "creatorUsername"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_feed_cache_creatorUsername` ON `${TABLE_NAME}` (`creatorUsername`)"
+          },
+          {
+            "name": "index_feed_cache_publishedAt",
+            "unique": false,
+            "columnNames": [
+              "publishedAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_feed_cache_publishedAt` ON `${TABLE_NAME}` (`publishedAt`)"
+          }
+        ]
+      },
+      {
+        "tableName": "model_downloads",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `modelId` INTEGER NOT NULL, `modelName` TEXT NOT NULL, `versionId` INTEGER NOT NULL, `versionName` TEXT NOT NULL, `fileId` INTEGER NOT NULL, `fileName` TEXT NOT NULL, `fileUrl` TEXT NOT NULL, `fileSizeBytes` INTEGER NOT NULL, `downloadedBytes` INTEGER NOT NULL, `status` TEXT NOT NULL, `modelType` TEXT NOT NULL, `destinationPath` TEXT, `errorMessage` TEXT, `expectedSha256` TEXT, `hashVerified` INTEGER, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "modelId",
+            "columnName": "modelId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "modelName",
+            "columnName": "modelName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "versionId",
+            "columnName": "versionId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "versionName",
+            "columnName": "versionName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fileId",
+            "columnName": "fileId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fileName",
+            "columnName": "fileName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fileUrl",
+            "columnName": "fileUrl",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fileSizeBytes",
+            "columnName": "fileSizeBytes",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "downloadedBytes",
+            "columnName": "downloadedBytes",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "modelType",
+            "columnName": "modelType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "destinationPath",
+            "columnName": "destinationPath",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "errorMessage",
+            "columnName": "errorMessage",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "expectedSha256",
+            "columnName": "expectedSha256",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "hashVerified",
+            "columnName": "hashVerified",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_model_downloads_modelId",
+            "unique": false,
+            "columnNames": [
+              "modelId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_model_downloads_modelId` ON `${TABLE_NAME}` (`modelId`)"
+          },
+          {
+            "name": "index_model_downloads_status",
+            "unique": false,
+            "columnNames": [
+              "status"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_model_downloads_status` ON `${TABLE_NAME}` (`status`)"
+          },
+          {
+            "name": "index_model_downloads_createdAt",
+            "unique": false,
+            "columnNames": [
+              "createdAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_model_downloads_createdAt` ON `${TABLE_NAME}` (`createdAt`)"
+          }
+        ]
+      },
+      {
+        "tableName": "plugins",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `name` TEXT NOT NULL, `version` TEXT NOT NULL, `author` TEXT NOT NULL, `description` TEXT NOT NULL, `pluginType` TEXT NOT NULL, `capabilities` TEXT NOT NULL, `minAppVersion` TEXT NOT NULL, `state` TEXT NOT NULL, `configJson` TEXT NOT NULL, `installedAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "version",
+            "columnName": "version",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "author",
+            "columnName": "author",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "pluginType",
+            "columnName": "pluginType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "capabilities",
+            "columnName": "capabilities",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "minAppVersion",
+            "columnName": "minAppVersion",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "state",
+            "columnName": "state",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "configJson",
+            "columnName": "configJson",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "installedAt",
+            "columnName": "installedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "share_hashtags",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`tag` TEXT NOT NULL, `isEnabled` INTEGER NOT NULL, `isCustom` INTEGER NOT NULL, `addedAt` INTEGER NOT NULL, PRIMARY KEY(`tag`))",
+        "fields": [
+          {
+            "fieldPath": "tag",
+            "columnName": "tag",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isEnabled",
+            "columnName": "isEnabled",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isCustom",
+            "columnName": "isCustom",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "addedAt",
+            "columnName": "addedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "tag"
+          ]
+        }
+      },
+      {
+        "tableName": "model_update_notifications",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `modelId` INTEGER NOT NULL, `modelName` TEXT NOT NULL, `newVersionName` TEXT NOT NULL, `newVersionId` INTEGER NOT NULL, `source` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, `isRead` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "modelId",
+            "columnName": "modelId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "modelName",
+            "columnName": "modelName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "newVersionName",
+            "columnName": "newVersionName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "newVersionId",
+            "columnName": "newVersionId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "source",
+            "columnName": "source",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isRead",
+            "columnName": "isRead",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_model_update_notifications_createdAt",
+            "unique": false,
+            "columnNames": [
+              "createdAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_model_update_notifications_createdAt` ON `${TABLE_NAME}` (`createdAt`)"
+          },
+          {
+            "name": "index_model_update_notifications_isRead",
+            "unique": false,
+            "columnNames": [
+              "isRead"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_model_update_notifications_isRead` ON `${TABLE_NAME}` (`isRead`)"
+          }
+        ]
+      },
+      {
+        "tableName": "quality_score_cache",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`modelId` INTEGER NOT NULL, `score` INTEGER NOT NULL, `downloadCount` INTEGER NOT NULL, `favoriteCount` INTEGER NOT NULL, `ratingCount` INTEGER NOT NULL, `cachedAt` INTEGER NOT NULL, PRIMARY KEY(`modelId`))",
+        "fields": [
+          {
+            "fieldPath": "modelId",
+            "columnName": "modelId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "score",
+            "columnName": "score",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "downloadCount",
+            "columnName": "downloadCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "favoriteCount",
+            "columnName": "favoriteCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ratingCount",
+            "columnName": "ratingCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cachedAt",
+            "columnName": "cachedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "modelId"
+          ]
+        }
+      },
+      {
+        "tableName": "model_embeddings",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`modelId` INTEGER NOT NULL, `embeddingModel` TEXT NOT NULL, `dim` INTEGER NOT NULL, `embedding` BLOB NOT NULL, `cachedAt` INTEGER NOT NULL, PRIMARY KEY(`modelId`))",
+        "fields": [
+          {
+            "fieldPath": "modelId",
+            "columnName": "modelId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "embeddingModel",
+            "columnName": "embeddingModel",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "dim",
+            "columnName": "dim",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "embedding",
+            "columnName": "embedding",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cachedAt",
+            "columnName": "cachedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "modelId"
+          ]
+        }
+      },
+      {
+        "tableName": "interaction_event",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `modelId` INTEGER NOT NULL, `type` TEXT NOT NULL, `timestamp` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "modelId",
+            "columnName": "modelId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timestamp",
+            "columnName": "timestamp",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_interaction_event_timestamp",
+            "unique": false,
+            "columnNames": [
+              "timestamp"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_interaction_event_timestamp` ON `${TABLE_NAME}` (`timestamp`)"
+          },
+          {
+            "name": "index_interaction_event_type_timestamp",
+            "unique": false,
+            "columnNames": [
+              "type",
+              "timestamp"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_interaction_event_type_timestamp` ON `${TABLE_NAME}` (`type`, `timestamp`)"
+          }
+        ]
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '2ea598593cafd1b1f6cea76434795a69')"
+    ]
+  }
+}

--- a/core/core-database/src/commonMain/kotlin/com/riox432/civitdeck/data/local/CivitDeckDatabase.kt
+++ b/core/core-database/src/commonMain/kotlin/com/riox432/civitdeck/data/local/CivitDeckDatabase.kt
@@ -16,6 +16,7 @@ import com.riox432.civitdeck.data.local.dao.ExternalServerConfigDao
 import com.riox432.civitdeck.data.local.dao.FeedCacheDao
 import com.riox432.civitdeck.data.local.dao.FollowedCreatorDao
 import com.riox432.civitdeck.data.local.dao.HiddenModelDao
+import com.riox432.civitdeck.data.local.dao.InteractionEventDao
 import com.riox432.civitdeck.data.local.dao.LocalModelFileDao
 import com.riox432.civitdeck.data.local.dao.ModelDownloadDao
 import com.riox432.civitdeck.data.local.dao.ModelEmbeddingDao
@@ -45,6 +46,7 @@ import com.riox432.civitdeck.data.local.entity.FeedCacheEntity
 import com.riox432.civitdeck.data.local.entity.FollowedCreatorEntity
 import com.riox432.civitdeck.data.local.entity.HiddenModelEntity
 import com.riox432.civitdeck.data.local.entity.ImageTagEntity
+import com.riox432.civitdeck.data.local.entity.InteractionEventEntity
 import com.riox432.civitdeck.data.local.entity.LocalModelFileEntity
 import com.riox432.civitdeck.data.local.entity.ModelDirectoryEntity
 import com.riox432.civitdeck.data.local.entity.ModelDownloadEntity
@@ -102,6 +104,7 @@ import com.riox432.civitdeck.data.local.migrations.MIGRATION_44_45
 import com.riox432.civitdeck.data.local.migrations.MIGRATION_45_46
 import com.riox432.civitdeck.data.local.migrations.MIGRATION_46_47
 import com.riox432.civitdeck.data.local.migrations.MIGRATION_47_48
+import com.riox432.civitdeck.data.local.migrations.MIGRATION_48_49
 import com.riox432.civitdeck.data.local.migrations.MIGRATION_4_5
 import com.riox432.civitdeck.data.local.migrations.MIGRATION_5_6
 import com.riox432.civitdeck.data.local.migrations.MIGRATION_6_7
@@ -144,8 +147,9 @@ import kotlinx.coroutines.IO
         ModelUpdateNotificationEntity::class,
         QualityScoreCacheEntity::class,
         ModelEmbeddingEntity::class,
+        InteractionEventEntity::class,
     ],
-    version = 48,
+    version = 49,
 )
 @ConstructedBy(CivitDeckDatabaseConstructor::class)
 abstract class CivitDeckDatabase : RoomDatabase() {
@@ -175,6 +179,7 @@ abstract class CivitDeckDatabase : RoomDatabase() {
     abstract fun modelUpdateNotificationDao(): ModelUpdateNotificationDao
     abstract fun qualityScoreCacheDao(): QualityScoreCacheDao
     abstract fun modelEmbeddingDao(): ModelEmbeddingDao
+    abstract fun interactionEventDao(): InteractionEventDao
 }
 
 @Suppress("NO_ACTUAL_FOR_EXPECT")
@@ -230,6 +235,7 @@ fun getRoomDatabase(builder: RoomDatabase.Builder<CivitDeckDatabase>): CivitDeck
             MIGRATION_45_46,
             MIGRATION_46_47,
             MIGRATION_47_48,
+            MIGRATION_48_49,
         )
         .fallbackToDestructiveMigrationOnDowngrade(dropAllTables = true)
         .addCallback(defaultCollectionCallback)

--- a/core/core-database/src/commonMain/kotlin/com/riox432/civitdeck/data/local/dao/InteractionEventDao.kt
+++ b/core/core-database/src/commonMain/kotlin/com/riox432/civitdeck/data/local/dao/InteractionEventDao.kt
@@ -10,8 +10,11 @@ interface InteractionEventDao {
     @Insert
     suspend fun insert(event: InteractionEventEntity)
 
-    @Query("SELECT * FROM interaction_event WHERE timestamp >= :sinceMillis")
-    suspend fun getEventsSince(sinceMillis: Long): List<InteractionEventEntity>
+    @Query(
+        "SELECT * FROM interaction_event WHERE timestamp >= :sinceMillis " +
+            "ORDER BY timestamp DESC LIMIT :limit",
+    )
+    suspend fun getEventsSince(sinceMillis: Long, limit: Int = 500): List<InteractionEventEntity>
 
     @Query(
         "SELECT COUNT(*) FROM interaction_event " +

--- a/core/core-database/src/commonMain/kotlin/com/riox432/civitdeck/data/local/dao/InteractionEventDao.kt
+++ b/core/core-database/src/commonMain/kotlin/com/riox432/civitdeck/data/local/dao/InteractionEventDao.kt
@@ -1,0 +1,27 @@
+package com.riox432.civitdeck.data.local.dao
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.Query
+import com.riox432.civitdeck.data.local.entity.InteractionEventEntity
+
+@Dao
+interface InteractionEventDao {
+    @Insert
+    suspend fun insert(event: InteractionEventEntity)
+
+    @Query("SELECT * FROM interaction_event WHERE timestamp >= :sinceMillis")
+    suspend fun getEventsSince(sinceMillis: Long): List<InteractionEventEntity>
+
+    @Query(
+        "SELECT COUNT(*) FROM interaction_event " +
+            "WHERE type = :type AND timestamp >= :sinceMillis",
+    )
+    suspend fun getCountByTypeSince(type: String, sinceMillis: Long): Int
+
+    @Query("DELETE FROM interaction_event WHERE timestamp < :cutoffMillis")
+    suspend fun deleteOlderThan(cutoffMillis: Long): Int
+
+    @Query("DELETE FROM interaction_event")
+    suspend fun deleteAll(): Int
+}

--- a/core/core-database/src/commonMain/kotlin/com/riox432/civitdeck/data/local/entity/InteractionEventEntity.kt
+++ b/core/core-database/src/commonMain/kotlin/com/riox432/civitdeck/data/local/entity/InteractionEventEntity.kt
@@ -1,0 +1,26 @@
+package com.riox432.civitdeck.data.local.entity
+
+import androidx.room.Entity
+import androidx.room.Index
+import androidx.room.PrimaryKey
+
+/**
+ * Append-only log of user interactions with a model (recommendation clicks, favorites,
+ * downloads, shares). Unlike the single overwritable `interactionType` column on
+ * [BrowsingHistoryEntity], every interaction is retained as its own row so signals
+ * accumulate and are never dropped — including for models that have no browsing-history
+ * row yet. Recommendation weighting derives engagement from this event log.
+ */
+@Entity(
+    tableName = "interaction_event",
+    indices = [
+        Index(value = ["timestamp"]),
+        Index(value = ["type", "timestamp"]),
+    ],
+)
+data class InteractionEventEntity(
+    @PrimaryKey(autoGenerate = true) val id: Long = 0,
+    val modelId: Long,
+    val type: String,
+    val timestamp: Long,
+)

--- a/core/core-database/src/commonMain/kotlin/com/riox432/civitdeck/data/local/migrations/Migration48to49.kt
+++ b/core/core-database/src/commonMain/kotlin/com/riox432/civitdeck/data/local/migrations/Migration48to49.kt
@@ -1,0 +1,37 @@
+package com.riox432.civitdeck.data.local.migrations
+
+import androidx.room.migration.Migration
+import androidx.sqlite.SQLiteConnection
+import androidx.sqlite.execSQL
+
+/**
+ * Adds the append-only `interaction_event` table and backfills the single-column
+ * interaction signal previously stored on `browsing_history`. The backfilled
+ * `timestamp` uses `viewedAt` as an approximation — only the most recent overwritten
+ * interaction per row survives, since earlier ones were already lost under the old
+ * overwrite scheme.
+ */
+val MIGRATION_48_49 = object : Migration(48, 49) {
+    override fun migrate(connection: SQLiteConnection) {
+        connection.execSQL(
+            "CREATE TABLE IF NOT EXISTS `interaction_event` (" +
+                "`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, " +
+                "`modelId` INTEGER NOT NULL, " +
+                "`type` TEXT NOT NULL, " +
+                "`timestamp` INTEGER NOT NULL)",
+        )
+        connection.execSQL(
+            "CREATE INDEX IF NOT EXISTS `index_interaction_event_timestamp` " +
+                "ON `interaction_event` (`timestamp`)",
+        )
+        connection.execSQL(
+            "CREATE INDEX IF NOT EXISTS `index_interaction_event_type_timestamp` " +
+                "ON `interaction_event` (`type`, `timestamp`)",
+        )
+        connection.execSQL(
+            "INSERT INTO `interaction_event` (`modelId`, `type`, `timestamp`) " +
+                "SELECT modelId, interactionType, viewedAt FROM browsing_history " +
+                "WHERE interactionType IS NOT NULL",
+        )
+    }
+}

--- a/core/core-database/src/commonMain/kotlin/com/riox432/civitdeck/data/local/repository/BrowsingHistoryRepositoryImpl.kt
+++ b/core/core-database/src/commonMain/kotlin/com/riox432/civitdeck/data/local/repository/BrowsingHistoryRepositoryImpl.kt
@@ -2,15 +2,19 @@ package com.riox432.civitdeck.data.local.repository
 
 import com.riox432.civitdeck.data.local.currentTimeMillis
 import com.riox432.civitdeck.data.local.dao.BrowsingHistoryDao
+import com.riox432.civitdeck.data.local.dao.InteractionEventDao
 import com.riox432.civitdeck.data.local.entity.BrowsingHistoryEntity
+import com.riox432.civitdeck.data.local.entity.InteractionEventEntity
 import com.riox432.civitdeck.domain.model.InteractionType
 import com.riox432.civitdeck.domain.model.RecentlyViewedModel
 import com.riox432.civitdeck.domain.repository.BrowsingHistoryRepository
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
+import kotlin.math.pow
 
 class BrowsingHistoryRepositoryImpl(
     private val dao: BrowsingHistoryDao,
+    private val interactionEventDao: InteractionEventDao,
 ) : BrowsingHistoryRepository {
 
     override suspend fun trackView(
@@ -64,6 +68,7 @@ class BrowsingHistoryRepositoryImpl(
 
     override suspend fun clearAll() {
         dao.deleteAll()
+        interactionEventDao.deleteAll()
     }
 
     override suspend fun deleteById(historyId: Long) {
@@ -81,6 +86,7 @@ class BrowsingHistoryRepositoryImpl(
     override suspend fun cleanup(cutoffMillis: Long, maxEntries: Int) {
         dao.deleteOlderThan(cutoffMillis)
         dao.deleteExcessEntries(maxEntries)
+        interactionEventDao.deleteOlderThan(cutoffMillis)
     }
 
     override suspend fun getWeightedTypes(limit: Int): Map<String, Double> {
@@ -107,8 +113,15 @@ class BrowsingHistoryRepositoryImpl(
     }
 
     override suspend fun trackInteraction(modelId: Long, interactionType: InteractionType) {
-        val id = dao.getLatestIdForModel(modelId) ?: return
-        dao.updateInteractionType(id, interactionType.name)
+        // Append-only: every interaction is retained, even when no browsing-history row
+        // exists yet for the model. Never overwrites, so signals accumulate.
+        interactionEventDao.insert(
+            InteractionEventEntity(
+                modelId = modelId,
+                type = interactionType.name,
+                timestamp = currentTimeMillis(),
+            ),
+        )
     }
 
     override suspend fun getAverageViewDurationMs(): Long? {
@@ -116,26 +129,52 @@ class BrowsingHistoryRepositoryImpl(
     }
 
     override suspend fun getRecommendationClickCount(sinceMillis: Long): Int {
-        return dao.getInteractionCountByType(InteractionType.RECOMMENDATION_CLICK.name, sinceMillis)
+        return interactionEventDao.getCountByTypeSince(
+            InteractionType.RECOMMENDATION_CLICK.name,
+            sinceMillis,
+        )
     }
 
     override suspend fun getInteractionCountByType(type: InteractionType, sinceMillis: Long): Int {
-        return dao.getInteractionCountByType(type.name, sinceMillis)
+        return interactionEventDao.getCountByTypeSince(type.name, sinceMillis)
     }
 
+    /**
+     * Derives affinity scores from both passive views (browsing_history) and the
+     * append-only interaction event log. View rows supply the metadata (tags/type/creator)
+     * and a base decayed weight; each interaction event adds engagement weight attributed
+     * to the keys of that model's most recent view row. Events for a model that was never
+     * viewed are still persisted but cannot be attributed to any tag/type/creator until the
+     * model is opened (its metadata is unknown until then). A model's metadata is stable
+     * across views, so attributing to the most recent row introduces no meaningful skew.
+     */
     private suspend fun computeWeightedScores(
         limit: Int,
         keysSelector: (BrowsingHistoryEntity) -> List<String>,
     ): Map<String, Double> {
         val now = currentTimeMillis()
-        val entries = dao.getRecentSince(now - DECAY_WINDOW_MS)
+        val since = now - DECAY_WINDOW_MS
+        val entries = dao.getRecentSince(since)
         val scores = mutableMapOf<String, Double>()
+
         for (entry in entries) {
-            val weight = decayWeight(now, entry.viewedAt) * engagementWeight(entry)
-            for (key in keysSelector(entry)) {
+            val weight = decayWeight(now, entry.viewedAt) * durationWeight(entry.durationMs)
+            for (key in keysSelector(entry).distinct()) {
                 scores[key] = (scores[key] ?: 0.0) + weight
             }
         }
+
+        val latestEntryByModel = entries
+            .groupBy { it.modelId }
+            .mapValues { (_, rows) -> rows.maxBy { it.viewedAt } }
+        for (event in interactionEventDao.getEventsSince(since)) {
+            val entry = latestEntryByModel[event.modelId] ?: continue
+            val weight = decayWeight(now, event.timestamp) * eventWeight(event.type)
+            for (key in keysSelector(entry).distinct()) {
+                scores[key] = (scores[key] ?: 0.0) + weight
+            }
+        }
+
         return scores.entries
             .sortedByDescending { it.value }
             .take(limit)
@@ -145,6 +184,7 @@ class BrowsingHistoryRepositoryImpl(
     companion object {
         private const val DAY_MS = 86_400_000L
         private const val DECAY_WINDOW_MS = 90 * DAY_MS
+        private const val DECAY_HALF_LIFE_MS = 14.0 * DAY_MS
         private const val LONG_VIEW_THRESHOLD_MS = 30_000L
         private const val SHORT_VIEW_THRESHOLD_MS = 5_000L
         private const val DOWNLOAD_WEIGHT = 5.0
@@ -152,26 +192,25 @@ class BrowsingHistoryRepositoryImpl(
         private const val LONG_VIEW_WEIGHT = 2.0
         private const val SHORT_VIEW_WEIGHT = 0.5
 
-        internal fun decayWeight(now: Long, viewedAt: Long): Double {
-            val ageMs = now - viewedAt
-            return when {
-                ageMs < 7 * DAY_MS -> 1.0
-                ageMs < 30 * DAY_MS -> 0.5
-                ageMs < 90 * DAY_MS -> 0.2
-                else -> 0.05
-            }
+        /**
+         * Continuous exponential time decay: weight halves every [DECAY_HALF_LIFE_MS].
+         * Fresh signals weigh ~1.0; a 14-day-old signal ~0.5, replacing the old
+         * 7/30/90-day step function with a smooth curve.
+         */
+        internal fun decayWeight(now: Long, timestamp: Long): Double {
+            val ageMs = (now - timestamp).coerceAtLeast(0L).toDouble()
+            return 2.0.pow(-ageMs / DECAY_HALF_LIFE_MS)
         }
 
-        internal fun engagementWeight(entry: BrowsingHistoryEntity): Double {
-            val interaction = entry.interactionType?.let {
-                runCatching { InteractionType.valueOf(it) }.getOrNull()
-            }
-            return when (interaction) {
+        internal fun eventWeight(type: String): Double {
+            return when (runCatching { InteractionType.valueOf(type) }.getOrNull()) {
                 InteractionType.DOWNLOAD -> DOWNLOAD_WEIGHT
                 InteractionType.FAVORITE -> FAVORITE_WEIGHT
                 InteractionType.SHARE -> FAVORITE_WEIGHT
                 InteractionType.RECOMMENDATION_CLICK -> FAVORITE_WEIGHT
-                InteractionType.VIEW, null -> durationWeight(entry.durationMs)
+                // Views are already represented by browsing_history rows; unknown types
+                // contribute nothing so a bad value can never inflate a score.
+                InteractionType.VIEW, null -> 0.0
             }
         }
 

--- a/core/core-database/src/commonMain/kotlin/com/riox432/civitdeck/di/DatabaseModule.kt
+++ b/core/core-database/src/commonMain/kotlin/com/riox432/civitdeck/di/DatabaseModule.kt
@@ -48,6 +48,7 @@ val databaseModule = module {
     single { get<CivitDeckDatabase>().savedPromptDao() }
     single { get<CivitDeckDatabase>().searchHistoryDao() }
     single { get<CivitDeckDatabase>().browsingHistoryDao() }
+    single { get<CivitDeckDatabase>().interactionEventDao() }
     single { get<CivitDeckDatabase>().excludedTagDao() }
     single { get<CivitDeckDatabase>().hiddenModelDao() }
     single { get<CivitDeckDatabase>().localModelFileDao() }
@@ -77,7 +78,7 @@ val databaseModule = module {
     // Repositories (DB-only)
     single<CacheRepository> { CacheRepositoryImpl(get()) }
     single<FavoriteRepository> { FavoriteRepositoryImpl(get()) }
-    single<BrowsingHistoryRepository> { BrowsingHistoryRepositoryImpl(get()) }
+    single<BrowsingHistoryRepository> { BrowsingHistoryRepositoryImpl(get(), get()) }
     single<ModelVersionCheckpointRepository> { ModelVersionCheckpointRepositoryImpl(get()) }
 
     // Mixed network + cache repositories (ModelRepository, LocalModelFile*,

--- a/desktopApp/src/jvmMain/kotlin/com/riox432/civitdeck/ui/DiscoverTabContent.kt
+++ b/desktopApp/src/jvmMain/kotlin/com/riox432/civitdeck/ui/DiscoverTabContent.kt
@@ -12,6 +12,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -136,9 +137,22 @@ private fun DiscoverBaseContent(
         }
         DiscoverSection.Trending -> {
             val discoveryVm: DesktopDiscoveryViewModel = koinViewModel()
+            // Recompute recommendations when the detail overlay closes so a just-recorded
+            // click reshapes the feed. Skips the initial empty state (init already loads).
+            var hasNavigatedAway by remember { mutableStateOf(false) }
+            LaunchedEffect(backstack.isEmpty()) {
+                if (backstack.isEmpty()) {
+                    if (hasNavigatedAway) discoveryVm.refresh()
+                } else {
+                    hasNavigatedAway = true
+                }
+            }
             DesktopDiscoveryScreen(
                 viewModel = discoveryVm,
-                onModelClick = { backstack.add(DesktopRoute.ModelDetail(it)) },
+                onModelClick = {
+                    discoveryVm.trackRecommendationClick(it)
+                    backstack.add(DesktopRoute.ModelDetail(it))
+                },
             )
         }
         DiscoverSection.Feed -> {

--- a/feature/feature-search/src/commonMain/kotlin/com/riox432/civitdeck/feature/search/presentation/ModelSearchViewModel.kt
+++ b/feature/feature-search/src/commonMain/kotlin/com/riox432/civitdeck/feature/search/presentation/ModelSearchViewModel.kt
@@ -163,7 +163,7 @@ class ModelSearchViewModel(
         observePreferences()
         filterDelegate.loadExcludedTags()
         loadDefaults(preferencesUseCases.observeDefaultSortOrder, preferencesUseCases.observeDefaultTimePeriod)
-        loadRecommendations()
+        refreshRecommendations()
     }
 
     // region Filter actions
@@ -353,7 +353,7 @@ class ModelSearchViewModel(
                 _uiState.update { it.copy(nsfwFilterLevel = level) }
                 _filterState.update { it.copy(nsfwFilterLevel = level) }
                 if (initialized && prev != level) {
-                    loadRecommendations()
+                    refreshRecommendations()
                     refresh()
                 }
                 initialized = true
@@ -366,7 +366,11 @@ class ModelSearchViewModel(
         }
     }
 
-    private fun loadRecommendations() {
+    /**
+     * (Re)computes recommendations from the latest interaction signals. Called on init and
+     * when returning from a detail view so a just-recorded click/view reshapes the feed.
+     */
+    fun refreshRecommendations() {
         recommendationsJob?.cancel()
         recommendationsJob = viewModelScope.launch {
             _uiState.update { it.copy(isLoadingRecommendations = true) }

--- a/iosApp/iosApp/Features/Search/ModelSearchScreen.swift
+++ b/iosApp/iosApp/Features/Search/ModelSearchScreen.swift
@@ -110,6 +110,11 @@ struct ModelSearchScreen: View {
                 navigationPath.append(id)
                 _ = router.consume()
             }
+            .onChange(of: navigationPath.count) { count in
+                // Returned to the search root (e.g. back from a detail view): recompute
+                // recommendations so a just-recorded click reshapes the feed.
+                if count == 0 { viewModel.refreshRecommendations() }
+            }
         }
     }
     private var activeFilterCount: Int {
@@ -485,6 +490,9 @@ extension ModelSearchScreen { // MARK: - Tag Sections
         )
     }
     var recommendationSections: some View {
-        RecommendationSectionsView(recommendations: viewModel.recommendations)
+        RecommendationSectionsView(
+            recommendations: viewModel.recommendations,
+            onRecommendationClick: { viewModel.trackRecommendationClick(modelId: $0) }
+        )
     }
 }

--- a/iosApp/iosApp/Features/Search/ModelSearchViewModel.swift
+++ b/iosApp/iosApp/Features/Search/ModelSearchViewModel.swift
@@ -251,4 +251,8 @@ final class ModelSearchViewModel: ObservableObject {
     func trackRecommendationClick(modelId: Int64) {
         vm.trackRecommendationClick(modelId: modelId)
     }
+
+    func refreshRecommendations() {
+        vm.refreshRecommendations()
+    }
 }

--- a/iosApp/iosApp/Features/Search/SearchFilterConstants.swift
+++ b/iosApp/iosApp/Features/Search/SearchFilterConstants.swift
@@ -56,6 +56,9 @@ struct HeaderHeightPreferenceKey: PreferenceKey {
 
 struct RecommendationSectionsView: View {
     let recommendations: [RecommendationSection]
+    // Records the recommendation-click signal before navigation; defaults to a no-op so
+    // previews and other call sites without a view model still compile.
+    var onRecommendationClick: (Int64) -> Void = { _ in }
     @Environment(\.horizontalSizeClass) private var sizeClass
 
     private var cardSize: CGSize {
@@ -81,6 +84,9 @@ struct RecommendationSectionsView: View {
                                     .frame(width: cardSize.width, height: cardSize.height)
                             }
                             .buttonStyle(.plain)
+                            .simultaneousGesture(TapGesture().onEnded {
+                                onRecommendationClick(model.id)
+                            })
                         }
                     }
                     .padding(.horizontal, Spacing.md)

--- a/shared/src/commonTest/kotlin/com/riox432/civitdeck/data/repository/BrowsingHistoryRepositoryImplTest.kt
+++ b/shared/src/commonTest/kotlin/com/riox432/civitdeck/data/repository/BrowsingHistoryRepositoryImplTest.kt
@@ -143,8 +143,10 @@ class BrowsingHistoryRepositoryImplTest {
             events.add(event.copy(id = idCounter++))
         }
 
-        override suspend fun getEventsSince(sinceMillis: Long): List<InteractionEventEntity> =
+        override suspend fun getEventsSince(sinceMillis: Long, limit: Int): List<InteractionEventEntity> =
             events.filter { it.timestamp >= sinceMillis }
+                .sortedByDescending { it.timestamp }
+                .take(limit)
 
         override suspend fun getCountByTypeSince(type: String, sinceMillis: Long): Int =
             events.count { it.type == type && it.timestamp >= sinceMillis }

--- a/shared/src/commonTest/kotlin/com/riox432/civitdeck/data/repository/BrowsingHistoryRepositoryImplTest.kt
+++ b/shared/src/commonTest/kotlin/com/riox432/civitdeck/data/repository/BrowsingHistoryRepositoryImplTest.kt
@@ -1,10 +1,14 @@
 package com.riox432.civitdeck.data.repository
 
+import com.riox432.civitdeck.data.local.currentTimeMillis
 import com.riox432.civitdeck.data.local.dao.BrowsingHistoryDao
 import com.riox432.civitdeck.data.local.dao.DayCount
+import com.riox432.civitdeck.data.local.dao.InteractionEventDao
 import com.riox432.civitdeck.data.local.dao.NameCount
 import com.riox432.civitdeck.data.local.entity.BrowsingHistoryEntity
+import com.riox432.civitdeck.data.local.entity.InteractionEventEntity
 import com.riox432.civitdeck.data.local.repository.BrowsingHistoryRepositoryImpl
+import com.riox432.civitdeck.domain.model.InteractionType
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.runTest
@@ -131,10 +135,37 @@ class BrowsingHistoryRepositoryImplTest {
         }
     }
 
+    private class FakeInteractionEventDao : InteractionEventDao {
+        val events = mutableListOf<InteractionEventEntity>()
+        private var idCounter = 1L
+
+        override suspend fun insert(event: InteractionEventEntity) {
+            events.add(event.copy(id = idCounter++))
+        }
+
+        override suspend fun getEventsSince(sinceMillis: Long): List<InteractionEventEntity> =
+            events.filter { it.timestamp >= sinceMillis }
+
+        override suspend fun getCountByTypeSince(type: String, sinceMillis: Long): Int =
+            events.count { it.type == type && it.timestamp >= sinceMillis }
+
+        override suspend fun deleteOlderThan(cutoffMillis: Long): Int {
+            val before = events.size
+            events.removeAll { it.timestamp < cutoffMillis }
+            return before - events.size
+        }
+
+        override suspend fun deleteAll(): Int {
+            val count = events.size
+            events.clear()
+            return count
+        }
+    }
+
     @Test
     fun trackView_inserts_entity() = runTest {
         val dao = FakeDao()
-        val repo = BrowsingHistoryRepositoryImpl(dao)
+        val repo = BrowsingHistoryRepositoryImpl(dao, FakeInteractionEventDao())
         repo.trackView(1L, "TestModel", "Checkpoint", "artist", null, listOf("anime"))
         assertEquals(1, dao.entities.size)
         assertEquals(1L, dao.entities[0].modelId)
@@ -147,7 +178,7 @@ class BrowsingHistoryRepositoryImplTest {
     @Test
     fun trackView_joins_tags_with_comma() = runTest {
         val dao = FakeDao()
-        val repo = BrowsingHistoryRepositoryImpl(dao)
+        val repo = BrowsingHistoryRepositoryImpl(dao, FakeInteractionEventDao())
         repo.trackView(1L, "Test", "LORA", null, null, listOf("anime", "portrait", "girl"))
         assertEquals("anime,portrait,girl", dao.entities[0].tags)
     }
@@ -155,7 +186,7 @@ class BrowsingHistoryRepositoryImplTest {
     @Test
     fun getRecentTypes_counts_by_type() = runTest {
         val dao = FakeDao()
-        val repo = BrowsingHistoryRepositoryImpl(dao)
+        val repo = BrowsingHistoryRepositoryImpl(dao, FakeInteractionEventDao())
         repo.trackView(1L, "M1", "Checkpoint", null, null, emptyList())
         repo.trackView(2L, "M2", "Checkpoint", null, null, emptyList())
         repo.trackView(3L, "M3", "LORA", null, null, emptyList())
@@ -168,7 +199,7 @@ class BrowsingHistoryRepositoryImplTest {
     @Test
     fun getRecentCreators_counts_by_creator() = runTest {
         val dao = FakeDao()
-        val repo = BrowsingHistoryRepositoryImpl(dao)
+        val repo = BrowsingHistoryRepositoryImpl(dao, FakeInteractionEventDao())
         repo.trackView(1L, "M1", "Checkpoint", "artist1", null, emptyList())
         repo.trackView(2L, "M2", "LORA", "artist1", null, emptyList())
         repo.trackView(3L, "M3", "LORA", "artist2", null, emptyList())
@@ -183,7 +214,7 @@ class BrowsingHistoryRepositoryImplTest {
     @Test
     fun getRecentTags_counts_split_tags() = runTest {
         val dao = FakeDao()
-        val repo = BrowsingHistoryRepositoryImpl(dao)
+        val repo = BrowsingHistoryRepositoryImpl(dao, FakeInteractionEventDao())
         repo.trackView(1L, "M1", "Checkpoint", null, null, listOf("anime", "girl"))
         repo.trackView(2L, "M2", "LORA", null, null, listOf("anime", "landscape"))
 
@@ -196,7 +227,7 @@ class BrowsingHistoryRepositoryImplTest {
     @Test
     fun getRecentTags_ignores_blank_tags() = runTest {
         val dao = FakeDao()
-        val repo = BrowsingHistoryRepositoryImpl(dao)
+        val repo = BrowsingHistoryRepositoryImpl(dao, FakeInteractionEventDao())
         repo.trackView(1L, "M1", "Checkpoint", null, null, emptyList())
 
         val tags = repo.getRecentTags()
@@ -206,7 +237,7 @@ class BrowsingHistoryRepositoryImplTest {
     @Test
     fun getAllViewedModelIds_returns_distinct_ids() = runTest {
         val dao = FakeDao()
-        val repo = BrowsingHistoryRepositoryImpl(dao)
+        val repo = BrowsingHistoryRepositoryImpl(dao, FakeInteractionEventDao())
         repo.trackView(1L, "M1", "Checkpoint", null, null, emptyList())
         repo.trackView(1L, "M1", "Checkpoint", null, null, emptyList())
         repo.trackView(2L, "M2", "LORA", null, null, emptyList())
@@ -218,9 +249,110 @@ class BrowsingHistoryRepositoryImplTest {
     @Test
     fun clearAll_removes_everything() = runTest {
         val dao = FakeDao()
-        val repo = BrowsingHistoryRepositoryImpl(dao)
+        val eventDao = FakeInteractionEventDao()
+        val repo = BrowsingHistoryRepositoryImpl(dao, eventDao)
         repo.trackView(1L, "M1", "Checkpoint", null, null, emptyList())
+        repo.trackInteraction(1L, InteractionType.FAVORITE)
         repo.clearAll()
         assertTrue(dao.entities.isEmpty())
+        assertTrue(eventDao.events.isEmpty())
+    }
+
+    @Test
+    fun trackInteraction_persists_event() = runTest {
+        val eventDao = FakeInteractionEventDao()
+        val repo = BrowsingHistoryRepositoryImpl(FakeDao(), eventDao)
+        repo.trackView(1L, "M1", "Checkpoint", null, null, listOf("anime"))
+        repo.trackInteraction(1L, InteractionType.RECOMMENDATION_CLICK)
+
+        assertEquals(1, eventDao.events.size)
+        assertEquals(1L, eventDao.events[0].modelId)
+        assertEquals(InteractionType.RECOMMENDATION_CLICK.name, eventDao.events[0].type)
+    }
+
+    @Test
+    fun trackInteraction_retained_without_history_row() = runTest {
+        // No trackView first: the model has no browsing_history row. The event must still
+        // be recorded rather than silently discarded.
+        val eventDao = FakeInteractionEventDao()
+        val repo = BrowsingHistoryRepositoryImpl(FakeDao(), eventDao)
+        repo.trackInteraction(42L, InteractionType.DOWNLOAD)
+
+        assertEquals(1, eventDao.events.size)
+        assertEquals(42L, eventDao.events[0].modelId)
+        assertEquals(
+            1,
+            repo.getInteractionCountByType(InteractionType.DOWNLOAD, sinceMillis = 0L),
+        )
+    }
+
+    @Test
+    fun trackInteraction_accumulates_without_overwrite() = runTest {
+        val eventDao = FakeInteractionEventDao()
+        val repo = BrowsingHistoryRepositoryImpl(FakeDao(), eventDao)
+        repo.trackInteraction(1L, InteractionType.RECOMMENDATION_CLICK)
+        repo.trackInteraction(1L, InteractionType.RECOMMENDATION_CLICK)
+        repo.trackInteraction(1L, InteractionType.FAVORITE)
+
+        assertEquals(3, eventDao.events.size)
+        assertEquals(2, repo.getRecommendationClickCount(sinceMillis = 0L))
+        assertEquals(
+            1,
+            repo.getInteractionCountByType(InteractionType.FAVORITE, sinceMillis = 0L),
+        )
+    }
+
+    @Test
+    fun weightedTags_include_interaction_event_signal() = runTest {
+        val dao = FakeDao()
+        val eventDao = FakeInteractionEventDao()
+        val repo = BrowsingHistoryRepositoryImpl(dao, eventDao)
+        // Two models viewed once each; a DOWNLOAD event on the "anime" model must push its
+        // tag above the merely-viewed "landscape" model.
+        repo.trackView(1L, "M1", "Checkpoint", null, null, listOf("anime"))
+        repo.trackView(2L, "M2", "Checkpoint", null, null, listOf("landscape"))
+        repo.trackInteraction(1L, InteractionType.DOWNLOAD)
+
+        val weighted = repo.getWeightedTags()
+        val anime = weighted["anime"] ?: 0.0
+        val landscape = weighted["landscape"] ?: 0.0
+        assertTrue(anime > landscape, "download event should raise anime above landscape")
+    }
+
+    @Test
+    fun weightedTags_decay_favours_recent_over_old() = runTest {
+        val dao = FakeDao()
+        val repo = BrowsingHistoryRepositoryImpl(dao, FakeInteractionEventDao())
+        val now = currentTimeMillis()
+        val dayMs = 86_400_000L
+        // Same duration/engagement; only recency differs. Continuous decay must rank the
+        // recently-viewed tag above the one viewed two months ago.
+        dao.entities.add(
+            BrowsingHistoryEntity(
+                id = 1L,
+                modelId = 1L,
+                modelName = "Recent",
+                modelType = "Checkpoint",
+                creatorName = null,
+                tags = "recent",
+                viewedAt = now - dayMs,
+            ),
+        )
+        dao.entities.add(
+            BrowsingHistoryEntity(
+                id = 2L,
+                modelId = 2L,
+                modelName = "Old",
+                modelType = "Checkpoint",
+                creatorName = null,
+                tags = "old",
+                viewedAt = now - 60 * dayMs,
+            ),
+        )
+
+        val weighted = repo.getWeightedTags()
+        val recent = weighted["recent"] ?: 0.0
+        val old = weighted["old"] ?: 0.0
+        assertTrue(recent > old, "recent view should outweigh a 60-day-old view")
     }
 }


### PR DESCRIPTION
## Description

Personalization signals were being dropped: `trackRecommendationClick()` existed on the VM but was never called from recommendation cards, and `trackInteraction()` overwrote a single `interactionType` column on `browsing_history` — discarding the signal entirely when no history row existed and losing earlier interactions.

This wires the click signal on all platforms and replaces the overwrite with an append-only event log.

### Changes
- **New append-only `interaction_event` table** (`modelId`, `type`, `timestamp`) + `InteractionEventDao`. DB version 48 -> 49 with `MIGRATION_48_49` (creates table + indices, backfills the old single-column signal from `browsing_history`). Room-exported `49.json` matches the migration exactly. Fresh installs get the table from the `@Database` entity list (no seed data needed).
- **`BrowsingHistoryRepositoryImpl`**: `trackInteraction` now appends an event (never overwrites, retained even with no history row). Recommendation weight is derived from the event log — each event's `eventWeight(type) * decayWeight(timestamp)` is attributed to the keys (tags/type/creator) of that model's most-recent view row, added on top of the passive view weight. Counts (`getRecommendationClickCount`, `getInteractionCountByType`) read the event log. `clearAll`/`cleanup` also clear events.
- **Continuous exponential time decay** (half-life 14 days) replacing the old 7/30/90-day step function, with a clamp on future timestamps.
- **Recommendation-click wiring**: Android (`RecommendationRow` via `ModelGridCallbacks.onRecommendationClick`), iOS (`RecommendationSectionsView` tap), Desktop (Trending discovery card). Each records the click, then navigates.
- **Refresh on return from detail**: shared VM exposes `refreshRecommendations()`; Android calls it on `ON_RESUME` (after the first), iOS on returning to the search root, Desktop when the detail overlay closes.

The domain `BrowsingHistoryRepository` interface is intentionally unchanged (only the impl + one DAO injection), so the many fake implementations in other test files are untouched.

### Design cross-review
Cross-reviewed with Codex MCP (schema, migration, weight derivation, decay). Adopted: clamp future timestamps in decay, wire event deletion into `clearAll`/`cleanup`, backfill `timestamp = viewedAt` as a documented approximation. Attribution uses the model's most-recent history row (a model's tags/type/creator are stable across views, and this ensures a recommendation-click event — whose view row is created immediately after — is attributed rather than skipped).

## Related Issue
Closes #987

## Automated Tests
- [x] Unit tests added/updated — new `commonTest` coverage: click -> event persisted, no-history path retained, accumulation without overwrite, event signal raises weighted tag, decay favours recent over old.

## Checklist
- [x] CLAUDE.md rules followed
- [x] No `!!` or force unwrap
- [x] No `GlobalScope`
- [x] Error handling complete

## Verification
CI-equivalent local run all green: `:shared:testAndroidHostTest`, `:core:core-data:testAndroidHostTest`, all six `:feature:*:testAndroidHostTest`, `:core:core-database:jvmTest`, `:feature:feature-comfyui:jvmTest`, `detekt` (twice), `:androidApp:assembleDebug` (fdroid + githubFull), `:shared:compileKotlinIosSimulatorArm64`, `:desktopApp:compileKotlinJvm`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
