### PR TITLE
Fix Download Queue crash: register AndroidDownloadScheduler in Koin

### DIFF
--- a/androidApp/src/main/kotlin/com/riox432/civitdeck/CivitDeckApplication.kt
+++ b/androidApp/src/main/kotlin/com/riox432/civitdeck/CivitDeckApplication.kt
@@ -20,12 +20,14 @@ import com.riox432.civitdeck.di.initializeFrontDoor
 import com.riox432.civitdeck.di.registerExportPlugins
 import com.riox432.civitdeck.di.registerThemePlugins
 import com.riox432.civitdeck.di.registerWorkflowPlugins
+import com.riox432.civitdeck.domain.download.DownloadScheduler
 import com.riox432.civitdeck.domain.model.PollingInterval
 import com.riox432.civitdeck.domain.repository.AppVersionProvider
 import com.riox432.civitdeck.domain.usecase.CleanupBrowsingHistoryUseCase
 import com.riox432.civitdeck.domain.usecase.ObserveNotificationsEnabledUseCase
 import com.riox432.civitdeck.domain.usecase.ObservePollingIntervalUseCase
 import com.riox432.civitdeck.domain.util.ApplicationScope
+import com.riox432.civitdeck.download.AndroidDownloadScheduler
 import com.riox432.civitdeck.feature.detail.presentation.ModelDetailViewModel
 import com.riox432.civitdeck.notification.ModelUpdateScheduler
 import com.riox432.civitdeck.ui.dataset.DuplicateReviewViewModel
@@ -123,6 +125,7 @@ class CivitDeckApplication : Application(), SingletonImageLoader.Factory, KoinCo
 
 val androidModule = module {
     single<AppVersionProvider> { AndroidAppVersionProvider() }
+    single<DownloadScheduler> { AndroidDownloadScheduler(androidContext()) }
     viewModel { params ->
         ModelDetailViewModel(params.get(), get(), get(), get(), get(), get(), get())
     }


### PR DESCRIPTION
## Problem
Opening **Settings → Downloads** (Download Queue) crashed the Android app:

```
org.koin.core.error.InstanceCreationException: Could not create instance for
'DownloadQueueViewModel'
Caused by: NoDefinitionFoundException: No definition found for type
'com.riox432.civitdeck.domain.download.DownloadScheduler' on scope '_root_'
```

## Root cause
`DownloadScheduler` is an `expect/actual`-style dependency provided per platform:
- iOS: `PlatformModule.ios.kt` → `single<DownloadScheduler> { IosDownloadScheduler() }`
- Desktop: `PlatformModule.jvm.kt` → `single<DownloadScheduler> { DesktopDownloadScheduler() }`
- **Android: never registered.**

The Android impl `AndroidDownloadScheduler` lives in the `androidApp` module (it wraps the WorkManager-based `object DownloadScheduler`), so `shared/androidMain/PlatformModule.android.kt` cannot reference it (dependency direction is androidApp → shared, not the reverse). Its binding therefore belongs in `androidApp`'s `androidModule`, and it was missed when `DownloadQueueViewModel` was moved to the shared `Phase3ViewModelModule` (introduced in #694). iOS and Desktop got their bindings; Android was the gap, so the Download Queue screen has crashed on Android since then. Not caused by the recent discovery batch (#986–#992).

## Fix
Register the Android binding in `androidModule` (`CivitDeckApplication.kt`):
```kotlin
single<DownloadScheduler> { AndroidDownloadScheduler(androidContext()) }
```

## Verification
- **On device (Galaxy S25 Ultra, githubFull debug):** Settings → Downloads now opens the Download Queue screen (empty state "No downloads yet") instead of crashing. Confirmed app process stays alive, MainActivity foreground, no `NoDefinitionFoundException` / FATAL in logcat after opening the screen.
- `./gradlew detekt` ×2 → BUILD SUCCESSFUL (2nd pass clean).
- `:androidApp:assembleDebug` (fdroid + githubFull) → BUILD SUCCESSFUL.

## Note
A Koin `checkModules()` verification test for `androidModule` would have caught this at CI time; filed as a potential follow-up (the Android runtime graph is not exercised by the current unit tests).