### PR TITLE
Isolate SigLIP-2 semantic search as Android-only experimental + corpus-index spike doc (#989)

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,8 +67,7 @@ CivitDeck is built for power users and creators who generate, not just browse.
 - **Generation Notifications** — get notified when ComfyUI generations finish via local notifications or ntfy.sh push, with background monitoring kept alive by a foreground service
 - **Hardware Monitoring** — view connected ComfyUI server hardware (VRAM/RAM/GPU) with per-model VRAM compatibility badges and optimization suggestions
 - **CivitAI Site Toggle** — choose whether web and share links open `civitai.com` (SFW) or `civitai.red` (full), independent of the content filter
-- **Image Similarity Search** — find visually similar models using on-device SigLIP-2 embeddings
-- **Text-to-Image Search** — describe what you want in natural language, find matching models via SigLIP-2 text encoder
+- **Semantic Search (experimental, Android-only, off by default)** — on-device SigLIP-2 embeddings for "find similar" and natural-language search. Not a shipped feature: it is gated behind a build flag, covers only locally-cached models (not the CivitAI catalog), and is not wired into the default search path. iOS and Desktop have no working encoder. See [docs/research/989-semantic-corpus-index-spike.md](docs/research/989-semantic-corpus-index-spike.md).
 - **Model Update Notifications** — get notified when followed models receive updates
 - **Smart Recommendations** — personalized model suggestions with time-decay scoring and engagement tracking
 - **Browsing History** — dedicated history screen with search frequency charts

--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/textsearch/TextSearchScreen.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/ui/textsearch/TextSearchScreen.kt
@@ -130,9 +130,10 @@ private fun TextSearchBody(
 private fun UnavailableState() {
     EmptyStateMessage(
         icon = Icons.Outlined.AutoAwesome,
-        title = "AI Search coming soon",
-        subtitle = "Text-to-image search using SigLIP-2 is under development. " +
-            "The text encoder and tokenizer are being integrated.",
+        title = "AI Search (experimental)",
+        subtitle = "On-device text-to-image search with SigLIP-2 is an Android-only experiment " +
+            "and is not yet available. It only covers models cached on this device, not the " +
+            "CivitAI catalog. The text encoder and tokenizer are still being integrated.",
     )
 }
 

--- a/core/core-ml/build.gradle.kts
+++ b/core/core-ml/build.gradle.kts
@@ -15,6 +15,12 @@ kotlin {
             implementation(libs.onnxruntime.android)
             implementation(libs.kotlinx.serialization.json)
         }
+
+        // SigLipTokenizer is androidMain-only, so its parity test runs as an
+        // Android host (JVM) unit test — task :core:core-ml:testAndroidHostTest.
+        getByName("androidHostTest").dependencies {
+            implementation(libs.kotlin.test)
+        }
     }
 
     android {

--- a/core/core-ml/src/androidHostTest/kotlin/com/riox432/civitdeck/domain/ml/SigLipTokenizerParityTest.kt
+++ b/core/core-ml/src/androidHostTest/kotlin/com/riox432/civitdeck/domain/ml/SigLipTokenizerParityTest.kt
@@ -1,0 +1,90 @@
+package com.riox432.civitdeck.domain.ml
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * Parity harness for [SigLipTokenizer].
+ *
+ * The tokenizer claims to implement SentencePiece **Unigram** segmentation (Viterbi
+ * over log-probability scores). These golden fixtures pin that algorithm against a
+ * small, hand-verified reference vocabulary: whitespace-prefix (`▁`), lowercasing,
+ * best-score segmentation, EOS append, padding, truncation, and unknown-token
+ * fallback each have a case with an expected token-id sequence computed by hand.
+ *
+ * IMPORTANT — scope of "parity": this proves the tokenizer matches the SentencePiece
+ * Unigram reference *algorithm*, NOT the real `google/siglip2-base-patch16-224`
+ * tokenizer. SigLIP-2 actually ships the multilingual **Gemma** tokenizer
+ * (`GemmaTokenizerFast`, 256k vocab, byte-fallback, digit splitting, case preserved),
+ * which this simplified encoder does not reproduce. Closing that gap requires a
+ * committed golden fixture generated from the real tokenizer.json — tracked in
+ * `docs/research/989-semantic-corpus-index-spike.md` and its follow-up issue.
+ */
+class SigLipTokenizerParityTest {
+
+    /**
+     * Reference Unigram vocab. Index = token id; second element = log-prob score.
+     * Higher (less negative) score wins during Viterbi segmentation.
+     */
+    private fun vocabJson(maxSeqLen: Int, addEos: Boolean = true): String = """
+        {
+          "pieces": [
+            ["<pad>", 0.0],
+            ["<eos>", 0.0],
+            ["<bos>", 0.0],
+            ["<unk>", 0.0],
+            ["▁", -3.0],
+            ["▁a", -1.0],
+            ["▁ab", -1.5],
+            ["b", -2.0],
+            ["a", -2.5],
+            ["▁cat", -1.0],
+            ["▁c", -4.0],
+            ["at", -4.0]
+          ],
+          "special": {"pad": 0, "eos": 1, "bos": 2, "unk": 3},
+          "max_seq_len": $maxSeqLen,
+          "add_eos": $addEos,
+          "add_bos": false
+        }
+    """.trimIndent()
+
+    private fun encode(text: String, maxSeqLen: Int = 8, addEos: Boolean = true): List<Long> =
+        SigLipTokenizer.fromVocabJson(vocabJson(maxSeqLen, addEos)).encode(text).toList()
+
+    @Test
+    fun singlePieceMatch_appendsEosAndPads() {
+        // "▁cat" (id 9, -1.0) beats "▁c"+"at" (-8.0). EOS(1) then pad(0).
+        assertEquals(listOf(9L, 1L, 0L, 0L, 0L, 0L, 0L, 0L), encode("cat"))
+    }
+
+    @Test
+    fun lowercasesBeforeSegmentation() {
+        // Upper-case input must map to the same ids as lower-case.
+        assertEquals(encode("cat"), encode("CAT"))
+    }
+
+    @Test
+    fun prefersLongerHigherScorePiece() {
+        // "▁ab" (id 6, -1.5) beats "▁a"+"b" (-3.0) and "▁"+"a"+"b" (-7.5).
+        assertEquals(listOf(6L, 1L, 0L, 0L, 0L, 0L, 0L, 0L), encode("ab"))
+    }
+
+    @Test
+    fun unknownCharacterFallsBackToUnkToken() {
+        // "▁x": "▁"(id4) then 'x' has no piece → unk(id3) fallback, then EOS(1).
+        assertEquals(listOf(4L, 3L, 1L, 0L, 0L, 0L, 0L, 0L), encode("x"))
+    }
+
+    @Test
+    fun truncationDropsEosWhenSequenceIsFull() {
+        // "▁abab" segments to ["▁ab"(6), "a"(8), "b"(7)]; maxSeqLen=2 keeps the
+        // first two ids and leaves no room for EOS.
+        assertEquals(listOf(6L, 8L), encode("abab", maxSeqLen = 2))
+    }
+
+    @Test
+    fun addEosDisabled_producesNoTrailingEos() {
+        assertEquals(listOf(9L, 0L, 0L, 0L, 0L, 0L, 0L, 0L), encode("cat", addEos = false))
+    }
+}

--- a/core/core-ml/src/androidMain/kotlin/com/riox432/civitdeck/domain/ml/SigLipTokenizer.kt
+++ b/core/core-ml/src/androidMain/kotlin/com/riox432/civitdeck/domain/ml/SigLipTokenizer.kt
@@ -157,6 +157,14 @@ internal class SigLipTokenizer private constructor(
         }
 
         /**
+         * Builds a tokenizer directly from a vocab JSON string, bypassing Android assets.
+         *
+         * Visible for testing — lets the tokenizer parity test construct a tokenizer from
+         * a fixture without an Android [Context]. The JSON format matches [parseVocab].
+         */
+        internal fun fromVocabJson(jsonStr: String): SigLipTokenizer = parseVocab(jsonStr)
+
+        /**
          * Parses the vocabulary JSON exported by the Python script.
          *
          * Format:

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -183,7 +183,7 @@ Also shipped in this pass: results-first search (recommendation carousels hidden
 Go beyond CivitAI-only search. Help users find the right model faster with cross-platform search and smart recommendations.
 
 - [x] Multi-platform model search (HuggingFace + TensorArt) — unified search with platform filter and source indicators
-- [x] Image similarity search — find visually similar models using on-device SigLIP-2 embeddings
+- [~] Image similarity search (experimental, Android-only, off by default) — on-device SigLIP-2 embeddings. Not shipped: build-flag gated, indexes only locally-cached models, no working iOS/Desktop encoder. Corpus-index path scoped in [docs/research/989-semantic-corpus-index-spike.md](research/989-semantic-corpus-index-spike.md).
 - [x] Smart feed with quality filtering (anti-Buzz-farming) — quality score based on downloads, favorites, and ratings
 - [x] Model update notifications for followed models
 - [x] ComfyHub workflow integration — browse and import community workflows directly into the workflow library

--- a/docs/research/989-semantic-corpus-index-spike.md
+++ b/docs/research/989-semantic-corpus-index-spike.md
@@ -1,0 +1,148 @@
+# Semantic Corpus Index Spike — Go/No-Go for SigLIP-2 as Primary Search (Issue #989)
+
+Status: **Decision — NO-GO on semantic-primary.** Adopt Option C (CivitAI API retrieval +
+optional Android-only re-ranker). Revisit only if the GO criteria below are met.
+Date: 2026-07-19
+Related: #602 (SigLIP-2 parent), #988 (unified search bar — must keep semantic experimental),
+#805 (iOS text encoder), #700/#701 (encoder conversion)
+
+> Per `.claude/rules/ai-ops.md` (Research → Implementation Gate): this document is a
+> **decision doc only**. It does not authorize building a corpus index. If a future
+> decision flips to GO, that becomes a new issue that passes weekly review first.
+
+## TL;DR
+
+On-device SigLIP-2 semantic search is **not a shipped feature** and must not become the primary
+search path. It currently indexes only models the user opened in detail (dozens), not the
+CivitAI catalog (~1M+ models); iOS/Desktop have no working encoder; and the Android tokenizer is
+not parity with the real SigLIP-2 tokenizer. Promoting it to primary would ship an effectively
+empty search screen plus a ~300 MB APK. Keep CivitAI's REST search as the authoritative retrieval
+layer. Semantic ranking stays an **Android-only experiment**, at most an optional re-ranker over
+keyword results — never the retrieval layer.
+
+## Verified current state (the reality check)
+
+| Platform | Text encoder | Vision encoder | Reality |
+|---|---|---|---|
+| Android | ONNX + simplified tokenizer (`SigLipTokenizer.kt`); model+vocab **gitignored, not committed** | ONNX (`siglip2_vision_q4f16.onnx`, githubFull-only, flag-gated) | Only works in a locally built `-Pcivitdeck.enableSimilaritySearch=true` `githubFull` APK |
+| iOS | **Stub** — `isAvailable = false`, `embed()` throws (`core-ml/src/iosMain/.../TextEmbeddingModelImpl.kt`) | Bridge exists but **no `.mlpackage` bundled** | Non-functional |
+| Desktop/JVM | **No-op** by design (`core-ml/src/jvmMain/.../*Impl.kt`) | No-op | Non-functional |
+
+- The index is built **only for models opened in detail** (`EmbedOnBrowseUseCase`) → search
+  covers a tiny local subset, not CivitAI.
+- Retrieval is O(N) cosine over all cached vectors (`ModelEmbeddingRepositoryImpl.findSimilar`) —
+  fine for dozens of vectors, not a catalog.
+- Feature is gated OFF everywhere by default: Android `BuildConfig.FEATURE_SIMILARITY_SEARCH`
+  (default `false`, and always `false` on the `fdroid` flavor); iOS `FeatureFlags.similaritySearch = false`.
+
+### Tokenizer parity gap (correctness blocker, not a nicety)
+
+`SigLipTokenizer.kt` implements a simplified SentencePiece **Unigram** loader: lowercases, one
+leading `▁`, small exported vocab, no digit splitting, ad-hoc unknown fallback. The real
+`google/siglip2-base-patch16-224` ships the multilingual **Gemma** tokenizer (`GemmaTokenizerFast`,
+**256k** vocab, byte-fallback, digit splitting, case preserved, `max_length=64`) — a 34 MB
+`tokenizer.json`. Corpus vectors and query vectors **must** use the identical tokenizer,
+model revision, image preprocessing, sequence length, normalization and quantization, or cosine
+similarity is meaningless. The current tokenizer does not meet this bar. The
+`SigLipTokenizerParityTest` added in this issue pins the *Unigram algorithm* the code claims to
+implement; a full HF-parity fixture (real `tokenizer.json` golden vectors) is a follow-up
+prerequisite for any GO.
+
+Sources: [SigLIP-2 blog](https://huggingface.co/blog/siglip2),
+[HF SigLIP2 docs](https://huggingface.co/docs/transformers/model_doc/siglip2),
+[model card](https://huggingface.co/google/siglip2-base-patch16-224).
+
+## Options evaluated
+
+| Option | What it is | Decision |
+|---|---|---|
+| **A. Downloadable precomputed ANN corpus** | Backend batch-embeds the catalog, builds an HNSW index, app downloads + delta-syncs. On-device query embed + local ANN. | **No-go now** |
+| **B. Hosted vector search service** | Backend hosts embeddings in a vector DB (pgvector/Qdrant/managed); app sends query embedding or text to a search endpoint. | **No-go now** |
+| **C. CivitAI API retrieval + optional re-ranker** | CivitAI keyword/tag/filter API is the retrieval layer; SigLIP re-ranks top candidates on capable Android devices only. | **Recommended direction** (still gated — not authorized by this doc) |
+| **D. Drop on-device semantic entirely** | Remove the encoders/UI. | Acceptable fallback if C still adds ~300 MB or unsustainable cross-platform maintenance |
+
+### Option A — cost/risk (index is bigger than it looks)
+
+- **Vector size**: 1M × 768-d ≈ **3.1 GB FP32 / 1.5 GB FP16 / 0.8 GB INT8**, before HNSW graph,
+  IDs, metadata and update structures. Product quantization shrinks this but adds a
+  recall-evaluation project. The ~300 MB encoder is *separate* from the corpus.
+- **Pipeline**: catalog crawling (deleted/private content, rate limits, thumbnail downloads,
+  dedup, NSFW handling), deterministic model/tokenizer/preprocessing/quantization versioning,
+  atomic index updates, corruption recovery, schema migrations.
+- **Delta-sync**: HNSW is awkward to delta-sync — inserts are OK, but deletions/compaction and
+  reproducible snapshots eventually force full index replacement.
+- **Staleness**: a stale index returns plausible-but-unavailable hits unless every result is
+  re-validated against CivitAI (which reintroduces the network round-trip A was meant to avoid).
+- A avoids a query *server*, but still needs backend infra to produce and publish signed snapshots.
+
+### Option B — cost/risk (worst organizational fit)
+
+- Cleaner freshness/coverage, but creates a **backend business**: hosting, monitoring, abuse
+  prevention, keys, rate limiting, backups, incident response, egress. Embedding generation and
+  image ingestion — not vector storage — are the large recurring liabilities.
+- Sending query text → network-dependent search + privacy boundary. Sending client vectors →
+  keeps the tokenizer/model parity problem and complicates upgrades.
+- Only attractive if semantic search becomes a funded, differentiating product feature.
+
+## Decision & rationale
+
+**Semantic-primary is rejected for the current product stage. CivitAI remains the retrieval
+system; local ML may be evaluated only as an optional candidate re-ranker.**
+
+Why:
+1. **Core value misfit** — CivitDeck's core values (comfortable browsing; send models to local
+   ComfyUI; mobile UX) do not include being a search engine. A/B both build search
+   infrastructure the product does not need. Fails the one-step Core Value test.
+2. **Solo-dev cost** — no backend today, no store distribution, wants zero/low recurring cost. A
+   is a data-engineering project; B is an ops commitment. Neither is justified by a non-core feature.
+3. **Correctness debt** — tokenizer and cross-platform encoder parity are unmet. A primary KMP
+   feature cannot be Android-only-correct.
+4. **Unproven benefit** — SigLIP-2 is image/text *alignment*-oriented; it is not automatically a
+   good text-to-text ranker over titles/tags/descriptions. No benchmark yet shows it beats the
+   CivitAI API ranking for model discovery.
+
+### Recommended shape (Option C, when/if pursued as an experiment)
+
+1. CivitAI keyword/tag/filter API retrieves the complete candidate set (unchanged default order).
+2. Optionally re-rank the top ~20–100 candidates on capable Android devices, behind the existing
+   experimental flag.
+3. Ship the encoder as an **explicit downloadable component**, so normal installs never gain ~300 MB.
+4. Silent, complete fallback to API ranking on iOS/Desktop and on failure.
+5. **Open problem to note**: re-ranking *unseen* results still needs candidate representations —
+   the detail-page cache cannot supply them. The experiment must embed candidate metadata at query
+   time or download+embed result thumbnails (slower/costlier). This is why re-ranking is scoped as
+   an experiment, not a promised feature, and why #988 must keep semantic non-default.
+
+## Isolation invariant (for #988 unified search)
+
+Semantic/SigLIP retrieval must stay **off the default retrieval path**. In a unified search bar it
+may only re-order keyword results as an opt-in Android experiment; it must never be the primary
+retrieval layer. Availability of search must never depend on embeddings.
+
+## GO criteria (revisit trigger)
+
+Reconsider semantic-primary only when **all** hold:
+- Offline semantic catalog search is validated as a core user need (not gut feeling — 2-axis test).
+- A representative benchmark shows meaningful ranking gains over the CivitAI API.
+- The index covers ~the full searchable catalog with defined freshness targets.
+- Model/tokenizer/preprocessing parity is proven on Android, iOS **and** Desktop against a shared
+  golden suite (incl. a real HF `tokenizer.json` fixture).
+- Download size, cold-start latency, memory and update costs meet explicit budgets.
+- The pipeline/service has sustainable ownership and funding.
+- Keyword/API fallback remains available for freshness and failure recovery.
+
+## Follow-ups (NOT implemented here — tracked in #995, pending weekly review)
+
+1. **HF-parity tokenizer fixture** — regenerate the Android tokenizer from the real Gemma
+   `tokenizer.json`; commit golden (text → token-id) vectors and extend `SigLipTokenizerParityTest`
+   to assert against them. Prerequisite for any GO.
+2. **Re-ranker experiment (Option C)** — Android-only, downloadable encoder, top-K re-rank over
+   CivitAI results, benchmarked vs API ranking before any wider rollout.
+
+## Cross-review
+
+Corpus-index options and the go/no-go were cross-reviewed with Codex MCP (per
+`.claude/rules/behavior.md`). Codex independently recommended **NO-GO on semantic-primary**,
+Option **C** with **D** as fallback, corrected the index-size estimates above, and flagged both
+the Gemma tokenizer mismatch as a correctness blocker and that SigLIP-2 is not inherently a good
+text-to-text catalog ranker.

--- a/iosApp/iosApp/FeatureFlags.swift
+++ b/iosApp/iosApp/FeatureFlags.swift
@@ -6,6 +6,11 @@ import Foundation
 /// Default off until the on-device SigLIP-2 embedder is producing real vectors
 /// (parent #602, phases C/D). Flip individual flags manually for development.
 enum FeatureFlags {
-    /// Gates the embedding-based "Find Similar Models" UI surface.
+    /// Gates the embedding-based "Find Similar Models" / "AI Search" UI surface.
+    ///
+    /// Semantic (SigLIP-2) search is an **Android-only experiment**. iOS ships no
+    /// text or vision encoder (see `core-ml/src/iosMain/.../ml/*`), so this flag
+    /// must stay `false` on iOS — flipping it would surface a permanently empty,
+    /// non-functional screen. Kept only to mirror Android's `BuildConfig` field.
     static let similaritySearch = false
 }

--- a/iosApp/iosApp/Features/TextSearch/TextSearchView.swift
+++ b/iosApp/iosApp/Features/TextSearch/TextSearchView.swift
@@ -60,9 +60,9 @@ struct TextSearchView: View {
     private var unavailableState: some View {
         EmptyStateView(
             icon: "sparkles",
-            title: "AI Search coming soon",
-            subtitle: "Text-to-image search using SigLIP-2 is under development. " +
-                "The text encoder and tokenizer are being integrated."
+            title: "AI Search (experimental)",
+            subtitle: "On-device text-to-image search is an experimental Android-only feature. " +
+                "iOS has no SigLIP-2 text encoder, so this screen is disabled here."
         )
     }
 


### PR DESCRIPTION
Closes #989

## Summary
SigLIP-2 semantic search was assumed "implemented across 3 platforms" but is not functional. This PR corrects that false-done state: it labels the feature honestly, keeps it off the default retrieval path, and adds a spike decision doc plus a tokenizer parity test. **No corpus index is built here** (Research→Implementation Gate — the spike is a decision doc only).

## Verified reality
- iOS text/vision encoders are stubs (`isAvailable=false`, `embed()` throws); no `.mlpackage` bundled.
- Desktop text/vision are no-ops by design.
- Android model + vocab are gitignored (not committed); the whole feature is build-flag gated OFF by default (`FEATURE_SIMILARITY_SEARCH`, hard-`false` on the fdroid flavor). iOS `FeatureFlags.similaritySearch = false`.
- The index is built only for models opened in detail, so search covers a tiny local subset, not CivitAI.

## Changes
1. **Honesty / labeling**
   - README + ROADMAP: semantic search reframed as **experimental, Android-only, off by default**; removed the implied "works on 3 platforms" claim. ROADMAP item downgraded from `[x]` to `[~]`.
   - Android `TextSearchScreen` and iOS `TextSearchView` copy now state it is an experimental Android-only feature (iOS has no encoder).
   - `FeatureFlags.swift` documents why the flag must stay `false` on iOS.
2. **Isolation** — semantic search remains off the default retrieval path (separate flag-gated "AI Search" surface). The spike doc records the invariant for #988 (unified search must keep semantic non-default): SigLIP may only act as a re-ranker over keyword results, never the primary retrieval layer.
3. **Spike decision doc** — `docs/research/989-semantic-corpus-index-spike.md`: evaluates precomputed downloadable ANN corpus (A), hosted vector service (B), API-retrieval + re-ranker (C), and drop (D). **Decision: NO-GO on semantic-primary; recommended direction is C (still gated).** Cross-reviewed with Codex MCP (independently reached NO-GO / Option C, corrected index-size math, flagged the Gemma-tokenizer parity gap as a correctness blocker).
4. **Tokenizer parity test** — new `SigLipTokenizerParityTest` (`core-ml/androidHostTest`) with a `fromVocabJson` test seam. Pins the SentencePiece Unigram algorithm (segmentation, lowercasing, EOS, padding, truncation, unk fallback) via hand-computed golden fixtures. Note: SigLIP-2 actually ships the Gemma 256k tokenizer, so full HF parity needs a real `tokenizer.json` fixture — scoped as a follow-up.

## Follow-up
Filed **#995** (HF-parity tokenizer fixture + Option C Android re-ranker experiment) — pending weekly review, not implemented here.

## ⚠️ CI wiring required (blocked by token scope)
The new test runs under `:core:core-ml:testAndroidHostTest`, which is **not yet in the CI Android job task list** (`.github/workflows/ci.yml`, after `:core:core-data:testAndroidHostTest`). I could not include that one-line workflow edit because this token lacks `workflow` scope. **A maintainer must add `:core:core-ml:testAndroidHostTest` to the CI task list**, or the new test won't run in CI.

## Verification (local, CI-equivalent)
- Android CI task list (`:shared` / `:core:core-data` / `:core:core-ml` / `:feature:{search,detail,gallery,prompts,creator,externalserver}` `:testAndroidHostTest` + `:core:core-database:jvmTest` + `:feature:feature-comfyui:jvmTest`): BUILD SUCCESSFUL
- `detekt` (twice): BUILD SUCCESSFUL
- `:shared:compileKotlinIosSimulatorArm64` + `:desktopApp:compileKotlinJvm`: BUILD SUCCESSFUL
- `:androidApp:assembleDebug` (fdroid + githubFull): BUILD SUCCESSFUL
- Self-review (2 parallel sonnet reviewers): critical 0, warning 0 after fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)