### PR TITLE
Sync docs with discovery batch (CHANGELOG, DB v49, unified search)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,7 +51,7 @@ CivitDeck/
 ├── core/
 │   ├── core-domain/          # Domain layer: models, repository interfaces, use cases, DomainModule + DomainPlatformModule (Koin)
 │   ├── core-network/         # Network layer: Ktor client, DTOs (CivitAI + ComfyUI + WebUI + ExternalServer), NetworkModule (Koin)
-│   ├── core-database/        # Local storage only: Room KMP entities/DAOs/migrations (v48), DatabaseModule (Koin); no core-network dep
+│   ├── core-database/        # Local storage only: Room KMP entities/DAOs/migrations (v49), DatabaseModule (Koin); no core-network dep
 │   ├── core-data/            # Network+cache repository impls (ModelRepositoryImpl etc.) + DTO→domain mappers, coreDataModule (Koin)
 │   ├── core-ui/              # Shared Compose components + design tokens (KMP: Android + Desktop)
 │   ├── core-plugin/          # Plugin system: interfaces, registry, capability adapters, PluginModule (Koin)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,36 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+Discovery-engine refocus: sharpen the app around native CivitAI discovery and open the FOSS distribution channel.
+
+### Added
+
+- Personalization signals — recommendation-card taps are recorded via an append-only interaction event log (retained even without a prior history row, accumulating instead of overwriting), and recommendations refresh on return from a detail view (#987, #994)
+- Unified search bar — keyword/tag, image, and experimental semantic search fold into one `ModelSearchViewModel` with explicit `Idle`/`Editing`/`Results` states; recommendations show only while idle (#988, #997)
+- Build flavors — `fdroid` (FOSS, no ML/self-update) and `githubFull` (bundled ML + in-app self-update), with a dedicated `core-ml` module extracted from `core-domain` so the F-Droid build excludes ONNX at the dependency level (#986, #993)
+- Deterministic QA foundation for the discovery flow — base-URL-injectable E2E seam, recorded CivitAI fixtures, stable discovery test tags, a semantic golden-query top-K test, and a Desktop Compose smoke test (PoC, not CI-gated) (#990, #998)
+- Semantic corpus-index spike decision doc and a `SigLipTokenizer` HF-parity test (#989, #996)
+
+### Changed
+
+- SigLIP-2 semantic search relabeled as **Android-only, experimental, off by default** and kept off the default retrieval path (keyword/tag stays primary); iOS/Desktop have no working encoder (#989, #996)
+- "Send to PC" (CV2) demoted to show only with a compatible connection; detail-screen Share/QR moved into an overflow menu; Analytics/Backup/Compare/Dataset/Hardware peripherals moved off the discovery-primary surface (kept, reversible) (#991, #1000)
+- Docs & positioning — README now leads with the single discovery promise, the ViewModel count is unified to the measured 42, and ROADMAP is reframed as a forward-looking compass (#992, #1001)
+
+### Removed
+
+- Reviews list/submit feature (reads/writes CivitAI's tRPC, conflicts with the "no SNS/community" scope) — `Model.stats.rating` is retained and still shown; the 2 tRPC review requests per model detail are eliminated (#991, #1000)
+
+### Fixed
+
+- Download Queue no longer crashes on Android — registered the missing `AndroidDownloadScheduler` Koin binding (`DownloadScheduler` was bound on iOS/Desktop but not Android since #694) (#1003)
+- Bounded the interaction-event query with a limit (#987)
+
+### Infrastructure
+
+- Extracted `core-ml`; network→database→core-data module load order; per-flavor packaging exclusions and manifest permissions (#986, #993)
+- Synced ai-dev-template common + KMP layer files (#980)
+
 ## [2.4.0] - 2026-07-11
 
 ### Added

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -31,7 +31,7 @@ CivitDeck/
 │   │       └── di/                   # NetworkModule (Koin)
 │   ├── core-database/        # Local storage only: Room KMP entities, DAOs, migrations
 │   │   └── src/commonMain/kotlin/.../
-│   │       ├── data/local/           # Entities, DAOs, CivitDeckDatabase (v48)
+│   │       ├── data/local/           # Entities, DAOs, CivitDeckDatabase (v49)
 │   │       ├── data/local/migration/ # Sequential migrations (1→2 … 47→48)
 │   │       └── di/                   # DatabaseModule (Koin) — no longer depends on core-network
 │   ├── core-data/            # Data aggregation: network+cache repositories (ModelRepositoryImpl,
@@ -52,7 +52,7 @@ CivitDeck/
 │   └── core-testing/         # Shared test infra (commonMain): fake repositories, ApplicationScope(TestScope)
 │       └── src/commonMain/kotlin/.../ # helper, Turbine — consumed by feature/core commonTest
 ├── feature/                  # Feature modules — each owns its ViewModels + use cases in commonMain
-│   ├── feature-search/       # Search, swipe discovery, text search, similar models, browsing history
+│   ├── feature-search/       # Unified search (keyword/tag + image + experimental semantic), swipe discovery, recommendations, browsing history
 │   ├── feature-detail/       # Model detail view + model comparison
 │   ├── feature-gallery/      # Image gallery, downloads, analytics, notifications, share, update
 │   ├── feature-creator/      # Creator profiles, follow system, feed
@@ -119,7 +119,7 @@ graph TB
 ### Data Layer (`core/core-network/` + `core/core-database/` + `core/core-data/`)
 
 - **API** (`core-network`): Ktor HTTP client targeting `https://civitai.com/api/v1`. Endpoints include `/models`, `/models/:id`, `/model-versions/:id`, `/images`, `/creators`, and `/tags`. Pagination is cursor-based for images and page-based for others. Also includes API clients for ComfyUI (REST + WebSocket), SD WebUI (Automatic1111/Forge), Civitai Link, ComfyHub, custom External Servers, multi-source search (HuggingFace, TensorArt), and GitHub Releases (in-app update check).
-- **Local** (`core-database`): Room KMP database (version 48) for offline favorites, user collections, saved prompts, saved search filters, SD WebUI/ComfyUI connections, external server configs, dataset collections, model notes, followed creators, feed cache, model downloads, plugin data, quality scores, and response caching with TTL. Migrations tracked sequentially from version 1. This module is pure local storage and does **not** depend on `core-network`.
+- **Local** (`core-database`): Room KMP database (version 49) for offline favorites, user collections, saved prompts, saved search filters, SD WebUI/ComfyUI connections, external server configs, dataset collections, model notes, followed creators, feed cache, model downloads, interaction events (recommendation signals), plugin data, quality scores, and response caching with TTL. Migrations tracked sequentially from version 1. This module is pure local storage and does **not** depend on `core-network`.
 - **Repository Implementations** (`core-data`): Combine remote API calls with local cache and map DTOs → domain models. `ModelRepositoryImpl` and friends live here (extracted from `core-database`) so the database layer stays network-free; `core-data` depends on both `core-network` and `core-database`.
 
 ### Domain Layer (`core/core-domain/`)


### PR DESCRIPTION
Documentation sync after the discovery batch (#986–#992) + the Download Queue crash fix (#1003). Docs-only, no source/test changes.

## Changes
- **CHANGELOG.md** — filled the empty `## [Unreleased]` with the discovery batch grouped by Added/Changed/Removed/Fixed/Infrastructure (personalization signals #987, unified search #988, build flavors + core-ml #986, QA foundation #990, SigLIP isolation #989, Reviews removal #991, docs/positioning #992, Download Queue crash fix #1003).
- **docs/ARCHITECTURE.md** — Room database `v48 → v49` (interaction_event table added in #987, migration 48→49; verified against `CivitDeckDatabase.kt` `version = 49`); reworded `feature-search` to the unified search reality (keyword/tag + image + experimental semantic; text-search/similar screens retired in #988).
- **AGENTS.md** — `core-database (v48) → (v49)`.

## Deliberately NOT changed
- **README.md / README.ja.md** — already current after #992 (leads with the discovery promise, ViewModel count = measured 42, semantic search labeled Android-only experimental). A few code-only internal capabilities (mask editor, duplicate detection, connection onboarding, deep links, Core Spotlight) were left out on purpose to keep the README's discovery-first positioning concise.
- **OSS docs** — SECURITY.md, LICENSE, CONTRIBUTING.md, CODE_OF_CONDUCT.md all already present; nothing to create.

## Verification
Docs-only. Internal links unchanged (none added/removed). ViewModel count (42) and DB version (49) verified against source.